### PR TITLE
Simplify AssertJ assertions and also make them more readable

### DIFF
--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/PackageTangleCheckTests.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/PackageTangleCheckTests.java
@@ -45,8 +45,7 @@ class PackageTangleCheckTests {
 	@Test
 	void whenPackagesAreTangledTaskFailsAndWritesAReport() throws Exception {
 		prepareTask("tangled", (packageTangleCheck) -> {
-			assertThatExceptionOfType(GradleException.class)
-					.isThrownBy(() -> packageTangleCheck.checkForPackageTangles());
+			assertThatExceptionOfType(GradleException.class).isThrownBy(packageTangleCheck::checkForPackageTangles);
 			assertThat(
 					new File(packageTangleCheck.getProject().getBuildDir(), "checkForPackageTangles/failure-report.txt")
 							.length()).isGreaterThan(0);

--- a/buildSrc/src/test/java/org/springframework/boot/build/bom/bomr/UpgradeApplicatorTests.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/bom/bomr/UpgradeApplicatorTests.java
@@ -55,7 +55,7 @@ class UpgradeApplicatorTests {
 				new Library("ActiveMQ", new LibraryVersion(DependencyVersion.parse("5.15.11"), null), null, null, null),
 				DependencyVersion.parse("5.16")));
 		String bomContents = Files.readString(bom.toPath());
-		assertThat(bomContents.length()).isEqualTo(originalContents.length() - 3);
+		assertThat(bomContents).hasSize(originalContents.length() - 3);
 	}
 
 	@Test
@@ -69,7 +69,7 @@ class UpgradeApplicatorTests {
 				new Upgrade(new Library("OAuth2 OIDC SDK", new LibraryVersion(DependencyVersion.parse("8.36.1"), null),
 						null, null, null), DependencyVersion.parse("8.36.2")));
 		String bomContents = Files.readString(bom.toPath());
-		assertThat(bomContents.length()).isEqualTo(originalContents.length());
+		assertThat(bomContents).hasSameSizeAs(originalContents);
 		assertThat(bomContents).contains("version(\"8.36.2\")");
 	}
 

--- a/buildSrc/src/test/java/org/springframework/boot/build/bom/bomr/version/ReleaseTrainDependencyVersionTests.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/bom/bomr/version/ReleaseTrainDependencyVersionTests.java
@@ -109,10 +109,10 @@ class ReleaseTrainDependencyVersionTests {
 
 	@Test
 	void whenComparedWithADifferentDependencyVersionTypeThenTheResultsAreNonZero() {
-		ReleaseTrainDependencyVersion dysprosium = ReleaseTrainDependencyVersion.parse("Dysprosium-SR16");
-		ArtifactVersionDependencyVersion twentyTwenty = ArtifactVersionDependencyVersion.parse("2020.0.0");
-		assertThat(dysprosium.compareTo(twentyTwenty)).isLessThan(0);
-		assertThat(twentyTwenty.compareTo(dysprosium)).isGreaterThan(0);
+		DependencyVersion dysprosium = ReleaseTrainDependencyVersion.parse("Dysprosium-SR16");
+		DependencyVersion twentyTwenty = ArtifactVersionDependencyVersion.parse("2020.0.0");
+		assertThat(dysprosium).isLessThan(twentyTwenty);
+		assertThat(twentyTwenty).isGreaterThan(dysprosium);
 	}
 
 	private static ReleaseTrainDependencyVersion version(String input) {

--- a/buildSrc/src/test/java/org/springframework/boot/build/context/properties/CompoundRowTests.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/context/properties/CompoundRowTests.java
@@ -39,8 +39,8 @@ class CompoundRowTests {
 		row.addProperty(new ConfigurationProperty("spring.test.third", "java.lang.String"));
 		Asciidoc asciidoc = new Asciidoc();
 		row.write(asciidoc);
-		assertThat(asciidoc.toString()).isEqualTo("|[[my.spring.test]]<<my.spring.test,`+spring.test.first+` +"
-				+ NEWLINE + "`+spring.test.second+` +" + NEWLINE + "`+spring.test.third+` +" + NEWLINE + ">>" + NEWLINE
+		assertThat(asciidoc).hasToString("|[[my.spring.test]]<<my.spring.test,`+spring.test.first+` +" + NEWLINE
+				+ "`+spring.test.second+` +" + NEWLINE + "`+spring.test.third+` +" + NEWLINE + ">>" + NEWLINE
 				+ "|+++This is a description.+++" + NEWLINE + "|" + NEWLINE);
 	}
 

--- a/buildSrc/src/test/java/org/springframework/boot/build/context/properties/SingleRowTests.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/context/properties/SingleRowTests.java
@@ -38,7 +38,7 @@ class SingleRowTests {
 		SingleRow row = new SingleRow(SNIPPET, property);
 		Asciidoc asciidoc = new Asciidoc();
 		row.write(asciidoc);
-		assertThat(asciidoc.toString()).isEqualTo("|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop+`>>"
+		assertThat(asciidoc).hasToString("|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop+`>>"
 				+ NEWLINE + "|+++This is a description.+++" + NEWLINE + "|`+something+`" + NEWLINE);
 	}
 
@@ -49,7 +49,7 @@ class SingleRowTests {
 		SingleRow row = new SingleRow(SNIPPET, property);
 		Asciidoc asciidoc = new Asciidoc();
 		row.write(asciidoc);
-		assertThat(asciidoc.toString()).isEqualTo("|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop+`>>"
+		assertThat(asciidoc).hasToString("|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop+`>>"
 				+ NEWLINE + "|+++This is a description.+++" + NEWLINE + "|" + NEWLINE);
 	}
 
@@ -60,7 +60,7 @@ class SingleRowTests {
 		SingleRow row = new SingleRow(SNIPPET, property);
 		Asciidoc asciidoc = new Asciidoc();
 		row.write(asciidoc);
-		assertThat(asciidoc.toString()).isEqualTo("|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop+`>>"
+		assertThat(asciidoc).hasToString("|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop+`>>"
 				+ NEWLINE + "|+++This is a description.+++" + NEWLINE + "|`+first\\|second+`" + NEWLINE);
 	}
 
@@ -71,7 +71,7 @@ class SingleRowTests {
 		SingleRow row = new SingleRow(SNIPPET, property);
 		Asciidoc asciidoc = new Asciidoc();
 		row.write(asciidoc);
-		assertThat(asciidoc.toString()).isEqualTo("|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop+`>>"
+		assertThat(asciidoc).hasToString("|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop+`>>"
 				+ NEWLINE + "|+++This is a description.+++" + NEWLINE + "|`+first\\\\second+`" + NEWLINE);
 	}
 
@@ -82,7 +82,7 @@ class SingleRowTests {
 		SingleRow row = new SingleRow(SNIPPET, property);
 		Asciidoc asciidoc = new Asciidoc();
 		row.write(asciidoc);
-		assertThat(asciidoc.toString()).isEqualTo("|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop+`>>"
+		assertThat(asciidoc).hasToString("|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop+`>>"
 				+ NEWLINE + "|+++This is a description with a \\| pipe.+++" + NEWLINE + "|" + NEWLINE);
 	}
 
@@ -93,9 +93,8 @@ class SingleRowTests {
 		SingleRow row = new SingleRow(SNIPPET, property);
 		Asciidoc asciidoc = new Asciidoc();
 		row.write(asciidoc);
-		assertThat(asciidoc.toString())
-				.isEqualTo("|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop.*+`>>" + NEWLINE
-						+ "|+++This is a description.+++" + NEWLINE + "|" + NEWLINE);
+		assertThat(asciidoc).hasToString("|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop.*+`>>"
+				+ NEWLINE + "|+++This is a description.+++" + NEWLINE + "|" + NEWLINE);
 	}
 
 	@Test
@@ -106,7 +105,7 @@ class SingleRowTests {
 		SingleRow row = new SingleRow(SNIPPET, property);
 		Asciidoc asciidoc = new Asciidoc();
 		row.write(asciidoc);
-		assertThat(asciidoc.toString()).isEqualTo("|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop+`>>"
+		assertThat(asciidoc).hasToString("|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop+`>>"
 				+ NEWLINE + "|+++This is a description.+++" + NEWLINE + "|`+first," + NEWLINE + "second," + NEWLINE
 				+ "third+`" + NEWLINE);
 	}

--- a/buildSrc/src/test/java/org/springframework/boot/build/context/properties/TableTests.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/context/properties/TableTests.java
@@ -41,17 +41,16 @@ class TableTests {
 		Asciidoc asciidoc = new Asciidoc();
 		table.write(asciidoc);
 		// @formatter:off
-		assertThat(asciidoc.toString()).isEqualTo(
-				"[cols=\"4,3,3\", options=\"header\"]" + NEWLINE +
-				"|===" + NEWLINE +
-				"|Name|Description|Default Value" + NEWLINE + NEWLINE +
-				"|[[my.spring.test.other]]<<my.spring.test.other,`+spring.test.other+`>>" + NEWLINE +
-				"|+++This is another description.+++" + NEWLINE +
-				"|`+other value+`" + NEWLINE + NEWLINE +
-				"|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop+`>>" + NEWLINE +
-				"|+++This is a description.+++" + NEWLINE +
-				"|`+something+`" + NEWLINE + NEWLINE +
-				"|===" + NEWLINE);
+		assertThat(asciidoc).hasToString("[cols=\"4,3,3\", options=\"header\"]" + NEWLINE +
+		"|===" + NEWLINE +
+		"|Name|Description|Default Value" + NEWLINE + NEWLINE +
+		"|[[my.spring.test.other]]<<my.spring.test.other,`+spring.test.other+`>>" + NEWLINE +
+		"|+++This is another description.+++" + NEWLINE +
+		"|`+other value+`" + NEWLINE + NEWLINE +
+		"|[[my.spring.test.prop]]<<my.spring.test.prop,`+spring.test.prop+`>>" + NEWLINE +
+		"|+++This is a description.+++" + NEWLINE +
+		"|`+something+`" + NEWLINE + NEWLINE +
+		"|===" + NEWLINE);
 		// @formatter:on
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/availability/AvailabilityProbesHealthEndpointGroupsPostProcessorTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/availability/AvailabilityProbesHealthEndpointGroupsPostProcessorTests.java
@@ -80,8 +80,8 @@ class AvailabilityProbesHealthEndpointGroupsPostProcessorTests {
 		HealthEndpointGroups postProcessed = getPostProcessed("true");
 		HealthEndpointGroup liveness = postProcessed.get("liveness");
 		HealthEndpointGroup readiness = postProcessed.get("readiness");
-		assertThat(liveness.getAdditionalPath().toString()).isEqualTo("server:/livez");
-		assertThat(readiness.getAdditionalPath().toString()).isEqualTo("server:/readyz");
+		assertThat(liveness.getAdditionalPath()).hasToString("server:/livez");
+		assertThat(readiness.getAdditionalPath()).hasToString("server:/readyz");
 	}
 
 	@Test
@@ -99,8 +99,8 @@ class AvailabilityProbesHealthEndpointGroupsPostProcessorTests {
 		HealthEndpointGroups postProcessed = postProcessor.postProcessHealthEndpointGroups(groups);
 		HealthEndpointGroup liveness = postProcessed.get("liveness");
 		HealthEndpointGroup readiness = postProcessed.get("readiness");
-		assertThat(liveness.getAdditionalPath().toString()).isEqualTo("server:/livez");
-		assertThat(readiness.getAdditionalPath().toString()).isEqualTo("server:/readyz");
+		assertThat(liveness.getAdditionalPath()).hasToString("server:/livez");
+		assertThat(readiness.getAdditionalPath()).hasToString("server:/readyz");
 	}
 
 	private HealthEndpointGroups getPostProcessed(String value) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/CloudFoundryWebEndpointDiscovererTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/CloudFoundryWebEndpointDiscovererTests.java
@@ -62,7 +62,7 @@ class CloudFoundryWebEndpointDiscovererTests {
 	void getEndpointsShouldAddCloudFoundryHealthExtension() {
 		load(TestConfiguration.class, (discoverer) -> {
 			Collection<ExposableWebEndpoint> endpoints = discoverer.getEndpoints();
-			assertThat(endpoints.size()).isEqualTo(2);
+			assertThat(endpoints).hasSize(2);
 			for (ExposableWebEndpoint endpoint : endpoints) {
 				if (endpoint.getEndpointId().equals(EndpointId.of("health"))) {
 					WebOperation operation = findMainReadOperation(endpoint);

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundrySecurityInterceptorTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundrySecurityInterceptorTests.java
@@ -117,7 +117,7 @@ class CloudFoundrySecurityInterceptorTests {
 		ArgumentCaptor<Token> tokenArgumentCaptor = ArgumentCaptor.forClass(Token.class);
 		then(this.tokenValidator).should().validate(tokenArgumentCaptor.capture());
 		Token token = tokenArgumentCaptor.getValue();
-		assertThat(token.toString()).isEqualTo(accessToken);
+		assertThat(token).hasToString(accessToken);
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK);
 		assertThat(this.request.getAttribute("cloudFoundryAccessLevel")).isEqualTo(AccessLevel.FULL);
 	}
@@ -131,7 +131,7 @@ class CloudFoundrySecurityInterceptorTests {
 		ArgumentCaptor<Token> tokenArgumentCaptor = ArgumentCaptor.forClass(Token.class);
 		then(this.tokenValidator).should().validate(tokenArgumentCaptor.capture());
 		Token token = tokenArgumentCaptor.getValue();
-		assertThat(token.toString()).isEqualTo(accessToken);
+		assertThat(token).hasToString(accessToken);
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK);
 		assertThat(this.request.getAttribute("cloudFoundryAccessLevel")).isEqualTo(AccessLevel.RESTRICTED);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundrySecurityServiceTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundrySecurityServiceTests.java
@@ -151,7 +151,7 @@ class CloudFoundrySecurityServiceTests {
 				.andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
 		Map<String, String> tokenKeys = this.securityService.fetchTokenKeys();
 		this.server.verify();
-		assertThat(tokenKeys.get("test-key")).isEqualTo(tokenKeyValue);
+		assertThat(tokenKeys).containsEntry("test-key", tokenKeyValue);
 	}
 
 	@Test
@@ -163,7 +163,7 @@ class CloudFoundrySecurityServiceTests {
 				.andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
 		Map<String, String> tokenKeys = this.securityService.fetchTokenKeys();
 		this.server.verify();
-		assertThat(tokenKeys).hasSize(0);
+		assertThat(tokenKeys).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/context/properties/ConfigurationPropertiesReportEndpointAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/context/properties/ConfigurationPropertiesReportEndpointAutoConfigurationTests.java
@@ -72,7 +72,7 @@ class ConfigurationPropertiesReportEndpointAutoConfigurationTests {
 					ConfigurationPropertiesReportEndpointWebExtension endpoint = context
 							.getBean(ConfigurationPropertiesReportEndpointWebExtension.class);
 					Set<String> roles = (Set<String>) ReflectionTestUtils.getField(endpoint, "roles");
-					assertThat(roles.contains("test")).isTrue();
+					assertThat(roles).contains("test");
 				});
 	}
 
@@ -119,8 +119,8 @@ class ConfigurationPropertiesReportEndpointAutoConfigurationTests {
 			Map<String, Object> nestedProperties = properties.getContexts().get(context.getId()).getBeans()
 					.get("testProperties").getProperties();
 			assertThat(nestedProperties).isNotNull();
-			assertThat(nestedProperties.get("dbPassword")).isEqualTo(dbPassword);
-			assertThat(nestedProperties.get("myTestProperty")).isEqualTo(myTestProperty);
+			assertThat(nestedProperties).containsEntry("dbPassword", dbPassword);
+			assertThat(nestedProperties).containsEntry("myTestProperty", myTestProperty);
 		};
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/jmx/DefaultEndpointObjectNameFactoryTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/jmx/DefaultEndpointObjectNameFactoryTests.java
@@ -51,20 +51,20 @@ class DefaultEndpointObjectNameFactoryTests {
 	@Test
 	void generateObjectName() {
 		ObjectName objectName = generateObjectName(endpoint(EndpointId.of("test")));
-		assertThat(objectName.toString()).isEqualTo("org.springframework.boot:type=Endpoint,name=Test");
+		assertThat(objectName).hasToString("org.springframework.boot:type=Endpoint,name=Test");
 	}
 
 	@Test
 	void generateObjectNameWithCapitalizedId() {
 		ObjectName objectName = generateObjectName(endpoint(EndpointId.of("testEndpoint")));
-		assertThat(objectName.toString()).isEqualTo("org.springframework.boot:type=Endpoint,name=TestEndpoint");
+		assertThat(objectName).hasToString("org.springframework.boot:type=Endpoint,name=TestEndpoint");
 	}
 
 	@Test
 	void generateObjectNameWithCustomDomain() {
 		this.properties.setDomain("com.example.acme");
 		ObjectName objectName = generateObjectName(endpoint(EndpointId.of("test")));
-		assertThat(objectName.toString()).isEqualTo("com.example.acme:type=Endpoint,name=Test");
+		assertThat(objectName).hasToString("com.example.acme:type=Endpoint,name=Test");
 	}
 
 	@Test
@@ -77,7 +77,7 @@ class DefaultEndpointObjectNameFactoryTests {
 		ExposableJmxEndpoint endpoint = endpoint(EndpointId.of("test"));
 		String id = ObjectUtils.getIdentityHexString(endpoint);
 		ObjectName objectName = generateObjectName(endpoint);
-		assertThat(objectName.toString()).isEqualTo("org.springframework.boot:type=Endpoint,name=Test,identity=" + id);
+		assertThat(objectName).hasToString("org.springframework.boot:type=Endpoint,name=Test,identity=" + id);
 	}
 
 	@Test
@@ -96,8 +96,7 @@ class DefaultEndpointObjectNameFactoryTests {
 		given(this.mBeanServer.queryNames(new ObjectName("org.springframework.boot:type=Endpoint,name=Test,*"), null))
 				.willReturn(Collections.singleton(new ObjectName("org.springframework.boot:type=Endpoint,name=Test")));
 		ObjectName objectName = generateObjectName(endpoint(EndpointId.of("test")));
-		assertThat(objectName.toString())
-				.isEqualTo("org.springframework.boot:type=Endpoint,name=Test,context=testContext");
+		assertThat(objectName).hasToString("org.springframework.boot:type=Endpoint,name=Test,context=testContext");
 
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointPropertiesTests.java
@@ -38,7 +38,7 @@ class WebEndpointPropertiesTests {
 	void basePathShouldBeCleaned() {
 		WebEndpointProperties properties = new WebEndpointProperties();
 		properties.setBasePath("/");
-		assertThat(properties.getBasePath()).isEqualTo("");
+		assertThat(properties.getBasePath()).isEmpty();
 		properties.setBasePath("/actuator/");
 		assertThat(properties.getBasePath()).isEqualTo("/actuator");
 	}
@@ -54,7 +54,7 @@ class WebEndpointPropertiesTests {
 	void basePathCanBeEmpty() {
 		WebEndpointProperties properties = new WebEndpointProperties();
 		properties.setBasePath("");
-		assertThat(properties.getBasePath()).isEqualTo("");
+		assertThat(properties.getBasePath()).isEmpty();
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/env/EnvironmentEndpointAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/env/EnvironmentEndpointAutoConfigurationTests.java
@@ -92,7 +92,7 @@ class EnvironmentEndpointAutoConfigurationTests {
 					assertThat(context).hasSingleBean(EnvironmentEndpointWebExtension.class);
 					EnvironmentEndpointWebExtension endpoint = context.getBean(EnvironmentEndpointWebExtension.class);
 					Set<String> roles = (Set<String>) ReflectionTestUtils.getField(endpoint, "roles");
-					assertThat(roles.contains("test")).isTrue();
+					assertThat(roles).contains("test");
 				});
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/info/InfoContributorAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/info/InfoContributorAutoConfigurationTests.java
@@ -108,7 +108,7 @@ class InfoContributorAutoConfigurationTests {
 					assertThat(git).isInstanceOf(Map.class);
 					Map<String, Object> gitInfo = (Map<String, Object>) git;
 					assertThat(gitInfo).containsOnlyKeys("branch", "commit", "foo");
-					assertThat(gitInfo.get("foo")).isEqualTo("bar");
+					assertThat(gitInfo).containsEntry("foo", "bar");
 				});
 	}
 
@@ -130,7 +130,7 @@ class InfoContributorAutoConfigurationTests {
 			assertThat(build).isInstanceOf(Map.class);
 			Map<String, Object> buildInfo = (Map<String, Object>) build;
 			assertThat(buildInfo).containsOnlyKeys("group", "artifact", "foo");
-			assertThat(buildInfo.get("foo")).isEqualTo("bar");
+			assertThat(buildInfo).containsEntry("foo", "bar");
 		});
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationIntegrationTests.java
@@ -118,7 +118,7 @@ class MetricsAutoConfigurationIntegrationTests {
 		new ApplicationContextRunner().with(MetricsRun.limitedTo(GraphiteMetricsExportAutoConfiguration.class,
 				JmxMetricsExportAutoConfiguration.class)).run((context) -> {
 					MeterRegistry composite = context.getBean(MeterRegistry.class);
-					assertThat(composite).extracting("filters", InstanceOfAssertFactories.ARRAY).hasSize(0);
+					assertThat(composite).extracting("filters", InstanceOfAssertFactories.ARRAY).isEmpty();
 					assertThat(composite).isInstanceOf(CompositeMeterRegistry.class);
 					Set<MeterRegistry> registries = ((CompositeMeterRegistry) composite).getRegistries();
 					assertThat(registries).hasSize(2);

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationMeterRegistryPostProcessorIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfigurationMeterRegistryPostProcessorIntegrationTests.java
@@ -81,7 +81,7 @@ class MetricsAutoConfigurationMeterRegistryPostProcessorIntegrationTests {
 					Map<String, MeterRegistry> registriesByName = context.getBeansOfType(MeterRegistry.class);
 					assertThat(registriesByName).hasSize(1);
 					MeterRegistry registry = registriesByName.values().iterator().next();
-					assertThat(registry.get("logback.events").tag("level", "error").counter().count()).isEqualTo(1);
+					assertThat(registry.get("logback.events").tag("level", "error").counter().count()).isOne();
 				});
 	}
 
@@ -95,10 +95,11 @@ class MetricsAutoConfigurationMeterRegistryPostProcessorIntegrationTests {
 					logger.error("Error.");
 					Map<String, MeterRegistry> registriesByName = context.getBeansOfType(MeterRegistry.class);
 					assertThat(registriesByName).hasSize(3);
-					registriesByName.forEach((name,
-							registry) -> assertThat(
-									registry.get("logback.events").tag("level", "error").counter().count())
-											.isEqualTo(1));
+					registriesByName
+							.forEach((name,
+									registry) -> assertThat(
+											registry.get("logback.events").tag("level", "error").counter().count())
+													.isOne());
 				});
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/data/RepositoryMetricsAutoConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/data/RepositoryMetricsAutoConfigurationIntegrationTests.java
@@ -54,7 +54,7 @@ class RepositoryMetricsAutoConfigurationIntegrationTests {
 			context.getBean(CityRepository.class).count();
 			MeterRegistry registry = context.getBean(MeterRegistry.class);
 			assertThat(registry.get("spring.data.repository.invocations").tag("repository", "CityRepository").timer()
-					.count()).isEqualTo(1);
+					.count()).isOne();
 		});
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/jersey/JerseyServerMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/jersey/JerseyServerMetricsAutoConfigurationTests.java
@@ -91,7 +91,7 @@ class JerseyServerMetricsAutoConfigurationTests {
 			doRequest(context);
 			MeterRegistry registry = context.getBean(MeterRegistry.class);
 			Timer timer = registry.get("http.server.requests").tag("uri", "/users/{id}").timer();
-			assertThat(timer.count()).isEqualTo(1);
+			assertThat(timer.count()).isOne();
 		});
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/mongo/MongoMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/mongo/MongoMetricsAutoConfigurationTests.java
@@ -59,7 +59,7 @@ class MongoMetricsAutoConfigurationTests {
 		this.contextRunner.with(MetricsRun.simple())
 				.withConfiguration(AutoConfigurations.of(MongoAutoConfiguration.class)).run((context) -> {
 					assertThat(context).hasSingleBean(MongoMetricsCommandListener.class);
-					assertThat(getActualMongoClientSettingsUsedToConstructClient(context)).isNotNull()
+					assertThat(getActualMongoClientSettingsUsedToConstructClient(context))
 							.extracting(MongoClientSettings::getCommandListeners).asList()
 							.containsExactly(context.getBean(MongoMetricsCommandListener.class));
 					assertThat(getMongoCommandTagsProviderUsedToConstructListener(context))
@@ -163,7 +163,7 @@ class MongoMetricsAutoConfigurationTests {
 	private ContextConsumer<AssertableApplicationContext> assertThatMetricsCommandListenerNotAdded() {
 		return (context) -> {
 			assertThat(context).doesNotHaveBean(MongoMetricsCommandListener.class);
-			assertThat(getActualMongoClientSettingsUsedToConstructClient(context)).isNotNull()
+			assertThat(getActualMongoClientSettingsUsedToConstructClient(context))
 					.extracting(MongoClientSettings::getCommandListeners).asList().isEmpty();
 		};
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/orm/jpa/HibernateMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/orm/jpa/HibernateMetricsAutoConfigurationTests.java
@@ -140,7 +140,7 @@ class HibernateMetricsAutoConfigurationTests {
 						() -> (builder) -> builder.setBootstrapExecutor(new SimpleAsyncTaskExecutor()))
 				.run((context) -> {
 					JdbcTemplate jdbcTemplate = new JdbcTemplate(context.getBean(DataSource.class));
-					assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) from CITY", Integer.class)).isEqualTo(1);
+					assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) from CITY", Integer.class)).isOne();
 					MeterRegistry registry = context.getBean(MeterRegistry.class);
 					registry.get("hibernate.statements").tags("entityManagerFactory", "entityManagerFactory").meter();
 				});

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/redis/LettuceMetricsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/redis/LettuceMetricsAutoConfigurationTests.java
@@ -57,10 +57,9 @@ class LettuceMetricsAutoConfigurationTests {
 		this.contextRunner.with(MetricsRun.simple())
 				.withConfiguration(AutoConfigurations.of(RedisAutoConfiguration.class)).run((context) -> {
 					MicrometerOptions micrometerOptions = context.getBean(MicrometerOptions.class);
-					assertThat(micrometerOptions.isEnabled()).isEqualTo(MicrometerOptions.DEFAULT_ENABLED);
-					assertThat(micrometerOptions.isHistogram()).isEqualTo(MicrometerOptions.DEFAULT_HISTOGRAM);
-					assertThat(micrometerOptions.localDistinction())
-							.isEqualTo(MicrometerOptions.DEFAULT_LOCAL_DISTINCTION);
+					assertThat(micrometerOptions.isEnabled()).isTrue();
+					assertThat(micrometerOptions.isHistogram()).isFalse();
+					assertThat(micrometerOptions.localDistinction()).isFalse();
 					assertThat(micrometerOptions.maxLatency()).isEqualTo(MicrometerOptions.DEFAULT_MAX_LATENCY);
 					assertThat(micrometerOptions.minLatency()).isEqualTo(MicrometerOptions.DEFAULT_MIN_LATENCY);
 				});

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/test/MetricsIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/test/MetricsIntegrationTests.java
@@ -106,14 +106,14 @@ class MetricsIntegrationTests {
 		server.expect(once(), requestTo("/api/external")).andExpect(method(HttpMethod.GET))
 				.andRespond(withSuccess("{\"message\": \"hello\"}", MediaType.APPLICATION_JSON));
 		assertThat(this.external.getForObject("/api/external", Map.class)).containsKey("message");
-		assertThat(this.registry.get("http.client.requests").timer().count()).isEqualTo(1);
+		assertThat(this.registry.get("http.client.requests").timer().count()).isOne();
 	}
 
 	@Test
 	void requestMappingIsInstrumented() {
 		this.loopback.getForObject("/api/people", Set.class);
-		waitAtMost(Duration.ofSeconds(5)).untilAsserted(
-				() -> assertThat(this.registry.get("http.server.requests").timer().count()).isEqualTo(1));
+		waitAtMost(Duration.ofSeconds(5))
+				.untilAsserted(() -> assertThat(this.registry.get("http.server.requests").timer().count()).isOne());
 
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationAutoConfigurationTests.java
@@ -149,7 +149,7 @@ class ObservationAutoConfigurationTests {
 			// When a DefaultMeterObservationHandler is registered, every stopped
 			// Observation leads to a timer
 			MeterRegistry meterRegistry = context.getBean(MeterRegistry.class);
-			assertThat(meterRegistry.get("test-observation").timer().count()).isEqualTo(1);
+			assertThat(meterRegistry.get("test-observation").timer().count()).isOne();
 			assertThat(context).hasSingleBean(DefaultMeterObservationHandler.class);
 			assertThat(context).hasSingleBean(ObservationHandler.class);
 		});
@@ -170,7 +170,7 @@ class ObservationAutoConfigurationTests {
 			// This isn't allowed by ObservationPredicates.customPredicate
 			Observation.start("observation2", observationRegistry).stop();
 			MeterRegistry meterRegistry = context.getBean(MeterRegistry.class);
-			assertThat(meterRegistry.get("observation1").timer().count()).isEqualTo(1);
+			assertThat(meterRegistry.get("observation1").timer().count()).isOne();
 			assertThatThrownBy(() -> meterRegistry.get("observation2").timer())
 					.isInstanceOf(MeterNotFoundException.class);
 		});

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfigurationTests.java
@@ -117,7 +117,7 @@ class WebFluxObservationAutoConfigurationTests {
 						ObservationAutoConfiguration.class, WebFluxAutoConfiguration.class))
 				.withPropertyValues("management.metrics.web.server.max-uri-tags=2").run((context) -> {
 					MeterRegistry registry = getInitializedMeterRegistry(context);
-					assertThat(registry.get("http.server.requests").meters().size()).isLessThanOrEqualTo(2);
+					assertThat(registry.get("http.server.requests").meters()).hasSizeLessThanOrEqualTo(2);
 					assertThat(output).contains("Reached the maximum number of URI tags for 'http.server.requests'");
 				});
 	}
@@ -132,7 +132,7 @@ class WebFluxObservationAutoConfigurationTests {
 						"management.metrics.web.server.request.metric-name=my.http.server.requests")
 				.run((context) -> {
 					MeterRegistry registry = getInitializedMeterRegistry(context);
-					assertThat(registry.get("my.http.server.requests").meters().size()).isLessThanOrEqualTo(2);
+					assertThat(registry.get("my.http.server.requests").meters()).hasSizeLessThanOrEqualTo(2);
 					assertThat(output).contains("Reached the maximum number of URI tags for 'my.http.server.requests'");
 				});
 	}
@@ -146,7 +146,7 @@ class WebFluxObservationAutoConfigurationTests {
 						"management.observations.http.server.requests.name=my.http.server.requests")
 				.run((context) -> {
 					MeterRegistry registry = getInitializedMeterRegistry(context);
-					assertThat(registry.get("my.http.server.requests").meters().size()).isLessThanOrEqualTo(2);
+					assertThat(registry.get("my.http.server.requests").meters()).hasSizeLessThanOrEqualTo(2);
 					assertThat(output).contains("Reached the maximum number of URI tags for 'my.http.server.requests'");
 				});
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfigurationTests.java
@@ -151,7 +151,7 @@ class WebMvcObservationAutoConfigurationTests {
 						ObservationAutoConfiguration.class, WebMvcAutoConfiguration.class))
 				.withPropertyValues("management.metrics.web.server.max-uri-tags=2").run((context) -> {
 					MeterRegistry registry = getInitializedMeterRegistry(context);
-					assertThat(registry.get("http.server.requests").meters().size()).isLessThanOrEqualTo(2);
+					assertThat(registry.get("http.server.requests").meters()).hasSizeLessThanOrEqualTo(2);
 					assertThat(output).contains("Reached the maximum number of URI tags for 'http.server.requests'");
 				});
 	}
@@ -166,7 +166,7 @@ class WebMvcObservationAutoConfigurationTests {
 						"management.metrics.web.server.request.metric-name=my.http.server.requests")
 				.run((context) -> {
 					MeterRegistry registry = getInitializedMeterRegistry(context);
-					assertThat(registry.get("my.http.server.requests").meters().size()).isLessThanOrEqualTo(2);
+					assertThat(registry.get("my.http.server.requests").meters()).hasSizeLessThanOrEqualTo(2);
 					assertThat(output).contains("Reached the maximum number of URI tags for 'my.http.server.requests'");
 				});
 	}
@@ -180,7 +180,7 @@ class WebMvcObservationAutoConfigurationTests {
 						"management.observations.http.server.requests.name=my.http.server.requests")
 				.run((context) -> {
 					MeterRegistry registry = getInitializedMeterRegistry(context);
-					assertThat(registry.get("my.http.server.requests").meters().size()).isLessThanOrEqualTo(2);
+					assertThat(registry.get("my.http.server.requests").meters()).hasSizeLessThanOrEqualTo(2);
 					assertThat(output).contains("Reached the maximum number of URI tags for 'my.http.server.requests'");
 				});
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/quartz/QuartzEndpointAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/quartz/QuartzEndpointAutoConfigurationTests.java
@@ -96,7 +96,7 @@ class QuartzEndpointAutoConfigurationTests {
 					assertThat(context).hasSingleBean(QuartzEndpointWebExtension.class);
 					QuartzEndpointWebExtension endpoint = context.getBean(QuartzEndpointWebExtension.class);
 					Set<String> roles = (Set<String>) ReflectionTestUtils.getField(endpoint, "roles");
-					assertThat(roles.contains("test")).isTrue();
+					assertThat(roles).contains("test");
 				});
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfigurationTests.java
@@ -137,7 +137,7 @@ class BraveAutoConfigurationTests {
 	void shouldSupplyB3PropagationFactoryViaProperty() {
 		this.contextRunner.withPropertyValues("management.tracing.propagation.type=B3").run((context) -> {
 			assertThat(context).hasBean("propagationFactory");
-			assertThat(context.getBean(Factory.class).toString()).isEqualTo("B3Propagation");
+			assertThat(context.getBean(Factory.class)).hasToString("B3Propagation");
 			assertThat(context).hasSingleBean(BaggagePropagation.FactoryBuilder.class);
 		});
 	}
@@ -168,7 +168,7 @@ class BraveAutoConfigurationTests {
 		this.contextRunner.withPropertyValues("management.tracing.baggage.enabled=false",
 				"management.tracing.propagation.type=B3").run((context) -> {
 					assertThat(context).hasBean("propagationFactory");
-					assertThat(context.getBean(Factory.class).toString()).isEqualTo("B3Propagation");
+					assertThat(context.getBean(Factory.class)).hasToString("B3Propagation");
 					assertThat(context).doesNotHaveBean(BaggagePropagation.FactoryBuilder.class);
 				});
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/wavefront/MeterRegistrySpanMetricsTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/wavefront/MeterRegistrySpanMetricsTests.java
@@ -47,7 +47,7 @@ class MeterRegistrySpanMetricsTests {
 	@Test
 	void reportDroppedShouldIncreaseCounter() {
 		this.sut.reportDropped();
-		assertThat(getCounterValue("wavefront.reporter.spans.dropped")).isEqualTo(1);
+		assertThat(getCounterValue("wavefront.reporter.spans.dropped")).isOne();
 		this.sut.reportDropped();
 		assertThat(getCounterValue("wavefront.reporter.spans.dropped")).isEqualTo(2);
 	}
@@ -55,7 +55,7 @@ class MeterRegistrySpanMetricsTests {
 	@Test
 	void reportReceivedShouldIncreaseCounter() {
 		this.sut.reportReceived();
-		assertThat(getCounterValue("wavefront.reporter.spans.received")).isEqualTo(1);
+		assertThat(getCounterValue("wavefront.reporter.spans.received")).isOne();
 		this.sut.reportReceived();
 		assertThat(getCounterValue("wavefront.reporter.spans.received")).isEqualTo(2);
 	}
@@ -63,7 +63,7 @@ class MeterRegistrySpanMetricsTests {
 	@Test
 	void reportErrorsShouldIncreaseCounter() {
 		this.sut.reportErrors();
-		assertThat(getCounterValue("wavefront.reporter.errors")).isEqualTo(1);
+		assertThat(getCounterValue("wavefront.reporter.errors")).isOne();
 		this.sut.reportErrors();
 		assertThat(getCounterValue("wavefront.reporter.errors")).isEqualTo(2);
 	}
@@ -72,9 +72,9 @@ class MeterRegistrySpanMetricsTests {
 	void registerQueueSizeShouldCreateGauge() {
 		BlockingQueue<Integer> queue = new ArrayBlockingQueue<Integer>(2);
 		this.sut.registerQueueSize(queue);
-		assertThat(getGaugeValue("wavefront.reporter.queue.size")).isEqualTo(0);
+		assertThat(getGaugeValue("wavefront.reporter.queue.size")).isZero();
 		queue.offer(1);
-		assertThat(getGaugeValue("wavefront.reporter.queue.size")).isEqualTo(1);
+		assertThat(getGaugeValue("wavefront.reporter.queue.size")).isOne();
 	}
 
 	@Test
@@ -83,7 +83,7 @@ class MeterRegistrySpanMetricsTests {
 		this.sut.registerQueueRemainingCapacity(queue);
 		assertThat(getGaugeValue("wavefront.reporter.queue.remaining_capacity")).isEqualTo(2);
 		queue.offer(1);
-		assertThat(getGaugeValue("wavefront.reporter.queue.remaining_capacity")).isEqualTo(1);
+		assertThat(getGaugeValue("wavefront.reporter.queue.remaining_capacity")).isOne();
 	}
 
 	private double getGaugeValue(String name) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/web/ManagementContextConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/web/ManagementContextConfigurationTests.java
@@ -35,14 +35,14 @@ class ManagementContextConfigurationTests {
 	void proxyBeanMethodsIsEnabledByDefault() {
 		AnnotationAttributes attributes = AnnotatedElementUtils
 				.getMergedAnnotationAttributes(DefaultManagementContextConfiguration.class, Configuration.class);
-		assertThat(attributes.get("proxyBeanMethods")).isEqualTo(true);
+		assertThat(attributes).containsEntry("proxyBeanMethods", true);
 	}
 
 	@Test
 	void proxyBeanMethodsCanBeDisabled() {
 		AnnotationAttributes attributes = AnnotatedElementUtils.getMergedAnnotationAttributes(
 				NoBeanMethodProxyingManagementContextConfiguration.class, Configuration.class);
-		assertThat(attributes.get("proxyBeanMethods")).isEqualTo(false);
+		assertThat(attributes).containsEntry("proxyBeanMethods", false);
 	}
 
 	@ManagementContextConfiguration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementServerPropertiesTests.java
@@ -44,7 +44,7 @@ class ManagementServerPropertiesTests {
 	@Test
 	void defaultBasePathIsEmptyString() {
 		ManagementServerProperties properties = new ManagementServerProperties();
-		assertThat(properties.getBasePath()).isEqualTo("");
+		assertThat(properties.getBasePath()).isEmpty();
 	}
 
 	@Test
@@ -65,7 +65,7 @@ class ManagementServerPropertiesTests {
 	void slashOfBasePathIsDefaultValue() {
 		ManagementServerProperties properties = new ManagementServerProperties();
 		properties.setBasePath("/");
-		assertThat(properties.getBasePath()).isEqualTo("");
+		assertThat(properties.getBasePath()).isEmpty();
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/audit/AuditEventTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/audit/AuditEventTests.java
@@ -37,7 +37,7 @@ class AuditEventTests {
 	@Test
 	void nowEvent() {
 		AuditEvent event = new AuditEvent("phil", "UNKNOWN", Collections.singletonMap("a", "b"));
-		assertThat(event.getData().get("a")).isEqualTo("b");
+		assertThat(event.getData()).containsEntry("a", "b");
 		assertThat(event.getType()).isEqualTo("UNKNOWN");
 		assertThat(event.getPrincipal()).isEqualTo("phil");
 		assertThat(event.getTimestamp()).isNotNull();
@@ -46,8 +46,8 @@ class AuditEventTests {
 	@Test
 	void convertStringsToData() {
 		AuditEvent event = new AuditEvent("phil", "UNKNOWN", "a=b", "c=d");
-		assertThat(event.getData().get("a")).isEqualTo("b");
-		assertThat(event.getData().get("c")).isEqualTo("d");
+		assertThat(event.getData()).containsEntry("a", "b");
+		assertThat(event.getData()).containsEntry("c", "d");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/audit/InMemoryAuditEventRepositoryTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/audit/InMemoryAuditEventRepositoryTests.java
@@ -42,7 +42,7 @@ class InMemoryAuditEventRepositoryTests {
 		repository.add(new AuditEvent("dave", "a"));
 		repository.add(new AuditEvent("dave", "b"));
 		List<AuditEvent> events = repository.find("dave", null, null);
-		assertThat(events.size()).isEqualTo(2);
+		assertThat(events).hasSize(2);
 		assertThat(events.get(0).getType()).isEqualTo("a");
 		assertThat(events.get(1).getType()).isEqualTo("b");
 	}
@@ -54,7 +54,7 @@ class InMemoryAuditEventRepositoryTests {
 		repository.add(new AuditEvent("dave", "b"));
 		repository.add(new AuditEvent("dave", "c"));
 		List<AuditEvent> events = repository.find("dave", null, null);
-		assertThat(events.size()).isEqualTo(2);
+		assertThat(events).hasSize(2);
 		assertThat(events.get(0).getType()).isEqualTo("b");
 		assertThat(events.get(1).getType()).isEqualTo("c");
 	}
@@ -74,7 +74,7 @@ class InMemoryAuditEventRepositoryTests {
 		repository.add(new AuditEvent("dave", "c"));
 		repository.add(new AuditEvent("phil", "d"));
 		List<AuditEvent> events = repository.find("dave", null, null);
-		assertThat(events.size()).isEqualTo(2);
+		assertThat(events).hasSize(2);
 		assertThat(events.get(0).getType()).isEqualTo("a");
 		assertThat(events.get(1).getType()).isEqualTo("c");
 	}
@@ -87,7 +87,7 @@ class InMemoryAuditEventRepositoryTests {
 		repository.add(new AuditEvent("dave", "c"));
 		repository.add(new AuditEvent("phil", "d"));
 		List<AuditEvent> events = repository.find("dave", null, "a");
-		assertThat(events.size()).isEqualTo(1);
+		assertThat(events).hasSize(1);
 		assertThat(events.get(0).getPrincipal()).isEqualTo("dave");
 		assertThat(events.get(0).getType()).isEqualTo("a");
 	}
@@ -103,11 +103,11 @@ class InMemoryAuditEventRepositoryTests {
 		repository.add(new AuditEvent(instant.plus(3, ChronoUnit.DAYS), "phil", "d", data));
 		Instant after = instant.plus(1, ChronoUnit.DAYS);
 		List<AuditEvent> events = repository.find(null, after, null);
-		assertThat(events.size()).isEqualTo(2);
+		assertThat(events).hasSize(2);
 		assertThat(events.get(0).getType()).isEqualTo("c");
 		assertThat(events.get(1).getType()).isEqualTo("d");
 		events = repository.find("dave", after, null);
-		assertThat(events.size()).isEqualTo(1);
+		assertThat(events).hasSize(1);
 		assertThat(events.get(0).getType()).isEqualTo("c");
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/beans/BeansEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/beans/BeansEndpointTests.java
@@ -52,7 +52,7 @@ class BeansEndpointTests {
 			ContextBeansDescriptor descriptor = result.getContexts().get(context.getId());
 			assertThat(descriptor.getParentId()).isNull();
 			Map<String, BeanDescriptor> beans = descriptor.getBeans();
-			assertThat(beans.size()).isLessThanOrEqualTo(context.getBeanDefinitionCount());
+			assertThat(beans).hasSizeLessThanOrEqualTo(context.getBeanDefinitionCount());
 			assertThat(beans).containsKey("endpoint");
 		});
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/cassandra/CassandraDriverHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/cassandra/CassandraDriverHealthIndicatorTests.java
@@ -120,7 +120,7 @@ class CassandraDriverHealthIndicatorTests {
 		CassandraDriverHealthIndicator healthIndicator = new CassandraDriverHealthIndicator(session);
 		Health health = healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails().get("version")).isEqualTo(Version.V4_0_0);
+		assertThat(health.getDetails()).containsEntry("version", Version.V4_0_0);
 	}
 
 	@Test
@@ -129,7 +129,7 @@ class CassandraDriverHealthIndicatorTests {
 		CassandraDriverHealthIndicator healthIndicator = new CassandraDriverHealthIndicator(session);
 		Health health = healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails().get("version")).isNull();
+		assertThat(health.getDetails()).doesNotContainKey("version");
 	}
 
 	@Test
@@ -139,8 +139,8 @@ class CassandraDriverHealthIndicatorTests {
 		CassandraDriverHealthIndicator healthIndicator = new CassandraDriverHealthIndicator(session);
 		Health health = healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
-		assertThat(health.getDetails().get("error"))
-				.isEqualTo(DriverTimeoutException.class.getName() + ": Test Exception");
+		assertThat(health.getDetails()).containsEntry("error",
+				DriverTimeoutException.class.getName() + ": Test Exception");
 	}
 
 	private CqlSession mockCqlSessionWithNodeState(NodeState... nodeStates) {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/cassandra/CassandraDriverReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/cassandra/CassandraDriverReactiveHealthIndicatorTests.java
@@ -131,7 +131,7 @@ class CassandraDriverReactiveHealthIndicatorTests {
 		StepVerifier.create(health).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.UP);
 			assertThat(h.getDetails()).containsOnlyKeys("version");
-			assertThat(h.getDetails().get("version")).isEqualTo(Version.V4_0_0);
+			assertThat(h.getDetails()).containsEntry("version", Version.V4_0_0);
 		}).verifyComplete();
 	}
 
@@ -142,7 +142,7 @@ class CassandraDriverReactiveHealthIndicatorTests {
 		Mono<Health> health = healthIndicator.health();
 		StepVerifier.create(health).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.UP);
-			assertThat(h.getDetails().get("version")).isNull();
+			assertThat(h.getDetails()).doesNotContainKey("version");
 		}).verifyComplete();
 	}
 
@@ -156,8 +156,8 @@ class CassandraDriverReactiveHealthIndicatorTests {
 		StepVerifier.create(health).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.DOWN);
 			assertThat(h.getDetails()).containsOnlyKeys("error");
-			assertThat(h.getDetails().get("error"))
-					.isEqualTo(DriverTimeoutException.class.getName() + ": Test Exception");
+			assertThat(h.getDetails()).containsEntry("error",
+					DriverTimeoutException.class.getName() + ": Test Exception");
 		}).verifyComplete();
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointFilteringTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointFilteringTests.java
@@ -109,7 +109,7 @@ class ConfigurationPropertiesReportEndpointFilteringTests {
 					.filter((id) -> findIdFromPrefix("only.bar", id)).findAny();
 			ConfigurationPropertiesBeanDescriptor descriptor = contextProperties.getBeans().get(key.get());
 			assertThat(descriptor.getPrefix()).isEqualTo("only.bar");
-			assertThat(descriptor.getProperties().get("name")).isEqualTo(value);
+			assertThat(descriptor.getProperties()).containsEntry("name", value);
 		});
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointProxyTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointProxyTests.java
@@ -76,7 +76,7 @@ class ConfigurationPropertiesReportEndpointProxyTests {
 					.getBean(ConfigurationPropertiesReportEndpoint.class).configurationProperties();
 			Map<String, Object> properties = applicationProperties.getContexts().get(context.getId()).getBeans()
 					.values().stream().map(ConfigurationPropertiesBeanDescriptor::getProperties).findFirst().get();
-			assertThat(properties.get("name")).isEqualTo("baz");
+			assertThat(properties).containsEntry("name", "baz");
 		});
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointSerializationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointSerializationTests.java
@@ -71,7 +71,7 @@ class ConfigurationPropertiesReportEndpointSerializationTests {
 			Map<String, Object> map = foo.getProperties();
 			assertThat(map).isNotNull();
 			assertThat(map).hasSize(2);
-			assertThat(map.get("name")).isEqualTo("foo");
+			assertThat(map).containsEntry("name", "foo");
 		});
 	}
 
@@ -90,7 +90,7 @@ class ConfigurationPropertiesReportEndpointSerializationTests {
 			Map<String, Object> map = foo.getProperties();
 			assertThat(map).isNotNull();
 			assertThat(map).hasSize(2);
-			assertThat(((Map<String, Object>) map.get("bar")).get("name")).isEqualTo("foo");
+			assertThat(((Map<String, Object>) map.get("bar"))).containsEntry("name", "foo");
 		});
 	}
 
@@ -150,7 +150,7 @@ class ConfigurationPropertiesReportEndpointSerializationTests {
 			Map<String, Object> map = fooProperties.getProperties();
 			assertThat(map).isNotNull();
 			assertThat(map).hasSize(3);
-			assertThat(((Map<String, Object>) map.get("map")).get("name")).isEqualTo("foo");
+			assertThat(((Map<String, Object>) map.get("map"))).containsEntry("name", "foo");
 		});
 	}
 
@@ -207,7 +207,7 @@ class ConfigurationPropertiesReportEndpointSerializationTests {
 			Map<String, Object> map = foo.getProperties();
 			assertThat(map).isNotNull();
 			assertThat(map).hasSize(3);
-			assertThat(map.get("address")).isEqualTo("192.168.1.10");
+			assertThat(map).containsEntry("address", "192.168.1.10");
 		});
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointTests.java
@@ -105,12 +105,12 @@ class ConfigurationPropertiesReportEndpointTests {
 					Map<String, Object> nested = (Map<String, Object>) inputs.get("nested");
 					Map<String, Object> name = (Map<String, Object>) nested.get("name");
 					Map<String, Object> counter = (Map<String, Object>) nested.get("counter");
-					assertThat(name.get("value")).isEqualTo("nested");
-					assertThat(name.get("origin"))
-							.isEqualTo("\"immutablenested.nested.name\" from property source \"test\"");
-					assertThat(counter.get("origin"))
-							.isEqualTo("\"immutablenested.nested.counter\" from property source \"test\"");
-					assertThat(counter.get("value")).isEqualTo("42");
+					assertThat(name).containsEntry("value", "nested");
+					assertThat(name).containsEntry("origin",
+							"\"immutablenested.nested.name\" from property source \"test\"");
+					assertThat(counter).containsEntry("origin",
+							"\"immutablenested.nested.counter\" from property source \"test\"");
+					assertThat(counter).containsEntry("value", "42");
 				}));
 	}
 
@@ -184,8 +184,8 @@ class ConfigurationPropertiesReportEndpointTests {
 				.withPropertyValues(String.format("data.size=%s", configSize)).run(assertProperties("data",
 						(properties) -> assertThat(properties.get("size")).isEqualTo(stringifySize), (inputs) -> {
 							Map<String, Object> size = (Map<String, Object>) inputs.get("size");
-							assertThat(size.get("value")).isEqualTo(configSize);
-							assertThat(size.get("origin")).isEqualTo("\"data.size\" from property source \"test\"");
+							assertThat(size).containsEntry("value", configSize);
+							assertThat(size).containsEntry("origin", "\"data.size\" from property source \"test\"");
 						}));
 	}
 
@@ -199,15 +199,15 @@ class ConfigurationPropertiesReportEndpointTests {
 					List<Object> list = (List<Object>) properties.get("listItems");
 					assertThat(list).hasSize(1);
 					Map<String, Object> item = (Map<String, Object>) list.get(0);
-					assertThat(item.get("somePassword")).isEqualTo("******");
+					assertThat(item).containsEntry("somePassword", "******");
 				}, (inputs) -> {
 					List<Object> list = (List<Object>) inputs.get("listItems");
 					assertThat(list).hasSize(1);
 					Map<String, Object> item = (Map<String, Object>) list.get(0);
 					Map<String, Object> somePassword = (Map<String, Object>) item.get("somePassword");
-					assertThat(somePassword.get("value")).isEqualTo("******");
-					assertThat(somePassword.get("origin"))
-							.isEqualTo("\"sensible.listItems[0].some-password\" from property source \"test\"");
+					assertThat(somePassword).containsEntry("value", "******");
+					assertThat(somePassword).containsEntry("origin",
+							"\"sensible.listItems[0].some-password\" from property source \"test\"");
 				}));
 	}
 
@@ -223,7 +223,7 @@ class ConfigurationPropertiesReportEndpointTests {
 					List<Object> list = listOfLists.get(0);
 					assertThat(list).hasSize(1);
 					Map<String, Object> item = (Map<String, Object>) list.get(0);
-					assertThat(item.get("somePassword")).isEqualTo("******");
+					assertThat(item).containsEntry("somePassword", "******");
 				}, (inputs) -> {
 					assertThat(inputs.get("listOfListItems")).isInstanceOf(List.class);
 					List<List<Object>> listOfLists = (List<List<Object>>) inputs.get("listOfListItems");
@@ -232,8 +232,8 @@ class ConfigurationPropertiesReportEndpointTests {
 					assertThat(list).hasSize(1);
 					Map<String, Object> item = (Map<String, Object>) list.get(0);
 					Map<String, Object> somePassword = (Map<String, Object>) item.get("somePassword");
-					assertThat(somePassword.get("value")).isEqualTo("******");
-					assertThat(somePassword.get("origin")).isEqualTo(
+					assertThat(somePassword).containsEntry("value", "******");
+					assertThat(somePassword).containsEntry("origin",
 							"\"sensible.listOfListItems[0][0].some-password\" from property source \"test\"");
 				}));
 	}
@@ -243,8 +243,8 @@ class ConfigurationPropertiesReportEndpointTests {
 		new ApplicationContextRunner().withUserConfiguration(CustomSanitizingEndpointConfig.class,
 				SanitizingFunctionConfiguration.class, TestPropertiesConfiguration.class)
 				.run(assertProperties("test", (properties) -> {
-					assertThat(properties.get("dbPassword")).isEqualTo("$$$");
-					assertThat(properties.get("myTestProperty")).isEqualTo("$$$");
+					assertThat(properties).containsEntry("dbPassword", "$$$");
+					assertThat(properties).containsEntry("myTestProperty", "$$$");
 				}));
 	}
 
@@ -254,8 +254,8 @@ class ConfigurationPropertiesReportEndpointTests {
 				.withUserConfiguration(CustomSanitizingEndpointConfig.class,
 						PropertySourceBasedSanitizingFunctionConfiguration.class, TestPropertiesConfiguration.class)
 				.withPropertyValues("test.my-test-property=abcde").run(assertProperties("test", (properties) -> {
-					assertThat(properties.get("dbPassword")).isEqualTo("123456");
-					assertThat(properties.get("myTestProperty")).isEqualTo("$$$");
+					assertThat(properties).containsEntry("dbPassword", "123456");
+					assertThat(properties).containsEntry("myTestProperty", "$$$");
 				}));
 	}
 
@@ -270,15 +270,15 @@ class ConfigurationPropertiesReportEndpointTests {
 					List<Object> list = (List<Object>) properties.get("listItems");
 					assertThat(list).hasSize(1);
 					Map<String, Object> item = (Map<String, Object>) list.get(0);
-					assertThat(item.get("custom")).isEqualTo("$$$");
+					assertThat(item).containsEntry("custom", "$$$");
 				}, (inputs) -> {
 					List<Object> list = (List<Object>) inputs.get("listItems");
 					assertThat(list).hasSize(1);
 					Map<String, Object> item = (Map<String, Object>) list.get(0);
 					Map<String, Object> somePassword = (Map<String, Object>) item.get("custom");
-					assertThat(somePassword.get("value")).isEqualTo("$$$");
-					assertThat(somePassword.get("origin"))
-							.isEqualTo("\"sensible.listItems[0].custom\" from property source \"test\"");
+					assertThat(somePassword).containsEntry("value", "$$$");
+					assertThat(somePassword).containsEntry("origin",
+							"\"sensible.listItems[0].custom\" from property source \"test\"");
 				}));
 	}
 
@@ -287,8 +287,8 @@ class ConfigurationPropertiesReportEndpointTests {
 		new ApplicationContextRunner()
 				.withUserConfiguration(EndpointConfigWithShowAlways.class, TestPropertiesConfiguration.class)
 				.run(assertProperties("test", (properties) -> {
-					assertThat(properties.get("dbPassword")).isEqualTo("123456");
-					assertThat(properties.get("myTestProperty")).isEqualTo("654321");
+					assertThat(properties).containsEntry("dbPassword", "123456");
+					assertThat(properties).containsEntry("myTestProperty", "654321");
 				}));
 	}
 
@@ -297,8 +297,8 @@ class ConfigurationPropertiesReportEndpointTests {
 		new ApplicationContextRunner()
 				.withUserConfiguration(EndpointConfigWithShowNever.class, TestPropertiesConfiguration.class)
 				.run(assertProperties("test", (properties) -> {
-					assertThat(properties.get("dbPassword")).isEqualTo("******");
-					assertThat(properties.get("myTestProperty")).isEqualTo("******");
+					assertThat(properties).containsEntry("dbPassword", "******");
+					assertThat(properties).containsEntry("myTestProperty", "******");
 				}));
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/EndpointIdTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/EndpointIdTests.java
@@ -80,7 +80,7 @@ class EndpointIdTests {
 		// Ideally we wouldn't support this but there are existing endpoints using the
 		// pattern. See gh-14773
 		EndpointId endpointId = EndpointId.of("foo.bar");
-		assertThat(endpointId.toString()).isEqualTo("foo.bar");
+		assertThat(endpointId).hasToString("foo.bar");
 	}
 
 	@Test
@@ -88,7 +88,7 @@ class EndpointIdTests {
 		// Ideally we wouldn't support this but there are existing endpoints using the
 		// pattern. See gh-14773
 		EndpointId endpointId = EndpointId.of("foo-bar");
-		assertThat(endpointId.toString()).isEqualTo("foo-bar");
+		assertThat(endpointId).hasToString("foo-bar");
 	}
 
 	@Test
@@ -102,21 +102,21 @@ class EndpointIdTests {
 	@Test
 	void ofWhenMigratingLegacyNameRemovesDots(CapturedOutput output) {
 		EndpointId endpointId = migrateLegacyName("one.two.three");
-		assertThat(endpointId.toString()).isEqualTo("onetwothree");
+		assertThat(endpointId).hasToString("onetwothree");
 		assertThat(output).doesNotContain("contains invalid characters");
 	}
 
 	@Test
 	void ofWhenMigratingLegacyNameRemovesHyphens(CapturedOutput output) {
 		EndpointId endpointId = migrateLegacyName("one-two-three");
-		assertThat(endpointId.toString()).isEqualTo("onetwothree");
+		assertThat(endpointId).hasToString("onetwothree");
 		assertThat(output).doesNotContain("contains invalid characters");
 	}
 
 	@Test
 	void ofWhenMigratingLegacyNameRemovesMixOfDashAndDot(CapturedOutput output) {
 		EndpointId endpointId = migrateLegacyName("one.two-three");
-		assertThat(endpointId.toString()).isEqualTo("onetwothree");
+		assertThat(endpointId).hasToString("onetwothree");
 		assertThat(output).doesNotContain("contains invalid characters");
 	}
 
@@ -135,7 +135,7 @@ class EndpointIdTests {
 		EndpointId four = EndpointId.of("foo.bar1");
 		EndpointId five = EndpointId.of("barfoo1");
 		EndpointId six = EndpointId.of("foobar2");
-		assertThat(one.hashCode()).isEqualTo(two.hashCode());
+		assertThat(one).hasSameHashCodeAs(two);
 		assertThat(one).isEqualTo(one).isEqualTo(two).isEqualTo(three).isEqualTo(four).isNotEqualTo(five)
 				.isNotEqualTo(six);
 	}
@@ -147,7 +147,7 @@ class EndpointIdTests {
 
 	@Test
 	void toStringReturnsString() {
-		assertThat(EndpointId.of("fooBar").toString()).isEqualTo("fooBar");
+		assertThat(EndpointId.of("fooBar")).hasToString("fooBar");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/ProducibleOperationArgumentResolverTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/ProducibleOperationArgumentResolverTests.java
@@ -61,7 +61,7 @@ class ProducibleOperationArgumentResolverTests {
 
 	@Test
 	void whenNothingIsAcceptableThenNullIsReturned() {
-		assertThat(resolve(acceptHeader("image/png"))).isEqualTo(null);
+		assertThat(resolve(acceptHeader("image/png"))).isNull();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/invoke/reflect/OperationMethodParametersTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/invoke/reflect/OperationMethodParametersTests.java
@@ -86,7 +86,7 @@ class OperationMethodParametersTests {
 	void getParameterCountShouldReturnParameterCount() {
 		OperationMethodParameters parameters = new OperationMethodParameters(this.exampleMethod,
 				new DefaultParameterNameDiscoverer());
-		assertThat(parameters.getParameterCount()).isEqualTo(1);
+		assertThat(parameters.getParameterCount()).isOne();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/invoke/reflect/OperationMethodTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/invoke/reflect/OperationMethodTests.java
@@ -64,7 +64,7 @@ class OperationMethodTests {
 	void getParametersShouldReturnParameters() {
 		OperationMethod operationMethod = new OperationMethod(this.exampleMethod, OperationType.READ);
 		OperationParameters parameters = operationMethod.getParameters();
-		assertThat(parameters.getParameterCount()).isEqualTo(1);
+		assertThat(parameters.getParameterCount()).isOne();
 		assertThat(parameters.iterator().next().getName()).isEqualTo("name");
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/jmx/MBeanInfoFactoryTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/jmx/MBeanInfoFactoryTests.java
@@ -54,29 +54,29 @@ class MBeanInfoFactoryTests {
 		MBeanOperationInfo operationInfo = info.getOperations()[0];
 		assertThat(operationInfo.getName()).isEqualTo("testOperation");
 		assertThat(operationInfo.getReturnType()).isEqualTo(String.class.getName());
-		assertThat(operationInfo.getImpact()).isEqualTo(MBeanOperationInfo.INFO);
-		assertThat(operationInfo.getSignature()).hasSize(0);
+		assertThat(operationInfo.getImpact()).isZero();
+		assertThat(operationInfo.getSignature()).isEmpty();
 	}
 
 	@Test
 	void getMBeanInfoWhenReadOperationShouldHaveInfoImpact() {
 		MBeanInfo info = this.factory
 				.getMBeanInfo(new TestExposableJmxEndpoint(new TestJmxOperation(OperationType.READ)));
-		assertThat(info.getOperations()[0].getImpact()).isEqualTo(MBeanOperationInfo.INFO);
+		assertThat(info.getOperations()[0].getImpact()).isZero();
 	}
 
 	@Test
 	void getMBeanInfoWhenWriteOperationShouldHaveActionImpact() {
 		MBeanInfo info = this.factory
 				.getMBeanInfo(new TestExposableJmxEndpoint(new TestJmxOperation(OperationType.WRITE)));
-		assertThat(info.getOperations()[0].getImpact()).isEqualTo(MBeanOperationInfo.ACTION);
+		assertThat(info.getOperations()[0].getImpact()).isOne();
 	}
 
 	@Test
 	void getMBeanInfoWhenDeleteOperationShouldHaveActionImpact() {
 		MBeanInfo info = this.factory
 				.getMBeanInfo(new TestExposableJmxEndpoint(new TestJmxOperation(OperationType.DELETE)));
-		assertThat(info.getOperations()[0].getImpact()).isEqualTo(MBeanOperationInfo.ACTION);
+		assertThat(info.getOperations()[0].getImpact()).isOne();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/EndpointMappingTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/EndpointMappingTests.java
@@ -29,12 +29,12 @@ class EndpointMappingTests {
 
 	@Test
 	void normalizationTurnsASlashIntoAnEmptyString() {
-		assertThat(new EndpointMapping("/").getPath()).isEqualTo("");
+		assertThat(new EndpointMapping("/").getPath()).isEmpty();
 	}
 
 	@Test
 	void normalizationLeavesAnEmptyStringAsIs() {
-		assertThat(new EndpointMapping("").getPath()).isEqualTo("");
+		assertThat(new EndpointMapping("").getPath()).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthEndpointSupportTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthEndpointSupportTests.java
@@ -351,7 +351,7 @@ abstract class HealthEndpointSupportTests<S extends HealthEndpointSupport<C, T>,
 				Collections.singletonMap("testGroup", testGroup));
 		HealthResult<T> result = create(this.registry, groups).getHealth(ApiVersion.V3, WebServerNamespace.SERVER,
 				SecurityContext.NONE, false, "healthz", "test");
-		assertThat(result).isEqualTo(null);
+		assertThat(result).isNull();
 	}
 
 	protected final S create(R registry, HealthEndpointGroups groups) {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthTests.java
@@ -65,8 +65,8 @@ class HealthTests {
 		assertThat(h1).isEqualTo(h1);
 		assertThat(h1).isEqualTo(h2);
 		assertThat(h1).isNotEqualTo(h3);
-		assertThat(h1.hashCode()).isEqualTo(h1.hashCode());
-		assertThat(h1.hashCode()).isEqualTo(h2.hashCode());
+		assertThat(h1).hasSameHashCodeAs(h1);
+		assertThat(h1).hasSameHashCodeAs(h2);
 		assertThat(h1.hashCode()).isNotEqualTo(h3.hashCode());
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/StatusTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/StatusTests.java
@@ -59,7 +59,7 @@ class StatusTests {
 		Status two = new Status("spring", "framework");
 		Status three = new Status("spock", "framework");
 		assertThat(one).isEqualTo(one).isEqualTo(two).isNotEqualTo(three);
-		assertThat(one.hashCode()).isEqualTo(two.hashCode());
+		assertThat(one).hasSameHashCodeAs(two);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/influx/InfluxDbHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/influx/InfluxDbHealthIndicatorTests.java
@@ -47,7 +47,7 @@ class InfluxDbHealthIndicatorTests {
 		InfluxDbHealthIndicator healthIndicator = new InfluxDbHealthIndicator(influxDb);
 		Health health = healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails().get("version")).isEqualTo("0.9");
+		assertThat(health.getDetails()).containsEntry("version", "0.9");
 		then(influxDb).should().ping();
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/info/EnvironmentInfoContributorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/info/EnvironmentInfoContributorTests.java
@@ -42,7 +42,7 @@ class EnvironmentInfoContributorTests {
 		Info actual = contributeFrom(this.environment);
 		assertThat(actual.get("app", String.class)).isEqualTo("my app");
 		assertThat(actual.get("version", String.class)).isEqualTo("1.0.0");
-		assertThat(actual.getDetails().size()).isEqualTo(2);
+		assertThat(actual.getDetails()).hasSize(2);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/info/GitInfoContributorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/info/GitInfoContributorTests.java
@@ -64,7 +64,7 @@ class GitInfoContributorTests {
 		Map<String, Object> content = contributor.generateContent();
 		assertThat(content.get("commit")).isInstanceOf(Map.class);
 		Map<String, Object> commit = (Map<String, Object>) content.get("commit");
-		assertThat(commit.get("id")).isEqualTo("8e29a0b");
+		assertThat(commit).containsEntry("id", "8e29a0b");
 	}
 
 	@Test
@@ -80,8 +80,8 @@ class GitInfoContributorTests {
 		Map<String, Object> commit = (Map<String, Object>) content.get("commit");
 		assertThat(commit.get("id")).isInstanceOf(Map.class);
 		Map<String, Object> id = (Map<String, Object>) commit.get("id");
-		assertThat(id.get("full")).isEqualTo("1b3cec34f7ca0a021244452f2cae07a80497a7c7");
-		assertThat(id.get("abbrev")).isEqualTo("1b3cec3");
+		assertThat(id).containsEntry("full", "1b3cec34f7ca0a021244452f2cae07a80497a7c7");
+		assertThat(id).containsEntry("abbrev", "1b3cec3");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jdbc/DataSourceHealthIndicatorTests.java
@@ -105,7 +105,7 @@ class DataSourceHealthIndicatorTests {
 		given(dataSource.getConnection()).willReturn(connection);
 		this.indicator.setDataSource(dataSource);
 		Health health = this.indicator.health();
-		assertThat(health.getDetails().get("database")).isNotNull();
+		assertThat(health.getDetails()).containsKey("database");
 		then(connection).should(times(2)).close();
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jms/JmsHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/jms/JmsHealthIndicatorTests.java
@@ -52,7 +52,7 @@ class JmsHealthIndicatorTests {
 		JmsHealthIndicator indicator = new JmsHealthIndicator(connectionFactory);
 		Health health = indicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails().get("provider")).isEqualTo("JMS test provider");
+		assertThat(health.getDetails()).containsEntry("provider", "JMS test provider");
 		then(connection).should().close();
 	}
 
@@ -63,7 +63,7 @@ class JmsHealthIndicatorTests {
 		JmsHealthIndicator indicator = new JmsHealthIndicator(connectionFactory);
 		Health health = indicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
-		assertThat(health.getDetails().get("provider")).isNull();
+		assertThat(health.getDetails()).doesNotContainKey("provider");
 	}
 
 	@Test
@@ -77,7 +77,7 @@ class JmsHealthIndicatorTests {
 		JmsHealthIndicator indicator = new JmsHealthIndicator(connectionFactory);
 		Health health = indicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
-		assertThat(health.getDetails().get("provider")).isNull();
+		assertThat(health.getDetails()).doesNotContainKey("provider");
 		then(connection).should().close();
 	}
 
@@ -93,7 +93,7 @@ class JmsHealthIndicatorTests {
 		JmsHealthIndicator indicator = new JmsHealthIndicator(connectionFactory);
 		Health health = indicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
-		assertThat(health.getDetails().get("provider")).isNull();
+		assertThat(health.getDetails()).doesNotContainKey("provider");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/ldap/LdapHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/ldap/LdapHealthIndicatorTests.java
@@ -45,7 +45,7 @@ class LdapHealthIndicatorTests {
 		LdapHealthIndicator healthIndicator = new LdapHealthIndicator(ldapTemplate);
 		Health health = healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails().get("version")).isEqualTo("3");
+		assertThat(health.getDetails()).containsEntry("version", "3");
 		then(ldapTemplate).should().executeReadOnly((ContextExecutor<String>) any());
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/mail/MailHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/mail/MailHealthIndicatorTests.java
@@ -66,7 +66,7 @@ class MailHealthIndicatorTests {
 		given(this.mailSender.getProtocol()).willReturn("success");
 		Health health = this.indicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails().get("location")).isEqualTo("smtp.acme.org:25");
+		assertThat(health.getDetails()).containsEntry("location", "smtp.acme.org:25");
 	}
 
 	@Test
@@ -74,10 +74,10 @@ class MailHealthIndicatorTests {
 		willThrow(new MessagingException("A test exception")).given(this.mailSender).testConnection();
 		Health health = this.indicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
-		assertThat(health.getDetails().get("location")).isEqualTo("smtp.acme.org:25");
+		assertThat(health.getDetails()).containsEntry("location", "smtp.acme.org:25");
 		Object errorMessage = health.getDetails().get("error");
 		assertThat(errorMessage).isNotNull();
-		assertThat(errorMessage.toString().contains("A test exception")).isTrue();
+		assertThat(errorMessage.toString()).contains("A test exception");
 	}
 
 	static class SuccessTransport extends Transport {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/management/ThreadDumpEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/management/ThreadDumpEndpointTests.java
@@ -36,7 +36,7 @@ class ThreadDumpEndpointTests {
 
 	@Test
 	void dumpThreads() {
-		assertThat(new ThreadDumpEndpoint().threadDump().getThreads().size()).isGreaterThan(0);
+		assertThat(new ThreadDumpEndpoint().threadDump().getThreads()).isNotEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/data/MetricsRepositoryMethodInvocationListenerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/data/MetricsRepositoryMethodInvocationListenerTests.java
@@ -86,7 +86,7 @@ class MetricsRepositoryMethodInvocationListenerTests {
 	}
 
 	private void assertMetricsContainsTag(String tagKey, String tagValue) {
-		assertThat(this.registry.get(REQUEST_METRICS_NAME).tag(tagKey, tagValue).timer().count()).isEqualTo(1);
+		assertThat(this.registry.get(REQUEST_METRICS_NAME).tag(tagKey, tagValue).timer().count()).isOne();
 	}
 
 	private RepositoryMethodInvocation createInvocation(Class<?> repositoryInterface) {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/mongo/MongoHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/mongo/MongoHealthIndicatorTests.java
@@ -46,7 +46,7 @@ class MongoHealthIndicatorTests {
 		MongoHealthIndicator healthIndicator = new MongoHealthIndicator(mongoTemplate);
 		Health health = healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails().get("maxWireVersion")).isEqualTo(10);
+		assertThat(health.getDetails()).containsEntry("maxWireVersion", 10);
 		then(commandResult).should().getInteger("maxWireVersion");
 		then(mongoTemplate).should().executeCommand("{ isMaster: 1 }");
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/mongo/MongoReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/mongo/MongoReactiveHealthIndicatorTests.java
@@ -50,7 +50,7 @@ class MongoReactiveHealthIndicatorTests {
 		StepVerifier.create(health).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.UP);
 			assertThat(h.getDetails()).containsOnlyKeys("maxWireVersion");
-			assertThat(h.getDetails().get("maxWireVersion")).isEqualTo(10);
+			assertThat(h.getDetails()).containsEntry("maxWireVersion", 10);
 		}).verifyComplete();
 	}
 
@@ -65,7 +65,7 @@ class MongoReactiveHealthIndicatorTests {
 		StepVerifier.create(health).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.DOWN);
 			assertThat(h.getDetails()).containsOnlyKeys("error");
-			assertThat(h.getDetails().get("error")).isEqualTo(MongoException.class.getName() + ": Connection failed");
+			assertThat(h.getDetails()).containsEntry("error", MongoException.class.getName() + ": Connection failed");
 		}).verifyComplete();
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/redis/RedisHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/redis/RedisHealthIndicatorTests.java
@@ -59,7 +59,7 @@ class RedisHealthIndicatorTests {
 		RedisHealthIndicator healthIndicator = createHealthIndicator(redisConnection);
 		Health health = healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails().get("version")).isEqualTo("2.8.9");
+		assertThat(health.getDetails()).containsEntry("version", "2.8.9");
 	}
 
 	@Test
@@ -80,9 +80,9 @@ class RedisHealthIndicatorTests {
 		RedisHealthIndicator healthIndicator = new RedisHealthIndicator(redisConnectionFactory);
 		Health health = healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails().get("cluster_size")).isEqualTo(4L);
-		assertThat(health.getDetails().get("slots_up")).isEqualTo(4L);
-		assertThat(health.getDetails().get("slots_fail")).isEqualTo(0L);
+		assertThat(health.getDetails()).containsEntry("cluster_size", 4L);
+		assertThat(health.getDetails()).containsEntry("slots_up", 4L);
+		assertThat(health.getDetails()).containsEntry("slots_fail", 0L);
 		then(redisConnectionFactory).should(atLeastOnce()).getConnection();
 	}
 
@@ -92,9 +92,9 @@ class RedisHealthIndicatorTests {
 		RedisHealthIndicator healthIndicator = new RedisHealthIndicator(redisConnectionFactory);
 		Health health = healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails().get("cluster_size")).isEqualTo(4L);
-		assertThat(health.getDetails().get("slots_up")).isEqualTo(4L);
-		assertThat(health.getDetails().get("slots_fail")).isEqualTo(0L);
+		assertThat(health.getDetails()).containsEntry("cluster_size", 4L);
+		assertThat(health.getDetails()).containsEntry("slots_up", 4L);
+		assertThat(health.getDetails()).containsEntry("slots_fail", 0L);
 		then(redisConnectionFactory).should(atLeastOnce()).getConnection();
 	}
 
@@ -104,9 +104,9 @@ class RedisHealthIndicatorTests {
 		RedisHealthIndicator healthIndicator = new RedisHealthIndicator(redisConnectionFactory);
 		Health health = healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
-		assertThat(health.getDetails().get("cluster_size")).isEqualTo(4L);
-		assertThat(health.getDetails().get("slots_up")).isEqualTo(3L);
-		assertThat(health.getDetails().get("slots_fail")).isEqualTo(1L);
+		assertThat(health.getDetails()).containsEntry("cluster_size", 4L);
+		assertThat(health.getDetails()).containsEntry("slots_up", 3L);
+		assertThat(health.getDetails()).containsEntry("slots_fail", 1L);
 		then(redisConnectionFactory).should(atLeastOnce()).getConnection();
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicatorTests.java
@@ -62,7 +62,7 @@ class RedisReactiveHealthIndicatorTests {
 		StepVerifier.create(health).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.UP);
 			assertThat(h.getDetails()).containsOnlyKeys("version");
-			assertThat(h.getDetails().get("version")).isEqualTo("2.8.9");
+			assertThat(h.getDetails()).containsEntry("version", "2.8.9");
 		}).verifyComplete();
 		then(redisConnection).should().closeLater();
 	}
@@ -74,9 +74,9 @@ class RedisReactiveHealthIndicatorTests {
 		Mono<Health> health = healthIndicator.health();
 		StepVerifier.create(health).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.UP);
-			assertThat(h.getDetails().get("cluster_size")).isEqualTo(4L);
-			assertThat(h.getDetails().get("slots_up")).isEqualTo(4L);
-			assertThat(h.getDetails().get("slots_fail")).isEqualTo(0L);
+			assertThat(h.getDetails()).containsEntry("cluster_size", 4L);
+			assertThat(h.getDetails()).containsEntry("slots_up", 4L);
+			assertThat(h.getDetails()).containsEntry("slots_fail", 0L);
 		}).verifyComplete();
 		then(redisConnectionFactory.getReactiveConnection()).should().closeLater();
 	}
@@ -88,9 +88,9 @@ class RedisReactiveHealthIndicatorTests {
 		Mono<Health> health = healthIndicator.health();
 		StepVerifier.create(health).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.UP);
-			assertThat(h.getDetails().get("cluster_size")).isEqualTo(4L);
-			assertThat(h.getDetails().get("slots_up")).isEqualTo(4L);
-			assertThat(h.getDetails().get("slots_fail")).isEqualTo(0L);
+			assertThat(h.getDetails()).containsEntry("cluster_size", 4L);
+			assertThat(h.getDetails()).containsEntry("slots_up", 4L);
+			assertThat(h.getDetails()).containsEntry("slots_fail", 0L);
 		}).verifyComplete();
 	}
 
@@ -101,8 +101,8 @@ class RedisReactiveHealthIndicatorTests {
 		Mono<Health> health = healthIndicator.health();
 		StepVerifier.create(health).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.DOWN);
-			assertThat(h.getDetails().get("slots_up")).isEqualTo(3L);
-			assertThat(h.getDetails().get("slots_fail")).isEqualTo(1L);
+			assertThat(h.getDetails()).containsEntry("slots_up", 3L);
+			assertThat(h.getDetails()).containsEntry("slots_fail", 1L);
 		}).verifyComplete();
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/scheduling/ScheduledTasksEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/scheduling/ScheduledTasksEndpointTests.java
@@ -93,7 +93,7 @@ class ScheduledTasksEndpointTests {
 			assertThat(tasks.getFixedDelay()).hasSize(1);
 			FixedDelayTaskDescriptor description = (FixedDelayTaskDescriptor) tasks.getFixedDelay().get(0);
 			assertThat(description.getInitialDelay()).isEqualTo(2);
-			assertThat(description.getInterval()).isEqualTo(1);
+			assertThat(description.getInterval()).isOne();
 			assertThat(description.getRunnable().getTarget())
 					.isEqualTo(FixedDelayScheduledMethod.class.getName() + ".fixedDelay");
 		});

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/system/DiskSpaceHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/system/DiskSpaceHealthIndicatorTests.java
@@ -64,11 +64,11 @@ class DiskSpaceHealthIndicatorTests {
 		given(this.fileMock.getAbsolutePath()).willReturn("/absolute-path");
 		Health health = this.healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.UP);
-		assertThat(health.getDetails().get("threshold")).isEqualTo(THRESHOLD.toBytes());
-		assertThat(health.getDetails().get("free")).isEqualTo(freeSpace);
-		assertThat(health.getDetails().get("total")).isEqualTo(TOTAL_SPACE.toBytes());
-		assertThat(health.getDetails().get("path")).isEqualTo("/absolute-path");
-		assertThat(health.getDetails().get("exists")).isEqualTo(true);
+		assertThat(health.getDetails()).containsEntry("threshold", THRESHOLD.toBytes());
+		assertThat(health.getDetails()).containsEntry("free", freeSpace);
+		assertThat(health.getDetails()).containsEntry("total", TOTAL_SPACE.toBytes());
+		assertThat(health.getDetails()).containsEntry("path", "/absolute-path");
+		assertThat(health.getDetails()).containsEntry("exists", true);
 	}
 
 	@Test
@@ -80,20 +80,20 @@ class DiskSpaceHealthIndicatorTests {
 		given(this.fileMock.getAbsolutePath()).willReturn("/absolute-path");
 		Health health = this.healthIndicator.health();
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
-		assertThat(health.getDetails().get("threshold")).isEqualTo(THRESHOLD.toBytes());
-		assertThat(health.getDetails().get("free")).isEqualTo(freeSpace);
-		assertThat(health.getDetails().get("total")).isEqualTo(TOTAL_SPACE.toBytes());
-		assertThat(health.getDetails().get("path")).isEqualTo("/absolute-path");
-		assertThat(health.getDetails().get("exists")).isEqualTo(true);
+		assertThat(health.getDetails()).containsEntry("threshold", THRESHOLD.toBytes());
+		assertThat(health.getDetails()).containsEntry("free", freeSpace);
+		assertThat(health.getDetails()).containsEntry("total", TOTAL_SPACE.toBytes());
+		assertThat(health.getDetails()).containsEntry("path", "/absolute-path");
+		assertThat(health.getDetails()).containsEntry("exists", true);
 	}
 
 	@Test
 	void whenPathDoesNotExistDiskSpaceIsDown() {
 		Health health = new DiskSpaceHealthIndicator(new File("does/not/exist"), THRESHOLD).health();
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
-		assertThat(health.getDetails().get("free")).isEqualTo(0L);
-		assertThat(health.getDetails().get("total")).isEqualTo(0L);
-		assertThat(health.getDetails().get("exists")).isEqualTo(false);
+		assertThat(health.getDetails()).containsEntry("free", 0L);
+		assertThat(health.getDetails()).containsEntry("total", 0L);
+		assertThat(health.getDetails()).containsEntry("exists", false);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/web/exchanges/servlet/HttpExchangesFilterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/web/exchanges/servlet/HttpExchangesFilterTests.java
@@ -115,7 +115,7 @@ class HttpExchangesFilterTests {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setServerName("<script>alert(document.domain)</script>");
 		this.filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
-		assertThat(this.repository.findAll()).hasSize(0);
+		assertThat(this.repository.findAll()).isEmpty();
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/web/exchanges/servlet/RecordableServletHttpRequestTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/web/exchanges/servlet/RecordableServletHttpRequestTests.java
@@ -62,7 +62,7 @@ class RecordableServletHttpRequestTests {
 
 	private void validate(String expectedUri) {
 		RecordableServletHttpRequest sourceRequest = new RecordableServletHttpRequest(this.request);
-		assertThat(sourceRequest.getUri().toString()).isEqualTo(expectedUri);
+		assertThat(sourceRequest.getUri()).hasToString(expectedUri);
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/AbstractDependsOnBeanFactoryPostProcessorTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/AbstractDependsOnBeanFactoryPostProcessorTests.java
@@ -75,7 +75,7 @@ class AbstractDependsOnBeanFactoryPostProcessorTests {
 
 	@Test
 	void postProcessorHasADefaultOrderOfZero() {
-		assertThat(new FooDependsOnBarTypePostProcessor().getOrder()).isEqualTo(0);
+		assertThat(new FooDependsOnBarTypePostProcessor().getOrder()).isZero();
 	}
 
 	private void assertThatFooDependsOnBar(AssertableApplicationContext context) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ImportAutoConfigurationImportSelectorTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ImportAutoConfigurationImportSelectorTests.java
@@ -125,7 +125,7 @@ class ImportAutoConfigurationImportSelectorTests {
 		Set<Object> set2 = this.importSelector
 				.determineImports(getAnnotationMetadata(ImportMetaAutoConfigurationWithUnrelatedTwo.class));
 		assertThat(set1).isEqualTo(set2);
-		assertThat(set1.hashCode()).isEqualTo(set2.hashCode());
+		assertThat(set1).hasSameHashCodeAs(set2);
 	}
 
 	@Test
@@ -153,7 +153,7 @@ class ImportAutoConfigurationImportSelectorTests {
 		Set<Object> set2 = this.importSelector
 				.determineImports(getAnnotationMetadata(ImportMetaAutoConfigurationExcludeWithUnrelatedTwo.class));
 		assertThat(set1).isEqualTo(set2);
-		assertThat(set1.hashCode()).isEqualTo(set2.hashCode());
+		assertThat(set1).hasSameHashCodeAs(set2);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/SpringBootApplicationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/SpringBootApplicationTests.java
@@ -39,28 +39,28 @@ class SpringBootApplicationTests {
 	void proxyBeanMethodsIsEnabledByDefault() {
 		AnnotationAttributes attributes = AnnotatedElementUtils
 				.getMergedAnnotationAttributes(DefaultSpringBootApplication.class, Configuration.class);
-		assertThat(attributes.get("proxyBeanMethods")).isEqualTo(true);
+		assertThat(attributes).containsEntry("proxyBeanMethods", true);
 	}
 
 	@Test
 	void proxyBeanMethodsCanBeDisabled() {
 		AnnotationAttributes attributes = AnnotatedElementUtils
 				.getMergedAnnotationAttributes(NoBeanMethodProxyingSpringBootApplication.class, Configuration.class);
-		assertThat(attributes.get("proxyBeanMethods")).isEqualTo(false);
+		assertThat(attributes).containsEntry("proxyBeanMethods", false);
 	}
 
 	@Test
 	void nameGeneratorDefaultToBeanNameGenerator() {
 		AnnotationAttributes attributes = AnnotatedElementUtils
 				.getMergedAnnotationAttributes(DefaultSpringBootApplication.class, ComponentScan.class);
-		assertThat(attributes.get("nameGenerator")).isEqualTo(BeanNameGenerator.class);
+		assertThat(attributes).containsEntry("nameGenerator", BeanNameGenerator.class);
 	}
 
 	@Test
 	void nameGeneratorCanBeSpecified() {
 		AnnotationAttributes attributes = AnnotatedElementUtils
 				.getMergedAnnotationAttributes(CustomNameGeneratorConfiguration.class, ComponentScan.class);
-		assertThat(attributes.get("nameGenerator")).isEqualTo(TestBeanNameGenerator.class);
+		assertThat(attributes).containsEntry("nameGenerator", TestBeanNameGenerator.class);
 	}
 
 	@SpringBootApplication

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfigurationTests.java
@@ -255,7 +255,7 @@ class BatchAutoConfigurationTests {
 					PlatformTransactionManager transactionManager = context.getBean(PlatformTransactionManager.class);
 					// It's a lazy proxy, but it does render its target if you ask for
 					// toString():
-					assertThat(transactionManager.toString().contains("JpaTransactionManager")).isTrue();
+					assertThat(transactionManager.toString()).contains("JpaTransactionManager");
 					assertThat(context).hasSingleBean(EntityManagerFactory.class);
 					// Ensure the JobRepository can be used (no problem with isolation
 					// level)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/JobExecutionExitCodeGeneratorTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/JobExecutionExitCodeGeneratorTests.java
@@ -35,7 +35,7 @@ class JobExecutionExitCodeGeneratorTests {
 	@Test
 	void testExitCodeForRunning() {
 		this.generator.onApplicationEvent(new JobExecutionEvent(new JobExecution(0L)));
-		assertThat(this.generator.getExitCode()).isEqualTo(1);
+		assertThat(this.generator.getExitCode()).isOne();
 	}
 
 	@Test
@@ -43,7 +43,7 @@ class JobExecutionExitCodeGeneratorTests {
 		JobExecution execution = new JobExecution(0L);
 		execution.setStatus(BatchStatus.COMPLETED);
 		this.generator.onApplicationEvent(new JobExecutionEvent(execution));
-		assertThat(this.generator.getExitCode()).isEqualTo(0);
+		assertThat(this.generator.getExitCode()).isZero();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/AbstractCacheAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/AbstractCacheAutoConfigurationTests.java
@@ -72,7 +72,7 @@ abstract class AbstractCacheAutoConfigurationTests {
 					assertThat(value.cacheManager).isNull();
 				}
 			});
-			assertThat(expected).hasSize(0);
+			assertThat(expected).isEmpty();
 		};
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheAutoConfigurationTests.java
@@ -696,7 +696,7 @@ class CacheAutoConfigurationTests extends AbstractCacheAutoConfigurationTests {
 					Cache foo = manager.getCache("foo");
 					foo.get("1");
 					// See next tests: no spec given so stats should be disabled
-					assertThat(((CaffeineCache) foo).getNativeCache().stats().missCount()).isEqualTo(0L);
+					assertThat(((CaffeineCache) foo).getNativeCache().stats().missCount()).isZero();
 				});
 	}
 
@@ -750,7 +750,7 @@ class CacheAutoConfigurationTests extends AbstractCacheAutoConfigurationTests {
 		assertThat(manager.getCacheNames()).containsOnly("foo", "bar");
 		Cache foo = manager.getCache("foo");
 		foo.get("1");
-		assertThat(((CaffeineCache) foo).getNativeCache().stats().missCount()).isEqualTo(1L);
+		assertThat(((CaffeineCache) foo).getNativeCache().stats().missCount()).isOne();
 	}
 
 	private CouchbaseCacheConfiguration getDefaultCouchbaseCacheConfiguration(CouchbaseCacheManager cacheManager) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheManagerCustomizersTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cache/CacheManagerCustomizersTests.java
@@ -56,14 +56,14 @@ class CacheManagerCustomizersTests {
 		list.add(new TestConcurrentMapCacheManagerCustomizer());
 		CacheManagerCustomizers customizers = new CacheManagerCustomizers(list);
 		customizers.customize(mock(CacheManager.class));
-		assertThat(list.get(0).getCount()).isEqualTo(1);
-		assertThat(list.get(1).getCount()).isEqualTo(0);
+		assertThat(list.get(0).getCount()).isOne();
+		assertThat(list.get(1).getCount()).isZero();
 		customizers.customize(mock(ConcurrentMapCacheManager.class));
 		assertThat(list.get(0).getCount()).isEqualTo(2);
-		assertThat(list.get(1).getCount()).isEqualTo(1);
+		assertThat(list.get(1).getCount()).isOne();
 		customizers.customize(mock(CaffeineCacheManager.class));
 		assertThat(list.get(0).getCount()).isEqualTo(3);
-		assertThat(list.get(1).getCount()).isEqualTo(1);
+		assertThat(list.get(1).getCount()).isOne();
 	}
 
 	static class CacheNamesCacheManagerCustomizer implements CacheManagerCustomizer<ConcurrentMapCacheManager> {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionEvaluationReportTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionEvaluationReportTests.java
@@ -122,7 +122,7 @@ class ConditionEvaluationReportTests {
 		this.report.recordConditionEvaluation("a", this.condition2, this.outcome2);
 		this.report.recordConditionEvaluation("b", this.condition3, this.outcome3);
 		Map<String, ConditionAndOutcomes> map = this.report.getConditionAndOutcomesBySource();
-		assertThat(map.size()).isEqualTo(2);
+		assertThat(map).hasSize(2);
 		Iterator<ConditionAndOutcome> iterator = map.get("a").iterator();
 		ConditionAndOutcome conditionAndOutcome = iterator.next();
 		assertThat(conditionAndOutcome.getCondition()).isEqualTo(this.condition1);
@@ -164,7 +164,7 @@ class ConditionEvaluationReportTests {
 	void springBootConditionPopulatesReport() {
 		ConditionEvaluationReport report = ConditionEvaluationReport
 				.get(new AnnotationConfigApplicationContext(Config.class).getBeanFactory());
-		assertThat(report.getConditionAndOutcomesBySource().size()).isNotEqualTo(0);
+		assertThat(report.getConditionAndOutcomesBySource().size()).isNotZero();
 	}
 
 	@Test
@@ -175,7 +175,6 @@ class ConditionEvaluationReportTests {
 				new ConditionOutcome(true, "Message 2"));
 		ConditionAndOutcome outcome3 = new ConditionAndOutcome(this.condition3,
 				new ConditionOutcome(true, "Message 2"));
-		assertThat(outcome1).isEqualTo(outcome1);
 		assertThat(outcome1).isNotEqualTo(outcome2);
 		assertThat(outcome2).isEqualTo(outcome3);
 		ConditionAndOutcomes outcomes = new ConditionAndOutcomes();

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionMessageTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionMessageTests.java
@@ -48,49 +48,49 @@ class ConditionMessageTests {
 	@Test
 	void toStringWhenEmptyShouldReturnEmptyString() {
 		ConditionMessage message = ConditionMessage.empty();
-		assertThat(message.toString()).isEqualTo("");
+		assertThat(message).hasToString("");
 	}
 
 	@Test
 	void toStringWhenHasMessageShouldReturnMessage() {
 		ConditionMessage message = ConditionMessage.of("Test");
-		assertThat(message.toString()).isEqualTo("Test");
+		assertThat(message).hasToString("Test");
 	}
 
 	@Test
 	void appendWhenHasExistingMessageShouldAddSpace() {
 		ConditionMessage message = ConditionMessage.of("a").append("b");
-		assertThat(message.toString()).isEqualTo("a b");
+		assertThat(message).hasToString("a b");
 	}
 
 	@Test
 	void appendWhenAppendingNullShouldDoNothing() {
 		ConditionMessage message = ConditionMessage.of("a").append(null);
-		assertThat(message.toString()).isEqualTo("a");
+		assertThat(message).hasToString("a");
 	}
 
 	@Test
 	void appendWhenNoMessageShouldNotAddSpace() {
 		ConditionMessage message = ConditionMessage.empty().append("b");
-		assertThat(message.toString()).isEqualTo("b");
+		assertThat(message).hasToString("b");
 	}
 
 	@Test
 	void andConditionWhenUsingClassShouldIncludeCondition() {
 		ConditionMessage message = ConditionMessage.empty().andCondition(Test.class).because("OK");
-		assertThat(message.toString()).isEqualTo("@Test OK");
+		assertThat(message).hasToString("@Test OK");
 	}
 
 	@Test
 	void andConditionWhenUsingStringShouldIncludeCondition() {
 		ConditionMessage message = ConditionMessage.empty().andCondition("@Test").because("OK");
-		assertThat(message.toString()).isEqualTo("@Test OK");
+		assertThat(message).hasToString("@Test OK");
 	}
 
 	@Test
 	void andConditionWhenIncludingDetailsShouldIncludeCondition() {
 		ConditionMessage message = ConditionMessage.empty().andCondition(Test.class, "(a=b)").because("OK");
-		assertThat(message.toString()).isEqualTo("@Test (a=b) OK");
+		assertThat(message).hasToString("@Test (a=b) OK");
 	}
 
 	@Test
@@ -99,7 +99,7 @@ class ConditionMessageTests {
 		messages.add(ConditionMessage.of("a"));
 		messages.add(ConditionMessage.of("b"));
 		ConditionMessage message = ConditionMessage.of(messages);
-		assertThat(message.toString()).isEqualTo("a; b");
+		assertThat(message).hasToString("a; b");
 	}
 
 	@Test
@@ -111,89 +111,89 @@ class ConditionMessageTests {
 	@Test
 	void forConditionShouldIncludeCondition() {
 		ConditionMessage message = ConditionMessage.forCondition("@Test").because("OK");
-		assertThat(message.toString()).isEqualTo("@Test OK");
+		assertThat(message).hasToString("@Test OK");
 	}
 
 	@Test
 	void forConditionShouldNotAddExtraSpaceWithEmptyCondition() {
 		ConditionMessage message = ConditionMessage.forCondition("").because("OK");
-		assertThat(message.toString()).isEqualTo("OK");
+		assertThat(message).hasToString("OK");
 	}
 
 	@Test
 	void forConditionWhenClassShouldIncludeCondition() {
 		ConditionMessage message = ConditionMessage.forCondition(Test.class, "(a=b)").because("OK");
-		assertThat(message.toString()).isEqualTo("@Test (a=b) OK");
+		assertThat(message).hasToString("@Test (a=b) OK");
 	}
 
 	@Test
 	void foundExactlyShouldConstructMessage() {
 		ConditionMessage message = ConditionMessage.forCondition(Test.class).foundExactly("abc");
-		assertThat(message.toString()).isEqualTo("@Test found abc");
+		assertThat(message).hasToString("@Test found abc");
 	}
 
 	@Test
 	void foundWhenSingleElementShouldUseSingular() {
 		ConditionMessage message = ConditionMessage.forCondition(Test.class).found("bean", "beans").items("a");
-		assertThat(message.toString()).isEqualTo("@Test found bean a");
+		assertThat(message).hasToString("@Test found bean a");
 	}
 
 	@Test
 	void foundNoneAtAllShouldConstructMessage() {
 		ConditionMessage message = ConditionMessage.forCondition(Test.class).found("no beans").atAll();
-		assertThat(message.toString()).isEqualTo("@Test found no beans");
+		assertThat(message).hasToString("@Test found no beans");
 	}
 
 	@Test
 	void foundWhenMultipleElementsShouldUsePlural() {
 		ConditionMessage message = ConditionMessage.forCondition(Test.class).found("bean", "beans").items("a", "b",
 				"c");
-		assertThat(message.toString()).isEqualTo("@Test found beans a, b, c");
+		assertThat(message).hasToString("@Test found beans a, b, c");
 	}
 
 	@Test
 	void foundWhenQuoteStyleShouldQuote() {
 		ConditionMessage message = ConditionMessage.forCondition(Test.class).found("bean", "beans").items(Style.QUOTE,
 				"a", "b", "c");
-		assertThat(message.toString()).isEqualTo("@Test found beans 'a', 'b', 'c'");
+		assertThat(message).hasToString("@Test found beans 'a', 'b', 'c'");
 	}
 
 	@Test
 	void didNotFindWhenSingleElementShouldUseSingular() {
 		ConditionMessage message = ConditionMessage.forCondition(Test.class).didNotFind("class", "classes").items("a");
-		assertThat(message.toString()).isEqualTo("@Test did not find class a");
+		assertThat(message).hasToString("@Test did not find class a");
 	}
 
 	@Test
 	void didNotFindWhenMultipleElementsShouldUsePlural() {
 		ConditionMessage message = ConditionMessage.forCondition(Test.class).didNotFind("class", "classes").items("a",
 				"b", "c");
-		assertThat(message.toString()).isEqualTo("@Test did not find classes a, b, c");
+		assertThat(message).hasToString("@Test did not find classes a, b, c");
 	}
 
 	@Test
 	void resultedInShouldConstructMessage() {
 		ConditionMessage message = ConditionMessage.forCondition(Test.class).resultedIn("Green");
-		assertThat(message.toString()).isEqualTo("@Test resulted in Green");
+		assertThat(message).hasToString("@Test resulted in Green");
 	}
 
 	@Test
 	void notAvailableShouldConstructMessage() {
 		ConditionMessage message = ConditionMessage.forCondition(Test.class).notAvailable("JMX");
-		assertThat(message.toString()).isEqualTo("@Test JMX is not available");
+		assertThat(message).hasToString("@Test JMX is not available");
 	}
 
 	@Test
 	void availableShouldConstructMessage() {
 		ConditionMessage message = ConditionMessage.forCondition(Test.class).available("JMX");
-		assertThat(message.toString()).isEqualTo("@Test JMX is available");
+		assertThat(message).hasToString("@Test JMX is available");
 	}
 
 	@Test
 	void itemsTolerateNullInput() {
 		Collection<?> items = null;
 		ConditionMessage message = ConditionMessage.forCondition(Test.class).didNotFind("item").items(items);
-		assertThat(message.toString()).isEqualTo("@Test did not find item");
+		assertThat(message).hasToString("@Test did not find item");
 	}
 
 	@Test
@@ -201,7 +201,7 @@ class ConditionMessageTests {
 		Collection<?> items = null;
 		ConditionMessage message = ConditionMessage.forCondition(Test.class).didNotFind("item").items(Style.QUOTE,
 				items);
-		assertThat(message.toString()).isEqualTo("@Test did not find item");
+		assertThat(message).hasToString("@Test did not find item");
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnSingleCandidateTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnSingleCandidateTests.java
@@ -58,7 +58,7 @@ class ConditionalOnSingleCandidateTests {
 				.withUserConfiguration(AlphaScopedProxyConfiguration.class, OnBeanSingleCandidateConfiguration.class)
 				.run((context) -> {
 					assertThat(context).hasBean("consumer");
-					assertThat(context.getBean("consumer").toString()).isEqualTo("alpha");
+					assertThat(context.getBean("consumer")).hasToString("alpha");
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/couchbase/CouchbasePropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/couchbase/CouchbasePropertiesTests.java
@@ -35,7 +35,7 @@ class CouchbasePropertiesTests {
 	@Test
 	void ioHaveConsistentDefaults() {
 		Io io = new CouchbaseProperties().getEnv().getIo();
-		assertThat(io.getMinEndpoints()).isEqualTo(IoConfig.DEFAULT_NUM_KV_CONNECTIONS);
+		assertThat(io.getMinEndpoints()).isOne();
 		assertThat(io.getMaxEndpoints()).isEqualTo(IoConfig.DEFAULT_MAX_HTTP_CONNECTIONS);
 		assertThat(io.getIdleHttpConnectionTimeout()).isEqualTo(IoConfig.DEFAULT_IDLE_HTTP_CONNECTION_TIMEOUT);
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jRepositoriesAutoConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jRepositoriesAutoConfigurationIntegrationTests.java
@@ -61,7 +61,7 @@ class Neo4jRepositoriesAutoConfigurationIntegrationTests {
 
 	@Test
 	void ensureRepositoryIsReady() {
-		assertThat(this.countryRepository.count()).isEqualTo(0);
+		assertThat(this.countryRepository.count()).isZero();
 	}
 
 	@Configuration

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationJedisTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationJedisTests.java
@@ -64,7 +64,7 @@ class RedisAutoConfigurationJedisTests {
 				.run((context) -> {
 					JedisConnectionFactory cf = context.getBean(JedisConnectionFactory.class);
 					assertThat(cf.getHostName()).isEqualTo("foo");
-					assertThat(cf.getDatabase()).isEqualTo(1);
+					assertThat(cf.getDatabase()).isOne();
 					assertThat(getUserName(cf)).isNull();
 					assertThat(cf.getPassword()).isNull();
 					assertThat(cf.isUseSsl()).isFalse();
@@ -112,7 +112,7 @@ class RedisAutoConfigurationJedisTests {
 			JedisConnectionFactory cf = context.getBean(JedisConnectionFactory.class);
 			assertThat(cf.getHostName()).isEqualTo("example");
 			assertThat(cf.getPort()).isEqualTo(33);
-			assertThat(getUserName(cf)).isEqualTo("");
+			assertThat(getUserName(cf)).isEmpty();
 			assertThat(cf.getPassword()).isEqualTo("pass:word");
 		});
 	}
@@ -137,7 +137,7 @@ class RedisAutoConfigurationJedisTests {
 				"spring.data.redis.jedis.pool.time-between-eviction-runs:30000").run((context) -> {
 					JedisConnectionFactory cf = context.getBean(JedisConnectionFactory.class);
 					assertThat(cf.getHostName()).isEqualTo("foo");
-					assertThat(cf.getPoolConfig().getMinIdle()).isEqualTo(1);
+					assertThat(cf.getPoolConfig().getMinIdle()).isOne();
 					assertThat(cf.getPoolConfig().getMaxIdle()).isEqualTo(4);
 					assertThat(cf.getPoolConfig().getMaxTotal()).isEqualTo(16);
 					assertThat(cf.getPoolConfig().getMaxWaitDuration()).isEqualTo(Duration.ofSeconds(2));
@@ -152,7 +152,7 @@ class RedisAutoConfigurationJedisTests {
 				.run((context) -> {
 					JedisConnectionFactory cf = context.getBean(JedisConnectionFactory.class);
 					assertThat(cf.getHostName()).isEqualTo("foo");
-					assertThat(cf.getClientConfiguration().isUsePooling()).isEqualTo(false);
+					assertThat(cf.getClientConfiguration().isUsePooling()).isFalse();
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationTests.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.cluster.ClusterClientOptions;
-import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
 import io.lettuce.core.cluster.ClusterTopologyRefreshOptions.RefreshTrigger;
 import io.lettuce.core.resource.DefaultClientResources;
 import io.lettuce.core.tracing.Tracing;
@@ -94,7 +93,7 @@ class RedisAutoConfigurationTests {
 				"spring.data.redis.lettuce.shutdown-timeout:500").run((context) -> {
 					LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
 					assertThat(cf.getHostName()).isEqualTo("foo");
-					assertThat(cf.getDatabase()).isEqualTo(1);
+					assertThat(cf.getDatabase()).isOne();
 					assertThat(getUserName(cf)).isNull();
 					assertThat(cf.getPassword()).isNull();
 					assertThat(cf.isUseSsl()).isFalse();
@@ -153,7 +152,7 @@ class RedisAutoConfigurationTests {
 			LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
 			assertThat(cf.getHostName()).isEqualTo("example");
 			assertThat(cf.getPort()).isEqualTo(33);
-			assertThat(getUserName(cf)).isEqualTo("");
+			assertThat(getUserName(cf)).isEmpty();
 			assertThat(cf.getPassword()).isEqualTo("pass:word");
 		});
 	}
@@ -194,7 +193,7 @@ class RedisAutoConfigurationTests {
 					LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
 					assertThat(cf.getHostName()).isEqualTo("foo");
 					GenericObjectPoolConfig<?> poolConfig = getPoolingClientConfiguration(cf).getPoolConfig();
-					assertThat(poolConfig.getMinIdle()).isEqualTo(1);
+					assertThat(poolConfig.getMinIdle()).isOne();
 					assertThat(poolConfig.getMaxIdle()).isEqualTo(4);
 					assertThat(poolConfig.getMaxTotal()).isEqualTo(16);
 					assertThat(poolConfig.getMaxWaitDuration()).isEqualTo(Duration.ofSeconds(2));
@@ -298,7 +297,7 @@ class RedisAutoConfigurationTests {
 						"spring.data.redis.sentinel.nodes:127.0.0.1:26379, 127.0.0.1:26380")
 				.run((context) -> {
 					LettuceConnectionFactory connectionFactory = context.getBean(LettuceConnectionFactory.class);
-					assertThat(connectionFactory.getDatabase()).isEqualTo(1);
+					assertThat(connectionFactory.getDatabase()).isOne();
 					assertThat(connectionFactory.isRedisSentinelAware()).isTrue();
 				});
 	}
@@ -467,7 +466,7 @@ class RedisAutoConfigurationTests {
 						"spring.data.redis.lettuce.cluster.refresh.dynamic-sources=")
 				.run(assertClientOptions(ClusterClientOptions.class,
 						(options) -> assertThat(options.getTopologyRefreshOptions().useDynamicRefreshSources())
-								.isEqualTo(ClusterTopologyRefreshOptions.DEFAULT_DYNAMIC_REFRESH_SOURCES)));
+								.isTrue()));
 	}
 
 	private <T extends ClientOptions> ContextConsumer<AssertableApplicationContext> assertClientOptions(

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
@@ -272,7 +272,7 @@ class FlywayAutoConfigurationTests {
 				.withPropertyValues("spring.flyway.schemas:public").run((context) -> {
 					assertThat(context).hasSingleBean(Flyway.class);
 					Flyway flyway = context.getBean(Flyway.class);
-					assertThat(Arrays.asList(flyway.getConfiguration().getSchemas()).toString()).isEqualTo("[public]");
+					assertThat(Arrays.asList(flyway.getConfiguration().getSchemas())).hasToString("[public]");
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/freemarker/FreeMarkerAutoConfigurationServletIntegrationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/freemarker/FreeMarkerAutoConfigurationServletIntegrationTests.java
@@ -119,7 +119,7 @@ class FreeMarkerAutoConfigurationServletIntegrationTests {
 	@Test
 	void disableCache() {
 		load("spring.freemarker.cache:false");
-		assertThat(this.context.getBean(FreeMarkerViewResolver.class).getCacheLimit()).isEqualTo(0);
+		assertThat(this.context.getBean(FreeMarkerViewResolver.class).getCacheLimit()).isZero();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/groovy/template/GroovyTemplateAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/groovy/template/GroovyTemplateAutoConfigurationTests.java
@@ -152,7 +152,7 @@ class GroovyTemplateAutoConfigurationTests {
 	@Test
 	void disableCache() {
 		registerAndRefreshContext("spring.groovy.template.cache:false");
-		assertThat(this.context.getBean(GroovyMarkupViewResolver.class).getCacheLimit()).isEqualTo(0);
+		assertThat(this.context.getBean(GroovyMarkupViewResolver.class).getCacheLimit()).isZero();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hateoas/HypermediaAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/hateoas/HypermediaAutoConfigurationTests.java
@@ -93,7 +93,7 @@ class HypermediaAutoConfigurationTests {
 			RequestMappingHandlerAdapter handlerAdapter = context.getBean(RequestMappingHandlerAdapter.class);
 			Optional<HttpMessageConverter<?>> mappingJacksonConverter = handlerAdapter.getMessageConverters().stream()
 					.filter(MappingJackson2HttpMessageConverter.class::isInstance).findFirst();
-			assertThat(mappingJacksonConverter).isPresent().hasValueSatisfying(
+			assertThat(mappingJacksonConverter).hasValueSatisfying(
 					(converter) -> assertThat(converter.canWrite(RepresentationModel.class, MediaType.APPLICATION_JSON))
 							.isTrue());
 		});
@@ -106,10 +106,8 @@ class HypermediaAutoConfigurationTests {
 					RequestMappingHandlerAdapter handlerAdapter = context.getBean(RequestMappingHandlerAdapter.class);
 					Optional<HttpMessageConverter<?>> mappingJacksonConverter = handlerAdapter.getMessageConverters()
 							.stream().filter(MappingJackson2HttpMessageConverter.class::isInstance).findFirst();
-					assertThat(mappingJacksonConverter).isPresent()
-							.hasValueSatisfying((converter) -> assertThat(
-									converter.canWrite(RepresentationModel.class, MediaType.APPLICATION_JSON))
-											.isFalse());
+					assertThat(mappingJacksonConverter).hasValueSatisfying((converter) -> assertThat(
+							converter.canWrite(RepresentationModel.class, MediaType.APPLICATION_JSON)).isFalse());
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/http/HttpMessageConvertersTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/http/HttpMessageConvertersTests.java
@@ -64,8 +64,8 @@ class HttpMessageConvertersTests {
 		MappingJackson2HttpMessageConverter converter1 = new MappingJackson2HttpMessageConverter();
 		MappingJackson2HttpMessageConverter converter2 = new MappingJackson2HttpMessageConverter();
 		HttpMessageConverters converters = new HttpMessageConverters(converter1, converter2);
-		assertThat(converters.getConverters().contains(converter1)).isTrue();
-		assertThat(converters.getConverters().contains(converter2)).isTrue();
+		assertThat(converters.getConverters()).contains(converter1);
+		assertThat(converters.getConverters()).contains(converter2);
 		List<MappingJackson2HttpMessageConverter> httpConverters = new ArrayList<>();
 		for (HttpMessageConverter<?> candidate : converters) {
 			if (candidate instanceof MappingJackson2HttpMessageConverter) {
@@ -74,9 +74,9 @@ class HttpMessageConvertersTests {
 		}
 		// The existing converter is still there, but with a lower priority
 		assertThat(httpConverters).hasSize(3);
-		assertThat(httpConverters.indexOf(converter1)).isEqualTo(0);
-		assertThat(httpConverters.indexOf(converter2)).isEqualTo(1);
-		assertThat(converters.getConverters().indexOf(converter1)).isNotEqualTo(0);
+		assertThat(httpConverters.indexOf(converter1)).isZero();
+		assertThat(httpConverters.indexOf(converter2)).isOne();
+		assertThat(converters.getConverters().indexOf(converter1)).isNotZero();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/http/codec/CodecsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/http/codec/CodecsAutoConfigurationTests.java
@@ -74,7 +74,7 @@ class CodecsAutoConfigurationTests {
 					CodecsAutoConfiguration.DefaultCodecsConfiguration.class, "defaultCodecCustomizer",
 					CodecProperties.class);
 			Integer order = new TestAnnotationAwareOrderComparator().findOrder(customizerMethod);
-			assertThat(order).isEqualTo(0);
+			assertThat(order).isZero();
 		});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationAutoConfigurationTests.java
@@ -423,7 +423,7 @@ class IntegrationAutoConfigurationTests {
 				.run((context) -> {
 					assertThat(context).hasSingleBean(PollerMetadata.class);
 					PollerMetadata metadata = context.getBean(PollerMetadata.DEFAULT_POLLER, PollerMetadata.class);
-					assertThat(metadata.getMaxMessagesPerPoll()).isEqualTo(1L);
+					assertThat(metadata.getMaxMessagesPerPoll()).isOne();
 					assertThat(metadata.getReceiveTimeout()).isEqualTo(10000L);
 					assertThat(metadata.getTrigger()).asInstanceOf(InstanceOfAssertFactories.type(CronTrigger.class))
 							.satisfies((trigger) -> assertThat(trigger.getExpression()).isEqualTo("* * * ? * *"));

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationPropertiesEnvironmentPostProcessorTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/integration/IntegrationPropertiesEnvironmentPostProcessorTests.java
@@ -102,7 +102,7 @@ class IntegrationPropertiesEnvironmentPostProcessorTests {
 		new IntegrationPropertiesEnvironmentPostProcessor().registerIntegrationPropertiesPropertySource(environment,
 				resource);
 		PropertySource<?> ps = environment.getPropertySources().get("META-INF/spring.integration.properties");
-		assertThat(ps).isNotNull().isInstanceOf(OriginLookup.class);
+		assertThat(ps).isInstanceOf(OriginLookup.class);
 		OriginLookup<String> originLookup = (OriginLookup<String>) ps;
 		assertThat(originLookup.getOrigin("spring.integration.channel.auto-create"))
 				.satisfies(textOrigin(resource, 0, 39));

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceJmxConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceJmxConfigurationTests.java
@@ -88,8 +88,8 @@ class DataSourceJmxConfigurationTests {
 					hikariDataSource.getConnection().close();
 					// We can't rely on the number of MBeans so we're checking that the
 					// pool and pool config MBeans were registered
-					assertThat(mBeanServer.queryMBeans(new ObjectName("com.zaxxer.hikari:type=*"), null).size())
-							.isEqualTo(existingInstances.size() + 2);
+					assertThat(mBeanServer.queryMBeans(new ObjectName("com.zaxxer.hikari:type=*"), null))
+							.hasSize(existingInstances.size() + 2);
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceJsonSerializationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceJsonSerializationTests.java
@@ -60,7 +60,7 @@ class DataSourceJsonSerializationTests {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.setSerializerFactory(factory);
 		String value = mapper.writeValueAsString(dataSource);
-		assertThat(value.contains("\"url\":")).isTrue();
+		assertThat(value).contains("\"url\":");
 	}
 
 	@Test
@@ -69,8 +69,8 @@ class DataSourceJsonSerializationTests {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.addMixIn(DataSource.class, DataSourceJson.class);
 		String value = mapper.writeValueAsString(dataSource);
-		assertThat(value.contains("\"url\":")).isTrue();
-		assertThat(StringUtils.countOccurrencesOf(value, "\"url\"")).isEqualTo(1);
+		assertThat(value).contains("\"url\":");
+		assertThat(StringUtils.countOccurrencesOf(value, "\"url\"")).isOne();
 	}
 
 	@JsonSerialize(using = TomcatDataSourceSerializer.class)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourcePropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourcePropertiesTests.java
@@ -121,7 +121,7 @@ class DataSourcePropertiesTests {
 		DataSourceProperties properties = new DataSourceProperties();
 		properties.setUsername("");
 		properties.afterPropertiesSet();
-		assertThat(properties.getUsername()).isEqualTo("");
+		assertThat(properties.getUsername()).isEmpty();
 		assertThat(properties.determineUsername()).isEqualTo("sa");
 	}
 
@@ -157,7 +157,7 @@ class DataSourcePropertiesTests {
 		DataSourceProperties properties = new DataSourceProperties();
 		properties.afterPropertiesSet();
 		assertThat(properties.getPassword()).isNull();
-		assertThat(properties.determinePassword()).isEqualTo("");
+		assertThat(properties.determinePassword()).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateAutoConfigurationTests.java
@@ -150,7 +150,7 @@ class JdbcTemplateAutoConfigurationTests {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(SqlInitializationAutoConfiguration.class))
 				.withUserConfiguration(DataSourceInitializationValidator.class).run((context) -> {
 					assertThat(context).hasNotFailed();
-					assertThat(context.getBean(DataSourceInitializationValidator.class).count).isEqualTo(1);
+					assertThat(context.getBean(DataSourceInitializationValidator.class).count).isOne();
 				});
 	}
 
@@ -160,7 +160,7 @@ class JdbcTemplateAutoConfigurationTests {
 				.withPropertyValues("spring.flyway.locations:classpath:db/city")
 				.withConfiguration(AutoConfigurations.of(FlywayAutoConfiguration.class)).run((context) -> {
 					assertThat(context).hasNotFailed();
-					assertThat(context.getBean(DataSourceMigrationValidator.class).count).isEqualTo(0);
+					assertThat(context.getBean(DataSourceMigrationValidator.class).count).isZero();
 				});
 	}
 
@@ -171,7 +171,7 @@ class JdbcTemplateAutoConfigurationTests {
 				.withConfiguration(AutoConfigurations.of(FlywayAutoConfiguration.class)).run((context) -> {
 					assertThat(context).hasNotFailed();
 					assertThat(context.getBean(JdbcTemplate.class)).isNotNull();
-					assertThat(context.getBean(NamedParameterDataSourceMigrationValidator.class).count).isEqualTo(0);
+					assertThat(context.getBean(NamedParameterDataSourceMigrationValidator.class).count).isZero();
 				});
 	}
 
@@ -181,7 +181,7 @@ class JdbcTemplateAutoConfigurationTests {
 				.withPropertyValues("spring.liquibase.changeLog:classpath:db/changelog/db.changelog-city.yaml")
 				.withConfiguration(AutoConfigurations.of(LiquibaseAutoConfiguration.class)).run((context) -> {
 					assertThat(context).hasNotFailed();
-					assertThat(context.getBean(DataSourceMigrationValidator.class).count).isEqualTo(0);
+					assertThat(context.getBean(DataSourceMigrationValidator.class).count).isZero();
 				});
 	}
 
@@ -192,7 +192,7 @@ class JdbcTemplateAutoConfigurationTests {
 				.withConfiguration(AutoConfigurations.of(LiquibaseAutoConfiguration.class)).run((context) -> {
 					assertThat(context).hasNotFailed();
 					assertThat(context.getBean(JdbcTemplate.class)).isNotNull();
-					assertThat(context.getBean(NamedParameterDataSourceMigrationValidator.class).count).isEqualTo(0);
+					assertThat(context.getBean(NamedParameterDataSourceMigrationValidator.class).count).isZero();
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/OracleUcpDataSourceConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/OracleUcpDataSourceConfigurationTests.java
@@ -75,13 +75,13 @@ class OracleUcpDataSourceConfigurationTests {
 	void testDataSourceDefaultsPreserved() {
 		this.contextRunner.run((context) -> {
 			PoolDataSourceImpl ds = context.getBean(PoolDataSourceImpl.class);
-			assertThat(ds.getInitialPoolSize()).isEqualTo(0);
-			assertThat(ds.getMinPoolSize()).isEqualTo(0);
+			assertThat(ds.getInitialPoolSize()).isZero();
+			assertThat(ds.getMinPoolSize()).isZero();
 			assertThat(ds.getMaxPoolSize()).isEqualTo(Integer.MAX_VALUE);
-			assertThat(ds.getInactiveConnectionTimeout()).isEqualTo(0);
+			assertThat(ds.getInactiveConnectionTimeout()).isZero();
 			assertThat(ds.getConnectionWaitTimeout()).isEqualTo(3);
-			assertThat(ds.getTimeToLiveConnectionTimeout()).isEqualTo(0);
-			assertThat(ds.getAbandonedConnectionTimeout()).isEqualTo(0);
+			assertThat(ds.getTimeToLiveConnectionTimeout()).isZero();
+			assertThat(ds.getAbandonedConnectionTimeout()).isZero();
 			assertThat(ds.getTimeoutCheckInterval()).isEqualTo(30);
 			assertThat(ds.getFastConnectionFailoverEnabled()).isFalse();
 		});

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfigurationCustomObjectMapperProviderTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jersey/JerseyAutoConfigurationCustomObjectMapperProviderTests.java
@@ -61,7 +61,7 @@ class JerseyAutoConfigurationCustomObjectMapperProviderTests {
 	void contextLoads() {
 		ResponseEntity<String> response = this.restTemplate.getForEntity("/rest/message", String.class);
 		assertThat(HttpStatus.OK).isEqualTo(response.getStatusCode());
-		assertThat("{\"subject\":\"Jersey\"}").isEqualTo(response.getBody());
+		assertThat(response.getBody()).isEqualTo("{\"subject\":\"Jersey\"}");
 	}
 
 	@MinimalWebConfiguration

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
@@ -261,7 +261,7 @@ class JmsAutoConfigurationTests {
 					assertThat(jmsTemplate.isPubSubDomain()).isFalse();
 					assertThat(jmsTemplate.getDefaultDestinationName()).isEqualTo("testQueue");
 					assertThat(jmsTemplate.getDeliveryDelay()).isEqualTo(500);
-					assertThat(jmsTemplate.getDeliveryMode()).isEqualTo(1);
+					assertThat(jmsTemplate.getDeliveryMode()).isOne();
 					assertThat(jmsTemplate.getPriority()).isEqualTo(6);
 					assertThat(jmsTemplate.getTimeToLive()).isEqualTo(6000);
 					assertThat(jmsTemplate.isExplicitQosEnabled()).isTrue();

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisAutoConfigurationTests.java
@@ -77,7 +77,7 @@ class ArtemisAutoConfigurationTests {
 			assertThat(connectionFactory.getTargetConnectionFactory()).isInstanceOf(ActiveMQConnectionFactory.class);
 			assertThat(connectionFactory.isCacheConsumers()).isFalse();
 			assertThat(connectionFactory.isCacheProducers()).isTrue();
-			assertThat(connectionFactory.getSessionCacheSize()).isEqualTo(1);
+			assertThat(connectionFactory.getSessionCacheSize()).isOne();
 		});
 	}
 
@@ -374,7 +374,7 @@ class ArtemisAutoConfigurationTests {
 			String host, int port) {
 		TransportConfiguration transportConfig = getSingleTransportConfiguration(connectionFactory);
 		assertThat(transportConfig.getFactoryClassName()).isEqualTo(NettyConnectorFactory.class.getName());
-		assertThat(transportConfig.getParams().get("host")).isEqualTo(host);
+		assertThat(transportConfig.getParams()).containsEntry("host", host);
 		Object transportConfigPort = transportConfig.getParams().get("port");
 		if (transportConfigPort instanceof String portString) {
 			transportConfigPort = Integer.parseInt(portString);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfigurationTests.java
@@ -171,7 +171,7 @@ class JooqAutoConfigurationTests {
 
 		@Override
 		public void run(org.jooq.Configuration configuration) {
-			assertThat(this.dsl.fetch(this.sql).getValue(0, 0).toString()).isEqualTo(this.expected);
+			assertThat(this.dsl.fetch(this.sql).getValue(0, 0)).hasToString(this.expected);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfigurationIntegrationTests.java
@@ -91,7 +91,7 @@ class KafkaAutoConfigurationIntegrationTests {
 
 		DefaultKafkaProducerFactory producerFactory = this.context.getBean(DefaultKafkaProducerFactory.class);
 		Producer producer = producerFactory.createProducer();
-		assertThat(producer.partitionsFor(ADMIN_CREATED_TOPIC).size()).isEqualTo(10);
+		assertThat(producer.partitionsFor(ADMIN_CREATED_TOPIC)).hasSize(10);
 		producer.close();
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfigurationTests.java
@@ -121,38 +121,38 @@ class KafkaAutoConfigurationTests {
 							.getBean(DefaultKafkaConsumerFactory.class);
 					Map<String, Object> configs = consumerFactory.getConfigurationProperties();
 					// common
-					assertThat(configs.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG))
-							.isEqualTo(Collections.singletonList("foo:1234"));
-					assertThat(configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG)).isEqualTo("p1");
+					assertThat(configs).containsEntry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+							Collections.singletonList("foo:1234"));
+					assertThat(configs).containsEntry(SslConfigs.SSL_KEY_PASSWORD_CONFIG, "p1");
 					assertThat((String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
 							.endsWith(File.separator + "ksLoc");
-					assertThat(configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG)).isEqualTo("p2");
-					assertThat(configs.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG)).isEqualTo("PKCS12");
+					assertThat(configs).containsEntry(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "p2");
+					assertThat(configs).containsEntry(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PKCS12");
 					assertThat((String) configs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG))
 							.endsWith(File.separator + "tsLoc");
-					assertThat(configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG)).isEqualTo("p3");
-					assertThat(configs.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG)).isEqualTo("PKCS12");
-					assertThat(configs.get(SslConfigs.SSL_PROTOCOL_CONFIG)).isEqualTo("TLSv1.2");
+					assertThat(configs).containsEntry(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, "p3");
+					assertThat(configs).containsEntry(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PKCS12");
+					assertThat(configs).containsEntry(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
 					// consumer
-					assertThat(configs.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("ccid"); // override
-					assertThat(configs.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)).isEqualTo(Boolean.FALSE);
-					assertThat(configs.get(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG)).isEqualTo(123);
-					assertThat(configs.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)).isEqualTo("earliest");
-					assertThat(configs.get(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG)).isEqualTo(456);
-					assertThat(configs.get(ConsumerConfig.FETCH_MIN_BYTES_CONFIG)).isEqualTo(1024);
-					assertThat(configs.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("bar");
-					assertThat(configs.get(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG)).isEqualTo(234);
-					assertThat(configs.get(ConsumerConfig.ISOLATION_LEVEL_CONFIG)).isEqualTo("read_committed");
-					assertThat(configs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
-							.isEqualTo(LongDeserializer.class);
-					assertThat(configs.get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)).isEqualTo("SSL");
-					assertThat(configs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
-							.isEqualTo(IntegerDeserializer.class);
-					assertThat(configs.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isEqualTo(42);
-					assertThat(configs.get("foo")).isEqualTo("bar");
-					assertThat(configs.get("baz")).isEqualTo("qux");
-					assertThat(configs.get("foo.bar.baz")).isEqualTo("qux.fiz.buz");
-					assertThat(configs.get("fiz.buz")).isEqualTo("fix.fox");
+					assertThat(configs).containsEntry(ConsumerConfig.CLIENT_ID_CONFIG, "ccid"); // override
+					assertThat(configs).containsEntry(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, Boolean.FALSE);
+					assertThat(configs).containsEntry(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 123);
+					assertThat(configs).containsEntry(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+					assertThat(configs).containsEntry(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, 456);
+					assertThat(configs).containsEntry(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, 1024);
+					assertThat(configs).containsEntry(ConsumerConfig.GROUP_ID_CONFIG, "bar");
+					assertThat(configs).containsEntry(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 234);
+					assertThat(configs).containsEntry(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+					assertThat(configs).containsEntry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+							LongDeserializer.class);
+					assertThat(configs).containsEntry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
+					assertThat(configs).containsEntry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+							IntegerDeserializer.class);
+					assertThat(configs).containsEntry(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 42);
+					assertThat(configs).containsEntry("foo", "bar");
+					assertThat(configs).containsEntry("baz", "qux");
+					assertThat(configs).containsEntry("foo.bar.baz", "qux.fiz.buz");
+					assertThat(configs).containsEntry("fiz.buz", "fix.fox");
 				});
 	}
 
@@ -177,33 +177,33 @@ class KafkaAutoConfigurationTests {
 							.getBean(DefaultKafkaProducerFactory.class);
 					Map<String, Object> configs = producerFactory.getConfigurationProperties();
 					// common
-					assertThat(configs.get(ProducerConfig.CLIENT_ID_CONFIG)).isEqualTo("cid");
+					assertThat(configs).containsEntry(ProducerConfig.CLIENT_ID_CONFIG, "cid");
 					// producer
-					assertThat(configs.get(ProducerConfig.ACKS_CONFIG)).isEqualTo("all");
-					assertThat(configs.get(ProducerConfig.BATCH_SIZE_CONFIG)).isEqualTo(2048);
-					assertThat(configs.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG))
-							.isEqualTo(Collections.singletonList("bar:1234")); // override
-					assertThat(configs.get(ProducerConfig.BUFFER_MEMORY_CONFIG)).isEqualTo(4096L);
-					assertThat(configs.get(ProducerConfig.COMPRESSION_TYPE_CONFIG)).isEqualTo("gzip");
-					assertThat(configs.get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG)).isEqualTo(LongSerializer.class);
-					assertThat(configs.get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)).isEqualTo("SSL");
-					assertThat(configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG)).isEqualTo("p4");
+					assertThat(configs).containsEntry(ProducerConfig.ACKS_CONFIG, "all");
+					assertThat(configs).containsEntry(ProducerConfig.BATCH_SIZE_CONFIG, 2048);
+					assertThat(configs).containsEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+							Collections.singletonList("bar:1234")); // override
+					assertThat(configs).containsEntry(ProducerConfig.BUFFER_MEMORY_CONFIG, 4096L);
+					assertThat(configs).containsEntry(ProducerConfig.COMPRESSION_TYPE_CONFIG, "gzip");
+					assertThat(configs).containsEntry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+					assertThat(configs).containsEntry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
+					assertThat(configs).containsEntry(SslConfigs.SSL_KEY_PASSWORD_CONFIG, "p4");
 					assertThat((String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
 							.endsWith(File.separator + "ksLocP");
-					assertThat(configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG)).isEqualTo("p5");
-					assertThat(configs.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG)).isEqualTo("PKCS12");
+					assertThat(configs).containsEntry(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "p5");
+					assertThat(configs).containsEntry(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PKCS12");
 					assertThat((String) configs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG))
 							.endsWith(File.separator + "tsLocP");
-					assertThat(configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG)).isEqualTo("p6");
-					assertThat(configs.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG)).isEqualTo("PKCS12");
-					assertThat(configs.get(SslConfigs.SSL_PROTOCOL_CONFIG)).isEqualTo("TLSv1.2");
-					assertThat(configs.get(ProducerConfig.RETRIES_CONFIG)).isEqualTo(2);
-					assertThat(configs.get(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG))
-							.isEqualTo(IntegerSerializer.class);
+					assertThat(configs).containsEntry(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, "p6");
+					assertThat(configs).containsEntry(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PKCS12");
+					assertThat(configs).containsEntry(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
+					assertThat(configs).containsEntry(ProducerConfig.RETRIES_CONFIG, 2);
+					assertThat(configs).containsEntry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+							IntegerSerializer.class);
 					assertThat(context.getBeansOfType(KafkaJaasLoginModuleInitializer.class)).isEmpty();
 					assertThat(context.getBeansOfType(KafkaTransactionManager.class)).isEmpty();
-					assertThat(configs.get("foo.bar.baz")).isEqualTo("qux.fiz.buz");
-					assertThat(configs.get("fiz.buz")).isEqualTo("fix.fox");
+					assertThat(configs).containsEntry("foo.bar.baz", "qux.fiz.buz");
+					assertThat(configs).containsEntry("fiz.buz", "fix.fox");
 				});
 	}
 
@@ -221,22 +221,22 @@ class KafkaAutoConfigurationTests {
 					KafkaAdmin admin = context.getBean(KafkaAdmin.class);
 					Map<String, Object> configs = admin.getConfigurationProperties();
 					// common
-					assertThat(configs.get(AdminClientConfig.CLIENT_ID_CONFIG)).isEqualTo("cid");
+					assertThat(configs).containsEntry(AdminClientConfig.CLIENT_ID_CONFIG, "cid");
 					// admin
-					assertThat(configs.get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)).isEqualTo("SSL");
-					assertThat(configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG)).isEqualTo("p4");
+					assertThat(configs).containsEntry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
+					assertThat(configs).containsEntry(SslConfigs.SSL_KEY_PASSWORD_CONFIG, "p4");
 					assertThat((String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
 							.endsWith(File.separator + "ksLocP");
-					assertThat(configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG)).isEqualTo("p5");
-					assertThat(configs.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG)).isEqualTo("PKCS12");
+					assertThat(configs).containsEntry(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "p5");
+					assertThat(configs).containsEntry(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PKCS12");
 					assertThat((String) configs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG))
 							.endsWith(File.separator + "tsLocP");
-					assertThat(configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG)).isEqualTo("p6");
-					assertThat(configs.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG)).isEqualTo("PKCS12");
-					assertThat(configs.get(SslConfigs.SSL_PROTOCOL_CONFIG)).isEqualTo("TLSv1.2");
+					assertThat(configs).containsEntry(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, "p6");
+					assertThat(configs).containsEntry(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PKCS12");
+					assertThat(configs).containsEntry(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
 					assertThat(context.getBeansOfType(KafkaJaasLoginModuleInitializer.class)).isEmpty();
-					assertThat(configs.get("foo.bar.baz")).isEqualTo("qux.fiz.buz");
-					assertThat(configs.get("fiz.buz")).isEqualTo("fix.fox");
+					assertThat(configs).containsEntry("foo.bar.baz", "qux.fiz.buz");
+					assertThat(configs).containsEntry("fiz.buz", "fix.fox");
 					assertThat(admin).hasFieldOrPropertyWithValue("fatalIfBrokerNotAvailable", true);
 					assertThat(admin).hasFieldOrPropertyWithValue("modifyTopicConfigs", true);
 				});
@@ -263,24 +263,24 @@ class KafkaAutoConfigurationTests {
 							.asProperties();
 					assertThat((List<String>) configs.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG))
 							.containsExactly("localhost:9092", "localhost:9093");
-					assertThat(configs.get(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG)).isEqualTo(1024);
-					assertThat(configs.get(StreamsConfig.CLIENT_ID_CONFIG)).isEqualTo("override");
-					assertThat(configs.get(StreamsConfig.REPLICATION_FACTOR_CONFIG)).isEqualTo(2);
-					assertThat(configs.get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)).isEqualTo("SSL");
-					assertThat(configs.get(StreamsConfig.STATE_DIR_CONFIG)).isEqualTo("/tmp/state");
-					assertThat(configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG)).isEqualTo("p7");
+					assertThat(configs).containsEntry(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 1024);
+					assertThat(configs).containsEntry(StreamsConfig.CLIENT_ID_CONFIG, "override");
+					assertThat(configs).containsEntry(StreamsConfig.REPLICATION_FACTOR_CONFIG, 2);
+					assertThat(configs).containsEntry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
+					assertThat(configs).containsEntry(StreamsConfig.STATE_DIR_CONFIG, "/tmp/state");
+					assertThat(configs).containsEntry(SslConfigs.SSL_KEY_PASSWORD_CONFIG, "p7");
 					assertThat((String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
 							.endsWith(File.separator + "ksLocP");
-					assertThat(configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG)).isEqualTo("p8");
-					assertThat(configs.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG)).isEqualTo("PKCS12");
+					assertThat(configs).containsEntry(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "p8");
+					assertThat(configs).containsEntry(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PKCS12");
 					assertThat((String) configs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG))
 							.endsWith(File.separator + "tsLocP");
-					assertThat(configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG)).isEqualTo("p9");
-					assertThat(configs.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG)).isEqualTo("PKCS12");
-					assertThat(configs.get(SslConfigs.SSL_PROTOCOL_CONFIG)).isEqualTo("TLSv1.2");
+					assertThat(configs).containsEntry(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, "p9");
+					assertThat(configs).containsEntry(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PKCS12");
+					assertThat(configs).containsEntry(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
 					assertThat(context.getBeansOfType(KafkaJaasLoginModuleInitializer.class)).isEmpty();
-					assertThat(configs.get("foo.bar.baz")).isEqualTo("qux.fiz.buz");
-					assertThat(configs.get("fiz.buz")).isEqualTo("fix.fox");
+					assertThat(configs).containsEntry("foo.bar.baz", "qux.fiz.buz");
+					assertThat(configs).containsEntry("fiz.buz", "fix.fox");
 					assertThat(context.getBean(KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_BUILDER_BEAN_NAME))
 							.isNotNull();
 				});
@@ -300,7 +300,7 @@ class KafkaAutoConfigurationTests {
 							.asProperties();
 					assertThat((List<String>) configs.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG))
 							.containsExactly("localhost:9092", "localhost:9093");
-					assertThat(configs.get(StreamsConfig.APPLICATION_ID_CONFIG)).isEqualTo("my-test-app");
+					assertThat(configs).containsEntry(StreamsConfig.APPLICATION_ID_CONFIG, "my-test-app");
 				});
 	}
 
@@ -316,9 +316,9 @@ class KafkaAutoConfigurationTests {
 							.getBean(KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME,
 									KafkaStreamsConfiguration.class)
 							.asProperties();
-					assertThat(configs.get(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG))
-							.isEqualTo("localhost:9094, localhost:9095");
-					assertThat(configs.get(StreamsConfig.APPLICATION_ID_CONFIG)).isEqualTo("test-id");
+					assertThat(configs).containsEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG,
+							"localhost:9094, localhost:9095");
+					assertThat(configs).containsEntry(StreamsConfig.APPLICATION_ID_CONFIG, "test-id");
 				});
 	}
 
@@ -479,7 +479,7 @@ class KafkaAutoConfigurationTests {
 					assertThat(kafkaListenerContainerFactory.getConsumerFactory()).isEqualTo(consumerFactory);
 					ContainerProperties containerProperties = kafkaListenerContainerFactory.getContainerProperties();
 					assertThat(containerProperties.getAckMode()).isEqualTo(AckMode.MANUAL);
-					assertThat(containerProperties.isAsyncAcks()).isEqualTo(true);
+					assertThat(containerProperties.isAsyncAcks()).isTrue();
 					assertThat(containerProperties.getClientId()).isEqualTo("client");
 					assertThat(containerProperties.getAckCount()).isEqualTo(123);
 					assertThat(containerProperties.getAckTime()).isEqualTo(456L);
@@ -672,10 +672,10 @@ class KafkaAutoConfigurationTests {
 					DefaultKafkaProducerFactory<?, ?> producerFactory = context
 							.getBean(DefaultKafkaProducerFactory.class);
 					Map<String, Object> producerConfigs = producerFactory.getConfigurationProperties();
-					assertThat(producerConfigs.get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)).isEqualTo("SSL");
+					assertThat(producerConfigs).containsEntry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
 					KafkaAdmin admin = context.getBean(KafkaAdmin.class);
 					Map<String, Object> configs = admin.getConfigurationProperties();
-					assertThat(configs.get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)).isEqualTo("PLAINTEXT");
+					assertThat(configs).containsEntry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "PLAINTEXT");
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaPropertiesTests.java
@@ -51,7 +51,7 @@ class KafkaPropertiesTests {
 				IsolationLevel.READ_COMMITTED.name());
 		assertThat(original).extracting("id").containsExactly(IsolationLevel.READ_UNCOMMITTED.id(),
 				IsolationLevel.READ_COMMITTED.id());
-		assertThat(original).hasSize(IsolationLevel.values().length);
+		assertThat(original).hasSameSizeAs(IsolationLevel.values());
 	}
 
 	@Test
@@ -76,10 +76,10 @@ class KafkaPropertiesTests {
 		properties.getSsl().setTrustStoreCertificates("-----BEGINtrust");
 		properties.getSsl().setKeyStoreCertificateChain("-----BEGINchain");
 		Map<String, Object> consumerProperties = properties.buildConsumerProperties();
-		assertThat(consumerProperties.get(SslConfigs.SSL_KEYSTORE_KEY_CONFIG)).isEqualTo("-----BEGINkey");
-		assertThat(consumerProperties.get(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG)).isEqualTo("-----BEGINtrust");
-		assertThat(consumerProperties.get(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG))
-				.isEqualTo("-----BEGINchain");
+		assertThat(consumerProperties).containsEntry(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, "-----BEGINkey");
+		assertThat(consumerProperties).containsEntry(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, "-----BEGINtrust");
+		assertThat(consumerProperties).containsEntry(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG,
+				"-----BEGINchain");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfigurationTests.java
@@ -103,10 +103,10 @@ class LdapAutoConfigurationTests {
 	void contextSourceWithNoCustomization() {
 		this.contextRunner.run((context) -> {
 			LdapContextSource contextSource = context.getBean(LdapContextSource.class);
-			assertThat(contextSource.getUserDn()).isEqualTo("");
-			assertThat(contextSource.getPassword()).isEqualTo("");
+			assertThat(contextSource.getUserDn()).isEmpty();
+			assertThat(contextSource.getPassword()).isEmpty();
 			assertThat(contextSource.isAnonymousReadOnly()).isTrue();
-			assertThat(contextSource.getBaseLdapPathAsString()).isEqualTo("");
+			assertThat(contextSource.getBaseLdapPathAsString()).isEmpty();
 		});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
@@ -183,9 +183,9 @@ class LiquibaseAutoConfigurationTests {
 					assertThat(liquibase.getDatabaseChangeLogLockTable()).isEqualTo("LIQUI_LOCK");
 					JdbcTemplate jdbcTemplate = new JdbcTemplate(context.getBean(DataSource.class));
 					assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM public.LIQUI_LOG", Integer.class))
-							.isEqualTo(1);
+							.isOne();
 					assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM public.LIQUI_LOCK", Integer.class))
-							.isEqualTo(1);
+							.isOne();
 				});
 	}
 
@@ -321,7 +321,7 @@ class LiquibaseAutoConfigurationTests {
 					Map<String, String> parameters = (Map<String, String>) ReflectionTestUtils.getField(liquibase,
 							"parameters");
 					assertThat(parameters).containsKey("foo");
-					assertThat(parameters.get("foo")).isEqualTo("bar");
+					assertThat(parameters).containsEntry("foo", "bar");
 				}));
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mail/MailSenderAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mail/MailSenderAutoConfigurationTests.java
@@ -112,7 +112,7 @@ class MailSenderAutoConfigurationTests {
 				.run((context) -> {
 					assertThat(context).hasSingleBean(JavaMailSenderImpl.class);
 					JavaMailSenderImpl mailSender = context.getBean(JavaMailSenderImpl.class);
-					assertThat(mailSender.getJavaMailProperties().get("mail.smtp.auth")).isEqualTo("true");
+					assertThat(mailSender.getJavaMailProperties()).containsEntry("mail.smtp.auth", "true");
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mustache/MustacheAutoConfigurationServletIntegrationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mustache/MustacheAutoConfigurationServletIntegrationTests.java
@@ -82,13 +82,13 @@ class MustacheAutoConfigurationServletIntegrationTests {
 	@Test
 	void testHomePage() {
 		String body = new TestRestTemplate().getForObject("http://localhost:" + this.port, String.class);
-		assertThat(body.contains("Hello World")).isTrue();
+		assertThat(body).contains("Hello World");
 	}
 
 	@Test
 	void testPartialPage() {
 		String body = new TestRestTemplate().getForObject("http://localhost:" + this.port + "/partial", String.class);
-		assertThat(body.contains("Hello World")).isTrue();
+		assertThat(body).contains("Hello World");
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jAutoConfigurationTests.java
@@ -275,8 +275,7 @@ class Neo4jAutoConfigurationTests {
 
 	@Test
 	void driverConfigShouldBeConfiguredToUseUseSpringJclLogging() {
-		assertThat(mapDriverConfig(new Neo4jProperties()).logging()).isNotNull()
-				.isInstanceOf(Neo4jSpringJclLogging.class);
+		assertThat(mapDriverConfig(new Neo4jProperties()).logging()).isInstanceOf(Neo4jSpringJclLogging.class);
 	}
 
 	private URI determineServerUri(Neo4jProperties properties, Environment environment) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/AbstractJpaAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/AbstractJpaAutoConfigurationTests.java
@@ -196,9 +196,9 @@ abstract class AbstractJpaAutoConfigurationTests {
 					LocalContainerEntityManagerFactoryBean bean = context
 							.getBean(LocalContainerEntityManagerFactoryBean.class);
 					Map<String, Object> map = bean.getJpaPropertyMap();
-					assertThat(map.get("a")).isEqualTo("b");
-					assertThat(map.get("c")).isEqualTo("d");
-					assertThat(map.get("a.b")).isEqualTo("c");
+					assertThat(map).containsEntry("a", "b");
+					assertThat(map).containsEntry("c", "d");
+					assertThat(map).containsEntry("a.b", "c");
 				});
 	}
 
@@ -209,7 +209,7 @@ abstract class AbstractJpaAutoConfigurationTests {
 					LocalContainerEntityManagerFactoryBean factoryBean = context
 							.getBean(LocalContainerEntityManagerFactoryBean.class);
 					Map<String, Object> map = factoryBean.getJpaPropertyMap();
-					assertThat(map.get("configured")).isEqualTo("manually");
+					assertThat(map).containsEntry("configured", "manually");
 				});
 	}
 
@@ -219,7 +219,7 @@ abstract class AbstractJpaAutoConfigurationTests {
 				.run((context) -> {
 					EntityManagerFactory factoryBean = context.getBean(EntityManagerFactory.class);
 					Map<String, Object> map = factoryBean.getProperties();
-					assertThat(map.get("configured")).isEqualTo("manually");
+					assertThat(map).containsEntry("configured", "manually");
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/CustomHibernateJpaAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/CustomHibernateJpaAutoConfigurationTests.java
@@ -68,7 +68,7 @@ class CustomHibernateJpaAutoConfigurationTests {
 					HibernateProperties hibernateProperties = context.getBean(HibernateProperties.class);
 					Map<String, Object> properties = hibernateProperties
 							.determineHibernateProperties(jpaProperties.getProperties(), new HibernateSettings());
-					assertThat(properties.get("hibernate.ejb.naming_strategy")).isNull();
+					assertThat(properties).doesNotContainKey("hibernate.ejb.naming_strategy");
 				});
 	}
 
@@ -78,10 +78,10 @@ class CustomHibernateJpaAutoConfigurationTests {
 				.withPropertyValues("spring.datasource.url:jdbc:h2:mem:naming-strategy-beans").run((context) -> {
 					HibernateJpaConfiguration jpaConfiguration = context.getBean(HibernateJpaConfiguration.class);
 					Map<String, Object> hibernateProperties = jpaConfiguration.getVendorProperties();
-					assertThat(hibernateProperties.get("hibernate.implicit_naming_strategy"))
-							.isEqualTo(NamingStrategyConfiguration.implicitNamingStrategy);
-					assertThat(hibernateProperties.get("hibernate.physical_naming_strategy"))
-							.isEqualTo(NamingStrategyConfiguration.physicalNamingStrategy);
+					assertThat(hibernateProperties).containsEntry("hibernate.implicit_naming_strategy",
+							NamingStrategyConfiguration.implicitNamingStrategy);
+					assertThat(hibernateProperties).containsEntry("hibernate.physical_naming_strategy",
+							NamingStrategyConfiguration.physicalNamingStrategy);
 				});
 	}
 
@@ -90,7 +90,7 @@ class CustomHibernateJpaAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(HibernatePropertiesCustomizerConfiguration.class).run((context) -> {
 			HibernateJpaConfiguration jpaConfiguration = context.getBean(HibernateJpaConfiguration.class);
 			Map<String, Object> hibernateProperties = jpaConfiguration.getVendorProperties();
-			assertThat(hibernateProperties.get("test.counter")).isEqualTo(2);
+			assertThat(hibernateProperties).containsEntry("test.counter", 2);
 		});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfigurationTests.java
@@ -374,7 +374,7 @@ class HibernateJpaAutoConfigurationTests extends AbstractJpaAutoConfigurationTes
 	void vendorPropertiesWithEmbeddedDatabaseAndNoDdlProperty() {
 		contextRunner().run(vendorProperties((vendorProperties) -> {
 			assertThat(vendorProperties).doesNotContainKeys(AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION);
-			assertThat(vendorProperties.get(AvailableSettings.HBM2DDL_AUTO)).isEqualTo("create-drop");
+			assertThat(vendorProperties).containsEntry(AvailableSettings.HBM2DDL_AUTO, "create-drop");
 		}));
 	}
 
@@ -383,7 +383,7 @@ class HibernateJpaAutoConfigurationTests extends AbstractJpaAutoConfigurationTes
 		contextRunner().withPropertyValues("spring.jpa.hibernate.ddl-auto=update")
 				.run(vendorProperties((vendorProperties) -> {
 					assertThat(vendorProperties).doesNotContainKeys(AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION);
-					assertThat(vendorProperties.get(AvailableSettings.HBM2DDL_AUTO)).isEqualTo("update");
+					assertThat(vendorProperties).containsEntry(AvailableSettings.HBM2DDL_AUTO, "update");
 				}));
 	}
 
@@ -394,7 +394,7 @@ class HibernateJpaAutoConfigurationTests extends AbstractJpaAutoConfigurationTes
 						"spring.jpa.properties.hibernate.hbm2ddl.auto=create-drop")
 				.run(vendorProperties((vendorProperties) -> {
 					assertThat(vendorProperties).doesNotContainKeys(AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION);
-					assertThat(vendorProperties.get(AvailableSettings.HBM2DDL_AUTO)).isEqualTo("create-drop");
+					assertThat(vendorProperties).containsEntry(AvailableSettings.HBM2DDL_AUTO, "create-drop");
 				}));
 	}
 
@@ -411,8 +411,8 @@ class HibernateJpaAutoConfigurationTests extends AbstractJpaAutoConfigurationTes
 				.withPropertyValues(
 						"spring.jpa.properties.jakarta.persistence.schema-generation.database.action=create")
 				.run(vendorProperties((vendorProperties) -> {
-					assertThat(vendorProperties.get(AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION))
-							.isEqualTo("create");
+					assertThat(vendorProperties).containsEntry(AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION,
+							"create");
 					assertThat(vendorProperties).doesNotContainKeys(AvailableSettings.HBM2DDL_AUTO);
 				}));
 	}
@@ -422,9 +422,9 @@ class HibernateJpaAutoConfigurationTests extends AbstractJpaAutoConfigurationTes
 		contextRunner().withPropertyValues(
 				"spring.jpa.properties.jakarta.persistence.schema-generation.database.action=create",
 				"spring.jpa.hibernate.ddl-auto=create-only").run(vendorProperties((vendorProperties) -> {
-					assertThat(vendorProperties.get(AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION))
-							.isEqualTo("create");
-					assertThat(vendorProperties.get(AvailableSettings.HBM2DDL_AUTO)).isEqualTo("create-only");
+					assertThat(vendorProperties).containsEntry(AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION,
+							"create");
+					assertThat(vendorProperties).containsEntry(AvailableSettings.HBM2DDL_AUTO, "create-only");
 				}));
 	}
 
@@ -467,7 +467,7 @@ class HibernateJpaAutoConfigurationTests extends AbstractJpaAutoConfigurationTes
 				.run((context) -> {
 					EntityManagerFactory factoryBean = context.getBean(EntityManagerFactory.class);
 					Map<String, Object> map = factoryBean.getProperties();
-					assertThat(map.get("configured")).isEqualTo("manually");
+					assertThat(map).containsEntry("configured", "manually");
 				});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/quartz/QuartzAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/quartz/QuartzAutoConfigurationTests.java
@@ -335,7 +335,7 @@ class QuartzAutoConfigurationTests {
 			assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM QRTZ_JOB_DETAILS", Integer.class))
 					.isEqualTo(2);
 			assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM QRTZ_SIMPLE_TRIGGERS", Integer.class))
-					.isEqualTo(0);
+					.isZero();
 		};
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
@@ -185,7 +185,7 @@ class ReactiveOAuth2ResourceServerAutoConfigurationTests {
 					reactiveJwtDecoderSupplier.block(TIMEOUT);
 				});
 		// The last request is to the JWK Set endpoint to look up the algorithm
-		assertThat(this.server.getRequestCount()).isEqualTo(1);
+		assertThat(this.server.getRequestCount()).isOne();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/rsocket/RSocketSecurityAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/rsocket/RSocketSecurityAutoConfigurationTests.java
@@ -76,7 +76,7 @@ class RSocketSecurityAutoConfigurationTests {
 		this.contextRunner.run((context) -> {
 			assertThat(context).hasSingleBean(RSocketMessageHandler.class);
 			RSocketMessageHandler handler = context.getBean(RSocketMessageHandler.class);
-			assertThat(handler.getArgumentResolverConfigurer().getCustomResolvers()).isNotEmpty()
+			assertThat(handler.getArgumentResolverConfigurer().getCustomResolvers())
 					.anyMatch((customResolver) -> customResolver instanceof AuthenticationPrincipalArgumentResolver);
 		});
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyAutoConfigurationTests.java
@@ -99,7 +99,7 @@ class Saml2RelyingPartyAutoConfigurationTests {
 			assertThat(registration.getAssertionConsumerServiceBinding()).isEqualTo(Saml2MessageBinding.REDIRECT);
 			assertThat(registration.getAssertingPartyDetails().getSingleSignOnServiceBinding())
 					.isEqualTo(Saml2MessageBinding.POST);
-			assertThat(registration.getAssertingPartyDetails().getWantAuthnRequestsSigned()).isEqualTo(false);
+			assertThat(registration.getAssertingPartyDetails().getWantAuthnRequestsSigned()).isFalse();
 			assertThat(registration.getSigningX509Credentials()).hasSize(1);
 			assertThat(registration.getDecryptionX509Credentials()).hasSize(1);
 			assertThat(registration.getAssertingPartyDetails().getVerificationX509Credentials()).isNotNull();
@@ -142,7 +142,7 @@ class Saml2RelyingPartyAutoConfigurationTests {
 			this.contextRunner.withPropertyValues(PREFIX + ".foo.assertingparty.metadata-uri=" + metadataUrl)
 					.run((context) -> {
 						assertThat(context).hasSingleBean(RelyingPartyRegistrationRepository.class);
-						assertThat(server.getRequestCount()).isEqualTo(1);
+						assertThat(server.getRequestCount()).isOne();
 					});
 		}
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyPropertiesTests.java
@@ -61,7 +61,7 @@ class Saml2RelyingPartyPropertiesTests {
 		bind("spring.security.saml2.relyingparty.registration.simplesamlphp.assertingparty.single-sign-on.sign-request",
 				"false");
 		assertThat(this.properties.getRegistration().get("simplesamlphp").getAssertingparty().getSinglesignon()
-				.isSignRequest()).isEqualTo(false);
+				.isSignRequest()).isFalse();
 	}
 
 	@Test
@@ -90,7 +90,7 @@ class Saml2RelyingPartyPropertiesTests {
 	void customizeSsoSignRequestsIsTrueByDefault() {
 		this.properties.getRegistration().put("simplesamlphp", new Saml2RelyingPartyProperties.Registration());
 		assertThat(this.properties.getRegistration().get("simplesamlphp").getAssertingparty().getSinglesignon()
-				.isSignRequest()).isEqualTo(true);
+				.isSignRequest()).isTrue();
 	}
 
 	private void bind(String name, String value) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/servlet/SecurityAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/servlet/SecurityAutoConfigurationTests.java
@@ -92,7 +92,7 @@ class SecurityAutoConfigurationTests {
 	void securityConfigurerBacksOffWhenOtherSecurityFilterChainBeanPresent() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(WebMvcAutoConfiguration.class))
 				.withUserConfiguration(TestSecurityFilterChainConfig.class).run((context) -> {
-					assertThat(context.getBeansOfType(SecurityFilterChain.class).size()).isEqualTo(1);
+					assertThat(context.getBeansOfType(SecurityFilterChain.class)).hasSize(1);
 					assertThat(context.containsBean("testSecurityFilterChain")).isTrue();
 				});
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/sendgrid/SendGridAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/sendgrid/SendGridAutoConfigurationTests.java
@@ -52,7 +52,7 @@ class SendGridAutoConfigurationTests {
 	void expectedSendGridBeanCreatedApiKey() {
 		loadContext("spring.sendgrid.api-key:SG.SECRET-API-KEY");
 		SendGrid sendGrid = this.context.getBean(SendGrid.class);
-		assertThat(sendGrid.getRequestHeaders().get("Authorization")).isEqualTo("Bearer SG.SECRET-API-KEY");
+		assertThat(sendGrid.getRequestHeaders()).containsEntry("Authorization", "Bearer SG.SECRET-API-KEY");
 	}
 
 	@Test
@@ -66,7 +66,7 @@ class SendGridAutoConfigurationTests {
 	void autoConfigurationNotFiredWhenBeanAlreadyCreated() {
 		loadContext(ManualSendGridConfiguration.class, "spring.sendgrid.api-key:SG.SECRET-API-KEY");
 		SendGrid sendGrid = this.context.getBean(SendGrid.class);
-		assertThat(sendGrid.getRequestHeaders().get("Authorization")).isEqualTo("Bearer SG.CUSTOM_API_KEY");
+		assertThat(sendGrid.getRequestHeaders()).containsEntry("Authorization", "Bearer SG.CUSTOM_API_KEY");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/transaction/TransactionManagerCustomizersTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/transaction/TransactionManagerCustomizersTests.java
@@ -48,7 +48,7 @@ class TransactionManagerCustomizersTests {
 		customizers.customize(mock(PlatformTransactionManager.class));
 		customizers.customize(mock(JtaTransactionManager.class));
 		assertThat(list.get(0).getCount()).isEqualTo(2);
-		assertThat(list.get(1).getCount()).isEqualTo(1);
+		assertThat(list.get(1).getCount()).isOne();
 	}
 
 	static class TestCustomizer<T extends PlatformTransactionManager>

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/validation/ValidationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/validation/ValidationAutoConfigurationTests.java
@@ -231,7 +231,7 @@ class ValidationAutoConfigurationTests {
 		this.contextRunner.run((parent) -> new ApplicationContextRunner()
 				.withConfiguration(AutoConfigurations.of(ValidationAutoConfiguration.class))
 				.withUserConfiguration(SampleService.class).withParent(parent).run((context) -> {
-					assertThat(context.getBeansOfType(Validator.class)).hasSize(0);
+					assertThat(context.getBeansOfType(Validator.class)).isEmpty();
 					assertThat(parent.getBeansOfType(Validator.class)).hasSize(1);
 					SampleService service = context.getBean(SampleService.class);
 					service.doSomething("Valid");

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/validation/ValidatorAdapterTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/validation/ValidatorAdapterTests.java
@@ -53,7 +53,7 @@ class ValidatorAdapterTests {
 			assertThat(wrapper.supports(SampleData.class)).isTrue();
 			MapBindingResult errors = new MapBindingResult(new HashMap<String, Object>(), "test");
 			wrapper.validate(new SampleData(40), errors);
-			assertThat(errors.getErrorCount()).isEqualTo(1);
+			assertThat(errors.getErrorCount()).isOne();
 		});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -44,7 +44,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.Test;
 import reactor.netty.http.HttpDecoderSpec;
-import reactor.netty.http.server.HttpRequestDecoderSpec;
 
 import org.springframework.boot.autoconfigure.web.ServerProperties.Tomcat.Accesslog;
 import org.springframework.boot.context.properties.bind.Bindable;
@@ -148,7 +147,7 @@ class ServerPropertiesTests {
 		assertThat(accesslog.getSuffix()).isEqualTo("-bar.log");
 		assertThat(accesslog.getEncoding()).isEqualTo("UTF-8");
 		assertThat(accesslog.getLocale()).isEqualTo("en-AU");
-		assertThat(accesslog.isCheckExists()).isEqualTo(true);
+		assertThat(accesslog.isCheckExists()).isTrue();
 		assertThat(accesslog.isRotate()).isFalse();
 		assertThat(accesslog.isRenameOnRotate()).isTrue();
 		assertThat(accesslog.isIpv6Canonical()).isTrue();
@@ -173,7 +172,7 @@ class ServerPropertiesTests {
 	@Test
 	void testSlashOfContextPathIsDefaultValue() {
 		bind("server.servlet.context-path", "/");
-		assertThat(this.properties.getServlet().getContextPath()).isEqualTo("");
+		assertThat(this.properties.getServlet().getContextPath()).isEmpty();
 	}
 
 	@Test
@@ -554,13 +553,12 @@ class ServerPropertiesTests {
 
 	@Test
 	void nettyValidateHeadersMatchesHttpDecoderSpecDefault() {
-		assertThat(this.properties.getNetty().isValidateHeaders()).isEqualTo(HttpDecoderSpec.DEFAULT_VALIDATE_HEADERS);
+		assertThat(this.properties.getNetty().isValidateHeaders()).isTrue();
 	}
 
 	@Test
 	void nettyH2cMaxContentLengthMatchesHttpDecoderSpecDefault() {
-		assertThat(this.properties.getNetty().getH2cMaxContentLength().toBytes())
-				.isEqualTo(HttpRequestDecoderSpec.DEFAULT_H2C_MAX_CONTENT_LENGTH);
+		assertThat(this.properties.getNetty().getH2cMaxContentLength().toBytes()).isZero();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/client/RestTemplateAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/client/RestTemplateAutoConfigurationTests.java
@@ -90,8 +90,7 @@ class RestTemplateAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(RestTemplateConfig.class).run((context) -> {
 			assertThat(context).hasSingleBean(RestTemplate.class);
 			RestTemplate restTemplate = context.getBean(RestTemplate.class);
-			assertThat(restTemplate.getMessageConverters().size())
-					.isEqualTo(new RestTemplate().getMessageConverters().size());
+			assertThat(restTemplate.getMessageConverters()).hasSameSizeAs(new RestTemplate().getMessageConverters());
 		});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizerTests.java
@@ -287,7 +287,7 @@ class TomcatWebServerFactoryCustomizerTests {
 	@Test
 	void defaultUseForwardHeaders() {
 		TomcatServletWebServerFactory factory = customizeAndGetFactory();
-		assertThat(factory.getEngineValves()).hasSize(0);
+		assertThat(factory.getEngineValves()).isEmpty();
 	}
 
 	@Test
@@ -301,7 +301,7 @@ class TomcatWebServerFactoryCustomizerTests {
 		this.environment.setProperty("DYNO", "-");
 		this.serverProperties.setForwardHeadersStrategy(ServerProperties.ForwardHeadersStrategy.NONE);
 		TomcatServletWebServerFactory factory = customizeAndGetFactory();
-		assertThat(factory.getEngineValves()).hasSize(0);
+		assertThat(factory.getEngineValves()).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/format/WebConversionServiceTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/format/WebConversionServiceTests.java
@@ -174,8 +174,8 @@ class WebConversionServiceTests {
 		Calendar calendar = Calendar.getInstance();
 		calendar.setTime(date);
 		assertThat(calendar.get(Calendar.YEAR)).isEqualTo(2018);
-		assertThat(calendar.get(Calendar.MONTH)).isEqualTo(Calendar.JANUARY);
-		assertThat(calendar.get(Calendar.DAY_OF_MONTH)).isEqualTo(1);
+		assertThat(calendar.get(Calendar.MONTH)).isZero();
+		assertThat(calendar.get(Calendar.DAY_OF_MONTH)).isOne();
 	}
 
 	private void customDateFormat(Object input) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfigurationTests.java
@@ -412,7 +412,7 @@ class WebFluxAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(CustomRequestMappingHandlerMapping.class).run((context) -> {
 			assertThat(context).getBean(RequestMappingHandlerMapping.class)
 					.isInstanceOf(MyRequestMappingHandlerMapping.class);
-			assertThat(context.getBean(CustomRequestMappingHandlerMapping.class).handlerMappings).isEqualTo(1);
+			assertThat(context.getBean(CustomRequestMappingHandlerMapping.class).handlerMappings).isOne();
 		});
 	}
 
@@ -421,7 +421,7 @@ class WebFluxAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(CustomRequestMappingHandlerAdapter.class).run((context) -> {
 			assertThat(context).getBean(RequestMappingHandlerAdapter.class)
 					.isInstanceOf(MyRequestMappingHandlerAdapter.class);
-			assertThat(context.getBean(CustomRequestMappingHandlerAdapter.class).handlerAdapters).isEqualTo(1);
+			assertThat(context.getBean(CustomRequestMappingHandlerAdapter.class).handlerAdapters).isOne();
 		});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/HttpEncodingAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/HttpEncodingAutoConfigurationTests.java
@@ -132,7 +132,7 @@ class HttpEncodingAutoConfigurationTests {
 	void noLocaleCharsetMapping() {
 		load(EmptyConfiguration.class);
 		Map<String, WebServerFactoryCustomizer<?>> beans = getWebServerFactoryCustomizerBeans();
-		assertThat(beans.size()).isEqualTo(1);
+		assertThat(beans).hasSize(1);
 		assertThat(this.context.getBean(MockServletWebServerFactory.class).getLocaleCharsetMappings()).isEmpty();
 	}
 
@@ -141,15 +141,10 @@ class HttpEncodingAutoConfigurationTests {
 		load(EmptyConfiguration.class, "server.servlet.encoding.mapping.en:UTF-8",
 				"server.servlet.encoding.mapping.fr_FR:UTF-8");
 		Map<String, WebServerFactoryCustomizer<?>> beans = getWebServerFactoryCustomizerBeans();
-		assertThat(beans.size()).isEqualTo(1);
-		assertThat(this.context.getBean(MockServletWebServerFactory.class).getLocaleCharsetMappings().size())
-				.isEqualTo(2);
-		assertThat(
-				this.context.getBean(MockServletWebServerFactory.class).getLocaleCharsetMappings().get(Locale.ENGLISH))
-						.isEqualTo(StandardCharsets.UTF_8);
-		assertThat(
-				this.context.getBean(MockServletWebServerFactory.class).getLocaleCharsetMappings().get(Locale.FRANCE))
-						.isEqualTo(StandardCharsets.UTF_8);
+		assertThat(beans).hasSize(1);
+		assertThat(this.context.getBean(MockServletWebServerFactory.class).getLocaleCharsetMappings()).hasSize(2)
+				.containsEntry(Locale.ENGLISH, StandardCharsets.UTF_8)
+				.containsEntry(Locale.FRANCE, StandardCharsets.UTF_8);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
@@ -177,9 +177,9 @@ class WebMvcAutoConfigurationTests {
 			assertThat(locations.get("/webjars/**").get(0))
 					.isEqualTo(new ClassPathResource("/META-INF/resources/webjars/"));
 			assertThat(getResourceResolvers(context, "/webjars/**")).hasSize(1);
-			assertThat(getResourceTransformers(context, "/webjars/**")).hasSize(0);
+			assertThat(getResourceTransformers(context, "/webjars/**")).isEmpty();
 			assertThat(getResourceResolvers(context, "/**")).hasSize(1);
-			assertThat(getResourceTransformers(context, "/**")).hasSize(0);
+			assertThat(getResourceTransformers(context, "/**")).isEmpty();
 		});
 	}
 
@@ -318,7 +318,7 @@ class WebMvcAutoConfigurationTests {
 					Locale locale = localeResolver.resolveLocale(request);
 					// test locale resolver uses fixed locale and not user preferred
 					// locale
-					assertThat(locale.toString()).isEqualTo("en_UK");
+					assertThat(locale).hasToString("en_UK");
 				});
 	}
 
@@ -333,7 +333,7 @@ class WebMvcAutoConfigurationTests {
 			assertThat(localeResolver).isInstanceOf(AcceptHeaderLocaleResolver.class);
 			Locale locale = localeResolver.resolveLocale(request);
 			// test locale resolver uses user preferred locale
-			assertThat(locale.toString()).isEqualTo("nl_NL");
+			assertThat(locale).hasToString("nl_NL");
 		});
 	}
 
@@ -346,7 +346,7 @@ class WebMvcAutoConfigurationTests {
 			assertThat(localeResolver).isInstanceOf(AcceptHeaderLocaleResolver.class);
 			Locale locale = localeResolver.resolveLocale(request);
 			// test locale resolver uses default locale if no header is set
-			assertThat(locale.toString()).isEqualTo("en_UK");
+			assertThat(locale).hasToString("en_UK");
 		});
 	}
 
@@ -611,7 +611,7 @@ class WebMvcAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(CustomRequestMappingHandlerMapping.class).run((context) -> {
 			assertThat(context).getBean(RequestMappingHandlerMapping.class)
 					.isInstanceOf(MyRequestMappingHandlerMapping.class);
-			assertThat(context.getBean(CustomRequestMappingHandlerMapping.class).handlerMappings).isEqualTo(1);
+			assertThat(context.getBean(CustomRequestMappingHandlerMapping.class).handlerMappings).isOne();
 		});
 	}
 
@@ -620,7 +620,7 @@ class WebMvcAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(CustomRequestMappingHandlerAdapter.class).run((context) -> {
 			assertThat(context).getBean(RequestMappingHandlerAdapter.class)
 					.isInstanceOf(MyRequestMappingHandlerAdapter.class);
-			assertThat(context.getBean(CustomRequestMappingHandlerAdapter.class).handlerAdapters).isEqualTo(1);
+			assertThat(context.getBean(CustomRequestMappingHandlerAdapter.class).handlerAdapters).isOne();
 		});
 	}
 
@@ -628,8 +628,7 @@ class WebMvcAutoConfigurationTests {
 	void customExceptionHandlerExceptionResolver() {
 		this.contextRunner.withUserConfiguration(CustomExceptionHandlerExceptionResolver.class)
 				.run((context) -> assertThat(
-						context.getBean(CustomExceptionHandlerExceptionResolver.class).exceptionResolvers)
-								.isEqualTo(1));
+						context.getBean(CustomExceptionHandlerExceptionResolver.class).exceptionResolvers).isOne());
 	}
 
 	@Test
@@ -996,7 +995,7 @@ class WebMvcAutoConfigurationTests {
 		if (bean instanceof HandlerMapping handlerMapping) {
 			return getMappingLocations(context, handlerMapping);
 		}
-		assertThat(bean.toString()).isEqualTo("null");
+		assertThat(bean).hasToString("null");
 		return Collections.emptyMap();
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/error/BasicErrorControllerIntegrationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/error/BasicErrorControllerIntegrationTests.java
@@ -333,7 +333,7 @@ class BasicErrorControllerIntegrationTests {
 
 	private void assertErrorAttributes(Map<?, ?> content, String status, String error, Class<?> exception,
 			String message, String path) {
-		assertThat(content.get("status").toString()).as("Wrong status").isEqualTo(status);
+		assertThat(content.get("status")).as("Wrong status").hasToString(status);
 		assertThat(content.get("error")).as("Wrong error").isEqualTo(error);
 		if (exception != null) {
 			assertThat(content.get("exception")).as("Wrong exception").isEqualTo(exception.getName());

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/websocket/servlet/WebSocketMessagingAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/websocket/servlet/WebSocketMessagingAutoConfigurationTests.java
@@ -121,7 +121,7 @@ class WebSocketMessagingAutoConfigurationTests {
 	void customizedConverterTypesMatchDefaultConverterTypes() {
 		List<MessageConverter> customizedConverters = getCustomizedConverters();
 		List<MessageConverter> defaultConverters = getDefaultConverters();
-		assertThat(customizedConverters.size()).isEqualTo(defaultConverters.size());
+		assertThat(customizedConverters).hasSameSizeAs(defaultConverters);
 		Iterator<MessageConverter> customizedIterator = customizedConverters.iterator();
 		Iterator<MessageConverter> defaultIterator = defaultConverters.iterator();
 		while (customizedIterator.hasNext()) {

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/env/DevToolsHomePropertiesPostProcessorTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/env/DevToolsHomePropertiesPostProcessorTests.java
@@ -152,7 +152,7 @@ class DevToolsHomePropertiesPostProcessorTests {
 		out2.close();
 		ConfigurableEnvironment environment = getPostProcessedEnvironment();
 		assertThat(environment.getProperty("abc")).isEqualTo("jkl");
-		assertThat(environment.getProperty("bar")).isEqualTo(null);
+		assertThat(environment.getProperty("bar")).isNull();
 	}
 
 	@Test
@@ -168,7 +168,7 @@ class DevToolsHomePropertiesPostProcessorTests {
 		out2.close();
 		ConfigurableEnvironment environment = getPostProcessedEnvironment();
 		assertThat(environment.getProperty("abc.xyz")).isEqualTo("def");
-		assertThat(environment.getProperty("bar")).isEqualTo(null);
+		assertThat(environment.getProperty("bar")).isNull();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/DirectorySnapshotTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/DirectorySnapshotTests.java
@@ -75,7 +75,7 @@ class DirectorySnapshotTests {
 	void equalsWhenNothingHasChanged() {
 		DirectorySnapshot updatedSnapshot = new DirectorySnapshot(this.directory);
 		assertThat(this.initialSnapshot).isEqualTo(updatedSnapshot);
-		assertThat(this.initialSnapshot.hashCode()).isEqualTo(updatedSnapshot.hashCode());
+		assertThat(this.initialSnapshot).hasSameHashCodeAs(updatedSnapshot);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/FileSnapshotTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/FileSnapshotTests.java
@@ -65,7 +65,7 @@ class FileSnapshotTests {
 		FileSnapshot snapshot1 = new FileSnapshot(file);
 		FileSnapshot snapshot2 = new FileSnapshot(fileCopy);
 		assertThat(snapshot1).isEqualTo(snapshot2);
-		assertThat(snapshot1.hashCode()).isEqualTo(snapshot2.hashCode());
+		assertThat(snapshot1).hasSameHashCodeAs(snapshot2);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/FileSystemWatcherTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/FileSystemWatcherTests.java
@@ -104,7 +104,7 @@ class FileSystemWatcherTests {
 	void sourceDirectoryMustNotBeAFile() throws IOException {
 		File file = new File(this.tempDir, "file");
 		assertThat(file.createNewFile()).isTrue();
-		assertThat(file.isFile()).isTrue();
+		assertThat(file).isFile();
 		assertThatIllegalArgumentException().isThrownBy(() -> this.watcher.addSourceDirectory(file))
 				.withMessageContaining("Directory '" + file + "' must not be a file");
 	}
@@ -137,7 +137,7 @@ class FileSystemWatcherTests {
 	@Test
 	void createSourceDirectoryAndAddFile() throws IOException {
 		File directory = new File(this.tempDir, "does/not/exist");
-		assertThat(directory.exists()).isFalse();
+		assertThat(directory).doesNotExist();
 		this.watcher.addSourceDirectory(directory);
 		this.watcher.start();
 		directory.mkdirs();
@@ -157,7 +157,7 @@ class FileSystemWatcherTests {
 		}
 		touch(new File(directory, "test2.txt"));
 		this.watcher.stopAfter(1);
-		assertThat(this.changes.size()).isEqualTo(2);
+		assertThat(this.changes).hasSize(2);
 	}
 
 	@Test
@@ -198,7 +198,7 @@ class FileSystemWatcherTests {
 		File file2 = touch(new File(directory2, "test.txt"));
 		this.watcher.stopAfter(1);
 		Set<ChangedFiles> change = this.changes.stream().flatMap(Set<ChangedFiles>::stream).collect(Collectors.toSet());
-		assertThat(change.size()).isEqualTo(2);
+		assertThat(change).hasSize(2);
 		for (ChangedFiles changedFiles : change) {
 			if (changedFiles.getSourceDirectory().equals(directory1)) {
 				ChangedFile file = new ChangedFile(directory1, file1, Type.ADD);

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/livereload/ConnectionOutputStreamTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/livereload/ConnectionOutputStreamTests.java
@@ -54,7 +54,7 @@ class ConnectionOutputStreamTests {
 		expected += "Content-Length: 2\r\n";
 		expected += "Connection: close\r\n\r\n";
 		expected += "hi";
-		assertThat(out.toString()).isEqualTo(expected);
+		assertThat(out).hasToString(expected);
 	}
 
 	@Test
@@ -66,7 +66,7 @@ class ConnectionOutputStreamTests {
 		String expected = "";
 		expected += "A: a\r\n";
 		expected += "B: b\r\n\r\n";
-		assertThat(out.toString()).isEqualTo(expected);
+		assertThat(out).hasToString(expected);
 	}
 
 }

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/livereload/LiveReloadServerTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/livereload/LiveReloadServerTests.java
@@ -141,7 +141,7 @@ class LiveReloadServerTests {
 		LiveReloadWebSocketHandler handler = connect();
 		handler.close();
 		awaitClosedException();
-		assertThat(this.server.getClosedExceptions().size()).isGreaterThan(0);
+		assertThat(this.server.getClosedExceptions()).isNotEmpty();
 	}
 
 	private void awaitClosedException() {

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/client/ClassPathChangeUploaderTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/client/ClassPathChangeUploaderTests.java
@@ -114,7 +114,7 @@ class ClassPathChangeUploaderTests {
 			throws IOException, ClassNotFoundException {
 		ClassLoaderFiles classLoaderFiles = deserialize(request.getBodyAsBytes());
 		Collection<SourceDirectory> sourceDirectories = classLoaderFiles.getSourceDirectories();
-		assertThat(sourceDirectories.size()).isEqualTo(1);
+		assertThat(sourceDirectories).hasSize(1);
 		SourceDirectory classSourceDirectory = sourceDirectories.iterator().next();
 		assertThat(classSourceDirectory.getName()).isEqualTo(sourceDirectory.getAbsolutePath());
 		Iterator<ClassLoaderFile> classFiles = classSourceDirectory.getFiles().iterator();

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/ChangeableUrlsTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/ChangeableUrlsTests.java
@@ -48,7 +48,7 @@ class ChangeableUrlsTests {
 	@Test
 	void directoryUrl() throws Exception {
 		URL url = makeUrl("myproject");
-		assertThat(ChangeableUrls.fromUrls(url).size()).isEqualTo(1);
+		assertThat(ChangeableUrls.fromUrls(url).size()).isOne();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/ClassLoaderFilesResourcePatternResolverTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/ClassLoaderFilesResourcePatternResolverTests.java
@@ -71,7 +71,7 @@ class ClassLoaderFilesResourcePatternResolverTests {
 	@Test
 	void getResourceShouldReturnResource() {
 		Resource resource = this.resolver.getResource("index.html");
-		assertThat(resource).isNotNull().isInstanceOf(ClassPathResource.class);
+		assertThat(resource).isInstanceOf(ClassPathResource.class);
 	}
 
 	@Test
@@ -79,7 +79,7 @@ class ClassLoaderFilesResourcePatternResolverTests {
 		GenericWebApplicationContext context = new GenericWebApplicationContext(new MockServletContext());
 		this.resolver = new ClassLoaderFilesResourcePatternResolver(context, this.files);
 		Resource resource = this.resolver.getResource("index.html");
-		assertThat(resource).isNotNull().isInstanceOf(ServletContextResource.class);
+		assertThat(resource).isInstanceOf(ServletContextResource.class);
 	}
 
 	@Test
@@ -87,7 +87,7 @@ class ClassLoaderFilesResourcePatternResolverTests {
 		File file = createFile(directory, "name.class");
 		this.files.addFile(directory.getName(), "name.class", new ClassLoaderFile(Kind.DELETED, null));
 		Resource resource = this.resolver.getResource("file:" + file.getAbsolutePath());
-		assertThat(resource).isNotNull().isInstanceOf(DeletedClassLoaderFileResource.class);
+		assertThat(resource).isInstanceOf(DeletedClassLoaderFileResource.class);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/DefaultRestartInitializerTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/DefaultRestartInitializerTests.java
@@ -107,7 +107,7 @@ class DefaultRestartInitializerTests {
 		StackTraceElement element = new StackTraceElement(s, "someMethod", "someFile", 123);
 		given(thread.getStackTrace()).willReturn(new StackTraceElement[] { element });
 		given(thread.getContextClassLoader()).willReturn(classLoader);
-		assertThat(initializer.getInitialUrls(thread)).isEqualTo(null);
+		assertThat(initializer.getInitialUrls(thread)).isNull();
 	}
 
 	static class MockAppClassLoader extends ClassLoader {

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/RestartScopeInitializerTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/RestartScopeInitializerTests.java
@@ -49,7 +49,7 @@ class RestartScopeInitializerTests {
 		context.close();
 		context = runApplication();
 		context.close();
-		assertThat(createCount.get()).isEqualTo(1);
+		assertThat(createCount.get()).isOne();
 		assertThat(refreshCount.get()).isEqualTo(2);
 	}
 

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/classloader/ClassLoaderFilesTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/classloader/ClassLoaderFilesTests.java
@@ -85,8 +85,8 @@ class ClassLoaderFilesTests {
 		this.files.addFile("a", "myfile", file1);
 		this.files.addFile("b", "myfile", file2);
 		assertThat(this.files.getFile("myfile")).isEqualTo(file2);
-		assertThat(this.files.getOrCreateSourceDirectory("a").getFiles().size()).isEqualTo(0);
-		assertThat(this.files.getOrCreateSourceDirectory("b").getFiles().size()).isEqualTo(1);
+		assertThat(this.files.getOrCreateSourceDirectory("a").getFiles()).isEmpty();
+		assertThat(this.files.getOrCreateSourceDirectory("b").getFiles()).hasSize(1);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/classloader/RestartClassLoaderTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/classloader/RestartClassLoaderTests.java
@@ -129,7 +129,7 @@ class RestartClassLoaderTests {
 	@Test
 	void getResourcesFiltersDuplicates() throws Exception {
 		List<URL> resources = toList(this.reloadClassLoader.getResources(PACKAGE_PATH + "/Sample.txt"));
-		assertThat(resources.size()).isEqualTo(1);
+		assertThat(resources).hasSize(1);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/tunnel/client/HttpTunnelConnectionTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/tunnel/client/HttpTunnelConnectionTests.java
@@ -121,7 +121,7 @@ class HttpTunnelConnectionTests {
 		write(channel, "hello");
 		write(channel, "1+1");
 		write(channel, "1+2");
-		assertThat(this.incomingData.toString()).isEqualTo("hi=2=3");
+		assertThat(this.incomingData).hasToString("hi=2=3");
 	}
 
 	@Test
@@ -132,8 +132,8 @@ class HttpTunnelConnectionTests {
 		this.requestFactory.willRespond("hi");
 		TunnelChannel channel = openTunnel(true);
 		write(channel, "hello");
-		assertThat(this.incomingData.toString()).isEqualTo("hi");
-		assertThat(this.requestFactory.getExecutedRequests().size()).isGreaterThan(10);
+		assertThat(this.incomingData).hasToString("hi");
+		assertThat(this.requestFactory.getExecutedRequests()).hasSizeGreaterThan(10);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/tunnel/client/TunnelClientTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/tunnel/client/TunnelClientTests.java
@@ -78,7 +78,7 @@ class TunnelClientTests {
 		channel.close();
 		client.getServerThread().stopAcceptingConnections();
 		client.getServerThread().join(2000);
-		assertThat(this.tunnelConnection.getOpenedTimes()).isEqualTo(1);
+		assertThat(this.tunnelConnection.getOpenedTimes()).isOne();
 		assertThat(this.tunnelConnection.isOpen()).isFalse();
 	}
 

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/tunnel/payload/HttpTunnelPayloadTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/tunnel/payload/HttpTunnelPayloadTests.java
@@ -63,7 +63,7 @@ class HttpTunnelPayloadTests {
 	@Test
 	void getSequence() {
 		HttpTunnelPayload payload = new HttpTunnelPayload(1, ByteBuffer.allocate(1));
-		assertThat(payload.getSequence()).isEqualTo(1L);
+		assertThat(payload.getSequence()).isOne();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/tunnel/server/HttpTunnelServerTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/tunnel/server/HttpTunnelServerTests.java
@@ -283,7 +283,7 @@ class HttpTunnelServerTests {
 		connection.waitForResponse();
 		connection.respond(HttpStatus.I_AM_A_TEAPOT);
 		assertThat(this.servletResponse.getStatus()).isEqualTo(418);
-		assertThat(this.servletResponse.getContentLength()).isEqualTo(0);
+		assertThat(this.servletResponse.getContentLength()).isZero();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/OverrideAutoConfigurationContextCustomizerFactoryTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/OverrideAutoConfigurationContextCustomizerFactoryTests.java
@@ -53,7 +53,7 @@ class OverrideAutoConfigurationContextCustomizerFactoryTests {
 	void hashCodeAndEquals() {
 		ContextCustomizer customizer1 = this.factory.createContextCustomizer(WithAnnotationEnabledFalse.class, null);
 		ContextCustomizer customizer2 = this.factory.createContextCustomizer(WithSameAnnotation.class, null);
-		assertThat(customizer1.hashCode()).isEqualTo(customizer2.hashCode());
+		assertThat(customizer1).hasSameHashCodeAs(customizer2);
 		assertThat(customizer1).isEqualTo(customizer1).isEqualTo(customizer2);
 	}
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/ldap/DataLdapTestIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/ldap/DataLdapTestIntegrationTests.java
@@ -55,7 +55,7 @@ class DataLdapTestIntegrationTests {
 	void testRepository() {
 		LdapQuery ldapQuery = LdapQueryBuilder.query().where("cn").is("Bob Smith");
 		Optional<ExampleEntry> entry = this.exampleRepository.findOne(ldapQuery);
-		assertThat(entry.isPresent()).isTrue();
+		assertThat(entry).isPresent();
 		assertThat(entry.get().getDn())
 				.isEqualTo(LdapUtils.newLdapName("cn=Bob Smith,ou=company1,c=Sweden,dc=spring,dc=org"));
 		assertThat(this.ldapTemplate.findOne(ldapQuery, ExampleEntry.class).getDn())

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/neo4j/DataNeo4jTestIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/neo4j/DataNeo4jTestIntegrationTests.java
@@ -69,7 +69,7 @@ class DataNeo4jTestIntegrationTests {
 		assertThat(exampleGraph.getId()).isNull();
 		ExampleGraph savedGraph = this.exampleRepository.save(exampleGraph);
 		assertThat(savedGraph.getId()).isNotNull();
-		assertThat(this.neo4jTemplate.count(ExampleGraph.class)).isEqualTo(1);
+		assertThat(this.neo4jTemplate.count(ExampleGraph.class)).isOne();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/filter/TypeExcludeFiltersContextCustomizerFactoryTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/filter/TypeExcludeFiltersContextCustomizerFactoryTests.java
@@ -68,7 +68,7 @@ class TypeExcludeFiltersContextCustomizerFactoryTests {
 		ContextCustomizer customizer1 = this.factory.createContextCustomizer(WithExcludeFilters.class, null);
 		ContextCustomizer customizer2 = this.factory.createContextCustomizer(WithSameExcludeFilters.class, null);
 		ContextCustomizer customizer3 = this.factory.createContextCustomizer(WithDifferentExcludeFilters.class, null);
-		assertThat(customizer1.hashCode()).isEqualTo(customizer2.hashCode());
+		assertThat(customizer1).hasSameHashCodeAs(customizer2);
 		assertThat(customizer1).isEqualTo(customizer1).isEqualTo(customizer2).isNotEqualTo(customizer3);
 	}
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jdbc/JdbcTestIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jdbc/JdbcTestIntegrationTests.java
@@ -60,7 +60,7 @@ class JdbcTestIntegrationTests {
 		Collection<ExampleEntity> entities = repository.findAll();
 		assertThat(entities).hasSize(1);
 		ExampleEntity entity = entities.iterator().next();
-		assertThat(entity.getId()).isEqualTo(1);
+		assertThat(entity.getId()).isOne();
 		assertThat(entity.getName()).isEqualTo("John");
 	}
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/properties/PropertyMappingContextCustomizerFactoryTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/properties/PropertyMappingContextCustomizerFactoryTests.java
@@ -73,7 +73,7 @@ class PropertyMappingContextCustomizerFactoryTests {
 		ContextCustomizer customizer1 = this.factory.createContextCustomizer(TypeMapping.class, null);
 		ContextCustomizer customizer2 = this.factory.createContextCustomizer(AttributeMapping.class, null);
 		ContextCustomizer customizer3 = this.factory.createContextCustomizer(OtherMapping.class, null);
-		assertThat(customizer1.hashCode()).isEqualTo(customizer2.hashCode());
+		assertThat(customizer1).hasSameHashCodeAs(customizer2);
 		assertThat(customizer1).isEqualTo(customizer1).isEqualTo(customizer2).isNotEqualTo(customizer3);
 	}
 

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/AbstractSpringBootTestEmbeddedReactiveWebEnvironmentTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/AbstractSpringBootTestEmbeddedReactiveWebEnvironmentTests.java
@@ -68,7 +68,7 @@ abstract class AbstractSpringBootTestEmbeddedReactiveWebEnvironmentTests {
 
 	@Test
 	void runAndTestHttpEndpoint() {
-		assertThat(this.port).isNotEqualTo(8080).isNotEqualTo(0);
+		assertThat(this.port).isNotEqualTo(8080).isNotZero();
 		WebTestClient.bindToServer().baseUrl("http://localhost:" + this.port).responseTimeout(Duration.ofMinutes(5))
 				.build().get().uri("/").exchange().expectBody(String.class).isEqualTo("Hello World");
 	}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/AbstractSpringBootTestWebServerWebEnvironmentTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/AbstractSpringBootTestWebServerWebEnvironmentTests.java
@@ -70,7 +70,7 @@ abstract class AbstractSpringBootTestWebServerWebEnvironmentTests {
 
 	@Test
 	void runAndTestHttpEndpoint() {
-		assertThat(this.port).isNotEqualTo(8080).isNotEqualTo(0);
+		assertThat(this.port).isNotEqualTo(8080).isNotZero();
 		String body = new RestTemplate().getForObject("http://localhost:" + this.port + "/", String.class);
 		assertThat(body).isEqualTo("Hello World");
 	}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/ImportsContextCustomizerFactoryTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/ImportsContextCustomizerFactoryTests.java
@@ -68,8 +68,8 @@ class ImportsContextCustomizerFactoryTests {
 		ContextCustomizer customizer3 = this.factory.createContextCustomizer(TestWithImportAndMetaImport.class, null);
 		ContextCustomizer customizer4 = this.factory.createContextCustomizer(TestWithSameImportAndMetaImport.class,
 				null);
-		assertThat(customizer1.hashCode()).isEqualTo(customizer1.hashCode());
-		assertThat(customizer1.hashCode()).isEqualTo(customizer2.hashCode());
+		assertThat(customizer1).hasSameHashCodeAs(customizer1);
+		assertThat(customizer1).hasSameHashCodeAs(customizer2);
 		assertThat(customizer1).isEqualTo(customizer1).isEqualTo(customizer2).isNotEqualTo(customizer3);
 		assertThat(customizer3).isEqualTo(customizer4);
 	}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootContextLoaderTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootContextLoaderTests.java
@@ -256,8 +256,8 @@ class SpringBootContextLoaderTests {
 	}
 
 	private void assertKey(Map<String, Object> actual, String key, Object value) {
-		assertThat(actual.containsKey(key)).as("Key '" + key + "' not found").isTrue();
-		assertThat(actual.get(key)).isEqualTo(value);
+		assertThat(actual).as("Key '" + key + "' not found").containsKey(key);
+		assertThat(actual).containsEntry(key, value);
 	}
 
 	@SpringBootTest(properties = { "key=myValue", "anotherKey:anotherValue" }, classes = Config.class)

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/TestConfigurationTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/TestConfigurationTests.java
@@ -35,14 +35,14 @@ class TestConfigurationTests {
 	void proxyBeanMethodsIsEnabledByDefault() {
 		AnnotationAttributes attributes = AnnotatedElementUtils
 				.getMergedAnnotationAttributes(DefaultTestConfiguration.class, Configuration.class);
-		assertThat(attributes.get("proxyBeanMethods")).isEqualTo(true);
+		assertThat(attributes).containsEntry("proxyBeanMethods", true);
 	}
 
 	@Test
 	void proxyBeanMethodsCanBeDisabled() {
 		AnnotationAttributes attributes = AnnotatedElementUtils
 				.getMergedAnnotationAttributes(NoBeanMethodProxyingTestConfiguration.class, Configuration.class);
-		assertThat(attributes.get("proxyBeanMethods")).isEqualTo(false);
+		assertThat(attributes).containsEntry("proxyBeanMethods", false);
 	}
 
 	@TestConfiguration

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/assertj/ApplicationContextAssertProviderTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/assertj/ApplicationContextAssertProviderTests.java
@@ -178,7 +178,7 @@ class ApplicationContextAssertProviderTests {
 	@Test
 	void toStringWhenContextFailsToStartShouldReturnSimpleString() {
 		ApplicationContextAssertProvider<ApplicationContext> context = get(this.startupFailureSupplier);
-		assertThat(context.toString()).isEqualTo("Unstarted application context "
+		assertThat(context).hasToString("Unstarted application context "
 				+ "org.springframework.context.ApplicationContext[startupFailure=java.lang.RuntimeException]");
 	}
 

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/runner/AbstractApplicationContextRunnerTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/runner/AbstractApplicationContextRunnerTests.java
@@ -71,19 +71,19 @@ abstract class AbstractApplicationContextRunnerTests<T extends AbstractApplicati
 	@Test
 	void runWithSystemPropertiesShouldSetAndRemoveProperties() {
 		String key = "test." + UUID.randomUUID();
-		assertThat(System.getProperties().containsKey(key)).isFalse();
+		assertThat(System.getProperties()).doesNotContainKey(key);
 		get().withSystemProperties(key + "=value")
 				.run((context) -> assertThat(System.getProperties()).containsEntry(key, "value"));
-		assertThat(System.getProperties().containsKey(key)).isFalse();
+		assertThat(System.getProperties()).doesNotContainKey(key);
 	}
 
 	@Test
 	void runWithSystemPropertiesWhenContextFailsShouldRemoveProperties() {
 		String key = "test." + UUID.randomUUID();
-		assertThat(System.getProperties().containsKey(key)).isFalse();
+		assertThat(System.getProperties()).doesNotContainKey(key);
 		get().withSystemProperties(key + "=value").withUserConfiguration(FailingConfig.class)
 				.run((context) -> assertThat(context).hasFailed());
-		assertThat(System.getProperties().containsKey(key)).isFalse();
+		assertThat(System.getProperties()).doesNotContainKey(key);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/json/JacksonTesterIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/json/JacksonTesterIntegrationTests.java
@@ -117,7 +117,7 @@ class JacksonTesterIntegrationTests {
 		ObjectContent<ExampleObjectWithView> content = this.jsonWithView.forView(ExampleObjectWithView.TestView.class)
 				.read(resource);
 		assertThat(content.getObject().getName()).isEqualTo("Spring");
-		assertThat(content.getObject().getAge()).isEqualTo(0);
+		assertThat(content.getObject().getAge()).isZero();
 	}
 
 	@Test
@@ -127,7 +127,7 @@ class JacksonTesterIntegrationTests {
 		ObjectContent<ExampleObjectWithView> content = this.jsonWithView.forView(ExampleObjectWithView.TestView.class)
 				.read(reader);
 		assertThat(content.getObject().getName()).isEqualTo("Spring");
-		assertThat(content.getObject().getAge()).isEqualTo(0);
+		assertThat(content.getObject().getAge()).isZero();
 	}
 
 }

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockBeanContextCachingTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockBeanContextCachingTests.java
@@ -66,7 +66,7 @@ class MockBeanContextCachingTests {
 	@Test
 	void whenThereIsANormalBeanAndAMockBeanThenTwoContextsAreCreated() {
 		bootstrapContext(TestClass.class);
-		assertThat(this.contextCache.size()).isEqualTo(1);
+		assertThat(this.contextCache.size()).isOne();
 		bootstrapContext(MockedBeanTestClass.class);
 		assertThat(this.contextCache.size()).isEqualTo(2);
 	}
@@ -74,9 +74,9 @@ class MockBeanContextCachingTests {
 	@Test
 	void whenThereIsTheSameMockedBeanInEachTestClassThenOneContextIsCreated() {
 		bootstrapContext(MockedBeanTestClass.class);
-		assertThat(this.contextCache.size()).isEqualTo(1);
+		assertThat(this.contextCache.size()).isOne();
 		bootstrapContext(AnotherMockedBeanTestClass.class);
-		assertThat(this.contextCache.size()).isEqualTo(1);
+		assertThat(this.contextCache.size()).isOne();
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockBeanOnContextHierarchyIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockBeanOnContextHierarchyIntegrationTests.java
@@ -52,8 +52,8 @@ class MockBeanOnContextHierarchyIntegrationTests {
 		ApplicationContext context = this.childConfig.getContext();
 		ApplicationContext parentContext = context.getParent();
 		assertThat(parentContext.getBeanNamesForType(ExampleService.class)).hasSize(1);
-		assertThat(parentContext.getBeanNamesForType(ExampleServiceCaller.class)).hasSize(0);
-		assertThat(context.getBeanNamesForType(ExampleService.class)).hasSize(0);
+		assertThat(parentContext.getBeanNamesForType(ExampleServiceCaller.class)).isEmpty();
+		assertThat(context.getBeanNamesForType(ExampleService.class)).isEmpty();
 		assertThat(context.getBeanNamesForType(ExampleServiceCaller.class)).hasSize(1);
 		assertThat(context.getBean(ExampleService.class)).isNotNull();
 		assertThat(context.getBean(ExampleServiceCaller.class)).isNotNull();

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockBeanWithAopProxyTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockBeanWithAopProxyTests.java
@@ -56,7 +56,7 @@ class MockBeanWithAopProxyTests {
 	void verifyShouldUseProxyTarget() {
 		given(this.dateService.getDate(false)).willReturn(1L);
 		Long d1 = this.dateService.getDate(false);
-		assertThat(d1).isEqualTo(1L);
+		assertThat(d1).isOne();
 		given(this.dateService.getDate(false)).willReturn(2L);
 		Long d2 = this.dateService.getDate(false);
 		assertThat(d2).isEqualTo(2L);

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockDefinitionTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockDefinitionTests.java
@@ -82,7 +82,7 @@ class MockDefinitionTests {
 		MockCreationSettings<?> settings = Mockito.mockingDetails(mock).getMockCreationSettings();
 		assertThat(mock).isInstanceOf(ExampleService.class);
 		assertThat(mock).isInstanceOf(ExampleExtraInterface.class);
-		assertThat(settings.getMockName().toString()).isEqualTo("name");
+		assertThat(settings.getMockName()).hasToString("name");
 		assertThat(settings.getDefaultAnswer()).isEqualTo(Answers.RETURNS_SMART_NULLS);
 		assertThat(settings.isSerializable()).isTrue();
 		assertThat(MockReset.get(mock)).isEqualTo(MockReset.BEFORE);

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoContextCustomizerFactoryTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoContextCustomizerFactoryTests.java
@@ -51,11 +51,9 @@ class MockitoContextCustomizerFactoryTests {
 		assertThat(customizer).isNotNull();
 		ContextCustomizer different = this.factory.createContextCustomizer(WithDifferentMockBeanAnnotation.class, null);
 		assertThat(different).isNotNull();
-		assertThat(customizer.hashCode()).isEqualTo(same.hashCode());
+		assertThat(customizer).hasSameHashCodeAs(same);
 		assertThat(customizer.hashCode()).isNotEqualTo(different.hashCode());
-		assertThat(customizer).isEqualTo(customizer);
-		assertThat(customizer).isEqualTo(same);
-		assertThat(customizer).isNotEqualTo(different);
+		assertThat(customizer).isEqualTo(customizer).isEqualTo(same).isNotEqualTo(different);
 	}
 
 	static class NoMockBeanAnnotation {

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoContextCustomizerTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/MockitoContextCustomizerTests.java
@@ -45,7 +45,7 @@ class MockitoContextCustomizerTests {
 		MockitoContextCustomizer c1 = new MockitoContextCustomizer(NO_DEFINITIONS);
 		MockitoContextCustomizer c2 = new MockitoContextCustomizer(new LinkedHashSet<>(Arrays.asList(d1, d2)));
 		MockitoContextCustomizer c3 = new MockitoContextCustomizer(new LinkedHashSet<>(Arrays.asList(d2, d1)));
-		assertThat(c2.hashCode()).isEqualTo(c3.hashCode());
+		assertThat(c2).hasSameHashCodeAs(c3);
 		assertThat(c1).isEqualTo(c1).isNotEqualTo(c2);
 		assertThat(c2).isEqualTo(c2).isEqualTo(c3).isNotEqualTo(c1);
 	}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/QualifierDefinitionTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/QualifierDefinitionTests.java
@@ -108,9 +108,9 @@ class QualifierDefinitionTests {
 				.forElement(ReflectionUtils.findField(ConfigA.class, "customQualifier"));
 		QualifierDefinition customQualifier2 = QualifierDefinition
 				.forElement(ReflectionUtils.findField(ConfigB.class, "customQualifier"));
-		assertThat(directQualifier1.hashCode()).isEqualTo(directQualifier2.hashCode());
-		assertThat(differentDirectQualifier1.hashCode()).isEqualTo(differentDirectQualifier2.hashCode());
-		assertThat(customQualifier1.hashCode()).isEqualTo(customQualifier2.hashCode());
+		assertThat(directQualifier1).hasSameHashCodeAs(directQualifier2);
+		assertThat(differentDirectQualifier1).hasSameHashCodeAs(differentDirectQualifier2);
+		assertThat(customQualifier1).hasSameHashCodeAs(customQualifier2);
 		assertThat(differentDirectQualifier1).isEqualTo(differentDirectQualifier1).isEqualTo(differentDirectQualifier2)
 				.isNotEqualTo(directQualifier2);
 		assertThat(directQualifier1).isEqualTo(directQualifier1).isEqualTo(directQualifier2)

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanOnContextHierarchyIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanOnContextHierarchyIntegrationTests.java
@@ -53,8 +53,8 @@ class SpyBeanOnContextHierarchyIntegrationTests {
 		ApplicationContext context = this.childConfig.getContext();
 		ApplicationContext parentContext = context.getParent();
 		assertThat(parentContext.getBeanNamesForType(ExampleService.class)).hasSize(1);
-		assertThat(parentContext.getBeanNamesForType(ExampleServiceCaller.class)).hasSize(0);
-		assertThat(context.getBeanNamesForType(ExampleService.class)).hasSize(0);
+		assertThat(parentContext.getBeanNamesForType(ExampleServiceCaller.class)).isEmpty();
+		assertThat(context.getBeanNamesForType(ExampleService.class)).isEmpty();
 		assertThat(context.getBeanNamesForType(ExampleServiceCaller.class)).hasSize(1);
 		assertThat(context.getBean(ExampleService.class)).isNotNull();
 		assertThat(context.getBean(ExampleServiceCaller.class)).isNotNull();

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanOnTestFieldForMultipleExistingBeansWithOnePrimaryIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanOnTestFieldForMultipleExistingBeansWithOnePrimaryIntegrationTests.java
@@ -50,8 +50,7 @@ class SpyBeanOnTestFieldForMultipleExistingBeansWithOnePrimaryIntegrationTests {
 	@Test
 	void testSpying() {
 		assertThat(this.caller.sayGreeting()).isEqualTo("I say two");
-		assertThat(Mockito.mockingDetails(this.spy).getMockCreationSettings().getMockName().toString())
-				.isEqualTo("two");
+		assertThat(Mockito.mockingDetails(this.spy).getMockCreationSettings().getMockName()).hasToString("two");
 		then(this.spy).should().greeting();
 	}
 

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanWithNameOnTestFieldForMultipleExistingBeansTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyBeanWithNameOnTestFieldForMultipleExistingBeansTests.java
@@ -45,7 +45,7 @@ class SpyBeanWithNameOnTestFieldForMultipleExistingBeansTests {
 	void testSpying() {
 		MockingDetails mockingDetails = Mockito.mockingDetails(this.spy);
 		assertThat(mockingDetails.isSpy()).isTrue();
-		assertThat(mockingDetails.getMockCreationSettings().getMockName().toString()).isEqualTo("two");
+		assertThat(mockingDetails.getMockCreationSettings().getMockName()).hasToString("two");
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyDefinitionTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/mock/mockito/SpyDefinitionTests.java
@@ -72,7 +72,7 @@ class SpyDefinitionTests {
 		RealExampleService spy = definition.createSpy(new RealExampleService("hello"));
 		MockCreationSettings<?> settings = Mockito.mockingDetails(spy).getMockCreationSettings();
 		assertThat(spy).isInstanceOf(ExampleService.class);
-		assertThat(settings.getMockName().toString()).isEqualTo("name");
+		assertThat(settings.getMockName()).hasToString("name");
 		assertThat(settings.getDefaultAnswer()).isEqualTo(Answers.CALLS_REAL_METHODS);
 		assertThat(MockReset.get(spy)).isEqualTo(MockReset.BEFORE);
 	}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/OutputCaptureTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/OutputCaptureTests.java
@@ -90,28 +90,28 @@ class OutputCaptureTests {
 		System.out.print("A");
 		this.output.pop();
 		System.out.print("B");
-		assertThat(this.systemOut.toString()).isEqualTo("AB");
+		assertThat(this.systemOut).hasToString("AB");
 	}
 
 	@Test
 	void captureAlsoWritesToSystemOut() {
 		this.output.push();
 		System.out.print("A");
-		assertThat(this.systemOut.toString()).isEqualTo("A");
+		assertThat(this.systemOut).hasToString("A");
 	}
 
 	@Test
 	void captureAlsoWritesToSystemErr() {
 		this.output.push();
 		System.err.print("A");
-		assertThat(this.systemErr.toString()).isEqualTo("A");
+		assertThat(this.systemErr).hasToString("A");
 	}
 
 	@Test
 	void lengthReturnsCapturedLength() {
 		this.output.push();
 		System.out.print("ABC");
-		assertThat(this.output.length()).isEqualTo(3);
+		assertThat(this.output).hasSize(3);
 	}
 
 	@Test
@@ -137,7 +137,7 @@ class OutputCaptureTests {
 	@Test
 	void toStringReturnsAllCapturedOutput() {
 		pushAndPrint();
-		assertThat(this.output.toString()).isEqualTo("ABC");
+		assertThat(this.output).hasToString("ABC");
 	}
 
 	@Test
@@ -158,7 +158,7 @@ class OutputCaptureTests {
 		for (int i = 0; i < 10; i++) {
 			assertThat(this.output.getAll()).isEqualTo("ABC");
 		}
-		assertThat(this.output.buildCount).isEqualTo(1);
+		assertThat(this.output.buildCount).isOne();
 		System.out.print("X");
 		assertThat(this.output.getAll()).isEqualTo("ABCX");
 		assertThat(this.output.buildCount).isEqualTo(2);
@@ -170,7 +170,7 @@ class OutputCaptureTests {
 		for (int i = 0; i < 10; i++) {
 			assertThat(this.output.getOut()).isEqualTo("AC");
 		}
-		assertThat(this.output.buildCount).isEqualTo(1);
+		assertThat(this.output.buildCount).isOne();
 		System.out.print("X");
 		assertThat(this.output.getOut()).isEqualTo("ACX");
 		assertThat(this.output.buildCount).isEqualTo(2);
@@ -182,7 +182,7 @@ class OutputCaptureTests {
 		for (int i = 0; i < 10; i++) {
 			assertThat(this.output.getErr()).isEqualTo("B");
 		}
-		assertThat(this.output.buildCount).isEqualTo(1);
+		assertThat(this.output.buildCount).isOne();
 		System.err.print("X");
 		assertThat(this.output.getErr()).isEqualTo("BX");
 		assertThat(this.output.buildCount).isEqualTo(2);

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/SpringBootTestRandomPortEnvironmentPostProcessorTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/SpringBootTestRandomPortEnvironmentPostProcessorTests.java
@@ -106,7 +106,7 @@ class SpringBootTestRandomPortEnvironmentPostProcessorTests {
 		this.propertySources.addLast(otherSource);
 		this.postProcessor.postProcessEnvironment(this.environment, null);
 		assertThat(this.environment.getProperty("server.port")).isEqualTo("0");
-		assertThat(this.environment.getProperty("management.server.port")).isEqualTo("");
+		assertThat(this.environment.getProperty("management.server.port")).isEmpty();
 	}
 
 	@Test
@@ -118,7 +118,7 @@ class SpringBootTestRandomPortEnvironmentPostProcessorTests {
 				.addLast(new MapPropertySource("other", Collections.singletonMap("management.server.port", "8080")));
 		this.postProcessor.postProcessEnvironment(this.environment, null);
 		assertThat(this.environment.getProperty("server.port")).isEqualTo("0");
-		assertThat(this.environment.getProperty("management.server.port")).isEqualTo("");
+		assertThat(this.environment.getProperty("management.server.port")).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/TestRestTemplateTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/TestRestTemplateTests.java
@@ -120,7 +120,7 @@ class TestRestTemplateTests {
 
 	@Test
 	void getRootUriRootUriNotSet() {
-		assertThat(new TestRestTemplate().getRootUri()).isEqualTo("");
+		assertThat(new TestRestTemplate().getRootUri()).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/ApiVersionTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/ApiVersionTests.java
@@ -53,7 +53,7 @@ class ApiVersionTests {
 	@Test
 	void parseReturnsVersion() {
 		ApiVersion version = ApiVersion.parse("1.2");
-		assertThat(version.getMajor()).isEqualTo(1);
+		assertThat(version.getMajor()).isOne();
 		assertThat(version.getMinor()).isEqualTo(2);
 	}
 
@@ -111,7 +111,7 @@ class ApiVersionTests {
 
 	@Test
 	void toStringReturnsString() {
-		assertThat(ApiVersion.parse("1.2").toString()).isEqualTo("1.2");
+		assertThat(ApiVersion.parse("1.2")).hasToString("1.2");
 	}
 
 	@Test
@@ -119,7 +119,7 @@ class ApiVersionTests {
 		ApiVersion v12a = ApiVersion.parse("1.2");
 		ApiVersion v12b = ApiVersion.parse("1.2");
 		ApiVersion v13 = ApiVersion.parse("1.3");
-		assertThat(v12a.hashCode()).isEqualTo(v12b.hashCode());
+		assertThat(v12a).hasSameHashCodeAs(v12b);
 		assertThat(v12a).isEqualTo(v12a).isEqualTo(v12b).isNotEqualTo(v13);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/ApiVersionsTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/ApiVersionsTests.java
@@ -70,12 +70,12 @@ class ApiVersionsTests {
 	@Test
 	void createFromRange() {
 		ApiVersions versions = ApiVersions.of(1, IntStream.rangeClosed(2, 7));
-		assertThat(versions.toString()).isEqualTo("1.2,1.3,1.4,1.5,1.6,1.7");
+		assertThat(versions).hasToString("1.2,1.3,1.4,1.5,1.6,1.7");
 	}
 
 	@Test
 	void toStringReturnsString() {
-		assertThat(ApiVersions.parse("1.1", "2.2", "3.3").toString()).isEqualTo("1.1,2.2,3.3");
+		assertThat(ApiVersions.parse("1.1", "2.2", "3.3")).hasToString("1.1,2.2,3.3");
 	}
 
 	@Test
@@ -83,7 +83,7 @@ class ApiVersionsTests {
 		ApiVersions v12a = ApiVersions.parse("1.2", "2.3");
 		ApiVersions v12b = ApiVersions.parse("1.2", "2.3");
 		ApiVersions v13 = ApiVersions.parse("1.3", "2.4");
-		assertThat(v12a.hashCode()).isEqualTo(v12b.hashCode());
+		assertThat(v12a).hasSameHashCodeAs(v12b);
 		assertThat(v12a).isEqualTo(v12a).isEqualTo(v12b).isNotEqualTo(v13);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildOwnerTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildOwnerTests.java
@@ -41,7 +41,7 @@ class BuildOwnerTests {
 		BuildOwner owner = BuildOwner.fromEnv(env);
 		assertThat(owner.getUid()).isEqualTo(123);
 		assertThat(owner.getGid()).isEqualTo(456);
-		assertThat(owner.toString()).isEqualTo("123/456");
+		assertThat(owner).hasToString("123/456");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildRequestTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildRequestTests.java
@@ -58,8 +58,8 @@ class BuildRequestTests {
 		File jarFile = new File(this.tempDir, "my-app-0.0.1.jar");
 		writeTestJarFile(jarFile);
 		BuildRequest request = BuildRequest.forJarFile(jarFile);
-		assertThat(request.getName().toString()).isEqualTo("docker.io/library/my-app:0.0.1");
-		assertThat(request.getBuilder().toString()).isEqualTo("docker.io/" + BuildRequest.DEFAULT_BUILDER_IMAGE_NAME);
+		assertThat(request.getName()).hasToString("docker.io/library/my-app:0.0.1");
+		assertThat(request.getBuilder()).hasToString("docker.io/" + BuildRequest.DEFAULT_BUILDER_IMAGE_NAME);
 		assertThat(request.getApplicationContent(Owner.ROOT)).satisfies(this::hasExpectedJarContent);
 		assertThat(request.getEnv()).isEmpty();
 	}
@@ -69,8 +69,8 @@ class BuildRequestTests {
 		File jarFile = new File(this.tempDir, "my-app-0.0.1.jar");
 		writeTestJarFile(jarFile);
 		BuildRequest request = BuildRequest.forJarFile(ImageReference.of("test-app"), jarFile);
-		assertThat(request.getName().toString()).isEqualTo("docker.io/library/test-app:latest");
-		assertThat(request.getBuilder().toString()).isEqualTo("docker.io/" + BuildRequest.DEFAULT_BUILDER_IMAGE_NAME);
+		assertThat(request.getName()).hasToString("docker.io/library/test-app:latest");
+		assertThat(request.getBuilder()).hasToString("docker.io/" + BuildRequest.DEFAULT_BUILDER_IMAGE_NAME);
 		assertThat(request.getApplicationContent(Owner.ROOT)).satisfies(this::hasExpectedJarContent);
 		assertThat(request.getEnv()).isEmpty();
 	}
@@ -98,14 +98,14 @@ class BuildRequestTests {
 	void withBuilderUpdatesBuilder() throws IOException {
 		BuildRequest request = BuildRequest.forJarFile(writeTestJarFile("my-app-0.0.1.jar"))
 				.withBuilder(ImageReference.of("spring/builder"));
-		assertThat(request.getBuilder().toString()).isEqualTo("docker.io/spring/builder:latest");
+		assertThat(request.getBuilder()).hasToString("docker.io/spring/builder:latest");
 	}
 
 	@Test
 	void withBuilderWhenHasDigestUpdatesBuilder() throws IOException {
 		BuildRequest request = BuildRequest.forJarFile(writeTestJarFile("my-app-0.0.1.jar")).withBuilder(ImageReference
 				.of("spring/builder@sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d"));
-		assertThat(request.getBuilder().toString()).isEqualTo(
+		assertThat(request.getBuilder()).hasToString(
 				"docker.io/spring/builder@sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d");
 	}
 
@@ -113,14 +113,14 @@ class BuildRequestTests {
 	void withRunImageUpdatesRunImage() throws IOException {
 		BuildRequest request = BuildRequest.forJarFile(writeTestJarFile("my-app-0.0.1.jar"))
 				.withRunImage(ImageReference.of("example.com/custom/run-image:latest"));
-		assertThat(request.getRunImage().toString()).isEqualTo("example.com/custom/run-image:latest");
+		assertThat(request.getRunImage()).hasToString("example.com/custom/run-image:latest");
 	}
 
 	@Test
 	void withRunImageWhenHasDigestUpdatesRunImage() throws IOException {
 		BuildRequest request = BuildRequest.forJarFile(writeTestJarFile("my-app-0.0.1.jar")).withRunImage(ImageReference
 				.of("example.com/custom/run-image@sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d"));
-		assertThat(request.getRunImage().toString()).isEqualTo(
+		assertThat(request.getRunImage()).hasToString(
 				"example.com/custom/run-image@sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d");
 	}
 
@@ -129,7 +129,7 @@ class BuildRequestTests {
 		BuildRequest request = BuildRequest.forJarFile(writeTestJarFile("my-app-0.0.1.jar"));
 		BuildRequest withCreator = request.withCreator(Creator.withVersion("1.0.0"));
 		assertThat(request.getCreator().getName()).isEqualTo("Spring Boot");
-		assertThat(request.getCreator().getVersion()).isEqualTo("");
+		assertThat(request.getCreator().getVersion()).isEmpty();
 		assertThat(withCreator.getCreator().getName()).isEqualTo("Spring Boot");
 		assertThat(withCreator.getCreator().getVersion()).isEqualTo("1.0.0");
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuilderExceptionTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuilderExceptionTests.java
@@ -31,7 +31,7 @@ class BuilderExceptionTests {
 	void create() {
 		BuilderException exception = new BuilderException("detector", 1);
 		assertThat(exception.getOperation()).isEqualTo("detector");
-		assertThat(exception.getStatusCode()).isEqualTo(1);
+		assertThat(exception.getStatusCode()).isOne();
 		assertThat(exception.getMessage()).isEqualTo("Builder lifecycle 'detector' failed with status code 1");
 	}
 
@@ -39,7 +39,7 @@ class BuilderExceptionTests {
 	void createWhenOperationIsNull() {
 		BuilderException exception = new BuilderException(null, 1);
 		assertThat(exception.getOperation()).isNull();
-		assertThat(exception.getStatusCode()).isEqualTo(1);
+		assertThat(exception.getStatusCode()).isOne();
 		assertThat(exception.getMessage()).isEqualTo("Builder failed with status code 1");
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildpackCoordinatesTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildpackCoordinatesTests.java
@@ -152,7 +152,7 @@ class BuildpackCoordinatesTests extends AbstractJsonTests {
 		BuildpackCoordinates c1b = BuildpackCoordinates.of("id", "1");
 		BuildpackCoordinates c2 = BuildpackCoordinates.of("id", "2");
 		assertThat(c1a).isEqualTo(c1a).isEqualTo(c1b).isNotEqualTo(c2);
-		assertThat(c1a.hashCode()).isEqualTo(c1b.hashCode());
+		assertThat(c1a).hasSameHashCodeAs(c1b);
 	}
 
 	private InputStream createTomlStream(String id, String version, boolean includeStacks, boolean includeOrder) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildpackReferenceTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildpackReferenceTests.java
@@ -54,7 +54,7 @@ class BuildpackReferenceTests {
 		BuildpackReference b = BuildpackReference.of("test1");
 		BuildpackReference c = BuildpackReference.of("test2");
 		assertThat(a).isEqualTo(a).isEqualTo(b).isNotEqualTo(c);
-		assertThat(a.hashCode()).isEqualTo(b.hashCode());
+		assertThat(a).hasSameHashCodeAs(b);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/EphemeralBuilderTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/EphemeralBuilderTests.java
@@ -122,11 +122,11 @@ class EphemeralBuilderTests extends AbstractJsonTests {
 		Instant createInstant = builder.getArchive().getCreateDate();
 		OffsetDateTime createDateTime = OffsetDateTime.ofInstant(createInstant, ZoneId.of("UTC"));
 		assertThat(createDateTime.getYear()).isEqualTo(1980);
-		assertThat(createDateTime.getMonthValue()).isEqualTo(1);
-		assertThat(createDateTime.getDayOfMonth()).isEqualTo(1);
-		assertThat(createDateTime.getHour()).isEqualTo(0);
-		assertThat(createDateTime.getMinute()).isEqualTo(0);
-		assertThat(createDateTime.getSecond()).isEqualTo(1);
+		assertThat(createDateTime.getMonthValue()).isOne();
+		assertThat(createDateTime.getDayOfMonth()).isOne();
+		assertThat(createDateTime.getHour()).isZero();
+		assertThat(createDateTime.getMinute()).isZero();
+		assertThat(createDateTime.getSecond()).isOne();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/LifecycleVersionTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/LifecycleVersionTests.java
@@ -49,9 +49,9 @@ class LifecycleVersionTests {
 	@Test
 	void compareTo() {
 		LifecycleVersion v4 = LifecycleVersion.parse("0.0.4");
-		assertThat(LifecycleVersion.parse("0.0.3").compareTo(v4)).isNegative();
-		assertThat(LifecycleVersion.parse("0.0.4").compareTo(v4)).isZero();
-		assertThat(LifecycleVersion.parse("0.0.5").compareTo(v4)).isPositive();
+		assertThat(LifecycleVersion.parse("0.0.3")).isLessThan(v4);
+		assertThat(LifecycleVersion.parse("0.0.4")).isEqualByComparingTo(v4);
+		assertThat(LifecycleVersion.parse("0.0.5")).isGreaterThan(v4);
 	}
 
 	@Test
@@ -64,9 +64,9 @@ class LifecycleVersionTests {
 
 	@Test
 	void parseReturnsVersion() {
-		assertThat(LifecycleVersion.parse("1.2.3").toString()).isEqualTo("v1.2.3");
-		assertThat(LifecycleVersion.parse("1.2").toString()).isEqualTo("v1.2.0");
-		assertThat(LifecycleVersion.parse("1").toString()).isEqualTo("v1.0.0");
+		assertThat(LifecycleVersion.parse("1.2.3")).hasToString("v1.2.3");
+		assertThat(LifecycleVersion.parse("1.2")).hasToString("v1.2.0");
+		assertThat(LifecycleVersion.parse("1")).hasToString("v1.0.0");
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/StackIdTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/StackIdTests.java
@@ -58,13 +58,13 @@ class StackIdTests {
 		given(image.getConfig()).willReturn(imageConfig);
 		given(imageConfig.getLabels()).willReturn(Collections.singletonMap("io.buildpacks.stack.id", "test"));
 		StackId stackId = StackId.fromImage(image);
-		assertThat(stackId.toString()).isEqualTo("test");
+		assertThat(stackId).hasToString("test");
 	}
 
 	@Test
 	void ofCreatesStackId() {
 		StackId stackId = StackId.of("test");
-		assertThat(stackId.toString()).isEqualTo("test");
+		assertThat(stackId).hasToString("test");
 	}
 
 	@Test
@@ -72,14 +72,14 @@ class StackIdTests {
 		StackId s1 = StackId.of("a");
 		StackId s2 = StackId.of("a");
 		StackId s3 = StackId.of("b");
-		assertThat(s1.hashCode()).isEqualTo(s2.hashCode());
+		assertThat(s1).hasSameHashCodeAs(s2);
 		assertThat(s1).isEqualTo(s1).isEqualTo(s2).isNotEqualTo(s3);
 	}
 
 	@Test
 	void toStringReturnsValue() {
 		StackId stackId = StackId.of("test");
-		assertThat(stackId.toString()).isEqualTo("test");
+		assertThat(stackId).hasToString("test");
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/DockerApiTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/DockerApiTests.java
@@ -403,11 +403,11 @@ class DockerApiTests {
 			given(http().post(eq(createUri), eq("application/json"), any()))
 					.willReturn(responseOf("create-container-response.json"));
 			ContainerReference containerReference = this.api.create(config);
-			assertThat(containerReference.toString()).isEqualTo("e90e34656806");
+			assertThat(containerReference).hasToString("e90e34656806");
 			then(http()).should().post(any(), any(), this.writer.capture());
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
 			this.writer.getValue().accept(out);
-			assertThat(out.toByteArray().length).isEqualTo(config.toString().length());
+			assertThat(out.toByteArray()).hasSize(config.toString().length());
 		}
 
 		@Test
@@ -425,11 +425,11 @@ class DockerApiTests {
 			URI uploadUri = new URI(CONTAINERS_URL + "/e90e34656806/archive?path=%2F");
 			given(http().put(eq(uploadUri), eq("application/x-tar"), any())).willReturn(emptyResponse());
 			ContainerReference containerReference = this.api.create(config, content);
-			assertThat(containerReference.toString()).isEqualTo("e90e34656806");
+			assertThat(containerReference).hasToString("e90e34656806");
 			then(http()).should().post(any(), any(), this.writer.capture());
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
 			this.writer.getValue().accept(out);
-			assertThat(out.toByteArray().length).isEqualTo(config.toString().length());
+			assertThat(out.toByteArray()).hasSize(config.toString().length());
 			then(http()).should().put(any(), any(), this.writer.capture());
 			this.writer.getValue().accept(out);
 			assertThat(out.toByteArray()).hasSizeGreaterThan(2000);
@@ -487,7 +487,7 @@ class DockerApiTests {
 			URI waitUri = new URI(CONTAINERS_URL + "/e90e34656806/wait");
 			given(http().post(waitUri)).willReturn(responseOf("container-wait-response.json"));
 			ContainerStatus status = this.api.wait(reference);
-			assertThat(status.getStatusCode()).isEqualTo(1);
+			assertThat(status.getStatusCode()).isOne();
 		}
 
 		@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/LogUpdateEventTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/LogUpdateEventTests.java
@@ -36,28 +36,28 @@ class LogUpdateEventTests {
 	void readAllWhenSimpleStreamReturnsEvents() throws Exception {
 		List<LogUpdateEvent> events = readAll("log-update-event.stream");
 		assertThat(events).hasSize(7);
-		assertThat(events.get(0).toString())
-				.isEqualTo("Analyzing image '307c032c4ceaa6330b6c02af945a1fe56a8c3c27c28268574b217c1d38b093cf'");
-		assertThat(events.get(1).toString())
-				.isEqualTo("Writing metadata for uncached layer 'org.cloudfoundry.openjdk:openjdk-jre'");
-		assertThat(events.get(2).toString())
-				.isEqualTo("Using cached launch layer 'org.cloudfoundry.jvmapplication:executable-jar'");
+		assertThat(events.get(0))
+				.hasToString("Analyzing image '307c032c4ceaa6330b6c02af945a1fe56a8c3c27c28268574b217c1d38b093cf'");
+		assertThat(events.get(1))
+				.hasToString("Writing metadata for uncached layer 'org.cloudfoundry.openjdk:openjdk-jre'");
+		assertThat(events.get(2))
+				.hasToString("Using cached launch layer 'org.cloudfoundry.jvmapplication:executable-jar'");
 	}
 
 	@Test
 	void readAllWhenAnsiStreamReturnsEvents() throws Exception {
 		List<LogUpdateEvent> events = readAll("log-update-event-ansi.stream");
 		assertThat(events).hasSize(20);
-		assertThat(events.get(0).toString()).isEqualTo("");
-		assertThat(events.get(1).toString()).isEqualTo("Cloud Foundry OpenJDK Buildpack v1.0.64");
-		assertThat(events.get(2).toString()).isEqualTo("  OpenJDK JRE 11.0.5: Reusing cached layer");
+		assertThat(events.get(0).toString()).isEmpty();
+		assertThat(events.get(1)).hasToString("Cloud Foundry OpenJDK Buildpack v1.0.64");
+		assertThat(events.get(2)).hasToString("  OpenJDK JRE 11.0.5: Reusing cached layer");
 	}
 
 	@Test
 	void readSucceedsWhenStreamTypeIsInvalid() throws IOException {
 		List<LogUpdateEvent> events = readAll("log-update-event-invalid-stream-type.stream");
 		assertThat(events).hasSize(1);
-		assertThat(events.get(0).toString()).isEqualTo("Stream type is out of bounds. Must be >= 0 and < 3, but was 3");
+		assertThat(events.get(0)).hasToString("Stream type is out of bounds. Must be >= 0 and < 3, but was 3");
 	}
 
 	private List<LogUpdateEvent> readAll(String name) throws IOException {

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ProgressUpdateEventTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ProgressUpdateEventTests.java
@@ -40,7 +40,7 @@ abstract class ProgressUpdateEventTests<E extends ProgressUpdateEvent> {
 	@Test
 	void getProgressDetailsReturnsProgressDetails() {
 		ProgressUpdateEvent event = createEvent();
-		assertThat(event.getProgressDetail().getCurrent()).isEqualTo(1);
+		assertThat(event.getProgressDetail().getCurrent()).isOne();
 		assertThat(event.getProgressDetail().getTotal()).isEqualTo(2);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/TotalProgressBarTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/TotalProgressBarTests.java
@@ -36,12 +36,11 @@ class TotalProgressBarTests {
 		TotalProgressBar bar = new TotalProgressBar("prefix:", '#', true, out);
 		assertThat(out).hasToString("prefix: [ ");
 		bar.accept(new TotalProgressEvent(10));
-		assertThat(out.toString()).isEqualTo("prefix: [ #####");
+		assertThat(out).hasToString("prefix: [ #####");
 		bar.accept(new TotalProgressEvent(50));
-		assertThat(out.toString()).isEqualTo("prefix: [ #########################");
+		assertThat(out).hasToString("prefix: [ #########################");
 		bar.accept(new TotalProgressEvent(100));
-		assertThat(out.toString())
-				.isEqualTo(String.format("prefix: [ ################################################## ]%n"));
+		assertThat(out).hasToString(String.format("prefix: [ ################################################## ]%n"));
 	}
 
 	@Test
@@ -50,11 +49,11 @@ class TotalProgressBarTests {
 		TotalProgressBar bar = new TotalProgressBar(null, '#', true, out);
 		assertThat(out).hasToString("[ ");
 		bar.accept(new TotalProgressEvent(10));
-		assertThat(out.toString()).isEqualTo("[ #####");
+		assertThat(out).hasToString("[ #####");
 		bar.accept(new TotalProgressEvent(50));
-		assertThat(out.toString()).isEqualTo("[ #########################");
+		assertThat(out).hasToString("[ #########################");
 		bar.accept(new TotalProgressEvent(100));
-		assertThat(out.toString()).isEqualTo(String.format("[ ################################################## ]%n"));
+		assertThat(out).hasToString(String.format("[ ################################################## ]%n"));
 	}
 
 	@Test
@@ -63,11 +62,11 @@ class TotalProgressBarTests {
 		TotalProgressBar bar = new TotalProgressBar("", '.', false, out);
 		assertThat(out).hasToString("");
 		bar.accept(new TotalProgressEvent(10));
-		assertThat(out.toString()).isEqualTo(".....");
+		assertThat(out).hasToString(".....");
 		bar.accept(new TotalProgressEvent(50));
-		assertThat(out.toString()).isEqualTo(".........................");
+		assertThat(out).hasToString(".........................");
 		bar.accept(new TotalProgressEvent(100));
-		assertThat(out.toString()).isEqualTo(String.format("..................................................%n"));
+		assertThat(out).hasToString(String.format("..................................................%n"));
 	}
 
 	static class TestPrintStream extends PrintStream {

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/TotalProgressEventTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/TotalProgressEventTests.java
@@ -30,7 +30,7 @@ class TotalProgressEventTests {
 
 	@Test
 	void create() {
-		assertThat(new TotalProgressEvent(0).getPercent()).isEqualTo(0);
+		assertThat(new TotalProgressEvent(0).getPercent()).isZero();
 		assertThat(new TotalProgressEvent(10).getPercent()).isEqualTo(10);
 		assertThat(new TotalProgressEvent(100).getPercent()).isEqualTo(100);
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ssl/CertificateParserTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ssl/CertificateParserTests.java
@@ -55,7 +55,7 @@ class CertificateParserTests {
 		Path certPath = this.fileWriter.writeFile("cert.pem", PemFileWriter.CERTIFICATE);
 		X509Certificate[] certificates = CertificateParser.parse(caPath, certPath);
 		assertThat(certificates).isNotNull();
-		assertThat(certificates.length).isEqualTo(2);
+		assertThat(certificates).hasSize(2);
 		assertThat(certificates[0].getType()).isEqualTo("X.509");
 		assertThat(certificates[1].getType()).isEqualTo("X.509");
 	}
@@ -65,7 +65,7 @@ class CertificateParserTests {
 		Path path = this.fileWriter.writeFile("ca.pem", PemFileWriter.CA_CERTIFICATE, PemFileWriter.CERTIFICATE);
 		X509Certificate[] certificates = CertificateParser.parse(path);
 		assertThat(certificates).isNotNull();
-		assertThat(certificates.length).isEqualTo(2);
+		assertThat(certificates).hasSize(2);
 		assertThat(certificates[0].getType()).isEqualTo("X.509");
 		assertThat(certificates[1].getType()).isEqualTo("X.509");
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/ErrorsTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/ErrorsTests.java
@@ -48,7 +48,7 @@ class ErrorsTests extends AbstractJsonTests {
 	@Test
 	void toStringHasErrorDetails() throws Exception {
 		Errors errors = getObjectMapper().readValue(getContent("errors.json"), Errors.class);
-		assertThat(errors.toString()).isEqualTo("[TEST1: Test One, TEST2: Test Two]");
+		assertThat(errors).hasToString("[TEST1: Test One, TEST2: Test Two]");
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/MessageTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/MessageTests.java
@@ -38,7 +38,7 @@ class MessageTests extends AbstractJsonTests {
 	@Test
 	void toStringHasErrorDetails() throws Exception {
 		Message errors = getObjectMapper().readValue(getContent("message.json"), Message.class);
-		assertThat(errors.toString()).isEqualTo("test message");
+		assertThat(errors).hasToString("test message");
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/ContainerReferenceTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/ContainerReferenceTests.java
@@ -32,7 +32,7 @@ class ContainerReferenceTests {
 	void ofCreatesInstance() {
 		ContainerReference reference = ContainerReference
 				.of("92691aec176333f7ae890de9aaeeafef11166efcaa3908edf83eb44a5c943781");
-		assertThat(reference.toString()).isEqualTo("92691aec176333f7ae890de9aaeeafef11166efcaa3908edf83eb44a5c943781");
+		assertThat(reference).hasToString("92691aec176333f7ae890de9aaeeafef11166efcaa3908edf83eb44a5c943781");
 	}
 
 	@Test
@@ -55,7 +55,7 @@ class ContainerReferenceTests {
 				.of("92691aec176333f7ae890de9aaeeafef11166efcaa3908edf83eb44a5c943781");
 		ContainerReference r3 = ContainerReference
 				.of("02691aec176333f7ae890de9aaeeafef11166efcaa3908edf83eb44a5c943781");
-		assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+		assertThat(r1).hasSameHashCodeAs(r2);
 		assertThat(r1).isEqualTo(r1).isEqualTo(r2).isNotEqualTo(r3);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/ContainerStatusTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/ContainerStatusTests.java
@@ -32,14 +32,14 @@ class ContainerStatusTests {
 	@Test
 	void ofCreatesFromJson() throws IOException {
 		ContainerStatus status = ContainerStatus.of(getClass().getResourceAsStream("container-status-error.json"));
-		assertThat(status.getStatusCode()).isEqualTo(1);
+		assertThat(status.getStatusCode()).isOne();
 		assertThat(status.getWaitingErrorMessage()).isEqualTo("error detail");
 	}
 
 	@Test
 	void ofCreatesFromValues() {
 		ContainerStatus status = ContainerStatus.of(1, "error detail");
-		assertThat(status.getStatusCode()).isEqualTo(1);
+		assertThat(status.getStatusCode()).isOne();
 		assertThat(status.getWaitingErrorMessage()).isEqualTo("error detail");
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/ImageNameTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/ImageNameTests.java
@@ -32,7 +32,7 @@ class ImageNameTests {
 	@Test
 	void ofWhenNameOnlyCreatesImageName() {
 		ImageName imageName = ImageName.of("ubuntu");
-		assertThat(imageName.toString()).isEqualTo("docker.io/library/ubuntu");
+		assertThat(imageName).hasToString("docker.io/library/ubuntu");
 		assertThat(imageName.getDomain()).isEqualTo("docker.io");
 		assertThat(imageName.getName()).isEqualTo("library/ubuntu");
 	}
@@ -40,7 +40,7 @@ class ImageNameTests {
 	@Test
 	void ofWhenSlashedNameCreatesImageName() {
 		ImageName imageName = ImageName.of("canonical/ubuntu");
-		assertThat(imageName.toString()).isEqualTo("docker.io/canonical/ubuntu");
+		assertThat(imageName).hasToString("docker.io/canonical/ubuntu");
 		assertThat(imageName.getDomain()).isEqualTo("docker.io");
 		assertThat(imageName.getName()).isEqualTo("canonical/ubuntu");
 	}
@@ -48,7 +48,7 @@ class ImageNameTests {
 	@Test
 	void ofWhenLocalhostNameCreatesImageName() {
 		ImageName imageName = ImageName.of("localhost/canonical/ubuntu");
-		assertThat(imageName.toString()).isEqualTo("localhost/canonical/ubuntu");
+		assertThat(imageName).hasToString("localhost/canonical/ubuntu");
 		assertThat(imageName.getDomain()).isEqualTo("localhost");
 		assertThat(imageName.getName()).isEqualTo("canonical/ubuntu");
 	}
@@ -56,7 +56,7 @@ class ImageNameTests {
 	@Test
 	void ofWhenDomainAndNameCreatesImageName() {
 		ImageName imageName = ImageName.of("repo.spring.io/canonical/ubuntu");
-		assertThat(imageName.toString()).isEqualTo("repo.spring.io/canonical/ubuntu");
+		assertThat(imageName).hasToString("repo.spring.io/canonical/ubuntu");
 		assertThat(imageName.getDomain()).isEqualTo("repo.spring.io");
 		assertThat(imageName.getName()).isEqualTo("canonical/ubuntu");
 	}
@@ -64,7 +64,7 @@ class ImageNameTests {
 	@Test
 	void ofWhenDomainNameAndPortCreatesImageName() {
 		ImageName imageName = ImageName.of("repo.spring.io:8080/canonical/ubuntu");
-		assertThat(imageName.toString()).isEqualTo("repo.spring.io:8080/canonical/ubuntu");
+		assertThat(imageName).hasToString("repo.spring.io:8080/canonical/ubuntu");
 		assertThat(imageName.getDomain()).isEqualTo("repo.spring.io:8080");
 		assertThat(imageName.getName()).isEqualTo("canonical/ubuntu");
 	}
@@ -72,7 +72,7 @@ class ImageNameTests {
 	@Test
 	void ofWhenSimpleNameAndPortCreatesImageName() {
 		ImageName imageName = ImageName.of("repo:8080/ubuntu");
-		assertThat(imageName.toString()).isEqualTo("repo:8080/ubuntu");
+		assertThat(imageName).hasToString("repo:8080/ubuntu");
 		assertThat(imageName.getDomain()).isEqualTo("repo:8080");
 		assertThat(imageName.getName()).isEqualTo("ubuntu");
 	}
@@ -80,7 +80,7 @@ class ImageNameTests {
 	@Test
 	void ofWhenSimplePathAndPortCreatesImageName() {
 		ImageName imageName = ImageName.of("repo:8080/canonical/ubuntu");
-		assertThat(imageName.toString()).isEqualTo("repo:8080/canonical/ubuntu");
+		assertThat(imageName).hasToString("repo:8080/canonical/ubuntu");
 		assertThat(imageName.getDomain()).isEqualTo("repo:8080");
 		assertThat(imageName.getName()).isEqualTo("canonical/ubuntu");
 	}
@@ -88,7 +88,7 @@ class ImageNameTests {
 	@Test
 	void ofWhenNameWithLongPathCreatesImageName() {
 		ImageName imageName = ImageName.of("path1/path2/path3/ubuntu");
-		assertThat(imageName.toString()).isEqualTo("docker.io/path1/path2/path3/ubuntu");
+		assertThat(imageName).hasToString("docker.io/path1/path2/path3/ubuntu");
 		assertThat(imageName.getDomain()).isEqualTo("docker.io");
 		assertThat(imageName.getName()).isEqualTo("path1/path2/path3/ubuntu");
 	}
@@ -110,7 +110,7 @@ class ImageNameTests {
 	@Test
 	void ofWhenLegacyDomainUsesNewDomain() {
 		ImageName imageName = ImageName.of("index.docker.io/ubuntu");
-		assertThat(imageName.toString()).isEqualTo("docker.io/library/ubuntu");
+		assertThat(imageName).hasToString("docker.io/library/ubuntu");
 		assertThat(imageName.getDomain()).isEqualTo("docker.io");
 		assertThat(imageName.getName()).isEqualTo("library/ubuntu");
 	}
@@ -153,8 +153,7 @@ class ImageNameTests {
 		ImageName n4 = ImageName.of("docker.io/library/ubuntu");
 		ImageName n5 = ImageName.of("index.docker.io/library/ubuntu");
 		ImageName n6 = ImageName.of("alpine");
-		assertThat(n1.hashCode()).isEqualTo(n2.hashCode()).isEqualTo(n3.hashCode()).isEqualTo(n4.hashCode())
-				.isEqualTo(n5.hashCode());
+		assertThat(n1).hasSameHashCodeAs(n2).hasSameHashCodeAs(n3).hasSameHashCodeAs(n4).hasSameHashCodeAs(n5);
 		assertThat(n1).isEqualTo(n1).isEqualTo(n2).isEqualTo(n3).isEqualTo(n4).isNotEqualTo(n6);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/ImageReferenceTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/ImageReferenceTests.java
@@ -39,7 +39,7 @@ class ImageReferenceTests {
 		assertThat(reference.getName()).isEqualTo("library/ubuntu");
 		assertThat(reference.getTag()).isNull();
 		assertThat(reference.getDigest()).isNull();
-		assertThat(reference.toString()).isEqualTo("docker.io/library/ubuntu");
+		assertThat(reference).hasToString("docker.io/library/ubuntu");
 	}
 
 	@Test
@@ -49,7 +49,7 @@ class ImageReferenceTests {
 		assertThat(reference.getName()).isEqualTo("library/ubuntu");
 		assertThat(reference.getTag()).isNull();
 		assertThat(reference.getDigest()).isNull();
-		assertThat(reference.toString()).isEqualTo("docker.io/library/ubuntu");
+		assertThat(reference).hasToString("docker.io/library/ubuntu");
 	}
 
 	@Test
@@ -59,7 +59,7 @@ class ImageReferenceTests {
 		assertThat(reference.getName()).isEqualTo("adoptopenjdk/openjdk11");
 		assertThat(reference.getTag()).isNull();
 		assertThat(reference.getDigest()).isNull();
-		assertThat(reference.toString()).isEqualTo("docker.io/adoptopenjdk/openjdk11");
+		assertThat(reference).hasToString("docker.io/adoptopenjdk/openjdk11");
 	}
 
 	@Test
@@ -69,7 +69,7 @@ class ImageReferenceTests {
 		assertThat(reference.getName()).isEqualTo("java/jdk");
 		assertThat(reference.getTag()).isNull();
 		assertThat(reference.getDigest()).isNull();
-		assertThat(reference.toString()).isEqualTo("repo.example.com/java/jdk");
+		assertThat(reference).hasToString("repo.example.com/java/jdk");
 	}
 
 	@Test
@@ -79,7 +79,7 @@ class ImageReferenceTests {
 		assertThat(reference.getName()).isEqualTo("java/jdk");
 		assertThat(reference.getTag()).isNull();
 		assertThat(reference.getDigest()).isNull();
-		assertThat(reference.toString()).isEqualTo("repo.example.com:8080/java/jdk");
+		assertThat(reference).hasToString("repo.example.com:8080/java/jdk");
 	}
 
 	@Test
@@ -89,7 +89,7 @@ class ImageReferenceTests {
 		assertThat(reference.getName()).isEqualTo("library/ubuntu");
 		assertThat(reference.getTag()).isNull();
 		assertThat(reference.getDigest()).isNull();
-		assertThat(reference.toString()).isEqualTo("docker.io/library/ubuntu");
+		assertThat(reference).hasToString("docker.io/library/ubuntu");
 	}
 
 	@Test
@@ -99,7 +99,7 @@ class ImageReferenceTests {
 		assertThat(reference.getName()).isEqualTo("library/ubuntu");
 		assertThat(reference.getTag()).isEqualTo("bionic");
 		assertThat(reference.getDigest()).isNull();
-		assertThat(reference.toString()).isEqualTo("docker.io/library/ubuntu:bionic");
+		assertThat(reference).hasToString("docker.io/library/ubuntu:bionic");
 	}
 
 	@Test
@@ -109,7 +109,7 @@ class ImageReferenceTests {
 		assertThat(reference.getName()).isEqualTo("library/ubuntu");
 		assertThat(reference.getTag()).isEqualTo("v1");
 		assertThat(reference.getDigest()).isNull();
-		assertThat(reference.toString()).isEqualTo("repo.example.com:8080/library/ubuntu:v1");
+		assertThat(reference).hasToString("repo.example.com:8080/library/ubuntu:v1");
 	}
 
 	@Test
@@ -121,7 +121,7 @@ class ImageReferenceTests {
 		assertThat(reference.getTag()).isNull();
 		assertThat(reference.getDigest())
 				.isEqualTo("sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d");
-		assertThat(reference.toString()).isEqualTo(
+		assertThat(reference).hasToString(
 				"docker.io/library/ubuntu@sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d");
 	}
 
@@ -134,7 +134,7 @@ class ImageReferenceTests {
 		assertThat(reference.getTag()).isEqualTo("bionic");
 		assertThat(reference.getDigest())
 				.isEqualTo("sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d");
-		assertThat(reference.toString()).isEqualTo(
+		assertThat(reference).hasToString(
 				"docker.io/library/ubuntu:bionic@sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d");
 	}
 
@@ -147,27 +147,27 @@ class ImageReferenceTests {
 		assertThat(reference.getTag()).isEqualTo("bionic");
 		assertThat(reference.getDigest())
 				.isEqualTo("sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d");
-		assertThat(reference.toString()).isEqualTo(
+		assertThat(reference).hasToString(
 				"example.com:8080/canonical/ubuntu:bionic@sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d");
 	}
 
 	@Test
 	void ofImageName() {
 		ImageReference reference = ImageReference.of(ImageName.of("ubuntu"));
-		assertThat(reference.toString()).isEqualTo("docker.io/library/ubuntu");
+		assertThat(reference).hasToString("docker.io/library/ubuntu");
 	}
 
 	@Test
 	void ofImageNameAndTag() {
 		ImageReference reference = ImageReference.of(ImageName.of("ubuntu"), "bionic");
-		assertThat(reference.toString()).isEqualTo("docker.io/library/ubuntu:bionic");
+		assertThat(reference).hasToString("docker.io/library/ubuntu:bionic");
 	}
 
 	@Test
 	void ofImageNameTagAndDigest() {
 		ImageReference reference = ImageReference.of(ImageName.of("ubuntu"), "bionic",
 				"sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d");
-		assertThat(reference.toString()).isEqualTo(
+		assertThat(reference).hasToString(
 				"docker.io/library/ubuntu:bionic@sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d");
 	}
 
@@ -233,33 +233,33 @@ class ImageReferenceTests {
 	@Test
 	void inTaggedFormWhenHasNoTagUsesLatest() {
 		ImageReference reference = ImageReference.of("ubuntu");
-		assertThat(reference.inTaggedForm().toString()).isEqualTo("docker.io/library/ubuntu:latest");
+		assertThat(reference.inTaggedForm()).hasToString("docker.io/library/ubuntu:latest");
 	}
 
 	@Test
 	void inTaggedFormWhenHasTagUsesTag() {
 		ImageReference reference = ImageReference.of("ubuntu:bionic");
-		assertThat(reference.inTaggedForm().toString()).isEqualTo("docker.io/library/ubuntu:bionic");
+		assertThat(reference.inTaggedForm()).hasToString("docker.io/library/ubuntu:bionic");
 	}
 
 	@Test
 	void inTaggedOrDigestFormWhenHasDigestUsesDigest() {
 		ImageReference reference = ImageReference
 				.of("ubuntu@sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d");
-		assertThat(reference.inTaggedOrDigestForm().toString()).isEqualTo(
+		assertThat(reference.inTaggedOrDigestForm()).hasToString(
 				"docker.io/library/ubuntu@sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d");
 	}
 
 	@Test
 	void inTaggedOrDigestFormWhenHasTagUsesTag() {
 		ImageReference reference = ImageReference.of("ubuntu:bionic");
-		assertThat(reference.inTaggedOrDigestForm().toString()).isEqualTo("docker.io/library/ubuntu:bionic");
+		assertThat(reference.inTaggedOrDigestForm()).hasToString("docker.io/library/ubuntu:bionic");
 	}
 
 	@Test
 	void inTaggedOrDigestFormWhenHasNoTagOrDigestUsesLatest() {
 		ImageReference reference = ImageReference.of("ubuntu");
-		assertThat(reference.inTaggedOrDigestForm().toString()).isEqualTo("docker.io/library/ubuntu:latest");
+		assertThat(reference.inTaggedOrDigestForm()).hasToString("docker.io/library/ubuntu:latest");
 	}
 
 	@Test
@@ -267,7 +267,7 @@ class ImageReferenceTests {
 		ImageReference r1 = ImageReference.of("ubuntu:bionic");
 		ImageReference r2 = ImageReference.of("docker.io/library/ubuntu:bionic");
 		ImageReference r3 = ImageReference.of("docker.io/library/ubuntu:latest");
-		assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+		assertThat(r1).hasSameHashCodeAs(r2);
 		assertThat(r1).isEqualTo(r1).isEqualTo(r2).isNotEqualTo(r3);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/ImageTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/ImageTests.java
@@ -55,10 +55,10 @@ class ImageTests extends AbstractJsonTests {
 		Image image = getImage();
 		List<LayerId> layers = image.getLayers();
 		assertThat(layers).hasSize(46);
-		assertThat(layers.get(0).toString())
-				.isEqualTo("sha256:733a8e5ce32984099ef675fce04730f6e2a6dcfdf5bd292fea01a8f936265342");
-		assertThat(layers.get(45).toString())
-				.isEqualTo("sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef");
+		assertThat(layers.get(0))
+				.hasToString("sha256:733a8e5ce32984099ef675fce04730f6e2a6dcfdf5bd292fea01a8f936265342");
+		assertThat(layers.get(45))
+				.hasToString("sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/LayerIdTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/LayerIdTests.java
@@ -37,7 +37,7 @@ class LayerIdTests {
 		LayerId id = LayerId.of("sha256:9a183e56c86d376b408bdf922746d0a657f62b0e18c7c8f82a496b87710c576f");
 		assertThat(id.getAlgorithm()).isEqualTo("sha256");
 		assertThat(id.getHash()).isEqualTo("9a183e56c86d376b408bdf922746d0a657f62b0e18c7c8f82a496b87710c576f");
-		assertThat(id.toString()).isEqualTo("sha256:9a183e56c86d376b408bdf922746d0a657f62b0e18c7c8f82a496b87710c576f");
+		assertThat(id).hasToString("sha256:9a183e56c86d376b408bdf922746d0a657f62b0e18c7c8f82a496b87710c576f");
 	}
 
 	@Test
@@ -45,7 +45,7 @@ class LayerIdTests {
 		LayerId id1 = LayerId.of("sha256:9a183e56c86d376b408bdf922746d0a657f62b0e18c7c8f82a496b87710c576f");
 		LayerId id2 = LayerId.of("sha256:9a183e56c86d376b408bdf922746d0a657f62b0e18c7c8f82a496b87710c576f");
 		LayerId id3 = LayerId.of("sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-		assertThat(id1.hashCode()).isEqualTo(id2.hashCode());
+		assertThat(id1).hasSameHashCodeAs(id2);
 		assertThat(id1).isEqualTo(id1).isEqualTo(id2).isNotEqualTo(id3);
 	}
 
@@ -65,7 +65,7 @@ class LayerIdTests {
 		MessageDigest digest = MessageDigest.getInstance("SHA-256");
 		digest.update("test".getBytes(StandardCharsets.UTF_8));
 		LayerId id = LayerId.ofSha256Digest(digest.digest());
-		assertThat(id.toString()).isEqualTo("sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08");
+		assertThat(id).hasToString("sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08");
 	}
 
 	@Test
@@ -74,7 +74,7 @@ class LayerIdTests {
 		Arrays.fill(digest, (byte) 127);
 		digest[0] = 1;
 		LayerId id = LayerId.ofSha256Digest(digest);
-		assertThat(id.toString()).isEqualTo("sha256:017f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f");
+		assertThat(id).hasToString("sha256:017f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/LayerTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/LayerTests.java
@@ -55,8 +55,8 @@ class LayerTests {
 			layout.directory("/directory", Owner.ROOT);
 			layout.file("/directory/file", Owner.ROOT, Content.of("test"));
 		});
-		assertThat(layer.getId().toString())
-				.isEqualTo("sha256:d03a34f73804698c875eb56ff694fc2fceccc69b645e4adceb004ed13588613b");
+		assertThat(layer.getId())
+				.hasToString("sha256:d03a34f73804698c875eb56ff694fc2fceccc69b645e4adceb004ed13588613b");
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 		layer.writeTo(outputStream);
 		try (TarArchiveInputStream tarStream = new TarArchiveInputStream(

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/VolumeNameTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/VolumeNameTests.java
@@ -81,7 +81,7 @@ class VolumeNameTests {
 	@Test
 	void basedOnGeneratesHashBasedName() {
 		VolumeName name = VolumeName.basedOn("index.docker.io/library/myapp:latest", "pack-cache-", ".build", 6);
-		assertThat(name.toString()).isEqualTo("pack-cache-40a311b545d7.build");
+		assertThat(name).hasToString("pack-cache-40a311b545d7.build");
 	}
 
 	@Test
@@ -99,7 +99,7 @@ class VolumeNameTests {
 	@Test
 	void ofGeneratesValue() {
 		VolumeName name = VolumeName.of("test");
-		assertThat(name.toString()).isEqualTo("test");
+		assertThat(name).hasToString("test");
 	}
 
 	@Test
@@ -107,7 +107,7 @@ class VolumeNameTests {
 		VolumeName n1 = VolumeName.of("test1");
 		VolumeName n2 = VolumeName.of("test1");
 		VolumeName n3 = VolumeName.of("test2");
-		assertThat(n1.hashCode()).isEqualTo(n2.hashCode());
+		assertThat(n1).hasSameHashCodeAs(n2);
 		assertThat(n1).isEqualTo(n1).isEqualTo(n2).isNotEqualTo(n3);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/FilePermissionsTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/FilePermissionsTests.java
@@ -85,7 +85,7 @@ class FilePermissionsTests {
 	@Test
 	void posixPermissionsToUmaskWithEmptyPermissions() {
 		Set<PosixFilePermission> permissions = Collections.emptySet();
-		assertThat(FilePermissions.posixPermissionsToUmask(permissions)).isEqualTo(0);
+		assertThat(FilePermissions.posixPermissionsToUmask(permissions)).isZero();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/TarArchiveTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/TarArchiveTests.java
@@ -68,8 +68,8 @@ class TarArchiveTests {
 			assertThat(entries.get(0).getLongUserId()).isEqualTo(123);
 			assertThat(entries.get(0).getLongGroupId()).isEqualTo(456);
 			assertThat(entries.get(2).getName()).isEqualTo("/cnb/");
-			assertThat(entries.get(2).getLongUserId()).isEqualTo(0);
-			assertThat(entries.get(2).getLongGroupId()).isEqualTo(0);
+			assertThat(entries.get(2).getLongUserId()).isZero();
+			assertThat(entries.get(2).getLongGroupId()).isZero();
 		}
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/TarLayoutWriterTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/TarLayoutWriterTests.java
@@ -51,13 +51,13 @@ class TarLayoutWriterTests {
 			assertThat(tarInputStream.getNextEntry()).isNull();
 			assertThat(directoryEntry.getName()).isEqualTo("/foo/");
 			assertThat(directoryEntry.getMode()).isEqualTo(0755);
-			assertThat(directoryEntry.getLongUserId()).isEqualTo(0);
-			assertThat(directoryEntry.getLongGroupId()).isEqualTo(0);
+			assertThat(directoryEntry.getLongUserId()).isZero();
+			assertThat(directoryEntry.getLongGroupId()).isZero();
 			assertThat(directoryEntry.getModTime()).isEqualTo(new Date(TarLayoutWriter.NORMALIZED_MOD_TIME));
 			assertThat(fileEntry.getName()).isEqualTo("/foo/bar.txt");
 			assertThat(fileEntry.getMode()).isEqualTo(0777);
-			assertThat(fileEntry.getLongUserId()).isEqualTo(1);
-			assertThat(fileEntry.getLongGroupId()).isEqualTo(1);
+			assertThat(fileEntry.getLongUserId()).isOne();
+			assertThat(fileEntry.getLongGroupId()).isOne();
 			assertThat(fileEntry.getModTime()).isEqualTo(new Date(TarLayoutWriter.NORMALIZED_MOD_TIME));
 			assertThat(fileContent).isEqualTo("test".getBytes(StandardCharsets.UTF_8));
 		}

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/socket/FileDescriptorTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/socket/FileDescriptorTests.java
@@ -76,7 +76,7 @@ class FileDescriptorTests {
 		FileDescriptor descriptor = new FileDescriptor(this.sourceHandle, this::close);
 		try (Handle handle = descriptor.acquire()) {
 			descriptor.close();
-			assertThat(this.closedHandle).isEqualTo(0);
+			assertThat(this.closedHandle).isZero();
 		}
 		assertThat(this.closedHandle).isEqualTo(this.sourceHandle);
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/CommandRunnerTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/CommandRunnerTests.java
@@ -121,14 +121,14 @@ class CommandRunnerTests {
 	@Test
 	void handlesSuccess() {
 		int status = this.commandRunner.runAndHandleErrors("command");
-		assertThat(status).isEqualTo(0);
+		assertThat(status).isZero();
 		assertThat(this.calls).isEmpty();
 	}
 
 	@Test
 	void handlesNoSuchCommand() {
 		int status = this.commandRunner.runAndHandleErrors("missing");
-		assertThat(status).isEqualTo(1);
+		assertThat(status).isOne();
 		assertThat(this.calls).containsOnly(Call.ERROR_MESSAGE);
 	}
 
@@ -136,7 +136,7 @@ class CommandRunnerTests {
 	void handlesRegularExceptionWithMessage() throws Exception {
 		willThrow(new RuntimeException("With Message")).given(this.regularCommand).run();
 		int status = this.commandRunner.runAndHandleErrors("command");
-		assertThat(status).isEqualTo(1);
+		assertThat(status).isOne();
 		assertThat(this.calls).containsOnly(Call.ERROR_MESSAGE);
 	}
 
@@ -144,7 +144,7 @@ class CommandRunnerTests {
 	void handlesRegularExceptionWithoutMessage() throws Exception {
 		willThrow(new RuntimeException()).given(this.regularCommand).run();
 		int status = this.commandRunner.runAndHandleErrors("command");
-		assertThat(status).isEqualTo(1);
+		assertThat(status).isOne();
 		assertThat(this.calls).containsOnly(Call.ERROR_MESSAGE, Call.PRINT_STACK_TRACE);
 	}
 
@@ -153,7 +153,7 @@ class CommandRunnerTests {
 		willThrow(new RuntimeException()).given(this.regularCommand).run();
 		int status = this.commandRunner.runAndHandleErrors("command", "--debug");
 		assertThat(System.getProperty("debug")).isEqualTo("true");
-		assertThat(status).isEqualTo(1);
+		assertThat(status).isOne();
 		assertThat(this.calls).containsOnly(Call.ERROR_MESSAGE, Call.PRINT_STACK_TRACE);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/init/InitCommandTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/init/InitCommandTests.java
@@ -84,12 +84,12 @@ class InitCommandTests extends AbstractHttpClientMockTests {
 	void generateProject() throws Exception {
 		String fileName = UUID.randomUUID().toString() + ".zip";
 		File file = new File(fileName);
-		assertThat(file.exists()).as("file should not exist").isFalse();
+		assertThat(file).as("file should not exist").doesNotExist();
 		MockHttpProjectGenerationRequest request = new MockHttpProjectGenerationRequest("application/zip", fileName);
 		mockSuccessfulProjectGeneration(request);
 		try {
 			assertThat(this.command.run()).isEqualTo(ExitStatus.OK);
-			assertThat(file.exists()).as("file should have been created").isTrue();
+			assertThat(file).as("file should have been created").exists();
 		}
 		finally {
 			assertThat(file.delete()).as("failed to delete test file").isTrue();
@@ -139,7 +139,7 @@ class InitCommandTests extends AbstractHttpClientMockTests {
 	@Test
 	void generateProjectArchiveExtractedByDefault() throws Exception {
 		String fileName = UUID.randomUUID().toString();
-		assertThat(fileName.contains(".")).as("No dot in filename").isFalse();
+		assertThat(fileName).as("No dot in filename").doesNotContain(".");
 		byte[] archive = createFakeZipArchive("test.txt", "Fake content");
 		MockHttpProjectGenerationRequest request = new MockHttpProjectGenerationRequest("application/zip", "demo.zip",
 				archive);
@@ -167,8 +167,8 @@ class InitCommandTests extends AbstractHttpClientMockTests {
 		File file = new File(fileName);
 		try {
 			assertThat(this.command.run(fileName)).isEqualTo(ExitStatus.OK);
-			assertThat(file.exists()).as("File not saved properly").isTrue();
-			assertThat(file.isFile()).as("Should not be a directory").isTrue();
+			assertThat(file).as("File not saved properly").exists();
+			assertThat(file).as("Should not be a directory").isFile();
 		}
 		finally {
 			file.delete();
@@ -179,14 +179,14 @@ class InitCommandTests extends AbstractHttpClientMockTests {
 	void generateProjectAndExtractUnsupportedArchive(@TempDir File tempDir) throws Exception {
 		String fileName = UUID.randomUUID().toString() + ".zip";
 		File file = new File(fileName);
-		assertThat(file.exists()).as("file should not exist").isFalse();
+		assertThat(file).as("file should not exist").doesNotExist();
 		try {
 			byte[] archive = createFakeZipArchive("test.txt", "Fake content");
 			MockHttpProjectGenerationRequest request = new MockHttpProjectGenerationRequest("application/foobar",
 					fileName, archive);
 			mockSuccessfulProjectGeneration(request);
 			assertThat(this.command.run("--extract", tempDir.getAbsolutePath())).isEqualTo(ExitStatus.OK);
-			assertThat(file.exists()).as("file should have been saved instead").isTrue();
+			assertThat(file).as("file should have been saved instead").exists();
 		}
 		finally {
 			assertThat(file.delete()).as("failed to delete test file").isTrue();
@@ -197,13 +197,13 @@ class InitCommandTests extends AbstractHttpClientMockTests {
 	void generateProjectAndExtractUnknownContentType(@TempDir File tempDir) throws Exception {
 		String fileName = UUID.randomUUID().toString() + ".zip";
 		File file = new File(fileName);
-		assertThat(file.exists()).as("file should not exist").isFalse();
+		assertThat(file).as("file should not exist").doesNotExist();
 		try {
 			byte[] archive = createFakeZipArchive("test.txt", "Fake content");
 			MockHttpProjectGenerationRequest request = new MockHttpProjectGenerationRequest(null, fileName, archive);
 			mockSuccessfulProjectGeneration(request);
 			assertThat(this.command.run("--extract", tempDir.getAbsolutePath())).isEqualTo(ExitStatus.OK);
-			assertThat(file.exists()).as("file should have been saved instead").isTrue();
+			assertThat(file).as("file should have been saved instead").exists();
 		}
 		finally {
 			assertThat(file.delete()).as("failed to delete test file").isTrue();
@@ -231,7 +231,7 @@ class InitCommandTests extends AbstractHttpClientMockTests {
 				file.getAbsolutePath());
 		mockSuccessfulProjectGeneration(request);
 		assertThat(this.command.run("--force")).isEqualTo(ExitStatus.OK);
-		assertThat(fileLength != file.length()).as("File should have changed").isTrue();
+		assertThat(fileLength).as("File should have changed").isNotEqualTo(file.length());
 	}
 
 	@Test
@@ -269,8 +269,8 @@ class InitCommandTests extends AbstractHttpClientMockTests {
 		assertThat(this.handler.lastRequest.getBootVersion()).isEqualTo("1.2.0.RELEASE");
 		List<String> dependencies = this.handler.lastRequest.getDependencies();
 		assertThat(dependencies).hasSize(2);
-		assertThat(dependencies.contains("web")).isTrue();
-		assertThat(dependencies.contains("data-jpa")).isTrue();
+		assertThat(dependencies).contains("web");
+		assertThat(dependencies).contains("data-jpa");
 	}
 
 	@Test
@@ -295,8 +295,8 @@ class InitCommandTests extends AbstractHttpClientMockTests {
 		assertThat(this.handler.lastRequest.getBootVersion()).isEqualTo("1.2.0.RELEASE");
 		List<String> dependencies = this.handler.lastRequest.getDependencies();
 		assertThat(dependencies).hasSize(2);
-		assertThat(dependencies.contains("web")).isTrue();
-		assertThat(dependencies.contains("data-jpa")).isTrue();
+		assertThat(dependencies).contains("web");
+		assertThat(dependencies).contains("data-jpa");
 	}
 
 	@Test
@@ -321,8 +321,8 @@ class InitCommandTests extends AbstractHttpClientMockTests {
 		assertThat(this.handler.lastRequest.getBootVersion()).isEqualTo("1.2.0.RELEASE");
 		List<String> dependencies = this.handler.lastRequest.getDependencies();
 		assertThat(dependencies).hasSize(2);
-		assertThat(dependencies.contains("web")).isTrue();
-		assertThat(dependencies.contains("data-jpa")).isTrue();
+		assertThat(dependencies).contains("web");
+		assertThat(dependencies).contains("data-jpa");
 	}
 
 	@Test
@@ -336,7 +336,7 @@ class InitCommandTests extends AbstractHttpClientMockTests {
 				archive);
 		mockSuccessfulProjectGeneration(request);
 		assertThat(this.command.run("--force", "--extract", tempDir.getAbsolutePath())).isEqualTo(ExitStatus.OK);
-		assertThat(fileLength != conflict.length()).as("File should have changed").isTrue();
+		assertThat(fileLength).as("File should have changed").isNotEqualTo(conflict.length());
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/init/InitializrServiceMetadataTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/init/InitializrServiceMetadataTests.java
@@ -40,17 +40,17 @@ class InitializrServiceMetadataTests {
 	@Test
 	void parseDefaults() throws Exception {
 		InitializrServiceMetadata metadata = createInstance("2.0.0");
-		assertThat(metadata.getDefaults().get("bootVersion")).isEqualTo("1.1.8.RELEASE");
-		assertThat(metadata.getDefaults().get("javaVersion")).isEqualTo("1.7");
-		assertThat(metadata.getDefaults().get("groupId")).isEqualTo("org.test");
-		assertThat(metadata.getDefaults().get("name")).isEqualTo("demo");
-		assertThat(metadata.getDefaults().get("description")).isEqualTo("Demo project for Spring Boot");
-		assertThat(metadata.getDefaults().get("packaging")).isEqualTo("jar");
-		assertThat(metadata.getDefaults().get("language")).isEqualTo("java");
-		assertThat(metadata.getDefaults().get("artifactId")).isEqualTo("demo");
-		assertThat(metadata.getDefaults().get("packageName")).isEqualTo("demo");
-		assertThat(metadata.getDefaults().get("type")).isEqualTo("maven-project");
-		assertThat(metadata.getDefaults().get("version")).isEqualTo("0.0.1-SNAPSHOT");
+		assertThat(metadata.getDefaults()).containsEntry("bootVersion", "1.1.8.RELEASE");
+		assertThat(metadata.getDefaults()).containsEntry("javaVersion", "1.7");
+		assertThat(metadata.getDefaults()).containsEntry("groupId", "org.test");
+		assertThat(metadata.getDefaults()).containsEntry("name", "demo");
+		assertThat(metadata.getDefaults()).containsEntry("description", "Demo project for Spring Boot");
+		assertThat(metadata.getDefaults()).containsEntry("packaging", "jar");
+		assertThat(metadata.getDefaults()).containsEntry("language", "java");
+		assertThat(metadata.getDefaults()).containsEntry("artifactId", "demo");
+		assertThat(metadata.getDefaults()).containsEntry("packageName", "demo");
+		assertThat(metadata.getDefaults()).containsEntry("type", "maven-project");
+		assertThat(metadata.getDefaults()).containsEntry("version", "0.0.1-SNAPSHOT");
 		assertThat(metadata.getDefaults()).as("Wrong number of defaults").hasSize(11);
 	}
 
@@ -73,8 +73,8 @@ class InitializrServiceMetadataTests {
 		InitializrServiceMetadata metadata = createInstance("2.0.0");
 		ProjectType projectType = metadata.getProjectTypes().get("maven-project");
 		assertThat(projectType).isNotNull();
-		assertThat(projectType.getTags().get("build")).isEqualTo("maven");
-		assertThat(projectType.getTags().get("format")).isEqualTo("project");
+		assertThat(projectType.getTags()).containsEntry("build", "maven");
+		assertThat(projectType.getTags()).containsEntry("format", "project");
 	}
 
 	private static InitializrServiceMetadata createInstance(String version) throws JSONException {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata/src/test/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataRepositoryJsonBuilderTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata/src/test/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataRepositoryJsonBuilderTests.java
@@ -221,29 +221,29 @@ class ConfigurationMetadataRepositoryJsonBuilderTests extends AbstractConfigurat
 		assertThat(source.getProperties()).hasSize(4);
 		ConfigurationMetadataProperty first = repo.getAllProperties().get("spring.map.first");
 		assertThat(first.getHints().getKeyHints()).hasSize(2);
-		assertThat(first.getHints().getValueProviders()).hasSize(0);
+		assertThat(first.getHints().getValueProviders()).isEmpty();
 		assertThat(first.getHints().getKeyHints().get(0).getValue()).isEqualTo("one");
 		assertThat(first.getHints().getKeyHints().get(0).getDescription()).isEqualTo("First.");
 		assertThat(first.getHints().getKeyHints().get(1).getValue()).isEqualTo("two");
 		assertThat(first.getHints().getKeyHints().get(1).getDescription()).isEqualTo("Second.");
 		ConfigurationMetadataProperty second = repo.getAllProperties().get("spring.map.second");
 		assertThat(second.getHints().getValueHints()).hasSize(2);
-		assertThat(second.getHints().getValueProviders()).hasSize(0);
+		assertThat(second.getHints().getValueProviders()).isEmpty();
 		assertThat(second.getHints().getValueHints().get(0).getValue()).isEqualTo("42");
 		assertThat(second.getHints().getValueHints().get(0).getDescription()).isEqualTo("Choose me.");
 		assertThat(second.getHints().getValueHints().get(1).getValue()).isEqualTo("24");
 		assertThat(second.getHints().getValueHints().get(1).getDescription()).isNull();
 		ConfigurationMetadataProperty keys = repo.getAllProperties().get("spring.map.keys");
-		assertThat(keys.getHints().getValueHints()).hasSize(0);
+		assertThat(keys.getHints().getValueHints()).isEmpty();
 		assertThat(keys.getHints().getValueProviders()).hasSize(1);
 		assertThat(keys.getHints().getValueProviders().get(0).getName()).isEqualTo("any");
 		ConfigurationMetadataProperty values = repo.getAllProperties().get("spring.map.values");
-		assertThat(values.getHints().getValueHints()).hasSize(0);
+		assertThat(values.getHints().getValueHints()).isEmpty();
 		assertThat(values.getHints().getValueProviders()).hasSize(1);
 		assertThat(values.getHints().getValueProviders().get(0).getName()).isEqualTo("handle-as");
 		assertThat(values.getHints().getValueProviders().get(0).getParameters()).hasSize(1);
-		assertThat(values.getHints().getValueProviders().get(0).getParameters().get("target"))
-				.isEqualTo("java.lang.Integer");
+		assertThat(values.getHints().getValueProviders().get(0).getParameters()).containsEntry("target",
+				"java.lang.Integer");
 	}
 
 	private void validateEmptyGroup(ConfigurationMetadataRepository repo) {
@@ -260,8 +260,8 @@ class ConfigurationMetadataRepositoryJsonBuilderTests extends AbstractConfigurat
 	}
 
 	private void validatePropertyHints(ConfigurationMetadataProperty property, int valueHints, int valueProviders) {
-		assertThat(property.getHints().getValueHints().size()).isEqualTo(valueHints);
-		assertThat(property.getHints().getValueProviders().size()).isEqualTo(valueProviders);
+		assertThat(property.getHints().getValueHints()).hasSize(valueHints);
+		assertThat(property.getHints().getValueProviders()).hasSize(valueProviders);
 	}
 
 	private void contains(Map<String, ?> source, String... keys) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata/src/test/java/org/springframework/boot/configurationmetadata/JsonReaderTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata/src/test/java/org/springframework/boot/configurationmetadata/JsonReaderTests.java
@@ -100,7 +100,7 @@ class JsonReaderTests extends AbstractConfigurationMetadataTests {
 		ValueProvider valueProvider = hint.getValueProviders().get(0);
 		assertThat(valueProvider.getName()).isEqualTo("handle-as");
 		assertThat(valueProvider.getParameters()).hasSize(1);
-		assertThat(valueProvider.getParameters().get("target")).isEqualTo(Integer.class.getName());
+		assertThat(valueProvider.getParameters()).containsEntry("target", Integer.class.getName());
 	}
 
 	@Test
@@ -123,7 +123,7 @@ class JsonReaderTests extends AbstractConfigurationMetadataTests {
 		ValueProvider valueProvider = hint.getValueProviders().get(0);
 		assertThat(valueProvider.getName()).isEqualTo("handle-as");
 		assertThat(valueProvider.getParameters()).hasSize(1);
-		assertThat(valueProvider.getParameters().get("target")).isEqualTo(String.class.getName());
+		assertThat(valueProvider.getParameters()).containsEntry("target", String.class.getName());
 		ValueProvider valueProvider2 = hint.getValueProviders().get(1);
 		assertThat(valueProvider2.getName()).isEqualTo("any");
 		assertThat(valueProvider2.getParameters()).isEmpty();

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -141,7 +141,7 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 		assertThat(metadata).has(Metadata.withProperty("simple.type.my-primitive-double", Double.class));
 		assertThat(metadata).has(Metadata.withProperty("simple.type.my-float", Float.class));
 		assertThat(metadata).has(Metadata.withProperty("simple.type.my-primitive-float", Float.class));
-		assertThat(metadata.getItems().size()).isEqualTo(18);
+		assertThat(metadata.getItems()).hasSize(18);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/fieldvalues/AbstractFieldValuesProcessorTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/fieldvalues/AbstractFieldValuesProcessorTests.java
@@ -55,7 +55,6 @@ public abstract class AbstractFieldValuesProcessorTests {
 		compiler.compile((compiled) -> {
 		});
 		Map<String, Object> values = processor.getValues();
-		assertThat(values.get("string")).isEqualTo("1");
 		assertThat(values.get("stringNone")).isNull();
 		assertThat(values.get("stringConst")).isEqualTo("c");
 		assertThat(values.get("bool")).isEqualTo(true);

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageTests.java
@@ -96,7 +96,7 @@ class BootBuildImageTests {
 	void springBootVersionDefaultValueIsUsed() {
 		BuildRequest request = this.buildImage.createRequest();
 		assertThat(request.getCreator().getName()).isEqualTo("Spring Boot");
-		assertThat(request.getCreator().getVersion()).isEqualTo("");
+		assertThat(request.getCreator().getVersion()).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/BootJarTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/BootJarTests.java
@@ -19,7 +19,6 @@ package org.springframework.boot.gradle.tasks.bundling;
 import java.io.File;
 import java.io.IOException;
 import java.util.jar.JarFile;
-import java.util.zip.ZipEntry;
 
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
@@ -77,14 +76,11 @@ class BootJarTests extends AbstractBootArchiveTests<BootJar> {
 	@Test
 	void jarsInLibAreStored() throws IOException {
 		try (JarFile jarFile = new JarFile(createLayeredJar())) {
-			assertThat(jarFile.getEntry("BOOT-INF/lib/first-library.jar").getMethod()).isEqualTo(ZipEntry.STORED);
-			assertThat(jarFile.getEntry("BOOT-INF/lib/second-library.jar").getMethod()).isEqualTo(ZipEntry.STORED);
-			assertThat(jarFile.getEntry("BOOT-INF/lib/third-library-SNAPSHOT.jar").getMethod())
-					.isEqualTo(ZipEntry.STORED);
-			assertThat(jarFile.getEntry("BOOT-INF/lib/first-project-library.jar").getMethod())
-					.isEqualTo(ZipEntry.STORED);
-			assertThat(jarFile.getEntry("BOOT-INF/lib/second-project-library-SNAPSHOT.jar").getMethod())
-					.isEqualTo(ZipEntry.STORED);
+			assertThat(jarFile.getEntry("BOOT-INF/lib/first-library.jar").getMethod()).isZero();
+			assertThat(jarFile.getEntry("BOOT-INF/lib/second-library.jar").getMethod()).isZero();
+			assertThat(jarFile.getEntry("BOOT-INF/lib/third-library-SNAPSHOT.jar").getMethod()).isZero();
+			assertThat(jarFile.getEntry("BOOT-INF/lib/first-project-library.jar").getMethod()).isZero();
+			assertThat(jarFile.getEntry("BOOT-INF/lib/second-project-library-SNAPSHOT.jar").getMethod()).isZero();
 		}
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/DockerSpecTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/DockerSpecTests.java
@@ -65,7 +65,7 @@ class DockerSpecTests {
 		DockerConfiguration dockerConfiguration = this.dockerSpec.asDockerConfiguration();
 		DockerHost host = dockerConfiguration.getHost();
 		assertThat(host.getAddress()).isEqualTo("docker.example.com");
-		assertThat(host.isSecure()).isEqualTo(true);
+		assertThat(host.isSecure()).isTrue();
 		assertThat(host.getCertificatePath()).isEqualTo("/tmp/ca-cert");
 		assertThat(dockerConfiguration.isBindHostToBuilder()).isFalse();
 		assertThat(this.dockerSpec.asDockerConfiguration().getBuilderRegistryAuthentication()).isNull();
@@ -80,7 +80,7 @@ class DockerSpecTests {
 		DockerConfiguration dockerConfiguration = this.dockerSpec.asDockerConfiguration();
 		DockerHost host = dockerConfiguration.getHost();
 		assertThat(host.getAddress()).isEqualTo("docker.example.com");
-		assertThat(host.isSecure()).isEqualTo(false);
+		assertThat(host.isSecure()).isFalse();
 		assertThat(host.getCertificatePath()).isNull();
 		assertThat(dockerConfiguration.isBindHostToBuilder()).isFalse();
 		assertThat(this.dockerSpec.asDockerConfiguration().getBuilderRegistryAuthentication()).isNull();
@@ -96,7 +96,7 @@ class DockerSpecTests {
 		DockerConfiguration dockerConfiguration = this.dockerSpec.asDockerConfiguration();
 		DockerHost host = dockerConfiguration.getHost();
 		assertThat(host.getAddress()).isEqualTo("docker.example.com");
-		assertThat(host.isSecure()).isEqualTo(false);
+		assertThat(host.isSecure()).isFalse();
 		assertThat(host.getCertificatePath()).isNull();
 		assertThat(dockerConfiguration.isBindHostToBuilder()).isTrue();
 		assertThat(this.dockerSpec.asDockerConfiguration().getBuilderRegistryAuthentication()).isNull();

--- a/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/test/java/org/springframework/boot/jarmode/layertools/TestPrintStream.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/test/java/org/springframework/boot/jarmode/layertools/TestPrintStream.java
@@ -64,7 +64,7 @@ class TestPrintStream extends PrintStream implements AssertProvider<PrintStreamA
 			try {
 				InputStream stream = this.actual.testClass.getResourceAsStream(resource);
 				String content = FileCopyUtils.copyToString(new InputStreamReader(stream, StandardCharsets.UTF_8));
-				Assertions.assertThat(this.actual.toString()).isEqualTo(content);
+				Assertions.assertThat(this.actual).hasToString(content);
 			}
 			catch (IOException ex) {
 				throw new IllegalStateException(ex);

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/AbstractPackagerTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/AbstractPackagerTests.java
@@ -407,8 +407,8 @@ abstract class AbstractPackagerTests<P extends Packager> {
 		this.testJarFile.addClass("A.class", ClassWithMainMethod.class);
 		P packager = createPackager();
 		execute(packager, (callback) -> callback.library(newLibrary(nestedFile, LibraryScope.COMPILE, false)));
-		assertThat(getPackagedEntry("BOOT-INF/lib/" + nestedFile.getName()).getMethod()).isEqualTo(ZipEntry.STORED);
-		assertThat(getPackagedEntry("BOOT-INF/classes/test/nested.jar").getMethod()).isEqualTo(ZipEntry.STORED);
+		assertThat(getPackagedEntry("BOOT-INF/lib/" + nestedFile.getName()).getMethod()).isZero();
+		assertThat(getPackagedEntry("BOOT-INF/classes/test/nested.jar").getMethod()).isZero();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/FileUtilsTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/FileUtilsTests.java
@@ -56,7 +56,7 @@ class FileUtilsTests {
 		file.createNewFile();
 		new File(this.originDirectory, "logback.xml").createNewFile();
 		FileUtils.removeDuplicatesFromOutputDirectory(this.outputDirectory, this.originDirectory);
-		assertThat(file.exists()).isFalse();
+		assertThat(file).doesNotExist();
 	}
 
 	@Test
@@ -67,7 +67,7 @@ class FileUtilsTests {
 		file.createNewFile();
 		new File(this.originDirectory, "sub/logback.xml").createNewFile();
 		FileUtils.removeDuplicatesFromOutputDirectory(this.outputDirectory, this.originDirectory);
-		assertThat(file.exists()).isFalse();
+		assertThat(file).doesNotExist();
 	}
 
 	@Test
@@ -78,7 +78,7 @@ class FileUtilsTests {
 		file.createNewFile();
 		new File(this.originDirectory, "sub/different.xml").createNewFile();
 		FileUtils.removeDuplicatesFromOutputDirectory(this.outputDirectory, this.originDirectory);
-		assertThat(file.exists()).isTrue();
+		assertThat(file).exists();
 	}
 
 	@Test
@@ -87,7 +87,7 @@ class FileUtilsTests {
 		file.createNewFile();
 		new File(this.originDirectory, "different.xml").createNewFile();
 		FileUtils.removeDuplicatesFromOutputDirectory(this.outputDirectory, this.originDirectory);
-		assertThat(file.exists()).isTrue();
+		assertThat(file).exists();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/LayerTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/LayerTests.java
@@ -50,7 +50,7 @@ class LayerTests {
 		Layer layer1 = new Layer("testa");
 		Layer layer2 = new Layer("testa");
 		Layer layer3 = new Layer("testb");
-		assertThat(layer1.hashCode()).isEqualTo(layer2.hashCode());
+		assertThat(layer1).hasSameHashCodeAs(layer2);
 		assertThat(layer1).isEqualTo(layer1).isEqualTo(layer2).isNotEqualTo(layer3);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/LibraryCoordinatesTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/LibraryCoordinatesTests.java
@@ -35,7 +35,7 @@ class LibraryCoordinatesTests {
 		assertThat(coordinates.getGroupId()).isEqualTo("g");
 		assertThat(coordinates.getArtifactId()).isEqualTo("a");
 		assertThat(coordinates.getVersion()).isEqualTo("v");
-		assertThat(coordinates.toString()).isEqualTo("g:a:v");
+		assertThat(coordinates).hasToString("g:a:v");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/MainClassFinderTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/MainClassFinderTests.java
@@ -164,7 +164,7 @@ class MainClassFinderTests {
 		this.testJarFile.addClass("a/b/G.class", ClassWithMainMethod.class);
 		ClassNameCollector callback = new ClassNameCollector();
 		MainClassFinder.doWithMainClasses(this.testJarFile.getJarSource(), callback);
-		assertThat(callback.getClassNames().toString()).isEqualTo("[a.b.G, a.b.c.D]");
+		assertThat(callback.getClassNames()).hasToString("[a.b.G, a.b.c.D]");
 	}
 
 	@Test
@@ -176,7 +176,7 @@ class MainClassFinderTests {
 		ClassNameCollector callback = new ClassNameCollector();
 		try (JarFile jarFile = this.testJarFile.getJarFile()) {
 			MainClassFinder.doWithMainClasses(jarFile, null, callback);
-			assertThat(callback.getClassNames().toString()).isEqualTo("[a.b.G, a.b.c.D]");
+			assertThat(callback.getClassNames()).hasToString("[a.b.G, a.b.c.D]");
 		}
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/ZipHeaderPeekInputStreamTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/ZipHeaderPeekInputStreamTests.java
@@ -50,8 +50,8 @@ class ZipHeaderPeekInputStreamTests {
 	void readIndividualBytes() throws IOException {
 		try (ZipHeaderPeekInputStream in = new ZipHeaderPeekInputStream(
 				new ByteArrayInputStream(new byte[] { 0, 1, 2, 3, 4, 5 }))) {
-			assertThat(in.read()).isEqualTo(0);
-			assertThat(in.read()).isEqualTo(1);
+			assertThat(in.read()).isZero();
+			assertThat(in.read()).isOne();
 			assertThat(in.read()).isEqualTo(2);
 			assertThat(in.read()).isEqualTo(3);
 			assertThat(in.read()).isEqualTo(4);
@@ -99,7 +99,7 @@ class ZipHeaderPeekInputStreamTests {
 	void readMoreThanEntireStreamWhenStreamLengthIsLessThanZipHeaderLength() throws IOException {
 		try (ZipHeaderPeekInputStream in = new ZipHeaderPeekInputStream(new ByteArrayInputStream(new byte[] { 10 }))) {
 			byte[] bytes = new byte[8];
-			assertThat(in.read(bytes)).isEqualTo(1);
+			assertThat(in.read(bytes)).isOne();
 			assertThat(bytes).containsExactly(10, 0, 0, 0, 0, 0, 0, 0);
 		}
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/LaunchedURLClassLoaderTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/LaunchedURLClassLoaderTests.java
@@ -78,7 +78,7 @@ class LaunchedURLClassLoaderTests {
 			URL url = jarFile.getUrl();
 			try (LaunchedURLClassLoader loader = new LaunchedURLClassLoader(new URL[] { url }, null)) {
 				URL resource = loader.getResource("nested.jar!/3.dat");
-				assertThat(resource.toString()).isEqualTo(url + "nested.jar!/3.dat");
+				assertThat(resource).hasToString(url + "nested.jar!/3.dat");
 				try (InputStream input = resource.openConnection().getInputStream()) {
 					assertThat(input.read()).isEqualTo(3);
 				}
@@ -95,7 +95,7 @@ class LaunchedURLClassLoaderTests {
 			try (LaunchedURLClassLoader loader = new LaunchedURLClassLoader(new URL[] { url }, null)) {
 				Thread.currentThread().interrupt();
 				URL resource = loader.getResource("nested.jar!/3.dat");
-				assertThat(resource.toString()).isEqualTo(url + "nested.jar!/3.dat");
+				assertThat(resource).hasToString(url + "nested.jar!/3.dat");
 				URLConnection connection = resource.openConnection();
 				try (InputStream input = connection.getInputStream()) {
 					assertThat(input.read()).isEqualTo(3);

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/PropertiesLauncherTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/PropertiesLauncherTests.java
@@ -142,7 +142,7 @@ class PropertiesLauncherTests {
 		System.setProperty("loader.config.name", "foo");
 		this.launcher = new PropertiesLauncher();
 		assertThat(this.launcher.getMainClass()).isEqualTo("my.Application");
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths").toString()).isEqualTo("[etc/]");
+		assertThat(ReflectionTestUtils.getField(this.launcher, "paths")).hasToString("[etc/]");
 	}
 
 	@Test
@@ -156,14 +156,14 @@ class PropertiesLauncherTests {
 	void testUserSpecifiedDotPath() {
 		System.setProperty("loader.path", ".");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths").toString()).isEqualTo("[.]");
+		assertThat(ReflectionTestUtils.getField(this.launcher, "paths")).hasToString("[.]");
 	}
 
 	@Test
 	void testUserSpecifiedSlashPath() throws Exception {
 		System.setProperty("loader.path", "jars/");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths").toString()).isEqualTo("[jars/]");
+		assertThat(ReflectionTestUtils.getField(this.launcher, "paths")).hasToString("[jars/]");
 		List<Archive> archives = new ArrayList<>();
 		this.launcher.getClassPathArchivesIterator().forEachRemaining(archives::add);
 		assertThat(archives).areExactly(1, endingWith("app.jar"));
@@ -174,7 +174,7 @@ class PropertiesLauncherTests {
 		System.setProperty("loader.path", "jars/*");
 		System.setProperty("loader.main", "demo.Application");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths").toString()).isEqualTo("[jars/]");
+		assertThat(ReflectionTestUtils.getField(this.launcher, "paths")).hasToString("[jars/]");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello World");
 	}
@@ -184,7 +184,7 @@ class PropertiesLauncherTests {
 		System.setProperty("loader.path", "jars/app.jar");
 		System.setProperty("loader.main", "demo.Application");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths").toString()).isEqualTo("[jars/app.jar]");
+		assertThat(ReflectionTestUtils.getField(this.launcher, "paths")).hasToString("[jars/app.jar]");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello World");
 	}
@@ -193,8 +193,8 @@ class PropertiesLauncherTests {
 	void testUserSpecifiedRootOfJarPath() throws Exception {
 		System.setProperty("loader.path", "jar:file:./src/test/resources/nested-jars/app.jar!/");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths").toString())
-				.isEqualTo("[jar:file:./src/test/resources/nested-jars/app.jar!/]");
+		assertThat(ReflectionTestUtils.getField(this.launcher, "paths"))
+				.hasToString("[jar:file:./src/test/resources/nested-jars/app.jar!/]");
 		List<Archive> archives = new ArrayList<>();
 		this.launcher.getClassPathArchivesIterator().forEachRemaining(archives::add);
 		assertThat(archives).areExactly(1, endingWith("foo.jar!/"));
@@ -236,8 +236,8 @@ class PropertiesLauncherTests {
 		System.setProperty("loader.path", "nested-jars/nested-jar-app.jar!/BOOT-INF/classes/");
 		System.setProperty("loader.main", "demo.Application");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths").toString())
-				.isEqualTo("[nested-jars/nested-jar-app.jar!/BOOT-INF/classes/]");
+		assertThat(ReflectionTestUtils.getField(this.launcher, "paths"))
+				.hasToString("[nested-jars/nested-jar-app.jar!/BOOT-INF/classes/]");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello World");
 	}
@@ -256,7 +256,7 @@ class PropertiesLauncherTests {
 		System.setProperty("loader.path", "./jars/app.jar");
 		System.setProperty("loader.main", "demo.Application");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths").toString()).isEqualTo("[jars/app.jar]");
+		assertThat(ReflectionTestUtils.getField(this.launcher, "paths")).hasToString("[jars/app.jar]");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello World");
 	}
@@ -266,7 +266,7 @@ class PropertiesLauncherTests {
 		System.setProperty("loader.path", "jars/app.jar");
 		System.setProperty("loader.classLoader", URLClassLoader.class.getName());
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths").toString()).isEqualTo("[jars/app.jar]");
+		assertThat(ReflectionTestUtils.getField(this.launcher, "paths")).hasToString("[jars/app.jar]");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello World");
 	}
@@ -276,8 +276,8 @@ class PropertiesLauncherTests {
 		System.setProperty("loader.path", "more-jars/app.jar,jars/app.jar");
 		System.setProperty("loader.classLoader", URLClassLoader.class.getName());
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths").toString())
-				.isEqualTo("[more-jars/app.jar, jars/app.jar]");
+		assertThat(ReflectionTestUtils.getField(this.launcher, "paths"))
+				.hasToString("[more-jars/app.jar, jars/app.jar]");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello Other World");
 	}
@@ -340,7 +340,7 @@ class PropertiesLauncherTests {
 	void testArgsEnhanced() throws Exception {
 		System.setProperty("loader.args", "foo");
 		this.launcher = new PropertiesLauncher();
-		assertThat(Arrays.asList(this.launcher.getArgs("bar")).toString()).isEqualTo("[foo, bar]");
+		assertThat(Arrays.asList(this.launcher.getArgs("bar"))).hasToString("[foo, bar]");
 	}
 
 	@SuppressWarnings("unchecked")
@@ -375,7 +375,7 @@ class PropertiesLauncherTests {
 		this.launcher = new PropertiesLauncher();
 		List<Archive> archives = new ArrayList<>();
 		this.launcher.getClassPathArchivesIterator().forEachRemaining(archives::add);
-		assertThat(archives.size()).isEqualTo(1);
+		assertThat(archives).hasSize(1);
 		File archiveRoot = (File) ReflectionTestUtils.getField(archives.get(0), "root");
 		assertThat(archiveRoot).isEqualTo(loaderPath);
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/archive/ExplodedArchiveTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/archive/ExplodedArchiveTests.java
@@ -119,7 +119,7 @@ class ExplodedArchiveTests {
 	void getNestedArchive() throws Exception {
 		Entry entry = getEntriesMap(this.archive).get("nested.jar");
 		Archive nested = this.archive.getNestedArchive(entry);
-		assertThat(nested.getUrl().toString()).isEqualTo(this.rootDirectory.toURI() + "nested.jar");
+		assertThat(nested.getUrl()).hasToString(this.rootDirectory.toURI() + "nested.jar");
 		nested.close();
 	}
 
@@ -128,15 +128,15 @@ class ExplodedArchiveTests {
 		Entry entry = getEntriesMap(this.archive).get("d/");
 		Archive nested = this.archive.getNestedArchive(entry);
 		Map<String, Entry> nestedEntries = getEntriesMap(nested);
-		assertThat(nestedEntries.size()).isEqualTo(1);
-		assertThat(nested.getUrl().toString()).isEqualTo("file:" + this.rootDirectory.toURI().getPath() + "d/");
+		assertThat(nestedEntries).hasSize(1);
+		assertThat(nested.getUrl()).hasToString("file:" + this.rootDirectory.toURI().getPath() + "d/");
 	}
 
 	@Test
 	void getNonRecursiveEntriesForRoot() throws Exception {
 		try (ExplodedArchive explodedArchive = new ExplodedArchive(new File("/"), false)) {
 			Map<String, Archive.Entry> entries = getEntriesMap(explodedArchive);
-			assertThat(entries.size()).isGreaterThan(1);
+			assertThat(entries).hasSizeGreaterThan(1);
 		}
 	}
 
@@ -145,7 +145,7 @@ class ExplodedArchiveTests {
 		try (ExplodedArchive explodedArchive = new ExplodedArchive(new File("src/test/resources/root"))) {
 			assertThat(explodedArchive.getManifest()).isNotNull();
 			Map<String, Archive.Entry> entries = getEntriesMap(explodedArchive);
-			assertThat(entries.size()).isEqualTo(4);
+			assertThat(entries).hasSize(4);
 		}
 	}
 
@@ -154,7 +154,7 @@ class ExplodedArchiveTests {
 		try (ExplodedArchive explodedArchive = new ExplodedArchive(new File("src/test/resources/root"), false)) {
 			assertThat(explodedArchive.getManifest()).isNotNull();
 			Map<String, Archive.Entry> entries = getEntriesMap(explodedArchive);
-			assertThat(entries.size()).isEqualTo(3);
+			assertThat(entries).hasSize(3);
 		}
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/archive/JarFileArchiveTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/archive/JarFileArchiveTests.java
@@ -87,20 +87,20 @@ class JarFileArchiveTests {
 	@Test
 	void getEntries() {
 		Map<String, Archive.Entry> entries = getEntriesMap(this.archive);
-		assertThat(entries.size()).isEqualTo(12);
+		assertThat(entries).hasSize(12);
 	}
 
 	@Test
 	void getUrl() throws Exception {
 		URL url = this.archive.getUrl();
-		assertThat(url.toString()).isEqualTo(this.rootJarFileUrl);
+		assertThat(url).hasToString(this.rootJarFileUrl);
 	}
 
 	@Test
 	void getNestedArchive() throws Exception {
 		Entry entry = getEntriesMap(this.archive).get("nested.jar");
 		try (Archive nested = this.archive.getNestedArchive(entry)) {
-			assertThat(nested.getUrl().toString()).isEqualTo("jar:" + this.rootJarFileUrl + "!/nested.jar!/");
+			assertThat(nested.getUrl()).hasToString("jar:" + this.rootJarFileUrl + "!/nested.jar!/");
 		}
 	}
 
@@ -139,7 +139,7 @@ class JarFileArchiveTests {
 						.getNestedArchive(getEntriesMap(this.archive).get("another-nested.jar"))) {
 			File nested = new File(nestedArchive.getUrl().toURI());
 			File anotherNested = new File(anotherNestedArchive.getUrl().toURI());
-			assertThat(nested.getParent()).isEqualTo(anotherNested.getParent());
+			assertThat(nested).hasParent(anotherNested.getParent());
 		}
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/data/RandomAccessDataFileTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/data/RandomAccessDataFileTests.java
@@ -174,8 +174,8 @@ class RandomAccessDataFileTests {
 		byte[] b = new byte[] { 0x0F };
 		int amountRead = this.inputStream.read(b, 0, 0);
 		assertThat(b).isEqualTo(new byte[] { 0x0F });
-		assertThat(amountRead).isEqualTo(0);
-		assertThat(this.inputStream.read()).isEqualTo(0);
+		assertThat(amountRead).isZero();
+		assertThat(this.inputStream.read()).isZero();
 	}
 
 	@Test
@@ -196,7 +196,7 @@ class RandomAccessDataFileTests {
 	void inputStreamSkipPastEnd() throws Exception {
 		this.inputStream.skip(256);
 		long amountSkipped = this.inputStream.skip(1);
-		assertThat(amountSkipped).isEqualTo(0L);
+		assertThat(amountSkipped).isZero();
 	}
 
 	@Test
@@ -205,7 +205,7 @@ class RandomAccessDataFileTests {
 		this.inputStream.skip(56);
 		assertThat(this.inputStream.available()).isEqualTo(200);
 		this.inputStream.skip(200);
-		assertThat(this.inputStream.available()).isEqualTo(0);
+		assertThat(this.inputStream.available()).isZero();
 	}
 
 	@Test
@@ -239,14 +239,14 @@ class RandomAccessDataFileTests {
 	@Test
 	void subsection() throws Exception {
 		RandomAccessData subsection = this.file.getSubsection(1, 1);
-		assertThat(subsection.getInputStream().read()).isEqualTo(1);
+		assertThat(subsection.getInputStream().read()).isOne();
 	}
 
 	@Test
 	void inputStreamReadPastSubsection() throws Exception {
 		RandomAccessData subsection = this.file.getSubsection(1, 2);
 		InputStream inputStream = subsection.getInputStream();
-		assertThat(inputStream.read()).isEqualTo(1);
+		assertThat(inputStream.read()).isOne();
 		assertThat(inputStream.read()).isEqualTo(2);
 		assertThat(inputStream.read()).isEqualTo(-1);
 	}
@@ -271,7 +271,7 @@ class RandomAccessDataFileTests {
 
 	@Test
 	void inputStreamSkipNegative() throws Exception {
-		assertThat(this.inputStream.skip(-1)).isEqualTo(0L);
+		assertThat(this.inputStream.skip(-1)).isZero();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/AsciiBytesTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/AsciiBytesTests.java
@@ -34,19 +34,19 @@ class AsciiBytesTests {
 	@Test
 	void createFromBytes() {
 		AsciiBytes bytes = new AsciiBytes(new byte[] { 65, 66 });
-		assertThat(bytes.toString()).isEqualTo("AB");
+		assertThat(bytes).hasToString("AB");
 	}
 
 	@Test
 	void createFromBytesWithOffset() {
 		AsciiBytes bytes = new AsciiBytes(new byte[] { 65, 66, 67, 68 }, 1, 2);
-		assertThat(bytes.toString()).isEqualTo("BC");
+		assertThat(bytes).hasToString("BC");
 	}
 
 	@Test
 	void createFromString() {
 		AsciiBytes bytes = new AsciiBytes("AB");
-		assertThat(bytes.toString()).isEqualTo("AB");
+		assertThat(bytes).hasToString("AB");
 	}
 
 	@Test
@@ -84,21 +84,21 @@ class AsciiBytesTests {
 	@Test
 	void substringFromBeingIndex() {
 		AsciiBytes abcd = new AsciiBytes(new byte[] { 65, 66, 67, 68 });
-		assertThat(abcd.substring(0).toString()).isEqualTo("ABCD");
-		assertThat(abcd.substring(1).toString()).isEqualTo("BCD");
-		assertThat(abcd.substring(2).toString()).isEqualTo("CD");
-		assertThat(abcd.substring(3).toString()).isEqualTo("D");
-		assertThat(abcd.substring(4).toString()).isEqualTo("");
+		assertThat(abcd.substring(0)).hasToString("ABCD");
+		assertThat(abcd.substring(1)).hasToString("BCD");
+		assertThat(abcd.substring(2)).hasToString("CD");
+		assertThat(abcd.substring(3)).hasToString("D");
+		assertThat(abcd.substring(4).toString()).isEmpty();
 		assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> abcd.substring(5));
 	}
 
 	@Test
 	void substring() {
 		AsciiBytes abcd = new AsciiBytes(new byte[] { 65, 66, 67, 68 });
-		assertThat(abcd.substring(0, 4).toString()).isEqualTo("ABCD");
-		assertThat(abcd.substring(1, 3).toString()).isEqualTo("BC");
-		assertThat(abcd.substring(3, 4).toString()).isEqualTo("D");
-		assertThat(abcd.substring(3, 3).toString()).isEqualTo("");
+		assertThat(abcd.substring(0, 4)).hasToString("ABCD");
+		assertThat(abcd.substring(1, 3)).hasToString("BC");
+		assertThat(abcd.substring(3, 4)).hasToString("D");
+		assertThat(abcd.substring(3, 3).toString()).isEmpty();
 		assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> abcd.substring(3, 5));
 	}
 
@@ -108,9 +108,9 @@ class AsciiBytesTests {
 		AsciiBytes bc = new AsciiBytes(new byte[] { 66, 67 });
 		AsciiBytes bc_substring = new AsciiBytes(new byte[] { 65, 66, 67, 68 }).substring(1, 3);
 		AsciiBytes bc_string = new AsciiBytes("BC");
-		assertThat(bc.hashCode()).isEqualTo(bc.hashCode());
-		assertThat(bc.hashCode()).isEqualTo(bc_substring.hashCode());
-		assertThat(bc.hashCode()).isEqualTo(bc_string.hashCode());
+		assertThat(bc).hasSameHashCodeAs(bc);
+		assertThat(bc).hasSameHashCodeAs(bc_substring);
+		assertThat(bc).hasSameHashCodeAs(bc_string);
 		assertThat(bc).isEqualTo(bc);
 		assertThat(bc).isEqualTo(bc_substring);
 		assertThat(bc).isEqualTo(bc_string);
@@ -139,7 +139,7 @@ class AsciiBytesTests {
 	}
 
 	private void hashCodeSameAsString(String input) {
-		assertThat(new AsciiBytes(input).hashCode()).isEqualTo(input.hashCode());
+		assertThat(new AsciiBytes(input)).hasSameHashCodeAs(input);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/CentralDirectoryParserTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/CentralDirectoryParserTests.java
@@ -73,18 +73,18 @@ class CentralDirectoryParserTests {
 		parser.addVisitor(collector);
 		parser.parse(this.jarData, false);
 		Iterator<CentralDirectoryFileHeader> headers = collector.getHeaders().iterator();
-		assertThat(headers.next().getName().toString()).isEqualTo("META-INF/");
-		assertThat(headers.next().getName().toString()).isEqualTo("META-INF/MANIFEST.MF");
-		assertThat(headers.next().getName().toString()).isEqualTo("1.dat");
-		assertThat(headers.next().getName().toString()).isEqualTo("2.dat");
-		assertThat(headers.next().getName().toString()).isEqualTo("d/");
-		assertThat(headers.next().getName().toString()).isEqualTo("d/9.dat");
-		assertThat(headers.next().getName().toString()).isEqualTo("special/");
-		assertThat(headers.next().getName().toString()).isEqualTo("special/\u00EB.dat");
-		assertThat(headers.next().getName().toString()).isEqualTo("nested.jar");
-		assertThat(headers.next().getName().toString()).isEqualTo("another-nested.jar");
-		assertThat(headers.next().getName().toString()).isEqualTo("space nested.jar");
-		assertThat(headers.next().getName().toString()).isEqualTo("multi-release.jar");
+		assertThat(headers.next().getName()).hasToString("META-INF/");
+		assertThat(headers.next().getName()).hasToString("META-INF/MANIFEST.MF");
+		assertThat(headers.next().getName()).hasToString("1.dat");
+		assertThat(headers.next().getName()).hasToString("2.dat");
+		assertThat(headers.next().getName()).hasToString("d/");
+		assertThat(headers.next().getName()).hasToString("d/9.dat");
+		assertThat(headers.next().getName()).hasToString("special/");
+		assertThat(headers.next().getName()).hasToString("special/\u00EB.dat");
+		assertThat(headers.next().getName()).hasToString("nested.jar");
+		assertThat(headers.next().getName()).hasToString("another-nested.jar");
+		assertThat(headers.next().getName()).hasToString("space nested.jar");
+		assertThat(headers.next().getName()).hasToString("multi-release.jar");
 		assertThat(headers.hasNext()).isFalse();
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/HandlerTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/HandlerTests.java
@@ -191,7 +191,7 @@ class HandlerTests {
 	private void assertStandardAndCustomHandlerUrlsAreEqual(String context, String spec) throws MalformedURLException {
 		URL standardUrl = new URL(new URL("jar:" + context), spec);
 		URL customHandlerUrl = new URL(new URL("jar", null, -1, context, this.handler), spec);
-		assertThat(customHandlerUrl.toString()).isEqualTo(standardUrl.toString());
+		assertThat(customHandlerUrl).hasToString(standardUrl.toString());
 		assertThat(customHandlerUrl.getFile()).isEqualTo(standardUrl.getFile());
 		assertThat(customHandlerUrl.getPath()).isEqualTo(standardUrl.getPath());
 		assertThat(customHandlerUrl.getQuery()).isEqualTo(standardUrl.getQuery());

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarFileTests.java
@@ -188,9 +188,9 @@ class JarFileTests {
 	@Test
 	void getInputStream() throws Exception {
 		InputStream inputStream = this.jarFile.getInputStream(this.jarFile.getEntry("1.dat"));
-		assertThat(inputStream.available()).isEqualTo(1);
-		assertThat(inputStream.read()).isEqualTo(1);
-		assertThat(inputStream.available()).isEqualTo(0);
+		assertThat(inputStream.available()).isOne();
+		assertThat(inputStream.read()).isOne();
+		assertThat(inputStream.available()).isZero();
 		assertThat(inputStream.read()).isEqualTo(-1);
 	}
 
@@ -249,7 +249,7 @@ class JarFileTests {
 	@Test
 	void getUrl() throws Exception {
 		URL url = this.jarFile.getUrl();
-		assertThat(url.toString()).isEqualTo("jar:" + this.rootJarFile.toURI() + "!/");
+		assertThat(url).hasToString("jar:" + this.rootJarFile.toURI() + "!/");
 		JarURLConnection jarURLConnection = (JarURLConnection) url.openConnection();
 		assertThat(JarFileWrapper.unwrap(jarURLConnection.getJarFile())).isSameAs(this.jarFile);
 		assertThat(jarURLConnection.getJarEntry()).isNull();
@@ -262,11 +262,11 @@ class JarFileTests {
 	@Test
 	void createEntryUrl() throws Exception {
 		URL url = new URL(this.jarFile.getUrl(), "1.dat");
-		assertThat(url.toString()).isEqualTo("jar:" + this.rootJarFile.toURI() + "!/1.dat");
+		assertThat(url).hasToString("jar:" + this.rootJarFile.toURI() + "!/1.dat");
 		JarURLConnection jarURLConnection = (JarURLConnection) url.openConnection();
 		assertThat(JarFileWrapper.unwrap(jarURLConnection.getJarFile())).isSameAs(this.jarFile);
 		assertThat(jarURLConnection.getJarEntry()).isSameAs(this.jarFile.getJarEntry("1.dat"));
-		assertThat(jarURLConnection.getContentLength()).isEqualTo(1);
+		assertThat(jarURLConnection.getContentLength()).isOne();
 		assertThat(jarURLConnection.getContent()).isInstanceOf(InputStream.class);
 		assertThat(jarURLConnection.getContentType()).isEqualTo("content/unknown");
 		assertThat(jarURLConnection.getPermission()).isInstanceOf(FilePermission.class);
@@ -278,7 +278,7 @@ class JarFileTests {
 	@Test
 	void getMissingEntryUrl() throws Exception {
 		URL url = new URL(this.jarFile.getUrl(), "missing.dat");
-		assertThat(url.toString()).isEqualTo("jar:" + this.rootJarFile.toURI() + "!/missing.dat");
+		assertThat(url).hasToString("jar:" + this.rootJarFile.toURI() + "!/missing.dat");
 		assertThatExceptionOfType(FileNotFoundException.class)
 				.isThrownBy(((JarURLConnection) url.openConnection())::getJarEntry);
 	}
@@ -295,7 +295,7 @@ class JarFileTests {
 		URL url = new URL(this.jarFile.getUrl(), "1.dat");
 		url.openConnection();
 		try (InputStream stream = url.openStream()) {
-			assertThat(stream.read()).isEqualTo(1);
+			assertThat(stream.read()).isOne();
 			assertThat(stream.read()).isEqualTo(-1);
 		}
 	}
@@ -317,10 +317,10 @@ class JarFileTests {
 			assertThat(inputStream.read()).isEqualTo(-1);
 
 			URL url = nestedJarFile.getUrl();
-			assertThat(url.toString()).isEqualTo("jar:" + this.rootJarFile.toURI() + "!/nested.jar!/");
+			assertThat(url).hasToString("jar:" + this.rootJarFile.toURI() + "!/nested.jar!/");
 			JarURLConnection conn = (JarURLConnection) url.openConnection();
 			assertThat(JarFileWrapper.unwrap(conn.getJarFile())).isSameAs(nestedJarFile);
-			assertThat(conn.getJarFileURL().toString()).isEqualTo("jar:" + this.rootJarFile.toURI() + "!/nested.jar");
+			assertThat(conn.getJarFileURL()).hasToString("jar:" + this.rootJarFile.toURI() + "!/nested.jar");
 			assertThat(conn.getInputStream()).isNotNull();
 			JarInputStream jarInputStream = new JarInputStream(conn.getInputStream());
 			assertThat(jarInputStream.getNextJarEntry().getName()).isEqualTo("3.dat");
@@ -347,7 +347,7 @@ class JarFileTests {
 			}
 
 			URL url = nestedJarFile.getUrl();
-			assertThat(url.toString()).isEqualTo("jar:" + this.rootJarFile.toURI() + "!/d!/");
+			assertThat(url).hasToString("jar:" + this.rootJarFile.toURI() + "!/d!/");
 			JarURLConnection connection = (JarURLConnection) url.openConnection();
 			assertThat(JarFileWrapper.unwrap(connection.getJarFile())).isSameAs(nestedJarFile);
 		}
@@ -357,7 +357,7 @@ class JarFileTests {
 	void getNestedJarEntryUrl() throws Exception {
 		try (JarFile nestedJarFile = this.jarFile.getNestedJarFile(this.jarFile.getEntry("nested.jar"))) {
 			URL url = nestedJarFile.getJarEntry("3.dat").getUrl();
-			assertThat(url.toString()).isEqualTo("jar:" + this.rootJarFile.toURI() + "!/nested.jar!/3.dat");
+			assertThat(url).hasToString("jar:" + this.rootJarFile.toURI() + "!/nested.jar!/3.dat");
 			try (InputStream inputStream = url.openStream()) {
 				assertThat(inputStream).isNotNull();
 				assertThat(inputStream.read()).isEqualTo(3);
@@ -369,14 +369,13 @@ class JarFileTests {
 	void createUrlFromString() throws Exception {
 		String spec = "jar:" + this.rootJarFile.toURI() + "!/nested.jar!/3.dat";
 		URL url = new URL(spec);
-		assertThat(url.toString()).isEqualTo(spec);
+		assertThat(url).hasToString(spec);
 		JarURLConnection connection = (JarURLConnection) url.openConnection();
 		try (InputStream inputStream = connection.getInputStream()) {
 			assertThat(inputStream).isNotNull();
 			assertThat(inputStream.read()).isEqualTo(3);
-			assertThat(connection.getURL().toString()).isEqualTo(spec);
-			assertThat(connection.getJarFileURL().toString())
-					.isEqualTo("jar:" + this.rootJarFile.toURI() + "!/nested.jar");
+			assertThat(connection.getURL()).hasToString(spec);
+			assertThat(connection.getJarFileURL()).hasToString("jar:" + this.rootJarFile.toURI() + "!/nested.jar");
 			assertThat(connection.getEntryName()).isEqualTo("3.dat");
 			connection.getJarFile().close();
 		}
@@ -395,12 +394,12 @@ class JarFileTests {
 	private void nonNestedJarFileFromString(String spec) throws Exception {
 		JarFile.registerUrlProtocolHandler();
 		URL url = new URL(spec);
-		assertThat(url.toString()).isEqualTo(spec);
+		assertThat(url).hasToString(spec);
 		JarURLConnection connection = (JarURLConnection) url.openConnection();
 		try (InputStream inputStream = connection.getInputStream()) {
 			assertThat(inputStream).isNotNull();
 			assertThat(inputStream.read()).isEqualTo(2);
-			assertThat(connection.getURL().toString()).isEqualTo(spec);
+			assertThat(connection.getURL()).hasToString(spec);
 			assertThat(connection.getJarFileURL().toURI()).isEqualTo(this.rootJarFile.toURI());
 			assertThat(connection.getEntryName()).isEqualTo("2.dat");
 		}
@@ -423,9 +422,9 @@ class JarFileTests {
 
 	@Test
 	void sensibleToString() throws Exception {
-		assertThat(this.jarFile.toString()).isEqualTo(this.rootJarFile.getPath());
+		assertThat(this.jarFile).hasToString(this.rootJarFile.getPath());
 		try (JarFile nested = this.jarFile.getNestedJarFile(this.jarFile.getEntry("nested.jar"))) {
-			assertThat(nested.toString()).isEqualTo(this.rootJarFile.getPath() + "!/nested.jar");
+			assertThat(nested).hasToString(this.rootJarFile.getPath() + "!/nested.jar");
 		}
 	}
 
@@ -560,7 +559,7 @@ class JarFileTests {
 			ZipEntry entry = multiRelease.getEntry("multi-release.dat");
 			assertThat(entry.getName()).isEqualTo("multi-release.dat");
 			InputStream inputStream = multiRelease.getInputStream(entry);
-			assertThat(inputStream.available()).isEqualTo(1);
+			assertThat(inputStream.available()).isOne();
 			assertThat(inputStream.read()).isEqualTo(Runtime.version().feature());
 		}
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarURLConnectionTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/JarURLConnectionTests.java
@@ -182,7 +182,7 @@ class JarURLConnectionTests {
 		URL url = new URL("jar:" + this.rootJarFile.toURI().toURL() + "!/nested.jar!/3.dat");
 		try (JarFile nested = this.jarFile.getNestedJarFile(this.jarFile.getEntry("nested.jar"))) {
 			JarURLConnection connection = JarURLConnection.get(url, nested);
-			assertThat(connection.getContentLength()).isEqualTo(1);
+			assertThat(connection.getContentLength()).isOne();
 		}
 	}
 
@@ -191,7 +191,7 @@ class JarURLConnectionTests {
 		URL url = new URL("jar:" + this.rootJarFile.toURI().toURL() + "!/nested.jar!/3.dat");
 		try (JarFile nested = this.jarFile.getNestedJarFile(this.jarFile.getEntry("nested.jar"))) {
 			JarURLConnection connection = JarURLConnection.get(url, nested);
-			assertThat(connection.getContentLengthLong()).isEqualTo(1);
+			assertThat(connection.getContentLengthLong()).isOne();
 		}
 	}
 
@@ -212,23 +212,22 @@ class JarURLConnectionTests {
 
 	@Test
 	void jarEntryBasicName() {
-		assertThat(new JarEntryName(new StringSequence("a/b/C.class")).toString()).isEqualTo("a/b/C.class");
+		assertThat(new JarEntryName(new StringSequence("a/b/C.class"))).hasToString("a/b/C.class");
 	}
 
 	@Test
 	void jarEntryNameWithSingleByteEncodedCharacters() {
-		assertThat(new JarEntryName(new StringSequence("%61/%62/%43.class")).toString()).isEqualTo("a/b/C.class");
+		assertThat(new JarEntryName(new StringSequence("%61/%62/%43.class"))).hasToString("a/b/C.class");
 	}
 
 	@Test
 	void jarEntryNameWithDoubleByteEncodedCharacters() {
-		assertThat(new JarEntryName(new StringSequence("%c3%a1/b/C.class")).toString()).isEqualTo("\u00e1/b/C.class");
+		assertThat(new JarEntryName(new StringSequence("%c3%a1/b/C.class"))).hasToString("\u00e1/b/C.class");
 	}
 
 	@Test
 	void jarEntryNameWithMixtureOfEncodedAndUnencodedDoubleByteCharacters() {
-		assertThat(new JarEntryName(new StringSequence("%c3%a1/b/\u00c7.class")).toString())
-				.isEqualTo("\u00e1/b/\u00c7.class");
+		assertThat(new JarEntryName(new StringSequence("%c3%a1/b/\u00c7.class"))).hasToString("\u00e1/b/\u00c7.class");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/StringSequenceTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/StringSequenceTests.java
@@ -55,38 +55,38 @@ class StringSequenceTests {
 
 	@Test
 	void createFromString() {
-		assertThat(new StringSequence("test").toString()).isEqualTo("test");
+		assertThat(new StringSequence("test")).hasToString("test");
 	}
 
 	@Test
 	void subSequenceWithJustStartShouldReturnSubSequence() {
-		assertThat(new StringSequence("smiles").subSequence(1).toString()).isEqualTo("miles");
+		assertThat(new StringSequence("smiles").subSequence(1)).hasToString("miles");
 	}
 
 	@Test
 	void subSequenceShouldReturnSubSequence() {
-		assertThat(new StringSequence("hamburger").subSequence(4, 8).toString()).isEqualTo("urge");
-		assertThat(new StringSequence("smiles").subSequence(1, 5).toString()).isEqualTo("mile");
+		assertThat(new StringSequence("hamburger").subSequence(4, 8)).hasToString("urge");
+		assertThat(new StringSequence("smiles").subSequence(1, 5)).hasToString("mile");
 	}
 
 	@Test
 	void subSequenceWhenCalledMultipleTimesShouldReturnSubSequence() {
-		assertThat(new StringSequence("hamburger").subSequence(4, 8).subSequence(1, 3).toString()).isEqualTo("rg");
+		assertThat(new StringSequence("hamburger").subSequence(4, 8).subSequence(1, 3)).hasToString("rg");
 	}
 
 	@Test
 	void subSequenceWhenEndPastExistingEndShouldThrowException() {
 		StringSequence sequence = new StringSequence("abcde").subSequence(1, 4);
-		assertThat(sequence.toString()).isEqualTo("bcd");
-		assertThat(sequence.subSequence(2, 3).toString()).isEqualTo("d");
+		assertThat(sequence).hasToString("bcd");
+		assertThat(sequence.subSequence(2, 3)).hasToString("d");
 		assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> sequence.subSequence(3, 4));
 	}
 
 	@Test
 	void subSequenceWhenStartPastExistingEndShouldThrowException() {
 		StringSequence sequence = new StringSequence("abcde").subSequence(1, 4);
-		assertThat(sequence.toString()).isEqualTo("bcd");
-		assertThat(sequence.subSequence(2, 3).toString()).isEqualTo("d");
+		assertThat(sequence).hasToString("bcd");
+		assertThat(sequence.subSequence(2, 3)).hasToString("d");
 		assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> sequence.subSequence(4, 3));
 	}
 
@@ -103,8 +103,8 @@ class StringSequenceTests {
 	@Test
 	void lengthShouldReturnLength() {
 		StringSequence sequence = new StringSequence("hamburger");
-		assertThat(sequence.length()).isEqualTo(9);
-		assertThat(sequence.subSequence(4, 8).length()).isEqualTo(4);
+		assertThat(sequence).hasSize(9);
+		assertThat(sequence.subSequence(4, 8)).hasSize(4);
 	}
 
 	@Test
@@ -119,7 +119,7 @@ class StringSequenceTests {
 	@Test
 	void indexOfCharShouldReturnIndexOf() {
 		StringSequence sequence = new StringSequence("aabbaacc");
-		assertThat(sequence.indexOf('a')).isEqualTo(0);
+		assertThat(sequence.indexOf('a')).isZero();
 		assertThat(sequence.indexOf('b')).isEqualTo(2);
 		assertThat(sequence.subSequence(2).indexOf('a')).isEqualTo(2);
 	}
@@ -127,7 +127,7 @@ class StringSequenceTests {
 	@Test
 	void indexOfStringShouldReturnIndexOf() {
 		StringSequence sequence = new StringSequence("aabbaacc");
-		assertThat(sequence.indexOf('a')).isEqualTo(0);
+		assertThat(sequence.indexOf('a')).isZero();
 		assertThat(sequence.indexOf('b')).isEqualTo(2);
 		assertThat(sequence.subSequence(2).indexOf('a')).isEqualTo(2);
 	}
@@ -142,8 +142,8 @@ class StringSequenceTests {
 
 	@Test
 	void hashCodeShouldBeSameAsString() {
-		assertThat(new StringSequence("hamburger").hashCode()).isEqualTo("hamburger".hashCode());
-		assertThat(new StringSequence("hamburger").subSequence(4, 8).hashCode()).isEqualTo("urge".hashCode());
+		assertThat(new StringSequence("hamburger")).hasSameHashCodeAs("hamburger");
+		assertThat(new StringSequence("hamburger").subSequence(4, 8)).hasSameHashCodeAs("urge");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/CustomLayersProviderTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/CustomLayersProviderTests.java
@@ -59,13 +59,13 @@ class CustomLayersProviderTests {
 		Library otherDependency = mockLibrary("other-library", "org.foo", null);
 		Library localSnapshotDependency = mockLibrary("local-library", "org.foo", "1.0-SNAPSHOT");
 		given(localSnapshotDependency.isLocal()).willReturn(true);
-		assertThat(layers.getLayer(snapshot).toString()).isEqualTo("snapshot-dependencies");
-		assertThat(layers.getLayer(groupId).toString()).isEqualTo("my-deps");
-		assertThat(layers.getLayer(otherDependency).toString()).isEqualTo("my-dependencies-name");
-		assertThat(layers.getLayer(localSnapshotDependency).toString()).isEqualTo("application");
-		assertThat(layers.getLayer("META-INF/resources/test.css").toString()).isEqualTo("my-resources");
-		assertThat(layers.getLayer("application.yml").toString()).isEqualTo("configuration");
-		assertThat(layers.getLayer("test").toString()).isEqualTo("application");
+		assertThat(layers.getLayer(snapshot)).hasToString("snapshot-dependencies");
+		assertThat(layers.getLayer(groupId)).hasToString("my-deps");
+		assertThat(layers.getLayer(otherDependency)).hasToString("my-dependencies-name");
+		assertThat(layers.getLayer(localSnapshotDependency)).hasToString("application");
+		assertThat(layers.getLayer("META-INF/resources/test.css")).hasToString("my-resources");
+		assertThat(layers.getLayer("application.yml")).hasToString("configuration");
+		assertThat(layers.getLayer("test")).hasToString("application");
 	}
 
 	private Library mockLibrary(String name, String groupId, String version) {
@@ -79,7 +79,7 @@ class CustomLayersProviderTests {
 	void getLayerResolverWhenDocumentContainsLibraryLayerWithNoFilters() throws Exception {
 		CustomLayers layers = this.customLayersProvider.getLayers(getDocument("dependencies-layer-no-filter.xml"));
 		Library library = mockLibrary("my-library", "com.acme", null);
-		assertThat(layers.getLayer(library).toString()).isEqualTo("my-deps");
+		assertThat(layers.getLayer(library)).hasToString("my-deps");
 		assertThatIllegalStateException().isThrownBy(() -> layers.getLayer("application.yml"))
 				.withMessageContaining("match any layer");
 	}
@@ -88,7 +88,7 @@ class CustomLayersProviderTests {
 	void getLayerResolverWhenDocumentContainsResourceLayerWithNoFilters() throws Exception {
 		CustomLayers layers = this.customLayersProvider.getLayers(getDocument("application-layer-no-filter.xml"));
 		Library library = mockLibrary("my-library", "com.acme", null);
-		assertThat(layers.getLayer("application.yml").toString()).isEqualTo("my-layer");
+		assertThat(layers.getLayer("application.yml")).hasToString("my-layer");
 		assertThatIllegalStateException().isThrownBy(() -> layers.getLayer(library))
 				.withMessageContaining("match any layer");
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/DockerTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/DockerTests.java
@@ -53,7 +53,7 @@ class DockerTests {
 		DockerConfiguration dockerConfiguration = docker.asDockerConfiguration();
 		DockerHost host = dockerConfiguration.getHost();
 		assertThat(host.getAddress()).isEqualTo("docker.example.com");
-		assertThat(host.isSecure()).isEqualTo(true);
+		assertThat(host.isSecure()).isTrue();
 		assertThat(host.getCertificatePath()).isEqualTo("/tmp/ca-cert");
 		assertThat(dockerConfiguration.isBindHostToBuilder()).isFalse();
 		assertThat(docker.asDockerConfiguration().getBuilderRegistryAuthentication()).isNull();
@@ -72,7 +72,7 @@ class DockerTests {
 		DockerConfiguration dockerConfiguration = docker.asDockerConfiguration();
 		DockerHost host = dockerConfiguration.getHost();
 		assertThat(host.getAddress()).isEqualTo("docker.example.com");
-		assertThat(host.isSecure()).isEqualTo(true);
+		assertThat(host.isSecure()).isTrue();
 		assertThat(host.getCertificatePath()).isEqualTo("/tmp/ca-cert");
 		assertThat(dockerConfiguration.isBindHostToBuilder()).isTrue();
 		assertThat(docker.asDockerConfiguration().getBuilderRegistryAuthentication()).isNull();

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ImageTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ImageTests.java
@@ -52,7 +52,7 @@ class ImageTests {
 	@Test
 	void getBuildRequestWhenNameIsNullDeducesName() {
 		BuildRequest request = new Image().getBuildRequest(createArtifact(), mockApplicationContent());
-		assertThat(request.getName().toString()).isEqualTo("docker.io/library/my-app:0.0.1-SNAPSHOT");
+		assertThat(request.getName()).hasToString("docker.io/library/my-app:0.0.1-SNAPSHOT");
 	}
 
 	@Test
@@ -60,13 +60,13 @@ class ImageTests {
 		Image image = new Image();
 		image.name = "demo";
 		BuildRequest request = image.getBuildRequest(createArtifact(), mockApplicationContent());
-		assertThat(request.getName().toString()).isEqualTo("docker.io/library/demo:latest");
+		assertThat(request.getName()).hasToString("docker.io/library/demo:latest");
 	}
 
 	@Test
 	void getBuildRequestWhenNoCustomizationsUsesDefaults() {
 		BuildRequest request = new Image().getBuildRequest(createArtifact(), mockApplicationContent());
-		assertThat(request.getName().toString()).isEqualTo("docker.io/library/my-app:0.0.1-SNAPSHOT");
+		assertThat(request.getName()).hasToString("docker.io/library/my-app:0.0.1-SNAPSHOT");
 		assertThat(request.getBuilder().toString()).contains("paketobuildpacks/builder");
 		assertThat(request.getRunImage()).isNull();
 		assertThat(request.getEnv()).isEmpty();
@@ -83,7 +83,7 @@ class ImageTests {
 		Image image = new Image();
 		image.builder = "springboot/builder:2.2.x";
 		BuildRequest request = image.getBuildRequest(createArtifact(), mockApplicationContent());
-		assertThat(request.getBuilder().toString()).isEqualTo("docker.io/springboot/builder:2.2.x");
+		assertThat(request.getBuilder()).hasToString("docker.io/springboot/builder:2.2.x");
 	}
 
 	@Test
@@ -91,7 +91,7 @@ class ImageTests {
 		Image image = new Image();
 		image.runImage = "springboot/run:latest";
 		BuildRequest request = image.getBuildRequest(createArtifact(), mockApplicationContent());
-		assertThat(request.getRunImage().toString()).isEqualTo("docker.io/springboot/run:latest");
+		assertThat(request.getRunImage()).hasToString("docker.io/springboot/run:latest");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/PropertiesMergingResourceTransformerTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/PropertiesMergingResourceTransformerTests.java
@@ -62,7 +62,7 @@ class PropertiesMergingResourceTransformerTests {
 		os.flush();
 		os.close();
 		byte[] bytes = out.toByteArray();
-		assertThat(bytes).hasSizeGreaterThan(0);
+		assertThat(bytes).isNotEmpty();
 		List<JarEntry> entries = new ArrayList<>();
 		try (JarInputStream is = new JarInputStream(new ByteArrayInputStream(bytes))) {
 			JarEntry entry;

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/SystemPropertyFormatterTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/SystemPropertyFormatterTests.java
@@ -29,7 +29,7 @@ class SystemPropertyFormatterTests {
 
 	@Test
 	void parseEmpty() {
-		assertThat(SystemPropertyFormatter.format(null, null)).isEqualTo("");
+		assertThat(SystemPropertyFormatter.format(null, null)).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/test/java/org/springframework/boot/testsupport/web/servlet/MockServletWebServerTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/test/java/org/springframework/boot/testsupport/web/servlet/MockServletWebServerTests.java
@@ -38,8 +38,7 @@ class MockServletWebServerTests {
 	@Test
 	void servletContextHasSessionCookieConfigConfigured() {
 		MockServletWebServer server = TestMockServletWebServer.create();
-		assertThat(server.getServletContext().getSessionCookieConfig()).isNotNull()
-				.isInstanceOf(MockSessionCookieConfig.class);
+		assertThat(server.getServletContext().getSessionCookieConfig()).isInstanceOf(MockSessionCookieConfig.class);
 	}
 
 	private static final class TestMockServletWebServer extends MockServletWebServer {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/BeanDefinitionLoaderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/BeanDefinitionLoaderTests.java
@@ -51,7 +51,7 @@ class BeanDefinitionLoaderTests {
 	@Test
 	void loadClass() {
 		BeanDefinitionLoader loader = new BeanDefinitionLoader(this.registry, MyComponent.class);
-		assertThat(load(loader)).isEqualTo(1);
+		assertThat(load(loader)).isOne();
 		assertThat(this.registry.containsBean("myComponent")).isTrue();
 	}
 
@@ -61,13 +61,13 @@ class BeanDefinitionLoaderTests {
 
 		};
 		BeanDefinitionLoader loader = new BeanDefinitionLoader(this.registry, myComponent.getClass());
-		assertThat(load(loader)).isEqualTo(0);
+		assertThat(load(loader)).isZero();
 	}
 
 	@Test
 	void loadJsr330Class() {
 		BeanDefinitionLoader loader = new BeanDefinitionLoader(this.registry, MyNamedComponent.class);
-		assertThat(load(loader)).isEqualTo(1);
+		assertThat(load(loader)).isOne();
 		assertThat(this.registry.containsBean("myNamedComponent")).isTrue();
 	}
 
@@ -75,7 +75,7 @@ class BeanDefinitionLoaderTests {
 	void loadXmlResource() {
 		ClassPathResource resource = new ClassPathResource("sample-beans.xml", getClass());
 		BeanDefinitionLoader loader = new BeanDefinitionLoader(this.registry, resource);
-		assertThat(load(loader)).isEqualTo(1);
+		assertThat(load(loader)).isOne();
 		assertThat(this.registry.containsBean("myXmlComponent")).isTrue();
 
 	}
@@ -84,7 +84,7 @@ class BeanDefinitionLoaderTests {
 	void loadGroovyResource() {
 		ClassPathResource resource = new ClassPathResource("sample-beans.groovy", getClass());
 		BeanDefinitionLoader loader = new BeanDefinitionLoader(this.registry, resource);
-		assertThat(load(loader)).isEqualTo(1);
+		assertThat(load(loader)).isOne();
 		assertThat(this.registry.containsBean("myGroovyComponent")).isTrue();
 
 	}
@@ -93,7 +93,7 @@ class BeanDefinitionLoaderTests {
 	void loadGroovyResourceWithNamespace() {
 		ClassPathResource resource = new ClassPathResource("sample-namespace.groovy", getClass());
 		BeanDefinitionLoader loader = new BeanDefinitionLoader(this.registry, resource);
-		assertThat(load(loader)).isEqualTo(1);
+		assertThat(load(loader)).isOne();
 		assertThat(this.registry.containsBean("myGroovyComponent")).isTrue();
 
 	}
@@ -109,7 +109,7 @@ class BeanDefinitionLoaderTests {
 	@Test
 	void loadClassName() {
 		BeanDefinitionLoader loader = new BeanDefinitionLoader(this.registry, MyComponent.class.getName());
-		assertThat(load(loader)).isEqualTo(1);
+		assertThat(load(loader)).isOne();
 		assertThat(this.registry.containsBean("myComponent")).isTrue();
 	}
 
@@ -117,7 +117,7 @@ class BeanDefinitionLoaderTests {
 	void loadResourceName() {
 		BeanDefinitionLoader loader = new BeanDefinitionLoader(this.registry,
 				"classpath:org/springframework/boot/sample-beans.xml");
-		assertThat(load(loader)).isEqualTo(1);
+		assertThat(load(loader)).isOne();
 		assertThat(this.registry.containsBean("myXmlComponent")).isTrue();
 	}
 
@@ -125,7 +125,7 @@ class BeanDefinitionLoaderTests {
 	void loadGroovyName() {
 		BeanDefinitionLoader loader = new BeanDefinitionLoader(this.registry,
 				"classpath:org/springframework/boot/sample-beans.groovy");
-		assertThat(load(loader)).isEqualTo(1);
+		assertThat(load(loader)).isOne();
 		assertThat(this.registry.containsBean("myGroovyComponent")).isTrue();
 	}
 
@@ -143,7 +143,7 @@ class BeanDefinitionLoaderTests {
 		BeanDefinitionLoader loader = new BeanDefinitionLoader(this.registry,
 				MyComponentInPackageWithoutDot.class.getPackage().getName());
 		int loaded = load(loader);
-		assertThat(loaded).isEqualTo(1);
+		assertThat(loaded).isOne();
 		assertThat(this.registry.containsBean("myComponentInPackageWithoutDot")).isTrue();
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/DefaultBootstrapContextTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/DefaultBootstrapContextTests.java
@@ -63,8 +63,8 @@ class DefaultBootstrapContextTests {
 	@Test
 	void registerWhenNotAlreadyRegisteredRegistersInstance() {
 		this.context.register(Integer.class, InstanceSupplier.from(this.counter::getAndIncrement));
-		assertThat(this.context.get(Integer.class)).isEqualTo(0);
-		assertThat(this.context.get(Integer.class)).isEqualTo(0);
+		assertThat(this.context.get(Integer.class)).isZero();
+		assertThat(this.context.get(Integer.class)).isZero();
 	}
 
 	@Test
@@ -123,7 +123,7 @@ class DefaultBootstrapContextTests {
 	void registerIfAbsentWhenPresentDoesNotRegister() {
 		this.context.registerIfAbsent(Long.class, InstanceSupplier.of(1L));
 		this.context.registerIfAbsent(Long.class, InstanceSupplier.of(100L));
-		assertThat(this.context.get(Long.class)).isEqualTo(1L);
+		assertThat(this.context.get(Long.class)).isOne();
 	}
 
 	@Test
@@ -167,16 +167,16 @@ class DefaultBootstrapContextTests {
 	@Test
 	void getWhenSingletonCreatesOnlyOneInstance() {
 		this.context.register(Integer.class, InstanceSupplier.from(this.counter::getAndIncrement));
-		assertThat(this.context.get(Integer.class)).isEqualTo(0);
-		assertThat(this.context.get(Integer.class)).isEqualTo(0);
+		assertThat(this.context.get(Integer.class)).isZero();
+		assertThat(this.context.get(Integer.class)).isZero();
 	}
 
 	@Test
 	void getWhenPrototypeCreatesOnlyNewInstances() {
 		this.context.register(Integer.class,
 				InstanceSupplier.from(this.counter::getAndIncrement).withScope(Scope.PROTOTYPE));
-		assertThat(this.context.get(Integer.class)).isEqualTo(0);
-		assertThat(this.context.get(Integer.class)).isEqualTo(1);
+		assertThat(this.context.get(Integer.class)).isZero();
+		assertThat(this.context.get(Integer.class)).isOne();
 	}
 
 	@Test
@@ -199,8 +199,8 @@ class DefaultBootstrapContextTests {
 	@Test
 	void getOrElseCreatesReturnsOnlyOneInstance() {
 		this.context.register(Integer.class, InstanceSupplier.from(this.counter::getAndIncrement));
-		assertThat(this.context.getOrElse(Integer.class, -1)).isEqualTo(0);
-		assertThat(this.context.getOrElse(Integer.class, -1)).isEqualTo(0);
+		assertThat(this.context.getOrElse(Integer.class, -1)).isZero();
+		assertThat(this.context.getOrElse(Integer.class, -1)).isZero();
 	}
 
 	@Test
@@ -218,8 +218,8 @@ class DefaultBootstrapContextTests {
 	@Test
 	void getOrElseSupplyCreatesOnlyOneInstance() {
 		this.context.register(Integer.class, InstanceSupplier.from(this.counter::getAndIncrement));
-		assertThat(this.context.getOrElseSupply(Integer.class, () -> -1)).isEqualTo(0);
-		assertThat(this.context.getOrElseSupply(Integer.class, () -> -1)).isEqualTo(0);
+		assertThat(this.context.getOrElseSupply(Integer.class, () -> -1)).isZero();
+		assertThat(this.context.getOrElseSupply(Integer.class, () -> -1)).isZero();
 	}
 
 	@Test
@@ -237,8 +237,8 @@ class DefaultBootstrapContextTests {
 	@Test
 	void getOrElseThrowCreatesOnlyOneInstance() {
 		this.context.register(Integer.class, InstanceSupplier.from(this.counter::getAndIncrement));
-		assertThat(this.context.getOrElseThrow(Integer.class, RuntimeException::new)).isEqualTo(0);
-		assertThat(this.context.getOrElseThrow(Integer.class, RuntimeException::new)).isEqualTo(0);
+		assertThat(this.context.getOrElseThrow(Integer.class, RuntimeException::new)).isZero();
+		assertThat(this.context.getOrElseThrow(Integer.class, RuntimeException::new)).isZero();
 	}
 
 	@Test
@@ -304,12 +304,12 @@ class DefaultBootstrapContextTests {
 		}
 
 		CloseListenerAssert wasCalledOnlyOnce() {
-			assertThat(this.actual.called).as("action calls").isEqualTo(1);
+			assertThat(this.actual.called).as("action calls").isOne();
 			return this;
 		}
 
 		CloseListenerAssert wasNotCalled() {
-			assertThat(this.actual.called).as("action calls").isEqualTo(0);
+			assertThat(this.actual.called).as("action calls").isZero();
 			return this;
 		}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/ExitCodeGeneratorsTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/ExitCodeGeneratorsTests.java
@@ -52,7 +52,7 @@ class ExitCodeGeneratorsTests {
 
 	@Test
 	void getExitCodeWhenNoGeneratorsShouldReturnZero() {
-		assertThat(new ExitCodeGenerators().getExitCode()).isEqualTo(0);
+		assertThat(new ExitCodeGenerators().getExitCode()).isZero();
 	}
 
 	@Test
@@ -61,7 +61,7 @@ class ExitCodeGeneratorsTests {
 		given(generator.getExitCode()).willThrow(new IllegalStateException());
 		ExitCodeGenerators generators = new ExitCodeGenerators();
 		generators.add(generator);
-		assertThat(generators.getExitCode()).isEqualTo(1);
+		assertThat(generators.getExitCode()).isOne();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
@@ -761,7 +761,7 @@ class SpringApplicationTests {
 		application.setWebApplicationType(WebApplicationType.NONE);
 		this.context = application.run();
 		assertThat(this.context).isNotNull();
-		assertThat(SpringApplication.exit(this.context)).isEqualTo(0);
+		assertThat(SpringApplication.exit(this.context)).isZero();
 	}
 
 	@Test
@@ -844,7 +844,7 @@ class SpringApplicationTests {
 		this.context = application.run("--bar=foo", "bucket", "crap");
 		assertThat(this.context).isInstanceOf(AnnotationConfigApplicationContext.class);
 		assertThat(getEnvironment().getProperty("bar")).isEqualTo("foo");
-		assertThat(getEnvironment().getProperty("baz")).isEqualTo("");
+		assertThat(getEnvironment().getProperty("baz")).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringBootConfigurationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringBootConfigurationTests.java
@@ -35,14 +35,14 @@ class SpringBootConfigurationTests {
 	void proxyBeanMethodsIsEnabledByDefault() {
 		AnnotationAttributes attributes = AnnotatedElementUtils
 				.getMergedAnnotationAttributes(DefaultSpringBootConfiguration.class, Configuration.class);
-		assertThat(attributes.get("proxyBeanMethods")).isEqualTo(true);
+		assertThat(attributes).containsEntry("proxyBeanMethods", true);
 	}
 
 	@Test
 	void proxyBeanMethodsCanBeDisabled() {
 		AnnotationAttributes attributes = AnnotatedElementUtils
 				.getMergedAnnotationAttributes(NoBeanMethodProxyingSpringBootConfiguration.class, Configuration.class);
-		assertThat(attributes.get("proxyBeanMethods")).isEqualTo(false);
+		assertThat(attributes).containsEntry("proxyBeanMethods", false);
 	}
 
 	@SpringBootConfiguration

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/ansi/Ansi8BitColorTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/ansi/Ansi8BitColorTests.java
@@ -31,12 +31,12 @@ class Ansi8BitColorTests {
 
 	@Test
 	void toStringWhenForegroundAddsCorrectPrefix() {
-		assertThat(Ansi8BitColor.foreground(208).toString()).isEqualTo("38;5;208");
+		assertThat(Ansi8BitColor.foreground(208)).hasToString("38;5;208");
 	}
 
 	@Test
 	void toStringWhenBackgroundAddsCorrectPrefix() {
-		assertThat(Ansi8BitColor.background(208).toString()).isEqualTo("48;5;208");
+		assertThat(Ansi8BitColor.background(208)).hasToString("48;5;208");
 	}
 
 	@Test
@@ -60,8 +60,8 @@ class Ansi8BitColorTests {
 		Ansi8BitColor one = Ansi8BitColor.foreground(123);
 		Ansi8BitColor two = Ansi8BitColor.foreground(123);
 		Ansi8BitColor three = Ansi8BitColor.background(123);
-		assertThat(one.hashCode()).isEqualTo(two.hashCode());
-		assertThat(one).isEqualTo(one).isEqualTo(two).isNotEqualTo(three).isNotEqualTo(null).isNotEqualTo("foo");
+		assertThat(one).hasSameHashCodeAs(two);
+		assertThat(one).isEqualTo(one).isEqualTo(two).isNotEqualTo(three).isNotNull().isNotEqualTo("foo");
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/cloudfoundry/CloudFoundryVcapEnvironmentPostProcessorTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/cloud/cloudfoundry/CloudFoundryVcapEnvironmentPostProcessorTests.java
@@ -102,7 +102,7 @@ class CloudFoundryVcapEnvironmentPostProcessorTests {
 		assertThat(getProperty("vcap.services.mysql.name")).isEqualTo("mysql");
 		assertThat(getProperty("vcap.services.mysql.credentials.port")).isEqualTo("3306");
 		assertThat(getProperty("vcap.services.mysql.credentials.ssl")).isEqualTo("true");
-		assertThat(getProperty("vcap.services.mysql.credentials.location")).isEqualTo("");
+		assertThat(getProperty("vcap.services.mysql.credentials.location")).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
@@ -232,7 +232,7 @@ class ConfigDataEnvironmentPostProcessorIntegrationTests {
 	@Test
 	void runWhenHaslocalFileLoadsWithLocalFileTakingPrecedenceOverClasspath() throws Exception {
 		File localFile = new File(new File("."), "application.properties");
-		assertThat(localFile.exists()).isFalse();
+		assertThat(localFile).doesNotExist();
 		try {
 			Properties properties = new Properties();
 			properties.put("my.property", "fromlocalfile");

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorTests.java
@@ -115,7 +115,7 @@ class ConfigDataEnvironmentPostProcessorTests {
 				listener);
 		assertThat(this.environment.getPropertySources().size()).isGreaterThan(before);
 		assertThat(this.environment.getActiveProfiles()).containsExactly("dev");
-		assertThat(listener.getAddedPropertySources()).hasSizeGreaterThan(0);
+		assertThat(listener.getAddedPropertySources()).isNotEmpty();
 		assertThat(listener.getProfiles().getActive()).containsExactly("dev");
 		assertThat(listener.getAddedPropertySources().stream().anyMatch((added) -> hasDevProfile(added.getResource())))
 				.isTrue();

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentTests.java
@@ -301,7 +301,7 @@ class ConfigDataEnvironmentTests {
 		assertThat(listener.getAddedPropertySources()).hasSize(1);
 		AddedPropertySource addedPropertySource = listener.getAddedPropertySources().get(0);
 		assertThat(addedPropertySource.getPropertySource().getProperty("spring")).isEqualTo("boot");
-		assertThat(addedPropertySource.getLocation().toString()).isEqualTo(getConfigLocation(info));
+		assertThat(addedPropertySource.getLocation()).hasToString(getConfigLocation(info));
 		assertThat(addedPropertySource.getResource().toString()).contains("class path resource")
 				.contains(info.getTestMethod().get().getName());
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataLocationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataLocationTests.java
@@ -97,7 +97,7 @@ class ConfigDataLocationTests {
 		ConfigDataLocation l2 = ConfigDataLocation.of("a");
 		ConfigDataLocation l3 = ConfigDataLocation.of("optional:a");
 		ConfigDataLocation l4 = ConfigDataLocation.of("b");
-		assertThat(l1.hashCode()).isEqualTo(l2.hashCode()).isEqualTo(l3.hashCode());
+		assertThat(l1).hasSameHashCodeAs(l2).hasSameHashCodeAs(l3);
 		assertThat(l1).isEqualTo(l2).isEqualTo(l3).isNotEqualTo(l4);
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigTreeConfigDataLoaderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigTreeConfigDataLoaderTests.java
@@ -53,10 +53,10 @@ class ConfigTreeConfigDataLoaderTests {
 		FileCopyUtils.copy("world\n".getBytes(StandardCharsets.UTF_8), file);
 		ConfigTreeConfigDataResource location = new ConfigTreeConfigDataResource(this.directory.toString());
 		ConfigData configData = this.loader.load(this.loaderContext, location);
-		assertThat(configData.getPropertySources().size()).isEqualTo(1);
+		assertThat(configData.getPropertySources()).hasSize(1);
 		PropertySource<?> source = configData.getPropertySources().get(0);
 		assertThat(source.getName()).isEqualTo("Config tree '" + this.directory.toString() + "'");
-		assertThat(source.getProperty("hello").toString()).isEqualTo("world");
+		assertThat(source.getProperty("hello")).hasToString("world");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigTreeConfigDataLocationResolverTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigTreeConfigDataLocationResolverTests.java
@@ -59,7 +59,7 @@ class ConfigTreeConfigDataLocationResolverTests {
 	void resolveReturnsConfigVolumeMountLocation() {
 		List<ConfigTreeConfigDataResource> locations = this.resolver.resolve(this.context,
 				ConfigDataLocation.of("configtree:/etc/config/"));
-		assertThat(locations.size()).isEqualTo(1);
+		assertThat(locations).hasSize(1);
 		assertThat(locations).extracting(Object::toString)
 				.containsExactly("config tree [" + new File("/etc/config").getAbsolutePath() + "]");
 	}
@@ -74,7 +74,7 @@ class ConfigTreeConfigDataLocationResolverTests {
 		FileCopyUtils.copy("test".getBytes(), new File(directoryB, "boot"));
 		List<ConfigTreeConfigDataResource> locations = this.resolver.resolve(this.context,
 				ConfigDataLocation.of("configtree:" + this.temp.getAbsolutePath() + "/*/"));
-		assertThat(locations.size()).isEqualTo(2);
+		assertThat(locations).hasSize(2);
 		assertThat(locations).extracting(Object::toString).containsExactly(
 				"config tree [" + directoryA.getAbsolutePath() + "]",
 				"config tree [" + directoryB.getAbsolutePath() + "]");

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigTreeConfigDataResourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigTreeConfigDataResourceTests.java
@@ -61,7 +61,7 @@ class ConfigTreeConfigDataResourceTests {
 	@Test
 	void toStringReturnsDescriptiveString() {
 		ConfigTreeConfigDataResource location = new ConfigTreeConfigDataResource("/etc/config");
-		assertThat(location.toString()).isEqualTo("config tree [" + new File("/etc/config").getAbsolutePath() + "]");
+		assertThat(location).hasToString("config tree [" + new File("/etc/config").getAbsolutePath() + "]");
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLoaderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLoaderTests.java
@@ -48,7 +48,7 @@ class StandardConfigDataLoaderTests {
 				"classpath:configdata/yaml/application", null, "yml", new YamlPropertySourceLoader());
 		StandardConfigDataResource location = new StandardConfigDataResource(reference, resource);
 		ConfigData configData = this.loader.load(this.loaderContext, location);
-		assertThat(configData.getPropertySources().size()).isEqualTo(2);
+		assertThat(configData.getPropertySources()).hasSize(2);
 		PropertySource<?> source1 = configData.getPropertySources().get(0);
 		PropertySource<?> source2 = configData.getPropertySources().get(1);
 		assertThat(source1.getName())
@@ -69,7 +69,7 @@ class StandardConfigDataLoaderTests {
 				"config/0-empty/testproperties", null, "properties", new PropertiesPropertySourceLoader());
 		StandardConfigDataResource location = new StandardConfigDataResource(reference, resource);
 		ConfigData configData = this.loader.load(this.loaderContext, location);
-		assertThat(configData.getPropertySources().size()).isEqualTo(0);
+		assertThat(configData.getPropertySources()).isEmpty();
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLocationResolverTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLocationResolverTests.java
@@ -73,7 +73,7 @@ class StandardConfigDataLocationResolverTests {
 	void resolveWhenLocationIsDirectoryResolvesAllMatchingFilesInDirectory() {
 		ConfigDataLocation location = ConfigDataLocation.of("classpath:/configdata/properties/");
 		List<StandardConfigDataResource> locations = this.resolver.resolve(this.context, location);
-		assertThat(locations.size()).isEqualTo(1);
+		assertThat(locations).hasSize(1);
 		assertThat(locations).extracting(Object::toString)
 				.containsExactly("class path resource [configdata/properties/application.properties]");
 	}
@@ -83,7 +83,7 @@ class StandardConfigDataLocationResolverTests {
 		ConfigDataLocation location = ConfigDataLocation
 				.of("file:src/test/resources/configdata/properties/application.properties");
 		List<StandardConfigDataResource> locations = this.resolver.resolve(this.context, location);
-		assertThat(locations.size()).isEqualTo(1);
+		assertThat(locations).hasSize(1);
 		assertThat(locations).extracting(Object::toString).containsExactly(
 				filePath("src", "test", "resources", "configdata", "properties", "application.properties"));
 	}
@@ -134,7 +134,7 @@ class StandardConfigDataLocationResolverTests {
 		this.resolver = new StandardConfigDataLocationResolver(new DeferredLogs(), this.environmentBinder,
 				this.resourceLoader);
 		List<StandardConfigDataResource> locations = this.resolver.resolve(this.context, location);
-		assertThat(locations.size()).isEqualTo(3);
+		assertThat(locations).hasSize(3);
 		assertThat(locations).extracting(Object::toString)
 				.contains(filePath("src", "test", "resources", "config", "1-first", "testproperties.properties"))
 				.contains(filePath("src", "test", "resources", "config", "2-second", "testproperties.properties"))
@@ -165,7 +165,7 @@ class StandardConfigDataLocationResolverTests {
 		ConfigDataLocation location = ConfigDataLocation
 				.of("file:src/test/resources/config/*/testproperties.properties");
 		List<StandardConfigDataResource> locations = this.resolver.resolve(this.context, location);
-		assertThat(locations.size()).isEqualTo(3);
+		assertThat(locations).hasSize(3);
 		assertThat(locations).extracting(Object::toString)
 				.contains(filePath("src", "test", "resources", "config", "1-first", "testproperties.properties"))
 				.contains(filePath("src", "test", "resources", "config", "2-second", "testproperties.properties"))
@@ -187,7 +187,7 @@ class StandardConfigDataLocationResolverTests {
 		StandardConfigDataResource parent = new StandardConfigDataResource(parentReference, parentResource);
 		given(this.context.getParent()).willReturn(parent);
 		List<StandardConfigDataResource> locations = this.resolver.resolve(this.context, location);
-		assertThat(locations.size()).isEqualTo(1);
+		assertThat(locations).hasSize(1);
 		assertThat(locations).extracting(Object::toString)
 				.contains("class path resource [configdata/properties/other.properties]");
 	}
@@ -205,7 +205,7 @@ class StandardConfigDataLocationResolverTests {
 		StandardConfigDataResource parent = new StandardConfigDataResource(parentReference, parentResource);
 		given(this.context.getParent()).willReturn(parent);
 		List<StandardConfigDataResource> locations = this.resolver.resolve(this.context, location);
-		assertThat(locations.size()).isEqualTo(1);
+		assertThat(locations).hasSize(1);
 		assertThat(locations).extracting(Object::toString)
 				.contains("class path resource [config/nested/3-third/testproperties.properties]");
 	}
@@ -228,7 +228,7 @@ class StandardConfigDataLocationResolverTests {
 	void resolveWhenLocationUsesOptionalExtensionSyntaxResolves() throws Exception {
 		ConfigDataLocation location = ConfigDataLocation.of("classpath:/application-props-no-extension[.properties]");
 		List<StandardConfigDataResource> locations = this.resolver.resolve(this.context, location);
-		assertThat(locations.size()).isEqualTo(1);
+		assertThat(locations).hasSize(1);
 		StandardConfigDataResource resolved = locations.get(0);
 		assertThat(resolved.getResource().getFilename()).endsWith("application-props-no-extension");
 		ConfigData loaded = new StandardConfigDataLoader().load(null, resolved);
@@ -243,7 +243,7 @@ class StandardConfigDataLocationResolverTests {
 		given(profiles.iterator()).willReturn(Collections.singletonList("dev").iterator());
 		List<StandardConfigDataResource> locations = this.resolver.resolveProfileSpecific(this.context, location,
 				profiles);
-		assertThat(locations.size()).isEqualTo(1);
+		assertThat(locations).hasSize(1);
 		assertThat(locations).extracting(Object::toString)
 				.containsExactly("class path resource [configdata/properties/application-dev.properties]");
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerIntegrationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerIntegrationTests.java
@@ -63,7 +63,7 @@ class LoggingApplicationListenerIntegrationTests {
 				.web(WebApplicationType.NONE).properties("logging.file.name=" + logFile).run()) {
 			SampleService service = context.getBean(SampleService.class);
 			assertThat(service.logFile).isNotNull();
-			assertThat(service.logFile.toString()).isEqualTo(logFile);
+			assertThat(service.logFile).hasToString(logFile);
 		}
 		finally {
 			System.clearProperty(LoggingSystemProperties.LOG_FILE);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
@@ -155,7 +155,7 @@ class LoggingApplicationListenerTests {
 		assertThat(this.output).contains("Hello world");
 		assertThat(this.output).doesNotContain("???");
 		assertThat(this.output).contains("[junit-");
-		assertThat(new File(this.tempDir + "/spring.log").exists()).isFalse();
+		assertThat(new File(this.tempDir + "/spring.log")).doesNotExist();
 	}
 
 	@Test
@@ -191,7 +191,7 @@ class LoggingApplicationListenerTests {
 		this.listener.initialize(this.context.getEnvironment(), this.context.getClassLoader());
 		this.logger.info("Hello world");
 		assertThat(this.output).contains("Hello world").doesNotContain("???");
-		assertThat(new File(this.tempDir.toFile(), "/spring.log").exists()).isFalse();
+		assertThat(new File(this.tempDir.toFile(), "/spring.log")).doesNotExist();
 	}
 
 	@Test
@@ -200,7 +200,7 @@ class LoggingApplicationListenerTests {
 		this.listener.initialize(this.context.getEnvironment(), this.context.getClassLoader());
 		this.logger.info("Hello world");
 		assertThat(this.output).contains("Hello world").doesNotContain("???");
-		assertThat(new File(this.tempDir.toFile(), "/spring.log").exists()).isFalse();
+		assertThat(new File(this.tempDir.toFile(), "/spring.log")).doesNotExist();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/metrics/buffering/BufferingApplicationStartupTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/metrics/buffering/BufferingApplicationStartupTests.java
@@ -57,11 +57,11 @@ class BufferingApplicationStartupTests {
 		List<TimelineEvent> events = applicationStartup.getBufferedTimeline().getEvents();
 		assertThat(events).hasSize(2);
 		StartupTimeline.TimelineEvent firstEvent = events.get(0);
-		assertThat(firstEvent.getStartupStep().getId()).isEqualTo(0);
+		assertThat(firstEvent.getStartupStep().getId()).isZero();
 		assertThat(firstEvent.getStartupStep().getParentId()).isNull();
 		StartupTimeline.TimelineEvent secondEvent = events.get(1);
 		assertThat(secondEvent.getStartupStep().getId()).isEqualTo(2);
-		assertThat(secondEvent.getStartupStep().getParentId()).isEqualTo(1);
+		assertThat(secondEvent.getStartupStep().getParentId()).isOne();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesScanRegistrarTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesScanRegistrarTests.java
@@ -100,7 +100,7 @@ class ConfigurationPropertiesScanRegistrarTests {
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.setAllowBeanDefinitionOverriding(false);
 		this.registrar.registerBeanDefinitions(getAnnotationMetadata(CombinedScanConfiguration.class), beanFactory);
-		assertThat(beanFactory.getBeanDefinitionCount()).isEqualTo(0);
+		assertThat(beanFactory.getBeanDefinitionCount()).isZero();
 	}
 
 	@Test
@@ -109,7 +109,7 @@ class ConfigurationPropertiesScanRegistrarTests {
 		beanFactory.setAllowBeanDefinitionOverriding(false);
 		this.registrar.registerBeanDefinitions(getAnnotationMetadata(OtherCombinedScanConfiguration.class),
 				beanFactory);
-		assertThat(beanFactory.getBeanDefinitionCount()).isEqualTo(0);
+		assertThat(beanFactory.getBeanDefinitionCount()).isZero();
 	}
 
 	private Consumer<BeanDefinition> configurationPropertiesBeanDefinition(BindMethod bindMethod) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
@@ -198,7 +198,7 @@ class ConfigurationPropertiesTests {
 	void loadWhenHasIgnoreInvalidFieldsTrueAndInvalidFieldsShouldBind() {
 		load(IgnoreInvalidFieldsFalseProperties.class, "com.example.bar=spam");
 		IgnoreInvalidFieldsFalseProperties bean = this.context.getBean(IgnoreInvalidFieldsFalseProperties.class);
-		assertThat(bean.getBar()).isEqualTo(0);
+		assertThat(bean.getBar()).isZero();
 	}
 
 	@Test
@@ -804,9 +804,9 @@ class ConfigurationPropertiesTests {
 		WithIntegerMapProperties bean = this.context.getBean(WithIntegerMapProperties.class);
 		Map<Integer, Foo> x = bean.getMap().get("x");
 		assertThat(x.get(-1).getA()).isEqualTo("baz");
-		assertThat(x.get(-1).getB()).isEqualTo(0);
+		assertThat(x.get(-1).getB()).isZero();
 		assertThat(x.get(1).getA()).isEqualTo("bar");
-		assertThat(x.get(1).getB()).isEqualTo(1);
+		assertThat(x.get(1).getB()).isOne();
 	}
 
 	@Test
@@ -851,7 +851,7 @@ class ConfigurationPropertiesTests {
 		load(ConstructorParameterConfiguration.class);
 		ConstructorParameterProperties bean = this.context.getBean(ConstructorParameterProperties.class);
 		assertThat(bean.getFoo()).isEqualTo("hello");
-		assertThat(bean.getBar()).isEqualTo(0);
+		assertThat(bean.getBar()).isZero();
 	}
 
 	@Test
@@ -979,7 +979,7 @@ class ConfigurationPropertiesTests {
 				.getBean(MultiConstructorConfigurationListProperties.class);
 		MultiConstructorConfigurationProperties nested = bean.getNested().get(0);
 		assertThat(nested.getName()).isEqualTo("spring");
-		assertThat(nested.getAge()).isEqualTo(0);
+		assertThat(nested.getAge()).isZero();
 	}
 
 	@Test // gh-18481

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/ArrayBinderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/ArrayBinderTests.java
@@ -144,9 +144,9 @@ class ArrayBinderTests {
 				.satisfies((ex) -> {
 					Set<ConfigurationProperty> unbound = ((UnboundConfigurationPropertiesException) ex.getCause())
 							.getUnboundProperties();
-					assertThat(unbound.size()).isEqualTo(1);
+					assertThat(unbound).hasSize(1);
 					ConfigurationProperty property = unbound.iterator().next();
-					assertThat(property.getName().toString()).isEqualTo("foo[3]");
+					assertThat(property.getName()).hasToString("foo[3]");
 					assertThat(property.getValue()).isEqualTo("3");
 				});
 	}
@@ -254,7 +254,7 @@ class ArrayBinderTests {
 		source.put("foo", "");
 		this.sources.add(source);
 		String[] result = this.binder.bind("foo", Bindable.of(String[].class)).get();
-		assertThat(result).isNotNull().isEmpty();
+		assertThat(result).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/BindResultTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/BindResultTests.java
@@ -163,7 +163,7 @@ class BindResultTests {
 		BindResult<?> result2 = BindResult.of("foo");
 		BindResult<?> result3 = BindResult.of("bar");
 		BindResult<?> result4 = BindResult.of(null);
-		assertThat(result1.hashCode()).isEqualTo(result2.hashCode());
+		assertThat(result1).hasSameHashCodeAs(result2);
 		assertThat(result1).isEqualTo(result1).isEqualTo(result2).isNotEqualTo(result3).isNotEqualTo(result4);
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/BindableTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/BindableTests.java
@@ -155,7 +155,7 @@ class BindableTests {
 		Bindable<String> bindable1 = Bindable.of(String.class).withExistingValue("foo").withAnnotations(annotation);
 		Bindable<String> bindable2 = Bindable.of(String.class).withExistingValue("foo").withAnnotations(annotation);
 		Bindable<String> bindable3 = Bindable.of(String.class).withExistingValue("fof").withAnnotations(annotation);
-		assertThat(bindable1.hashCode()).isEqualTo(bindable2.hashCode());
+		assertThat(bindable1).hasSameHashCodeAs(bindable2);
 		assertThat(bindable1).isEqualTo(bindable1).isEqualTo(bindable2);
 		assertThat(bindable1).isEqualTo(bindable3);
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/BinderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/BinderTests.java
@@ -258,7 +258,7 @@ class BinderTests {
 		DateTimeFormat annotation = AnnotationUtils.synthesizeAnnotation(
 				Collections.singletonMap("iso", DateTimeFormat.ISO.DATE_TIME), DateTimeFormat.class, null);
 		LocalDate result = this.binder.bind("foo", Bindable.of(LocalDate.class).withAnnotations(annotation)).get();
-		assertThat(result.toString()).isEqualTo("2014-04-01");
+		assertThat(result).hasToString("2014-04-01");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/CollectionBinderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/CollectionBinderTests.java
@@ -118,7 +118,7 @@ class CollectionBinderTests {
 							.getUnboundProperties();
 					assertThat(unbound).hasSize(1);
 					ConfigurationProperty property = unbound.iterator().next();
-					assertThat(property.getName().toString()).isEqualTo("foo[3]");
+					assertThat(property.getName()).hasToString("foo[3]");
 					assertThat(property.getValue()).isEqualTo("3");
 				});
 	}
@@ -137,7 +137,7 @@ class CollectionBinderTests {
 							.getUnboundProperties();
 					assertThat(unbound).hasSize(1);
 					ConfigurationProperty property = unbound.iterator().next();
-					assertThat(property.getName().toString()).isEqualTo("foo[4].value");
+					assertThat(property.getName()).hasToString("foo[4].value");
 					assertThat(property.getValue()).isEqualTo("4");
 				});
 	}
@@ -265,7 +265,7 @@ class CollectionBinderTests {
 		source.put("foo", "");
 		this.sources.add(source);
 		List<String> result = this.binder.bind("foo", STRING_LIST).get();
-		assertThat(result).isNotNull().isEmpty();
+		assertThat(result).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/DefaultBindConstructorProviderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/DefaultBindConstructorProviderTests.java
@@ -55,7 +55,7 @@ class DefaultBindConstructorProviderTests {
 		Constructor<?> constructor = this.provider.getBindConstructor(TwoConstructorsWithOneConstructorBinding.class,
 				false);
 		assertThat(constructor).isNotNull();
-		assertThat(constructor.getParameterCount()).isEqualTo(1);
+		assertThat(constructor.getParameterCount()).isOne();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/JavaBeanBinderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/JavaBeanBinderTests.java
@@ -395,7 +395,7 @@ class JavaBeanBinderTests {
 		IgnoreErrorsBindHandler handler = new IgnoreErrorsBindHandler();
 		ExampleValueBean bean = this.binder.bind("foo", Bindable.of(ExampleValueBean.class), handler).get();
 		assertThat(bean.getIntValue()).isEqualTo(12);
-		assertThat(bean.getLongValue()).isEqualTo(0);
+		assertThat(bean.getLongValue()).isZero();
 		assertThat(bean.getStringValue()).isEqualTo("foo");
 		assertThat(bean.getEnumValue()).isEqualTo(ExampleEnum.FOO_BAR);
 	}
@@ -445,7 +445,7 @@ class JavaBeanBinderTests {
 		this.sources.add(source);
 		ConverterAnnotatedExampleBean bean = this.binder.bind("foo", Bindable.of(ConverterAnnotatedExampleBean.class))
 				.get();
-		assertThat(bean.getDate().toString()).isEqualTo("2014-04-01");
+		assertThat(bean.getDate()).hasToString("2014-04-01");
 	}
 
 	@Test
@@ -488,8 +488,8 @@ class JavaBeanBinderTests {
 		source.put("foo.booleans[b].value", "true");
 		this.sources.add(source);
 		ExampleWithGenericMap bean = this.binder.bind("foo", Bindable.of(ExampleWithGenericMap.class)).get();
-		assertThat(bean.getIntegers().get("a").getValue()).isEqualTo(1);
-		assertThat(bean.getBooleans().get("b").getValue()).isEqualTo(true);
+		assertThat(bean.getIntegers().get("a").getValue()).isOne();
+		assertThat(bean.getBooleans().get("b").getValue()).isTrue();
 	}
 
 	@Test
@@ -563,8 +563,8 @@ class JavaBeanBinderTests {
 		source.put("foo.beta", "0");
 		this.sources.add(source);
 		PropertyOrderBean bean = this.binder.bind("foo", Bindable.of(PropertyOrderBean.class)).get();
-		assertThat(bean.getAlpha()).isEqualTo(0);
-		assertThat(bean.getBeta()).isEqualTo(1);
+		assertThat(bean.getAlpha()).isZero();
+		assertThat(bean.getBeta()).isOne();
 		assertThat(bean.getGamma()).isEqualTo(2);
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/MapBinderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/MapBinderTests.java
@@ -185,9 +185,9 @@ class MapBinderTests {
 		source.put("foo", "bar");
 		this.sources.add(source);
 		Map<String, Object> result = this.binder.bind("", Bindable.mapOf(String.class, Object.class)).get();
-		assertThat(result.get("commit")).isEqualTo(Collections.singletonMap("id", "abcdefg"));
-		assertThat(result.get("branch")).isEqualTo("master");
-		assertThat(result.get("foo")).isEqualTo("bar");
+		assertThat(result).containsEntry("commit", Collections.singletonMap("id", "abcdefg"));
+		assertThat(result).containsEntry("branch", "master");
+		assertThat(result).containsEntry("foo", "bar");
 	}
 
 	@Test
@@ -503,8 +503,8 @@ class MapBinderTests {
 		source.put("foo", "a,b");
 		this.sources.add(source);
 		Map<String, String> map = binder.bind("foo", STRING_STRING_MAP).get();
-		assertThat(map.get("a")).isNotNull();
-		assertThat(map.get("b")).isNotNull();
+		assertThat(map).containsKey("a");
+		assertThat(map).containsKey("b");
 	}
 
 	@Test
@@ -519,8 +519,8 @@ class MapBinderTests {
 		source.put("foo.b", "b");
 		this.sources.add(source);
 		Map<String, String> map = binder.bind("foo", STRING_STRING_MAP).get();
-		assertThat(map.get("a")).isEqualTo("a");
-		assertThat(map.get("b")).isEqualTo("b");
+		assertThat(map).containsEntry("a", "a");
+		assertThat(map).containsEntry("b", "b");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/ValueObjectBinderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/ValueObjectBinderTests.java
@@ -163,9 +163,9 @@ class ValueObjectBinderTests {
 		source.put("foo.string-value", "foo");
 		this.sources.add(source);
 		ExampleValueBean bean = this.binder.bind("foo", Bindable.of(ExampleValueBean.class)).get();
-		assertThat(bean.getIntValue()).isEqualTo(0);
-		assertThat(bean.getLongValue()).isEqualTo(0);
-		assertThat(bean.isBooleanValue()).isEqualTo(false);
+		assertThat(bean.getIntValue()).isZero();
+		assertThat(bean.getLongValue()).isZero();
+		assertThat(bean.isBooleanValue()).isFalse();
 		assertThat(bean.getStringValue()).isEqualTo("foo");
 	}
 
@@ -193,7 +193,7 @@ class ValueObjectBinderTests {
 		this.sources.add(source);
 		ConverterAnnotatedExampleBean bean = this.binder.bind("foo", Bindable.of(ConverterAnnotatedExampleBean.class))
 				.get();
-		assertThat(bean.getDate().toString()).isEqualTo("2014-04-01");
+		assertThat(bean.getDate()).hasToString("2014-04-01");
 	}
 
 	@Test
@@ -203,7 +203,7 @@ class ValueObjectBinderTests {
 		this.sources.add(source);
 		ConverterAnnotatedExampleBean bean = this.binder.bind("foo", Bindable.of(ConverterAnnotatedExampleBean.class))
 				.get();
-		assertThat(bean.getDate().toString()).isEqualTo("2019-05-10");
+		assertThat(bean.getDate()).hasToString("2019-05-10");
 	}
 
 	@Test
@@ -219,9 +219,9 @@ class ValueObjectBinderTests {
 	@Test
 	void createShouldReturnCreatedValue() {
 		ExampleValueBean value = this.binder.bindOrCreate("foo", Bindable.of(ExampleValueBean.class));
-		assertThat(value.getIntValue()).isEqualTo(0);
-		assertThat(value.getLongValue()).isEqualTo(0);
-		assertThat(value.isBooleanValue()).isEqualTo(false);
+		assertThat(value.getIntValue()).isZero();
+		assertThat(value.getLongValue()).isZero();
+		assertThat(value.isBooleanValue()).isFalse();
 		assertThat(value.getStringValue()).isNull();
 		assertThat(value.getEnumValue()).isNull();
 	}
@@ -229,7 +229,7 @@ class ValueObjectBinderTests {
 	@Test
 	void createWithNestedShouldReturnCreatedValue() {
 		ExampleNestedBean value = this.binder.bindOrCreate("foo", Bindable.of(ExampleNestedBean.class));
-		assertThat(value.getValueBean()).isEqualTo(null);
+		assertThat(value.getValueBean()).isNull();
 	}
 
 	@Test
@@ -244,7 +244,7 @@ class ValueObjectBinderTests {
 	void createWithDefaultValuesAndAnnotationsShouldReturnCreatedWithDefaultValues() {
 		ConverterAnnotatedExampleBean bean = this.binder.bindOrCreate("foo",
 				Bindable.of(ConverterAnnotatedExampleBean.class));
-		assertThat(bean.getDate().toString()).isEqualTo("2019-05-10");
+		assertThat(bean.getDate()).hasToString("2019-05-10");
 	}
 
 	@Test
@@ -267,7 +267,7 @@ class ValueObjectBinderTests {
 		GenericValue<Map<String, String>> bean = this.binder.bind("foo", Bindable
 				.<GenericValue<Map<String, String>>>of(ResolvableType.forClassWithGenerics(GenericValue.class, type)))
 				.get();
-		assertThat(bean.getValue().get("bar")).isEqualTo("baz");
+		assertThat(bean.getValue()).containsEntry("bar", "baz");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/handler/IgnoreErrorsBindHandlerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/handler/IgnoreErrorsBindHandlerTests.java
@@ -60,7 +60,7 @@ class IgnoreErrorsBindHandlerTests {
 	@Test
 	void bindWhenIgnoringErrorsShouldBind() {
 		Example bound = this.binder.bind("example", Bindable.of(Example.class), new IgnoreErrorsBindHandler()).get();
-		assertThat(bound.getFoo()).isEqualTo(0);
+		assertThat(bound.getFoo()).isZero();
 	}
 
 	static class Example {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/validation/OriginTrackedFieldErrorTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/validation/OriginTrackedFieldErrorTests.java
@@ -56,8 +56,8 @@ class OriginTrackedFieldErrorTests {
 
 	@Test
 	void toStringShouldAddOrigin() {
-		assertThat(OriginTrackedFieldError.of(FIELD_ERROR, ORIGIN).toString())
-				.isEqualTo("Field error in object 'foo' on field 'bar': rejected value [null]"
+		assertThat(OriginTrackedFieldError.of(FIELD_ERROR, ORIGIN))
+				.hasToString("Field error in object 'foo' on field 'bar': rejected value [null]"
 						+ "; codes []; arguments []; default message [faf]; origin afile");
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/validation/ValidationBindHandlerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/validation/ValidationBindHandlerTests.java
@@ -106,7 +106,7 @@ class ValidationBindHandlerTests {
 		BindValidationException cause = bindAndExpectValidationError(() -> this.binder
 				.bind(ConfigurationPropertyName.of("foo"), Bindable.of(ExampleValidatedBean.class), this.handler));
 		ObjectError objectError = cause.getValidationErrors().getAllErrors().get(0);
-		assertThat(Origin.from(objectError).toString()).isEqualTo("file");
+		assertThat(Origin.from(objectError)).hasToString("file");
 	}
 
 	@Test
@@ -128,7 +128,7 @@ class ValidationBindHandlerTests {
 		this.sources.add(new MockConfigurationPropertySource("foo.nested.age", "4"));
 		BindValidationException cause = bindAndExpectValidationError(() -> this.binder.bind(
 				ConfigurationPropertyName.of("foo"), Bindable.of(ExampleValidatedWithNestedBean.class), this.handler));
-		assertThat(cause.getValidationErrors().getName().toString()).isEqualTo("foo.nested");
+		assertThat(cause.getValidationErrors().getName()).hasToString("foo.nested");
 		assertThat(cause.getMessage()).contains("nested.age");
 		assertThat(cause.getMessage()).contains("rejected value [4]");
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/ConfigurationPropertyNameTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/ConfigurationPropertyNameTests.java
@@ -81,8 +81,8 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void ofNameWhenSimple() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("name");
-		assertThat(name.toString()).isEqualTo("name");
-		assertThat(name.getNumberOfElements()).isEqualTo(1);
+		assertThat(name).hasToString("name");
+		assertThat(name.getNumberOfElements()).isOne();
 		assertThat(name.getElement(0, Form.ORIGINAL)).isEqualTo("name");
 		assertThat(name.isIndexed(0)).isFalse();
 	}
@@ -90,8 +90,8 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void ofNameWhenStartsWithNumber() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("1foo");
-		assertThat(name.toString()).isEqualTo("1foo");
-		assertThat(name.getNumberOfElements()).isEqualTo(1);
+		assertThat(name).hasToString("1foo");
+		assertThat(name.getNumberOfElements()).isOne();
 		assertThat(name.getElement(0, Form.ORIGINAL)).isEqualTo("1foo");
 		assertThat(name.isIndexed(0)).isFalse();
 	}
@@ -99,7 +99,7 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void ofNameWhenRunOnAssociative() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("foo[bar]");
-		assertThat(name.toString()).isEqualTo("foo[bar]");
+		assertThat(name).hasToString("foo[bar]");
 		assertThat(name.getElement(0, Form.ORIGINAL)).isEqualTo("foo");
 		assertThat(name.getElement(1, Form.ORIGINAL)).isEqualTo("bar");
 		assertThat(name.isIndexed(0)).isFalse();
@@ -109,7 +109,7 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void ofNameWhenDotOnAssociative() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("foo.bar");
-		assertThat(name.toString()).isEqualTo("foo.bar");
+		assertThat(name).hasToString("foo.bar");
 		assertThat(name.getElement(0, Form.ORIGINAL)).isEqualTo("foo");
 		assertThat(name.getElement(1, Form.ORIGINAL)).isEqualTo("bar");
 		assertThat(name.isIndexed(0)).isFalse();
@@ -119,7 +119,7 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void ofNameWhenDotAndAssociative() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("foo.[bar]");
-		assertThat(name.toString()).isEqualTo("foo[bar]");
+		assertThat(name).hasToString("foo[bar]");
 		assertThat(name.getElement(0, Form.ORIGINAL)).isEqualTo("foo");
 		assertThat(name.getElement(1, Form.ORIGINAL)).isEqualTo("bar");
 		assertThat(name.isIndexed(0)).isFalse();
@@ -129,7 +129,7 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void ofNameWhenDoubleRunOnAndAssociative() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("foo[bar]baz");
-		assertThat(name.toString()).isEqualTo("foo[bar].baz");
+		assertThat(name).hasToString("foo[bar].baz");
 		assertThat(name.getElement(0, Form.ORIGINAL)).isEqualTo("foo");
 		assertThat(name.getElement(1, Form.ORIGINAL)).isEqualTo("bar");
 		assertThat(name.getElement(2, Form.ORIGINAL)).isEqualTo("baz");
@@ -141,7 +141,7 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void ofNameWhenDoubleDotAndAssociative() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("foo.[bar].baz");
-		assertThat(name.toString()).isEqualTo("foo[bar].baz");
+		assertThat(name).hasToString("foo[bar].baz");
 		assertThat(name.getElement(0, Form.ORIGINAL)).isEqualTo("foo");
 		assertThat(name.getElement(1, Form.ORIGINAL)).isEqualTo("bar");
 		assertThat(name.getElement(2, Form.ORIGINAL)).isEqualTo("baz");
@@ -171,7 +171,7 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void ofNameWhenNestedBrackets() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("foo[a[c][[b]ar]]");
-		assertThat(name.toString()).isEqualTo("foo[a[c][[b]ar]]");
+		assertThat(name).hasToString("foo[a[c][[b]ar]]");
 		assertThat(name.getElement(0, Form.ORIGINAL)).isEqualTo("foo");
 		assertThat(name.getElement(1, Form.ORIGINAL)).isEqualTo("a[c][[b]ar]");
 	}
@@ -185,7 +185,7 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void ofNameWithWhitespaceInAssociativeElement() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("foo[b a r]");
-		assertThat(name.toString()).isEqualTo("foo[b a r]");
+		assertThat(name).hasToString("foo[b a r]");
 		assertThat(name.getElement(0, Form.ORIGINAL)).isEqualTo("foo");
 		assertThat(name.getElement(1, Form.ORIGINAL)).isEqualTo("b a r");
 		assertThat(name.isIndexed(0)).isFalse();
@@ -195,7 +195,7 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void ofNameWithUppercaseInAssociativeElement() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("foo[BAR]");
-		assertThat(name.toString()).isEqualTo("foo[BAR]");
+		assertThat(name).hasToString("foo[BAR]");
 		assertThat(name.getElement(0, Form.ORIGINAL)).isEqualTo("foo");
 		assertThat(name.getElement(1, Form.ORIGINAL)).isEqualTo("BAR");
 		assertThat(name.isIndexed(0)).isFalse();
@@ -205,8 +205,8 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void ofWhenNameIsEmptyShouldReturnEmptyName() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("");
-		assertThat(name.toString()).isEqualTo("");
-		assertThat(name.append("foo").toString()).isEqualTo("foo");
+		assertThat(name.toString()).isEmpty();
+		assertThat(name.append("foo")).hasToString("foo");
 	}
 
 	@Test
@@ -230,7 +230,7 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void adaptWhenElementValueProcessorIsNullShouldAdapt() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.adapt("foo", '.', null);
-		assertThat(name.toString()).isEqualTo("foo");
+		assertThat(name).hasToString("foo");
 	}
 
 	@Test
@@ -247,7 +247,7 @@ class ConfigurationPropertyNameTests {
 		assertThat(name.getElement(0, Form.ORIGINAL)).isEqualTo("f");
 		assertThat(name.getElement(1, Form.UNIFORM)).isEqualTo("br");
 		assertThat(name.getElement(1, Form.ORIGINAL)).isEqualTo("br");
-		assertThat(name.toString()).isEqualTo("f.br");
+		assertThat(name).hasToString("f.br");
 	}
 
 	@Test
@@ -257,7 +257,7 @@ class ConfigurationPropertyNameTests {
 		assertThat(name.getElement(0, Form.ORIGINAL)).isEqualTo("f-_o");
 		assertThat(name.getElement(1, Form.UNIFORM)).isEqualTo("br");
 		assertThat(name.getElement(1, Form.ORIGINAL)).isEqualTo("b_r");
-		assertThat(name.toString()).isEqualTo("f-o.br");
+		assertThat(name).hasToString("f-o.br");
 	}
 
 	@Test
@@ -267,32 +267,32 @@ class ConfigurationPropertyNameTests {
 		assertThat(name.getElement(0, Form.ORIGINAL)).isEqualTo("fOo");
 		assertThat(name.getElement(1, Form.UNIFORM)).isEqualTo("bar");
 		assertThat(name.getElement(1, Form.ORIGINAL)).isEqualTo("bAr");
-		assertThat(name.toString()).isEqualTo("foo.bar");
+		assertThat(name).hasToString("foo.bar");
 	}
 
 	@Test
 	void adaptShouldUseElementValueProcessor() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.adapt("FOO_THE-BAR", '_',
 				(c) -> c.toString().replace("-", ""));
-		assertThat(name.toString()).isEqualTo("foo.thebar");
+		assertThat(name).hasToString("foo.thebar");
 	}
 
 	@Test
 	void adaptShouldSupportIndexedElements() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.adapt("foo", '.');
-		assertThat(name.toString()).isEqualTo("foo");
-		assertThat(name.getNumberOfElements()).isEqualTo(1);
+		assertThat(name).hasToString("foo");
+		assertThat(name.getNumberOfElements()).isOne();
 		name = ConfigurationPropertyName.adapt("[foo]", '.');
-		assertThat(name.toString()).isEqualTo("[foo]");
-		assertThat(name.getNumberOfElements()).isEqualTo(1);
+		assertThat(name).hasToString("[foo]");
+		assertThat(name.getNumberOfElements()).isOne();
 		name = ConfigurationPropertyName.adapt("foo.bar", '.');
-		assertThat(name.toString()).isEqualTo("foo.bar");
+		assertThat(name).hasToString("foo.bar");
 		assertThat(name.getNumberOfElements()).isEqualTo(2);
 		name = ConfigurationPropertyName.adapt("foo[foo.bar]", '.');
-		assertThat(name.toString()).isEqualTo("foo[foo.bar]");
+		assertThat(name).hasToString("foo[foo.bar]");
 		assertThat(name.getNumberOfElements()).isEqualTo(2);
 		name = ConfigurationPropertyName.adapt("foo.[bar].baz", '.');
-		assertThat(name.toString()).isEqualTo("foo[bar].baz");
+		assertThat(name).hasToString("foo[bar].baz");
 		assertThat(name.getNumberOfElements()).isEqualTo(3);
 	}
 
@@ -333,8 +333,8 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void getLastElementWhenEmptyShouldReturnEmptyString() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.EMPTY;
-		assertThat(name.getLastElement(Form.ORIGINAL)).isEqualTo("");
-		assertThat(name.getLastElement(Form.UNIFORM)).isEqualTo("");
+		assertThat(name.getLastElement(Form.ORIGINAL)).isEmpty();
+		assertThat(name.getLastElement(Form.UNIFORM)).isEmpty();
 	}
 
 	@Test
@@ -386,8 +386,8 @@ class ConfigurationPropertyNameTests {
 
 	@Test
 	void getNumberOfElementsShouldReturnNumberOfElement() {
-		assertThat(ConfigurationPropertyName.of("").getNumberOfElements()).isEqualTo(0);
-		assertThat(ConfigurationPropertyName.of("x").getNumberOfElements()).isEqualTo(1);
+		assertThat(ConfigurationPropertyName.of("").getNumberOfElements()).isZero();
+		assertThat(ConfigurationPropertyName.of("x").getNumberOfElements()).isOne();
 		assertThat(ConfigurationPropertyName.of("x.y").getNumberOfElements()).isEqualTo(2);
 		assertThat(ConfigurationPropertyName.of("x[0].y").getNumberOfElements()).isEqualTo(3);
 	}
@@ -395,14 +395,14 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void appendWhenNotIndexedShouldAppendWithDot() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("foo");
-		assertThat(name.append("bar").toString()).isEqualTo("foo.bar");
+		assertThat(name.append("bar")).hasToString("foo.bar");
 	}
 
 	@Test
 	void appendWhenIndexedShouldAppendWithBrackets() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("foo").append("[bar]");
 		assertThat(name.isLastElementIndexed()).isTrue();
-		assertThat(name.toString()).isEqualTo("foo[bar]");
+		assertThat(name).hasToString("foo[bar]");
 	}
 
 	@Test
@@ -415,7 +415,7 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void appendWhenElementNameMultiDotShouldAppend() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("foo").append("bar.baz");
-		assertThat(name.toString()).isEqualTo("foo.bar.baz");
+		assertThat(name).hasToString("foo.bar.baz");
 		assertThat(name.getNumberOfElements()).isEqualTo(3);
 	}
 
@@ -461,8 +461,8 @@ class ConfigurationPropertyNameTests {
 	@Test
 	void chopWhenLessThenSizeShouldReturnChopped() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("foo.bar.baz");
-		assertThat(name.chop(1).toString()).isEqualTo("foo");
-		assertThat(name.chop(2).toString()).isEqualTo("foo.bar");
+		assertThat(name.chop(1)).hasToString("foo");
+		assertThat(name.chop(2)).hasToString("foo.bar");
 	}
 
 	@Test
@@ -589,19 +589,19 @@ class ConfigurationPropertyNameTests {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("spring.web.resources.chain.strategy.content");
 		ConfigurationPropertyName other = ConfigurationPropertyName
 				.of("spring.web.resources.chain.strategy.content.enabled");
-		assertThat(name.compareTo(other)).isLessThan(0);
+		assertThat(name).isLessThan(other);
 	}
 
 	@Test
 	void toStringShouldBeLowerCaseDashed() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.adapt("fOO.b_-a-r", '.');
-		assertThat(name.toString()).isEqualTo("foo.b-a-r");
+		assertThat(name).hasToString("foo.b-a-r");
 	}
 
 	@Test
 	void toStringFromOfShouldBeLowerCaseDashed() {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("foo.bar-baz");
-		assertThat(name.toString()).isEqualTo("foo.bar-baz");
+		assertThat(name).hasToString("foo.bar-baz");
 	}
 
 	@Test
@@ -622,17 +622,17 @@ class ConfigurationPropertyNameTests {
 		ConfigurationPropertyName n14 = ConfigurationPropertyName.of("[1]");
 		ConfigurationPropertyName n15 = ConfigurationPropertyName.of("[-1]");
 		assertThat((Object) n01).isEqualTo(n01);
-		assertThat(n01.hashCode()).isEqualTo(n01.hashCode());
+		assertThat(n01).hasSameHashCodeAs(n01);
 		assertThat((Object) n01).isEqualTo(n02);
-		assertThat(n01.hashCode()).isEqualTo(n02.hashCode());
+		assertThat(n01).hasSameHashCodeAs(n02);
 		assertThat((Object) n01).isEqualTo(n03);
-		assertThat(n01.hashCode()).isEqualTo(n03.hashCode());
+		assertThat(n01).hasSameHashCodeAs(n03);
 		assertThat((Object) n01).isEqualTo(n04);
-		assertThat(n01.hashCode()).isEqualTo(n04.hashCode());
+		assertThat(n01).hasSameHashCodeAs(n04);
 		assertThat((Object) n11).isEqualTo(n03);
-		assertThat(n11.hashCode()).isEqualTo(n03.hashCode());
+		assertThat(n11).hasSameHashCodeAs(n03);
 		assertThat((Object) n03).isEqualTo(n11);
-		assertThat(n03.hashCode()).isEqualTo(n11.hashCode());
+		assertThat(n03).hasSameHashCodeAs(n11);
 		assertThat((Object) n01).isNotEqualTo(n05);
 		assertThat((Object) n01).isNotEqualTo(n06);
 		assertThat((Object) n07).isNotEqualTo(n08);
@@ -647,7 +647,7 @@ class ConfigurationPropertyNameTests {
 		ConfigurationPropertyName n1 = ConfigurationPropertyName.of("nested");
 		ConfigurationPropertyName n2 = ConfigurationPropertyName.EMPTY.append("nested");
 		ConfigurationPropertyName n3 = ConfigurationPropertyName.of("nested.value").getParent();
-		assertThat(n1.hashCode()).isEqualTo(n2.hashCode()).isEqualTo(n3.hashCode());
+		assertThat(n1).hasSameHashCodeAs(n2).hasSameHashCodeAs(n3);
 		assertThat(n1).isEqualTo(n2).isEqualTo(n3);
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/ConfigurationPropertySourcesPropertyResolverTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/ConfigurationPropertySourcesPropertyResolverTests.java
@@ -49,7 +49,7 @@ class ConfigurationPropertySourcesPropertyResolverTests {
 		ResolverEnvironment environment = new ResolverEnvironment();
 		CountingMockPropertySource propertySource = createMockPropertySource(environment, true);
 		environment.getProperty("missing");
-		assertThat(propertySource.getCount("missing")).isEqualTo(1);
+		assertThat(propertySource.getCount("missing")).isOne();
 	}
 
 	@Test
@@ -58,8 +58,8 @@ class ConfigurationPropertySourcesPropertyResolverTests {
 		CountingMockPropertySource propertySource = createMockPropertySource(environment, true);
 		assertThat(environment.containsProperty("spring")).isTrue();
 		assertThat(environment.containsProperty("sprong")).isFalse();
-		assertThat(propertySource.getCount("spring")).isEqualTo(1);
-		assertThat(propertySource.getCount("sprong")).isEqualTo(1);
+		assertThat(propertySource.getCount("spring")).isOne();
+		assertThat(propertySource.getCount("sprong")).isOne();
 	}
 
 	@Test
@@ -68,8 +68,8 @@ class ConfigurationPropertySourcesPropertyResolverTests {
 		CountingMockPropertySource propertySource = createMockPropertySource(environment, true);
 		assertThat(environment.containsProperty("spr!ng")).isTrue();
 		assertThat(environment.containsProperty("spr*ng")).isFalse();
-		assertThat(propertySource.getCount("spr!ng")).isEqualTo(1);
-		assertThat(propertySource.getCount("spr*ng")).isEqualTo(1);
+		assertThat(propertySource.getCount("spr!ng")).isOne();
+		assertThat(propertySource.getCount("spr*ng")).isOne();
 	}
 
 	@Test
@@ -78,8 +78,8 @@ class ConfigurationPropertySourcesPropertyResolverTests {
 		CountingMockPropertySource propertySource = createMockPropertySource(environment, true);
 		assertThat(environment.getProperty("spring")).isEqualTo("boot");
 		assertThat(environment.getProperty("sprong")).isNull();
-		assertThat(propertySource.getCount("spring")).isEqualTo(1);
-		assertThat(propertySource.getCount("sprong")).isEqualTo(1);
+		assertThat(propertySource.getCount("spring")).isOne();
+		assertThat(propertySource.getCount("sprong")).isOne();
 	}
 
 	@Test
@@ -88,8 +88,8 @@ class ConfigurationPropertySourcesPropertyResolverTests {
 		CountingMockPropertySource propertySource = createMockPropertySource(environment, true);
 		assertThat(environment.getProperty("spr!ng")).isEqualTo("boot");
 		assertThat(environment.getProperty("spr*ng")).isNull();
-		assertThat(propertySource.getCount("spr!ng")).isEqualTo(1);
-		assertThat(propertySource.getCount("spr*ng")).isEqualTo(1);
+		assertThat(propertySource.getCount("spr!ng")).isOne();
+		assertThat(propertySource.getCount("spr*ng")).isOne();
 	}
 
 	@Test
@@ -98,8 +98,8 @@ class ConfigurationPropertySourcesPropertyResolverTests {
 		CountingMockPropertySource propertySource = createMockPropertySource(environment, false);
 		assertThat(environment.getProperty("spring")).isEqualTo("boot");
 		assertThat(environment.getProperty("sprong")).isNull();
-		assertThat(propertySource.getCount("spring")).isEqualTo(1);
-		assertThat(propertySource.getCount("sprong")).isEqualTo(1);
+		assertThat(propertySource.getCount("spring")).isOne();
+		assertThat(propertySource.getCount("sprong")).isOne();
 	}
 
 	@Test // gh-26732
@@ -110,7 +110,7 @@ class ConfigurationPropertySourcesPropertyResolverTests {
 		propertySource.withProperty("v2", "${v1}");
 		environment.getPropertySources().addFirst(propertySource);
 		assertThat(environment.getProperty("v2")).isEqualTo("1");
-		assertThat(environment.getProperty("v2", Integer.class)).isEqualTo(1);
+		assertThat(environment.getProperty("v2", Integer.class)).isOne();
 	}
 
 	private CountingMockPropertySource createMockPropertySource(StandardEnvironment environment, boolean attach) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/ConfigurationPropertySourcesPropertySourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/ConfigurationPropertySourcesPropertySourceTests.java
@@ -66,7 +66,7 @@ class ConfigurationPropertySourcesPropertySourceTests {
 	@Test
 	void getPropertyOriginShouldReturnOrigin() {
 		this.configurationSources.add(new MockConfigurationPropertySource("foo.bar", "baz", "line1"));
-		assertThat(this.propertySource.getOrigin("foo.bar").toString()).isEqualTo("line1");
+		assertThat(this.propertySource.getOrigin("foo.bar")).hasToString("line1");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/ConfigurationPropertyTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/ConfigurationPropertyTests.java
@@ -82,7 +82,7 @@ class ConfigurationPropertyTests {
 		ConfigurationProperty property2 = new ConfigurationProperty(ConfigurationPropertyName.of("foo"), "bar", null);
 		ConfigurationProperty property3 = new ConfigurationProperty(ConfigurationPropertyName.of("foo"), "baz", null);
 		ConfigurationProperty property4 = new ConfigurationProperty(ConfigurationPropertyName.of("baz"), "bar", null);
-		assertThat(property1.hashCode()).isEqualTo(property2.hashCode());
+		assertThat(property1).hasSameHashCodeAs(property2);
 		assertThat(property1).isEqualTo(property2).isNotEqualTo(property3).isNotEqualTo(property4);
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/PrefixedConfigurationPropertySourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/PrefixedConfigurationPropertySourceTests.java
@@ -33,9 +33,9 @@ class PrefixedConfigurationPropertySourceTests {
 		source.put("my.foo.bar", "bing");
 		source.put("my.foo.baz", "biff");
 		ConfigurationPropertySource prefixed = source.nonIterable().withPrefix("my");
-		assertThat(getName(prefixed, "foo.bar").toString()).isEqualTo("foo.bar");
+		assertThat(getName(prefixed, "foo.bar")).hasToString("foo.bar");
 		assertThat(getValue(prefixed, "foo.bar")).isEqualTo("bing");
-		assertThat(getName(prefixed, "foo.baz").toString()).isEqualTo("foo.baz");
+		assertThat(getName(prefixed, "foo.baz")).hasToString("foo.baz");
 		assertThat(getValue(prefixed, "foo.baz")).isEqualTo("biff");
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringConfigurationPropertySourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringConfigurationPropertySourceTests.java
@@ -70,7 +70,7 @@ class SpringConfigurationPropertySourceTests {
 		mapper.addFromConfigurationProperty(name, "key");
 		SpringConfigurationPropertySource adapter = new SpringConfigurationPropertySource(propertySource, mapper);
 		ConfigurationProperty configurationProperty = adapter.getConfigurationProperty(name);
-		assertThat(configurationProperty.getOrigin().toString()).isEqualTo("\"key\" from property source \"test\"");
+		assertThat(configurationProperty.getOrigin()).hasToString("\"key\" from property source \"test\"");
 		assertThat(configurationProperty.getSource()).isEqualTo(adapter);
 	}
 
@@ -83,7 +83,7 @@ class SpringConfigurationPropertySourceTests {
 		ConfigurationPropertyName name = ConfigurationPropertyName.of("my.key");
 		mapper.addFromConfigurationProperty(name, "key");
 		SpringConfigurationPropertySource adapter = new SpringConfigurationPropertySource(propertySource, mapper);
-		assertThat(adapter.getConfigurationProperty(name).getOrigin().toString()).isEqualTo("TestOrigin key");
+		assertThat(adapter.getConfigurationProperty(name).getOrigin()).hasToString("TestOrigin key");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringConfigurationPropertySourcesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringConfigurationPropertySourcesTests.java
@@ -139,7 +139,7 @@ class SpringConfigurationPropertySourcesTests {
 	void shouldTrackChanges() {
 		MutablePropertySources sources = new MutablePropertySources();
 		SpringConfigurationPropertySources configurationSources = new SpringConfigurationPropertySources(sources);
-		assertThat(configurationSources.iterator()).toIterable().hasSize(0);
+		assertThat(configurationSources.iterator()).toIterable().isEmpty();
 		MapPropertySource source1 = new MapPropertySource("test1", Collections.singletonMap("a", "b"));
 		sources.addLast(source1);
 		assertThat(configurationSources.iterator()).toIterable().hasSize(1);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySourceTests.java
@@ -115,8 +115,8 @@ class SpringIterableConfigurationPropertySourceTests {
 		mapper.addFromConfigurationProperty(name, "key");
 		SpringIterableConfigurationPropertySource adapter = new SpringIterableConfigurationPropertySource(
 				propertySource, mapper);
-		assertThat(adapter.getConfigurationProperty(name).getOrigin().toString())
-				.isEqualTo("\"key\" from property source \"test\"");
+		assertThat(adapter.getConfigurationProperty(name).getOrigin())
+				.hasToString("\"key\" from property source \"test\"");
 	}
 
 	@Test
@@ -130,7 +130,7 @@ class SpringIterableConfigurationPropertySourceTests {
 		mapper.addFromConfigurationProperty(name, "key");
 		SpringIterableConfigurationPropertySource adapter = new SpringIterableConfigurationPropertySource(
 				propertySource, mapper);
-		assertThat(adapter.getConfigurationProperty(name).getOrigin().toString()).isEqualTo("TestOrigin key");
+		assertThat(adapter.getConfigurationProperty(name).getOrigin()).hasToString("TestOrigin key");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/CharSequenceToObjectConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/CharSequenceToObjectConverterTests.java
@@ -39,12 +39,12 @@ class CharSequenceToObjectConverterTests {
 
 	@ConversionServiceTest
 	void convertWhenCanConvertViaToString(ConversionService conversionService) {
-		assertThat(conversionService.convert(new StringBuilder("1"), Integer.class)).isEqualTo(1);
+		assertThat(conversionService.convert(new StringBuilder("1"), Integer.class)).isOne();
 	}
 
 	@ConversionServiceTest
 	void convertWhenCanConvertDirectlySkipsStringConversion(ConversionService conversionService) {
-		assertThat(conversionService.convert(new String("1"), Long.class)).isEqualTo(1);
+		assertThat(conversionService.convert(new String("1"), Long.class)).isOne();
 		if (!ConversionServiceArguments.isApplicationConversionService(conversionService)) {
 			assertThat(conversionService.convert(new StringBuilder("1"), Long.class)).isEqualTo(2);
 		}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BeanCurrentlyInCreationFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BeanCurrentlyInCreationFailureAnalyzerTests.java
@@ -58,7 +58,7 @@ class BeanCurrentlyInCreationFailureAnalyzerTests {
 		assertThat(lines).hasSize(9);
 		assertThat(lines.get(0))
 				.isEqualTo("The dependencies of some of the beans in the application context form a cycle:");
-		assertThat(lines.get(1)).isEqualTo("");
+		assertThat(lines.get(1)).isEmpty();
 		assertThat(lines.get(2)).isEqualTo("┌─────┐");
 		assertThat(lines.get(3)).startsWith("|  one defined in " + InnerInnerConfiguration.class.getName());
 		assertThat(lines.get(4)).isEqualTo("↑     ↓");
@@ -78,7 +78,7 @@ class BeanCurrentlyInCreationFailureAnalyzerTests {
 		assertThat(lines).hasSize(9);
 		assertThat(lines.get(0))
 				.isEqualTo("The dependencies of some of the beans in the application context form a cycle:");
-		assertThat(lines.get(1)).isEqualTo("");
+		assertThat(lines.get(1)).isEmpty();
 		assertThat(lines.get(2)).isEqualTo("┌─────┐");
 		assertThat(lines.get(3)).startsWith("|  three defined in " + BeanThreeConfiguration.class.getName());
 		assertThat(lines.get(4)).isEqualTo("↑     ↓");
@@ -97,7 +97,7 @@ class BeanCurrentlyInCreationFailureAnalyzerTests {
 		assertThat(lines).hasSize(12);
 		assertThat(lines.get(0))
 				.isEqualTo("The dependencies of some of the beans in the application context form a cycle:");
-		assertThat(lines.get(1)).isEqualTo("");
+		assertThat(lines.get(1)).isEmpty();
 		assertThat(lines.get(2)).contains("refererOne (field " + RefererTwo.class.getName());
 		assertThat(lines.get(3)).isEqualTo("      ↓");
 		assertThat(lines.get(4)).contains("refererTwo (field " + BeanOne.class.getName());
@@ -121,7 +121,7 @@ class BeanCurrentlyInCreationFailureAnalyzerTests {
 		assertThat(lines).hasSize(5);
 		assertThat(lines.get(0))
 				.isEqualTo("The dependencies of some of the beans in the application context form a cycle:");
-		assertThat(lines.get(1)).isEqualTo("");
+		assertThat(lines.get(1)).isEmpty();
 		assertThat(lines.get(2)).isEqualTo("┌──->──┐");
 		assertThat(lines.get(3)).startsWith("|  bean defined in " + SelfReferenceBeanConfiguration.class.getName());
 		assertThat(lines.get(4)).isEqualTo("└──<-──┘");

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/NoSuchMethodFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/NoSuchMethodFailureAnalyzerTests.java
@@ -48,7 +48,7 @@ class NoSuchMethodFailureAnalyzerTests {
 		assertThat(descriptor.getErrorMessage()).isEqualTo(
 				"'boolean org.springframework.util.MimeType.isMoreSpecific(org.springframework.util.MimeType)'");
 		assertThat(descriptor.getClassName()).isEqualTo("org.springframework.util.MimeType");
-		assertThat(descriptor.getCandidateLocations().size()).isGreaterThan(1);
+		assertThat(descriptor.getCandidateLocations()).hasSizeGreaterThan(1);
 		List<ClassDescriptor> typeHierarchy = descriptor.getTypeHierarchy();
 		assertThat(typeHierarchy).hasSize(1);
 		assertThat(typeHierarchy.get(0).getLocation()).asString().contains("spring-core-5.3.12.jar");
@@ -66,7 +66,7 @@ class NoSuchMethodFailureAnalyzerTests {
 		assertThat(descriptor.getErrorMessage())
 				.isEqualTo("org/springframework/util/MimeType.isMoreSpecific(Lorg/springframework/util/MimeType;)Z");
 		assertThat(descriptor.getClassName()).isEqualTo("org.springframework.util.MimeType");
-		assertThat(descriptor.getCandidateLocations().size()).isGreaterThan(1);
+		assertThat(descriptor.getCandidateLocations()).hasSizeGreaterThan(1);
 		List<ClassDescriptor> typeHierarchy = descriptor.getTypeHierarchy();
 		assertThat(typeHierarchy).hasSize(1);
 		assertThat(typeHierarchy.get(0).getLocation()).asString().contains("spring-core-5.3.12.jar");

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/ConfigTreePropertySourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/ConfigTreePropertySourceTests.java
@@ -143,8 +143,8 @@ class ConfigTreePropertySourceTests {
 		ConfigTreePropertySource propertySource = getFlatPropertySource();
 		TextResourceOrigin origin = (TextResourceOrigin) propertySource.getOrigin("b");
 		assertThat(origin.getResource().getFile()).isEqualTo(this.directory.resolve("b").toFile());
-		assertThat(origin.getLocation().getLine()).isEqualTo(0);
-		assertThat(origin.getLocation().getColumn()).isEqualTo(0);
+		assertThat(origin.getLocation().getLine()).isZero();
+		assertThat(origin.getLocation().getColumn()).isZero();
 	}
 
 	@Test
@@ -163,7 +163,7 @@ class ConfigTreePropertySourceTests {
 		assertThat(environment.getProperty("b")).isEqualTo("B");
 		assertThat(environment.getProperty("c", InputStreamSource.class).getInputStream()).hasContent("C");
 		assertThat(environment.getProperty("c", byte[].class)).contains('C');
-		assertThat(environment.getProperty("one", Integer.class)).isEqualTo(1);
+		assertThat(environment.getProperty("one", Integer.class)).isOne();
 	}
 
 	@Test
@@ -214,7 +214,7 @@ class ConfigTreePropertySourceTests {
 		addProperty("a", "a\nb\n");
 		ConfigTreePropertySource propertySource = new ConfigTreePropertySource("test", this.directory,
 				Option.AUTO_TRIM_TRAILING_NEW_LINE);
-		assertThat(propertySource.getProperty("a").toString()).isEqualTo("a\nb\n");
+		assertThat(propertySource.getProperty("a")).hasToString("a\nb\n");
 	}
 
 	@Test
@@ -222,7 +222,7 @@ class ConfigTreePropertySourceTests {
 		addProperty("a", "a\n");
 		ConfigTreePropertySource propertySource = new ConfigTreePropertySource("test", this.directory,
 				Option.AUTO_TRIM_TRAILING_NEW_LINE);
-		assertThat(propertySource.getProperty("a").toString()).isEqualTo("a");
+		assertThat(propertySource.getProperty("a")).hasToString("a");
 	}
 
 	@Test
@@ -230,7 +230,7 @@ class ConfigTreePropertySourceTests {
 		addProperty("a", "a\r\n");
 		ConfigTreePropertySource propertySource = new ConfigTreePropertySource("test", this.directory,
 				Option.AUTO_TRIM_TRAILING_NEW_LINE);
-		assertThat(propertySource.getProperty("a").toString()).isEqualTo("a");
+		assertThat(propertySource.getProperty("a")).hasToString("a");
 	}
 
 	private ConfigTreePropertySource getFlatPropertySource() throws IOException {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/OriginTrackedPropertiesLoaderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/OriginTrackedPropertiesLoaderTests.java
@@ -327,7 +327,7 @@ class OriginTrackedPropertiesLoaderTests {
 	void existingCommentsAreNotTreatedAsMultiDoc() throws Exception {
 		this.resource = new ClassPathResource("existing-non-multi-document.properties", getClass());
 		this.documents = new OriginTrackedPropertiesLoader(this.resource).load();
-		assertThat(this.documents.size()).isEqualTo(1);
+		assertThat(this.documents).hasSize(1);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/OriginTrackedYamlLoaderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/OriginTrackedYamlLoaderTests.java
@@ -55,7 +55,7 @@ class OriginTrackedYamlLoaderTests {
 	@Test
 	void processSimpleKey() {
 		OriginTrackedValue value = getValue("name");
-		assertThat(value.toString()).isEqualTo("Martin D'vloper");
+		assertThat(value).hasToString("Martin D'vloper");
 		assertThat(getLocation(value)).isEqualTo("3:7");
 	}
 
@@ -64,11 +64,11 @@ class OriginTrackedYamlLoaderTests {
 		OriginTrackedValue perl = getValue("languages.perl");
 		OriginTrackedValue python = getValue("languages.python");
 		OriginTrackedValue pascal = getValue("languages.pascal");
-		assertThat(perl.toString()).isEqualTo("Elite");
+		assertThat(perl).hasToString("Elite");
 		assertThat(getLocation(perl)).isEqualTo("13:11");
-		assertThat(python.toString()).isEqualTo("Elite");
+		assertThat(python).hasToString("Elite");
 		assertThat(getLocation(python)).isEqualTo("14:13");
-		assertThat(pascal.toString()).isEqualTo("Lame");
+		assertThat(pascal).hasToString("Lame");
 		assertThat(getLocation(pascal)).isEqualTo("15:13");
 	}
 
@@ -78,20 +78,20 @@ class OriginTrackedYamlLoaderTests {
 		OriginTrackedValue orange = getValue("foods[1]");
 		OriginTrackedValue strawberry = getValue("foods[2]");
 		OriginTrackedValue mango = getValue("foods[3]");
-		assertThat(apple.toString()).isEqualTo("Apple");
+		assertThat(apple).hasToString("Apple");
 		assertThat(getLocation(apple)).isEqualTo("8:7");
-		assertThat(orange.toString()).isEqualTo("Orange");
+		assertThat(orange).hasToString("Orange");
 		assertThat(getLocation(orange)).isEqualTo("9:7");
-		assertThat(strawberry.toString()).isEqualTo("Strawberry");
+		assertThat(strawberry).hasToString("Strawberry");
 		assertThat(getLocation(strawberry)).isEqualTo("10:7");
-		assertThat(mango.toString()).isEqualTo("Mango");
+		assertThat(mango).hasToString("Mango");
 		assertThat(getLocation(mango)).isEqualTo("11:7");
 	}
 
 	@Test
 	void processMultiline() {
 		OriginTrackedValue education = getValue("education");
-		assertThat(education.toString()).isEqualTo("4 GCSEs\n3 A-Levels\nBSc in the Internet of Things\n");
+		assertThat(education).hasToString("4 GCSEs\n3 A-Levels\nBSc in the Internet of Things\n");
 		assertThat(getLocation(education)).isEqualTo("16:12");
 	}
 
@@ -101,13 +101,13 @@ class OriginTrackedYamlLoaderTests {
 		OriginTrackedValue url = getValue("example.foo[0].url");
 		OriginTrackedValue bar1 = getValue("example.foo[0].bar[0].bar1");
 		OriginTrackedValue bar2 = getValue("example.foo[0].bar[1].bar2");
-		assertThat(name.toString()).isEqualTo("springboot");
+		assertThat(name).hasToString("springboot");
 		assertThat(getLocation(name)).isEqualTo("22:15");
-		assertThat(url.toString()).isEqualTo("https://springboot.example.com/");
+		assertThat(url).hasToString("https://springboot.example.com/");
 		assertThat(getLocation(url)).isEqualTo("23:14");
-		assertThat(bar1.toString()).isEqualTo("baz");
+		assertThat(bar1).hasToString("baz");
 		assertThat(getLocation(bar1)).isEqualTo("25:19");
-		assertThat(bar2.toString()).isEqualTo("bling");
+		assertThat(bar2).hasToString("bling");
 		assertThat(getLocation(bar2)).isEqualTo("26:19");
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/PropertiesPropertySourceLoaderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/PropertiesPropertySourceLoaderTests.java
@@ -52,7 +52,7 @@ class PropertiesPropertySourceLoaderTests {
 	void loadMultiDocumentPropertiesWithSeparatorAtTheBeginningOfFile() throws Exception {
 		List<PropertySource<?>> loaded = this.loader.load("test.properties",
 				new ClassPathResource("multi-document-properties-2.properties", getClass()));
-		assertThat(loaded.size()).isEqualTo(2);
+		assertThat(loaded).hasSize(2);
 		PropertySource<?> source1 = loaded.get(0);
 		PropertySource<?> source2 = loaded.get(1);
 		assertThat(source1.getProperty("blah")).isEqualTo("hello world");
@@ -63,7 +63,7 @@ class PropertiesPropertySourceLoaderTests {
 	void loadMultiDocumentProperties() throws Exception {
 		List<PropertySource<?>> loaded = this.loader.load("test.properties",
 				new ClassPathResource("multi-document-properties.properties", getClass()));
-		assertThat(loaded.size()).isEqualTo(2);
+		assertThat(loaded).hasSize(2);
 		PropertySource<?> source1 = loaded.get(0);
 		PropertySource<?> source2 = loaded.get(1);
 		assertThat(source1.getProperty("blah")).isEqualTo("hello world");
@@ -74,7 +74,7 @@ class PropertiesPropertySourceLoaderTests {
 	void loadMultiDocumentPropertiesWithEmptyDocument() throws Exception {
 		List<PropertySource<?>> loaded = this.loader.load("test.properties",
 				new ClassPathResource("multi-document-properties-empty.properties", getClass()));
-		assertThat(loaded.size()).isEqualTo(2);
+		assertThat(loaded).hasSize(2);
 		PropertySource<?> source1 = loaded.get(0);
 		PropertySource<?> source2 = loaded.get(1);
 		assertThat(source1.getProperty("blah")).isEqualTo("hello world");

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/RandomValuePropertySourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/env/RandomValuePropertySourceTests.java
@@ -69,8 +69,8 @@ class RandomValuePropertySourceTests {
 	void getPropertyWhenIntRangeReturnsValue() {
 		Integer value = (Integer) this.source.getProperty("random.int[4,10]");
 		assertThat(value).isNotNull();
-		assertThat(value >= 4).isTrue();
-		assertThat(value < 10).isTrue();
+		assertThat(value).isGreaterThanOrEqualTo(4);
+		assertThat(value).isLessThan(10);
 	}
 
 	@Test
@@ -82,8 +82,8 @@ class RandomValuePropertySourceTests {
 	@Test
 	void intRangeWhenLowerBoundNegative() {
 		Integer value = (Integer) this.source.getProperty("random.int[-4,4]");
-		assertThat(value >= -4).isTrue();
-		assertThat(value < 4).isTrue();
+		assertThat(value).isGreaterThanOrEqualTo(-4);
+		assertThat(value).isLessThan(4);
 	}
 
 	@Test
@@ -125,8 +125,8 @@ class RandomValuePropertySourceTests {
 	@Test
 	void longRangeWhenLowerBoundNegative() {
 		Long value = (Long) this.source.getProperty("random.long[-4,4]");
-		assertThat(value >= -4).isTrue();
-		assertThat(value < 4).isTrue();
+		assertThat(value).isGreaterThanOrEqualTo(-4);
+		assertThat(value).isLessThan(4);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/metadata/AbstractDataSourcePoolMetadataTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/metadata/AbstractDataSourcePoolMetadataTests.java
@@ -47,7 +47,7 @@ abstract class AbstractDataSourcePoolMetadataTests<D extends AbstractDataSourceP
 
 	@Test
 	void getMinPoolSize() {
-		assertThat(getDataSourceMetadata().getMin()).isEqualTo(0);
+		assertThat(getDataSourceMetadata().getMin()).isZero();
 	}
 
 	@Test
@@ -55,15 +55,15 @@ abstract class AbstractDataSourcePoolMetadataTests<D extends AbstractDataSourceP
 		// Make sure the pool is initialized
 		JdbcTemplate jdbcTemplate = new JdbcTemplate(getDataSourceMetadata().getDataSource());
 		jdbcTemplate.execute((ConnectionCallback<Void>) (connection) -> null);
-		assertThat(getDataSourceMetadata().getActive()).isEqualTo(0);
-		assertThat(getDataSourceMetadata().getUsage()).isEqualTo(0f);
+		assertThat(getDataSourceMetadata().getActive()).isZero();
+		assertThat(getDataSourceMetadata().getUsage()).isZero();
 	}
 
 	@Test
 	void getPoolSizeOneConnection() {
 		JdbcTemplate jdbcTemplate = new JdbcTemplate(getDataSourceMetadata().getDataSource());
 		jdbcTemplate.execute((ConnectionCallback<Void>) (connection) -> {
-			assertThat(getDataSourceMetadata().getActive()).isEqualTo(1);
+			assertThat(getDataSourceMetadata().getActive()).isOne();
 			assertThat(getDataSourceMetadata().getUsage()).isEqualTo(0.5f);
 			return null;
 		});
@@ -73,7 +73,7 @@ abstract class AbstractDataSourcePoolMetadataTests<D extends AbstractDataSourceP
 	void getIdle() {
 		JdbcTemplate jdbcTemplate = new JdbcTemplate(getDataSourceMetadata().getDataSource());
 		jdbcTemplate.execute((ConnectionCallback<Void>) (connection) -> null);
-		assertThat(getDataSourceMetadata().getIdle()).isEqualTo(1);
+		assertThat(getDataSourceMetadata().getIdle()).isOne();
 	}
 
 	@Test
@@ -82,7 +82,7 @@ abstract class AbstractDataSourcePoolMetadataTests<D extends AbstractDataSourceP
 		jdbcTemplate.execute((ConnectionCallback<Void>) (connection) -> {
 			jdbcTemplate.execute((ConnectionCallback<Void>) (connection1) -> {
 				assertThat(getDataSourceMetadata().getActive()).isEqualTo(2);
-				assertThat(getDataSourceMetadata().getUsage()).isEqualTo(1.0f);
+				assertThat(getDataSourceMetadata().getUsage()).isOne();
 				return null;
 			});
 			return null;

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/json/AbstractJsonParserTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/json/AbstractJsonParserTests.java
@@ -45,30 +45,30 @@ abstract class AbstractJsonParserTests {
 	void simpleMap() {
 		Map<String, Object> map = this.parser.parseMap("{\"foo\":\"bar\",\"spam\":1}");
 		assertThat(map).hasSize(2);
-		assertThat(map.get("foo")).isEqualTo("bar");
-		assertThat(((Number) map.get("spam")).longValue()).isEqualTo(1L);
+		assertThat(map).containsEntry("foo", "bar");
+		assertThat(((Number) map.get("spam")).longValue()).isOne();
 	}
 
 	@Test
 	void doubleValue() {
 		Map<String, Object> map = this.parser.parseMap("{\"foo\":\"bar\",\"spam\":1.23}");
 		assertThat(map).hasSize(2);
-		assertThat(map.get("foo")).isEqualTo("bar");
-		assertThat(map.get("spam")).isEqualTo(1.23d);
+		assertThat(map).containsEntry("foo", "bar");
+		assertThat(map).containsEntry("spam", 1.23d);
 	}
 
 	@Test
 	void stringContainingNumber() {
 		Map<String, Object> map = this.parser.parseMap("{\"foo\":\"123\"}");
 		assertThat(map).hasSize(1);
-		assertThat(map.get("foo")).isEqualTo("123");
+		assertThat(map).containsEntry("foo", "123");
 	}
 
 	@Test
 	void stringContainingComma() {
 		Map<String, Object> map = this.parser.parseMap("{\"foo\":\"bar1,bar2\"}");
 		assertThat(map).hasSize(1);
-		assertThat(map.get("foo")).isEqualTo("bar1,bar2");
+		assertThat(map).containsEntry("foo", "bar1,bar2");
 	}
 
 	@Test
@@ -159,7 +159,7 @@ abstract class AbstractJsonParserTests {
 	void mapWithLeadingWhitespace() {
 		Map<String, Object> map = this.parser.parseMap("\n\t{\"foo\":\"bar\"}");
 		assertThat(map).hasSize(1);
-		assertThat(map.get("foo")).isEqualTo("bar");
+		assertThat(map).containsEntry("foo", "bar");
 	}
 
 	@Test
@@ -176,7 +176,7 @@ abstract class AbstractJsonParserTests {
 	void escapeDoubleQuote() {
 		String input = "{\"foo\": \"\\\"bar\\\"\"}";
 		Map<String, Object> map = this.parser.parseMap(input);
-		assertThat(map.get("foo")).isEqualTo("\"bar\"");
+		assertThat(map).containsEntry("foo", "\"bar\"");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LogFileTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LogFileTests.java
@@ -56,7 +56,7 @@ class LogFileTests {
 		LogFile logFile = LogFile.get(resolver);
 		Properties properties = new Properties();
 		logFile.applyTo(properties);
-		assertThat(logFile.toString()).isEqualTo("log.file");
+		assertThat(logFile).hasToString("log.file");
 		assertThat(properties.getProperty(LoggingSystemProperties.LOG_FILE)).isEqualTo("log.file");
 		assertThat(properties.getProperty(LoggingSystemProperties.LOG_PATH)).isNull();
 	}
@@ -71,7 +71,7 @@ class LogFileTests {
 		LogFile logFile = LogFile.get(resolver);
 		Properties properties = new Properties();
 		logFile.applyTo(properties);
-		assertThat(logFile.toString()).isEqualTo("logpath" + File.separatorChar + "spring.log");
+		assertThat(logFile).hasToString("logpath" + File.separatorChar + "spring.log");
 		assertThat(properties.getProperty(LoggingSystemProperties.LOG_FILE))
 				.isEqualTo("logpath" + File.separatorChar + "spring.log");
 		assertThat(properties.getProperty(LoggingSystemProperties.LOG_PATH)).isEqualTo("logpath");
@@ -90,7 +90,7 @@ class LogFileTests {
 		LogFile logFile = LogFile.get(resolver);
 		Properties properties = new Properties();
 		logFile.applyTo(properties);
-		assertThat(logFile.toString()).isEqualTo("log.file");
+		assertThat(logFile).hasToString("log.file");
 		assertThat(properties.getProperty(LoggingSystemProperties.LOG_FILE)).isEqualTo("log.file");
 		assertThat(properties.getProperty(LoggingSystemProperties.LOG_PATH)).isEqualTo("logpath");
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LoggerConfigurationComparatorTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LoggerConfigurationComparatorTests.java
@@ -75,7 +75,7 @@ class LoggerConfigurationComparatorTests {
 	void lexicalEqual() {
 		LoggerConfiguration first = new LoggerConfiguration("alpha", null, LogLevel.OFF);
 		LoggerConfiguration second = new LoggerConfiguration("alpha", null, LogLevel.OFF);
-		assertThat(this.comparator.compare(first, second)).isEqualTo(0);
+		assertThat(this.comparator.compare(first, second)).isZero();
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/java/JavaLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/java/JavaLoggingSystemTests.java
@@ -85,7 +85,7 @@ class JavaLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.loggingSystem.initialize(null, null, null);
 		this.logger.info("Hello world");
 		assertThat(output).contains("Hello world").doesNotContain("Hidden");
-		assertThat(new File(tmpDir() + "/spring.log").exists()).isFalse();
+		assertThat(new File(tmpDir() + "/spring.log")).doesNotExist();
 	}
 
 	@Test
@@ -100,7 +100,7 @@ class JavaLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.loggingSystem.initialize(null, null, getLogFile(null, tmpDir()));
 		this.logger.info("Hello world");
 		assertThat(output).contains("Hello world").doesNotContain("Hidden");
-		assertThat(temp.listFiles(SPRING_LOG_FILTER)).hasSizeGreaterThan(0);
+		assertThat(temp.listFiles(SPRING_LOG_FILTER)).isNotEmpty();
 	}
 
 	@Test
@@ -150,7 +150,7 @@ class JavaLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.logger.fine("Hello");
 		this.loggingSystem.setLogLevel("org.springframework.boot", LogLevel.DEBUG);
 		this.logger.fine("Hello");
-		assertThat(StringUtils.countOccurrencesOf(output.toString(), "Hello")).isEqualTo(1);
+		assertThat(StringUtils.countOccurrencesOf(output.toString(), "Hello")).isOne();
 	}
 
 	@Test
@@ -162,7 +162,7 @@ class JavaLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.logger.fine("Hello");
 		this.loggingSystem.setLogLevel("org.springframework.boot", null);
 		this.logger.fine("Hello");
-		assertThat(StringUtils.countOccurrencesOf(output.toString(), "Hello")).isEqualTo(1);
+		assertThat(StringUtils.countOccurrencesOf(output.toString(), "Hello")).isOne();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/ColorConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/ColorConverterTests.java
@@ -61,49 +61,49 @@ class ColorConverterTests {
 	void faint() {
 		StringBuilder output = new StringBuilder();
 		newConverter("faint").format(this.event, output);
-		assertThat(output.toString()).isEqualTo("\033[2min\033[0;39m");
+		assertThat(output).hasToString("\033[2min\033[0;39m");
 	}
 
 	@Test
 	void red() {
 		StringBuilder output = new StringBuilder();
 		newConverter("red").format(this.event, output);
-		assertThat(output.toString()).isEqualTo("\033[31min\033[0;39m");
+		assertThat(output).hasToString("\033[31min\033[0;39m");
 	}
 
 	@Test
 	void green() {
 		StringBuilder output = new StringBuilder();
 		newConverter("green").format(this.event, output);
-		assertThat(output.toString()).isEqualTo("\033[32min\033[0;39m");
+		assertThat(output).hasToString("\033[32min\033[0;39m");
 	}
 
 	@Test
 	void yellow() {
 		StringBuilder output = new StringBuilder();
 		newConverter("yellow").format(this.event, output);
-		assertThat(output.toString()).isEqualTo("\033[33min\033[0;39m");
+		assertThat(output).hasToString("\033[33min\033[0;39m");
 	}
 
 	@Test
 	void blue() {
 		StringBuilder output = new StringBuilder();
 		newConverter("blue").format(this.event, output);
-		assertThat(output.toString()).isEqualTo("\033[34min\033[0;39m");
+		assertThat(output).hasToString("\033[34min\033[0;39m");
 	}
 
 	@Test
 	void magenta() {
 		StringBuilder output = new StringBuilder();
 		newConverter("magenta").format(this.event, output);
-		assertThat(output.toString()).isEqualTo("\033[35min\033[0;39m");
+		assertThat(output).hasToString("\033[35min\033[0;39m");
 	}
 
 	@Test
 	void cyan() {
 		StringBuilder output = new StringBuilder();
 		newConverter("cyan").format(this.event, output);
-		assertThat(output.toString()).isEqualTo("\033[36min\033[0;39m");
+		assertThat(output).hasToString("\033[36min\033[0;39m");
 	}
 
 	@Test
@@ -111,7 +111,7 @@ class ColorConverterTests {
 		this.event.setLevel(Level.FATAL);
 		StringBuilder output = new StringBuilder();
 		newConverter(null).format(this.event, output);
-		assertThat(output.toString()).isEqualTo("\033[31min\033[0;39m");
+		assertThat(output).hasToString("\033[31min\033[0;39m");
 	}
 
 	@Test
@@ -119,7 +119,7 @@ class ColorConverterTests {
 		this.event.setLevel(Level.ERROR);
 		StringBuilder output = new StringBuilder();
 		newConverter(null).format(this.event, output);
-		assertThat(output.toString()).isEqualTo("\033[31min\033[0;39m");
+		assertThat(output).hasToString("\033[31min\033[0;39m");
 	}
 
 	@Test
@@ -127,7 +127,7 @@ class ColorConverterTests {
 		this.event.setLevel(Level.WARN);
 		StringBuilder output = new StringBuilder();
 		newConverter(null).format(this.event, output);
-		assertThat(output.toString()).isEqualTo("\033[33min\033[0;39m");
+		assertThat(output).hasToString("\033[33min\033[0;39m");
 	}
 
 	@Test
@@ -135,7 +135,7 @@ class ColorConverterTests {
 		this.event.setLevel(Level.DEBUG);
 		StringBuilder output = new StringBuilder();
 		newConverter(null).format(this.event, output);
-		assertThat(output.toString()).isEqualTo("\033[32min\033[0;39m");
+		assertThat(output).hasToString("\033[32min\033[0;39m");
 	}
 
 	@Test
@@ -143,7 +143,7 @@ class ColorConverterTests {
 		this.event.setLevel(Level.TRACE);
 		StringBuilder output = new StringBuilder();
 		newConverter(null).format(this.event, output);
-		assertThat(output.toString()).isEqualTo("\033[32min\033[0;39m");
+		assertThat(output).hasToString("\033[32min\033[0;39m");
 	}
 
 	static class TestLogEvent extends AbstractLogEvent {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/ExtendedWhitespaceThrowablePatternConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/ExtendedWhitespaceThrowablePatternConverterTests.java
@@ -40,7 +40,7 @@ class ExtendedWhitespaceThrowablePatternConverterTests {
 		LogEvent event = Log4jLogEvent.newBuilder().build();
 		StringBuilder builder = new StringBuilder();
 		this.converter.format(event, builder);
-		assertThat(builder.toString()).isEqualTo("");
+		assertThat(builder).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
@@ -132,7 +132,7 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 		this.logger.info("Hello world");
 		Configuration configuration = this.loggingSystem.getConfiguration();
 		assertThat(output).contains("Hello world").doesNotContain("Hidden");
-		assertThat(new File(tmpDir() + "/spring.log").exists()).isFalse();
+		assertThat(new File(tmpDir() + "/spring.log")).doesNotExist();
 		assertThat(configuration.getConfigurationSource().getFile()).isNotNull();
 	}
 
@@ -145,7 +145,7 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 		this.logger.info("Hello world");
 		Configuration configuration = this.loggingSystem.getConfiguration();
 		assertThat(output).contains("Hello world").doesNotContain("Hidden");
-		assertThat(new File(tmpDir() + "/spring.log").exists()).isTrue();
+		assertThat(new File(tmpDir() + "/spring.log")).exists();
 		assertThat(configuration.getConfigurationSource().getFile()).isNotNull();
 	}
 
@@ -157,7 +157,7 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 		this.logger.info("Hello world");
 		Configuration configuration = this.loggingSystem.getConfiguration();
 		assertThat(output).contains("Hello world").contains(tmpDir() + "/tmp.log");
-		assertThat(new File(tmpDir() + "/tmp.log").exists()).isFalse();
+		assertThat(new File(tmpDir() + "/tmp.log")).doesNotExist();
 		assertThat(configuration.getConfigurationSource().getFile().getAbsolutePath())
 				.contains("log4j2-nondefault.xml");
 		assertThat(configuration.getWatchManager().getIntervalSeconds()).isEqualTo(30);
@@ -182,7 +182,7 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 		this.logger.debug("Hello");
 		this.loggingSystem.setLogLevel("org.springframework.boot", LogLevel.DEBUG);
 		this.logger.debug("Hello");
-		assertThat(StringUtils.countOccurrencesOf(output.toString(), "Hello")).isEqualTo(1);
+		assertThat(StringUtils.countOccurrencesOf(output.toString(), "Hello")).isOne();
 	}
 
 	@Test
@@ -194,7 +194,7 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 		this.logger.debug("Hello");
 		this.loggingSystem.setLogLevel("org.springframework.boot", null);
 		this.logger.debug("Hello");
-		assertThat(StringUtils.countOccurrencesOf(output.toString(), "Hello")).isEqualTo(1);
+		assertThat(StringUtils.countOccurrencesOf(output.toString(), "Hello")).isOne();
 	}
 
 	@Test
@@ -225,8 +225,8 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	private void assertIsPresent(String loggerName, Map<String, LogLevel> loggers, LogLevel logLevel) {
-		assertThat(loggers.containsKey(loggerName)).isTrue();
-		assertThat(loggers.get(loggerName)).isEqualTo(logLevel);
+		assertThat(loggers).containsKey(loggerName);
+		assertThat(loggers).containsEntry(loggerName, logLevel);
 	}
 
 	@Test
@@ -254,7 +254,7 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 		this.loggingSystem.initialize(this.initializationContext, null, null);
 		this.loggingSystem.setLogLevel(getClass().getName(), LogLevel.DEBUG);
 		LoggerConfiguration configuration = this.loggingSystem.getLoggerConfiguration("doesnotexist");
-		assertThat(configuration).isEqualTo(null);
+		assertThat(configuration).isNull();
 	}
 
 	@Test
@@ -421,7 +421,7 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 		java.util.logging.Logger rootLogger = java.util.logging.Logger.getLogger("");
 		// check if Log4jBridgeHandler is used
 		Handler[] handlers = rootLogger.getHandlers();
-		assertThat(handlers.length).isEqualTo(1);
+		assertThat(handlers).hasSize(1);
 		assertThat(handlers[0]).isInstanceOf(Log4jBridgeHandler.class);
 
 		this.loggingSystem.initialize(this.initializationContext, null, null);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/WhitespaceThrowablePatternConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/WhitespaceThrowablePatternConverterTests.java
@@ -39,7 +39,7 @@ class WhitespaceThrowablePatternConverterTests {
 		LogEvent event = Log4jLogEvent.newBuilder().build();
 		StringBuilder builder = new StringBuilder();
 		this.converter.format(event, builder);
-		assertThat(builder.toString()).isEqualTo("");
+		assertThat(builder).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -146,7 +146,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.logger.info("Hello world");
 		assertThat(output).contains("Hello world").doesNotContain("Hidden");
 		assertThat(getLineWithText(output, "Hello world")).contains("INFO");
-		assertThat(new File(tmpDir() + "/spring.log").exists()).isFalse();
+		assertThat(new File(tmpDir() + "/spring.log")).doesNotExist();
 	}
 
 	@Test
@@ -159,9 +159,9 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		assertThat(output).doesNotContain("LOGBACK:");
 		assertThat(output).contains("Hello world").doesNotContain("Hidden");
 		assertThat(getLineWithText(output, "Hello world")).contains("INFO");
-		assertThat(file.exists()).isTrue();
+		assertThat(file).exists();
 		assertThat(getLineWithText(file, "Hello world")).contains("INFO");
-		assertThat(ReflectionTestUtils.getField(getRollingPolicy(), "maxFileSize").toString()).isEqualTo("10 MB");
+		assertThat(ReflectionTestUtils.getField(getRollingPolicy(), "maxFileSize")).hasToString("10 MB");
 		assertThat(getRollingPolicy().getMaxHistory()).isEqualTo(7);
 	}
 
@@ -180,7 +180,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.logger.info("Hello world");
 		assertThat(output).doesNotContain("DEBUG").contains("Hello world").contains(tmpDir() + "/tmp.log")
 				.endsWith("BOOTBOOT");
-		assertThat(new File(tmpDir() + "/tmp.log").exists()).isFalse();
+		assertThat(new File(tmpDir() + "/tmp.log")).doesNotExist();
 	}
 
 	@Test
@@ -217,7 +217,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.logger.debug("Hello");
 		this.loggingSystem.setLogLevel("org.springframework.boot", LogLevel.DEBUG);
 		this.logger.debug("Hello");
-		assertThat(StringUtils.countOccurrencesOf(output.toString(), "Hello")).isEqualTo(1);
+		assertThat(StringUtils.countOccurrencesOf(output.toString(), "Hello")).isOne();
 	}
 
 	@Test
@@ -229,7 +229,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		this.logger.debug("Hello");
 		this.loggingSystem.setLogLevel("org.springframework.boot", null);
 		this.logger.debug("Hello");
-		assertThat(StringUtils.countOccurrencesOf(output.toString(), "Hello")).isEqualTo(1);
+		assertThat(StringUtils.countOccurrencesOf(output.toString(), "Hello")).isOne();
 	}
 
 	@Test
@@ -411,8 +411,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		initialize(loggingInitializationContext, null, logFile);
 		this.logger.info("Hello world");
 		assertThat(getLineWithText(file, "Hello world")).contains("INFO");
-		assertThat(ReflectionTestUtils.getField(getRollingPolicy(), "maxFileSize").toString())
-				.isEqualTo(expectedFileSize);
+		assertThat(ReflectionTestUtils.getField(getRollingPolicy(), "maxFileSize")).hasToString(expectedFileSize);
 	}
 
 	@Test
@@ -424,7 +423,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		initialize(loggingInitializationContext, "classpath:logback-include-base.xml", logFile);
 		this.logger.info("Hello world");
 		assertThat(getLineWithText(file, "Hello world")).contains("INFO");
-		assertThat(ReflectionTestUtils.getField(getRollingPolicy(), "maxFileSize").toString()).isEqualTo("100 MB");
+		assertThat(ReflectionTestUtils.getField(getRollingPolicy(), "maxFileSize")).hasToString("100 MB");
 	}
 
 	@Test
@@ -474,8 +473,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		initialize(loggingInitializationContext, null, logFile);
 		this.logger.info("Hello world");
 		assertThat(getLineWithText(file, "Hello world")).contains("INFO");
-		assertThat(ReflectionTestUtils.getField(getRollingPolicy(), "totalSizeCap").toString())
-				.isEqualTo(expectedFileSize);
+		assertThat(ReflectionTestUtils.getField(getRollingPolicy(), "totalSizeCap")).hasToString(expectedFileSize);
 	}
 
 	@Test
@@ -488,7 +486,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		initialize(loggingInitializationContext, "classpath:logback-include-base.xml", logFile);
 		this.logger.info("Hello world");
 		assertThat(getLineWithText(file, "Hello world")).contains("INFO");
-		assertThat(ReflectionTestUtils.getField(getRollingPolicy(), "totalSizeCap").toString()).isEqualTo(expectedSize);
+		assertThat(ReflectionTestUtils.getField(getRollingPolicy(), "totalSizeCap")).hasToString(expectedSize);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/WhitespaceThrowableProxyConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/WhitespaceThrowableProxyConverterTests.java
@@ -37,7 +37,7 @@ class WhitespaceThrowableProxyConverterTests {
 	@Test
 	void noStackTrace() {
 		String s = this.converter.convert(this.event);
-		assertThat(s).isEqualTo("");
+		assertThat(s).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/origin/OriginTrackedResourceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/origin/OriginTrackedResourceTests.java
@@ -171,7 +171,7 @@ class OriginTrackedResourceTests {
 		OriginTrackedResource r2o1 = OriginTrackedResource.of(r2, o1);
 		OriginTrackedResource r2o2 = OriginTrackedResource.of(r2, o2);
 		assertThat(r1o1a).isEqualTo(r1o1a).isEqualTo(r1o1a).isNotEqualTo(r1o2).isNotEqualTo(r2o1).isNotEqualTo(r2o2);
-		assertThat(r1o1a.hashCode()).isEqualTo(r1o1b.hashCode());
+		assertThat(r1o1a).hasSameHashCodeAs(r1o1b);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/origin/OriginTrackedValueTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/origin/OriginTrackedValueTests.java
@@ -44,7 +44,7 @@ class OriginTrackedValueTests {
 	@Test
 	void toStringShouldReturnValueToString() {
 		Object value = new Object();
-		assertThat(OriginTrackedValue.of(value).toString()).isEqualTo(value.toString());
+		assertThat(OriginTrackedValue.of(value)).hasToString(value.toString());
 	}
 
 	@Test
@@ -53,7 +53,7 @@ class OriginTrackedValueTests {
 		OriginTrackedValue tracked1 = OriginTrackedValue.of(value1);
 		OriginTrackedValue tracked2 = OriginTrackedValue.of(value1, mock(Origin.class));
 		OriginTrackedValue tracked3 = OriginTrackedValue.of(new Object());
-		assertThat(tracked1.hashCode()).isEqualTo(tracked2.hashCode());
+		assertThat(tracked1).hasSameHashCodeAs(tracked2);
 		assertThat(tracked1).isEqualTo(tracked1).isEqualTo(tracked2).isNotEqualTo(tracked3);
 	}
 
@@ -69,7 +69,7 @@ class OriginTrackedValueTests {
 		OriginTrackedValue tracked = OriginTrackedValue.of(value);
 		assertThat(tracked).isInstanceOf(CharSequence.class);
 		CharSequence charSequence = (CharSequence) tracked;
-		assertThat(charSequence.length()).isEqualTo(value.length());
+		assertThat(charSequence).hasSameSizeAs(value);
 		assertThat(charSequence.charAt(0)).isEqualTo(value.charAt(0));
 		assertThat(charSequence.subSequence(0, 1)).isEqualTo(value.subSequence(0, 1));
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/origin/PropertySourceOriginTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/origin/PropertySourceOriginTests.java
@@ -73,7 +73,7 @@ class PropertySourceOriginTests {
 	void toStringShouldShowDetails() {
 		MapPropertySource propertySource = new MapPropertySource("test", new HashMap<>());
 		PropertySourceOrigin origin = new PropertySourceOrigin(propertySource, "foo");
-		assertThat(origin.toString()).isEqualTo("\"foo\" from property source \"test\"");
+		assertThat(origin).hasToString("\"foo\" from property source \"test\"");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/origin/SystemEnvironmentOriginTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/origin/SystemEnvironmentOriginTests.java
@@ -47,7 +47,7 @@ class SystemEnvironmentOriginTests {
 	@Test
 	void toStringShouldReturnStringWithDetails() {
 		SystemEnvironmentOrigin origin = new SystemEnvironmentOrigin("FOO_BAR");
-		assertThat(origin.toString()).isEqualTo("System Environment Property \"FOO_BAR\"");
+		assertThat(origin).hasToString("System Environment Property \"FOO_BAR\"");
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/origin/TextResourceOriginTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/origin/TextResourceOriginTests.java
@@ -79,7 +79,7 @@ class TextResourceOriginTests {
 	@Test
 	void getLocationLineReturnsLine() {
 		Location location = new Location(1, 2);
-		assertThat(location.getLine()).isEqualTo(1);
+		assertThat(location.getLine()).isOne();
 	}
 
 	@Test
@@ -91,7 +91,7 @@ class TextResourceOriginTests {
 	@Test
 	void locationToStringReturnsNiceString() {
 		Location location = new Location(1, 2);
-		assertThat(location.toString()).isEqualTo("2:3");
+		assertThat(location).hasToString("2:3");
 	}
 
 	@Test
@@ -99,21 +99,21 @@ class TextResourceOriginTests {
 		ClassPathResource resource = new ClassPathResource("foo.txt");
 		Location location = new Location(1, 2);
 		TextResourceOrigin origin = new TextResourceOrigin(resource, location);
-		assertThat(origin.toString()).isEqualTo("class path resource [foo.txt] - 2:3");
+		assertThat(origin).hasToString("class path resource [foo.txt] - 2:3");
 	}
 
 	@Test
 	void toStringWhenResourceIsNullReturnsNiceString() {
 		Location location = new Location(1, 2);
 		TextResourceOrigin origin = new TextResourceOrigin(null, location);
-		assertThat(origin.toString()).isEqualTo("unknown resource [?] - 2:3");
+		assertThat(origin).hasToString("unknown resource [?] - 2:3");
 	}
 
 	@Test
 	void toStringWhenLocationIsNullReturnsNiceString() {
 		ClassPathResource resource = new ClassPathResource("foo.txt");
 		TextResourceOrigin origin = new TextResourceOrigin(resource, null);
-		assertThat(origin.toString()).isEqualTo("class path resource [foo.txt]");
+		assertThat(origin).hasToString("class path resource [foo.txt]");
 	}
 
 	@Test
@@ -134,7 +134,7 @@ class TextResourceOriginTests {
 		};
 		Location location = new Location(1, 2);
 		TextResourceOrigin origin = new TextResourceOrigin(resource, location);
-		assertThat(origin.toString()).isEqualTo("class path resource [foo.txt] from project-0.0.1-SNAPSHOT.jar - 2:3");
+		assertThat(origin).hasToString("class path resource [foo.txt] from project-0.0.1-SNAPSHOT.jar - 2:3");
 	}
 
 	@Test
@@ -142,8 +142,8 @@ class TextResourceOriginTests {
 		Location location1 = new Location(1, 2);
 		Location location2 = new Location(1, 2);
 		Location location3 = new Location(2, 2);
-		assertThat(location1.hashCode()).isEqualTo(location1.hashCode());
-		assertThat(location1.hashCode()).isEqualTo(location2.hashCode());
+		assertThat(location1).hasSameHashCodeAs(location1);
+		assertThat(location1).hasSameHashCodeAs(location2);
 		assertThat(location1.hashCode()).isNotEqualTo(location3.hashCode());
 		assertThat(location1).isEqualTo(location1);
 		assertThat(location1).isEqualTo(location2);
@@ -156,8 +156,8 @@ class TextResourceOriginTests {
 		TextResourceOrigin origin2 = new TextResourceOrigin(new ClassPathResource("foo.txt"), new Location(1, 2));
 		TextResourceOrigin origin3 = new TextResourceOrigin(new ClassPathResource("foo.txt"), new Location(2, 2));
 		TextResourceOrigin origin4 = new TextResourceOrigin(new ClassPathResource("foo2.txt"), new Location(1, 2));
-		assertThat(origin1.hashCode()).isEqualTo(origin1.hashCode());
-		assertThat(origin1.hashCode()).isEqualTo(origin2.hashCode());
+		assertThat(origin1).hasSameHashCodeAs(origin1);
+		assertThat(origin1).hasSameHashCodeAs(origin2);
 		assertThat(origin1.hashCode()).isNotEqualTo(origin3.hashCode());
 		assertThat(origin1.hashCode()).isNotEqualTo(origin4.hashCode());
 		assertThat(origin1).isEqualTo(origin1);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/sql/init/AbstractScriptDatabaseInitializerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/sql/init/AbstractScriptDatabaseInitializerTests.java
@@ -41,7 +41,7 @@ public abstract class AbstractScriptDatabaseInitializerTests<T extends AbstractS
 		settings.setDataLocations(Arrays.asList("data.sql"));
 		T initializer = createEmbeddedDatabaseInitializer(settings);
 		assertThat(initializer.initializeDatabase()).isTrue();
-		assertThat(numberOfEmbeddedRows("SELECT COUNT(*) FROM EXAMPLE")).isEqualTo(1);
+		assertThat(numberOfEmbeddedRows("SELECT COUNT(*) FROM EXAMPLE")).isOne();
 	}
 
 	@Test
@@ -131,7 +131,7 @@ public abstract class AbstractScriptDatabaseInitializerTests<T extends AbstractS
 		settings.setMode(DatabaseInitializationMode.EMBEDDED);
 		T initializer = createEmbeddedDatabaseInitializer(settings);
 		assertThat(initializer.initializeDatabase()).isTrue();
-		assertThat(numberOfEmbeddedRows("SELECT COUNT(*) FROM EXAMPLE")).isEqualTo(1);
+		assertThat(numberOfEmbeddedRows("SELECT COUNT(*) FROM EXAMPLE")).isOne();
 	}
 
 	@Test
@@ -153,7 +153,7 @@ public abstract class AbstractScriptDatabaseInitializerTests<T extends AbstractS
 		settings.setMode(DatabaseInitializationMode.ALWAYS);
 		T initializer = createEmbeddedDatabaseInitializer(settings);
 		assertThat(initializer.initializeDatabase()).isTrue();
-		assertThat(numberOfEmbeddedRows("SELECT COUNT(*) FROM EXAMPLE")).isEqualTo(1);
+		assertThat(numberOfEmbeddedRows("SELECT COUNT(*) FROM EXAMPLE")).isOne();
 	}
 
 	@Test
@@ -164,7 +164,7 @@ public abstract class AbstractScriptDatabaseInitializerTests<T extends AbstractS
 		settings.setMode(DatabaseInitializationMode.ALWAYS);
 		T initializer = createStandaloneDatabaseInitializer(settings);
 		assertThat(initializer.initializeDatabase()).isTrue();
-		assertThat(numberOfStandaloneRows("SELECT COUNT(*) FROM EXAMPLE")).isEqualTo(1);
+		assertThat(numberOfStandaloneRows("SELECT COUNT(*) FROM EXAMPLE")).isOne();
 	}
 
 	protected abstract T createStandaloneDatabaseInitializer(DatabaseInitializationSettings settings);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/system/ApplicationPidTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/system/ApplicationPidTests.java
@@ -37,12 +37,12 @@ class ApplicationPidTests {
 
 	@Test
 	void toStringWithPid() {
-		assertThat(new ApplicationPid("123").toString()).isEqualTo("123");
+		assertThat(new ApplicationPid("123")).hasToString("123");
 	}
 
 	@Test
 	void toStringWithoutPid() {
-		assertThat(new ApplicationPid(null).toString()).isEqualTo("???");
+		assertThat(new ApplicationPid(null)).hasToString("???");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/system/JavaVersionTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/system/JavaVersionTests.java
@@ -36,17 +36,17 @@ class JavaVersionTests {
 
 	@Test
 	void compareToWhenComparingSmallerToGreaterShouldBeLessThanZero() {
-		assertThat(JavaVersion.SEVENTEEN.compareTo(JavaVersion.EIGHTEEN)).isLessThan(0);
+		assertThat(JavaVersion.SEVENTEEN).isLessThan(JavaVersion.EIGHTEEN);
 	}
 
 	@Test
 	void compareToWhenComparingGreaterToSmallerShouldBeGreaterThanZero() {
-		assertThat(JavaVersion.EIGHTEEN.compareTo(JavaVersion.SEVENTEEN)).isGreaterThan(0);
+		assertThat(JavaVersion.EIGHTEEN).isGreaterThan(JavaVersion.SEVENTEEN);
 	}
 
 	@Test
 	void compareToWhenComparingSameShouldBeZero() {
-		assertThat(JavaVersion.SEVENTEEN.compareTo(JavaVersion.SEVENTEEN)).isEqualTo(0);
+		assertThat(JavaVersion.SEVENTEEN).isEqualByComparingTo(JavaVersion.SEVENTEEN);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/undertow/FileSessionPersistenceTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/undertow/FileSessionPersistenceTests.java
@@ -67,7 +67,7 @@ class FileSessionPersistenceTests {
 		Map<String, PersistentSession> restored = this.persistence.loadSessionAttributes("test", this.classLoader);
 		assertThat(restored).isNotNull();
 		assertThat(restored.get("abc").getExpiration()).isEqualTo(this.expiration);
-		assertThat(restored.get("abc").getSessionData().get("spring")).isEqualTo("boot");
+		assertThat(restored.get("abc").getSessionData()).containsEntry("spring", "boot");
 	}
 
 	@Test
@@ -89,9 +89,9 @@ class FileSessionPersistenceTests {
 		File sessionFile = new File(this.dir, "test.session");
 		Map<String, PersistentSession> sessionData = new LinkedHashMap<>();
 		this.persistence.persistSessions("test", sessionData);
-		assertThat(sessionFile.exists()).isTrue();
+		assertThat(sessionFile).exists();
 		this.persistence.clear("test");
-		assertThat(sessionFile.exists()).isFalse();
+		assertThat(sessionFile).doesNotExist();
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/undertow/UndertowReactiveWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/undertow/UndertowReactiveWebServerFactoryTests.java
@@ -135,7 +135,7 @@ class UndertowReactiveWebServerFactoryTests extends AbstractReactiveWebServerFac
 		factory.setAccessLogSuffix(suffix);
 		File accessLogDirectory = this.tempDir;
 		factory.setAccessLogDirectory(accessLogDirectory);
-		assertThat(accessLogDirectory.listFiles()).isEmpty();
+		assertThat(accessLogDirectory).isEmptyDirectory();
 		this.webServer = factory.getWebServer(new EchoHandler());
 		this.webServer.start();
 		WebClient client = getWebClient(this.webServer.getPort()).build();

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactoryTests.java
@@ -219,7 +219,7 @@ class UndertowServletWebServerFactoryTests extends AbstractServletWebServerFacto
 		factory.setAccessLogSuffix(suffix);
 		File accessLogDirectory = this.tempDir;
 		factory.setAccessLogDirectory(accessLogDirectory);
-		assertThat(accessLogDirectory.listFiles()).isEmpty();
+		assertThat(accessLogDirectory).isEmptyDirectory();
 		this.webServer = factory.getWebServer(new ServletRegistrationBean<>(new ExampleServlet(), "/hello"));
 		this.webServer.start();
 		assertThat(getResponse(getLocalUrl("/hello"))).isEqualTo("Hello World");

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributesTests.java
@@ -82,8 +82,8 @@ class DefaultErrorAttributesTests {
 		MockServerHttpRequest request = MockServerHttpRequest.get("/test").build();
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(buildServerRequest(request, error),
 				ErrorAttributeOptions.defaults());
-		assertThat(attributes.get("error")).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase());
-		assertThat(attributes.get("status")).isEqualTo(500);
+		assertThat(attributes).containsEntry("error", HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase());
+		assertThat(attributes).containsEntry("status", 500);
 	}
 
 	@Test
@@ -92,9 +92,9 @@ class DefaultErrorAttributesTests {
 		MockServerHttpRequest request = MockServerHttpRequest.get("/test").build();
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(buildServerRequest(request, error),
 				ErrorAttributeOptions.defaults());
-		assertThat(attributes.get("error")).isEqualTo(HttpStatus.I_AM_A_TEAPOT.getReasonPhrase());
+		assertThat(attributes).containsEntry("error", HttpStatus.I_AM_A_TEAPOT.getReasonPhrase());
 		assertThat(attributes).doesNotContainKey("message");
-		assertThat(attributes.get("status")).isEqualTo(HttpStatus.I_AM_A_TEAPOT.value());
+		assertThat(attributes).containsEntry("status", HttpStatus.I_AM_A_TEAPOT.value());
 	}
 
 	@Test
@@ -103,9 +103,9 @@ class DefaultErrorAttributesTests {
 		MockServerHttpRequest request = MockServerHttpRequest.get("/test").build();
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(buildServerRequest(request, error),
 				ErrorAttributeOptions.of(Include.MESSAGE));
-		assertThat(attributes.get("error")).isEqualTo(HttpStatus.I_AM_A_TEAPOT.getReasonPhrase());
-		assertThat(attributes.get("message")).isEqualTo("Test Message");
-		assertThat(attributes.get("status")).isEqualTo(HttpStatus.I_AM_A_TEAPOT.value());
+		assertThat(attributes).containsEntry("error", HttpStatus.I_AM_A_TEAPOT.getReasonPhrase());
+		assertThat(attributes).containsEntry("message", "Test Message");
+		assertThat(attributes).containsEntry("status", HttpStatus.I_AM_A_TEAPOT.value());
 	}
 
 	@Test
@@ -114,9 +114,9 @@ class DefaultErrorAttributesTests {
 		MockServerHttpRequest request = MockServerHttpRequest.get("/test").build();
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(buildServerRequest(request, error),
 				ErrorAttributeOptions.of(Include.MESSAGE));
-		assertThat(attributes.get("error")).isEqualTo(HttpStatus.I_AM_A_TEAPOT.getReasonPhrase());
-		assertThat(attributes.get("status")).isEqualTo(HttpStatus.I_AM_A_TEAPOT.value());
-		assertThat(attributes.get("message")).isEqualTo("Nope!");
+		assertThat(attributes).containsEntry("error", HttpStatus.I_AM_A_TEAPOT.getReasonPhrase());
+		assertThat(attributes).containsEntry("status", HttpStatus.I_AM_A_TEAPOT.value());
+		assertThat(attributes).containsEntry("message", "Nope!");
 	}
 
 	@Test
@@ -124,8 +124,8 @@ class DefaultErrorAttributesTests {
 		MockServerHttpRequest request = MockServerHttpRequest.get("/test").build();
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(buildServerRequest(request, NOT_FOUND),
 				ErrorAttributeOptions.defaults());
-		assertThat(attributes.get("error")).isEqualTo(HttpStatus.NOT_FOUND.getReasonPhrase());
-		assertThat(attributes.get("status")).isEqualTo(404);
+		assertThat(attributes).containsEntry("error", HttpStatus.NOT_FOUND.getReasonPhrase());
+		assertThat(attributes).containsEntry("status", 404);
 	}
 
 	@Test
@@ -136,8 +136,8 @@ class DefaultErrorAttributesTests {
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(serverRequest,
 				ErrorAttributeOptions.of(Include.MESSAGE));
 		assertThat(this.errorAttributes.getError(serverRequest)).isSameAs(error);
-		assertThat(attributes.get("exception")).isNull();
-		assertThat(attributes.get("message")).isEqualTo("Test error");
+		assertThat(attributes).doesNotContainKey("exception");
+		assertThat(attributes).containsEntry("message", "Test error");
 	}
 
 	@Test
@@ -161,8 +161,8 @@ class DefaultErrorAttributesTests {
 				ErrorAttributeOptions.of(Include.EXCEPTION, Include.MESSAGE));
 		assertThat(this.errorAttributes.getError(serverRequest)).isSameAs(error);
 		assertThat(serverRequest.attribute(ErrorAttributes.ERROR_ATTRIBUTE)).containsSame(error);
-		assertThat(attributes.get("exception")).isEqualTo(RuntimeException.class.getName());
-		assertThat(attributes.get("message")).isEqualTo("Test");
+		assertThat(attributes).containsEntry("exception", RuntimeException.class.getName());
+		assertThat(attributes).containsEntry("message", "Test");
 	}
 
 	@Test
@@ -174,9 +174,9 @@ class DefaultErrorAttributesTests {
 		ServerRequest serverRequest = buildServerRequest(request, error);
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(serverRequest,
 				ErrorAttributeOptions.of(Include.EXCEPTION, Include.MESSAGE));
-		assertThat(attributes.get("status")).isEqualTo(400);
-		assertThat(attributes.get("message")).isEqualTo("invalid request");
-		assertThat(attributes.get("exception")).isEqualTo(RuntimeException.class.getName());
+		assertThat(attributes).containsEntry("status", 400);
+		assertThat(attributes).containsEntry("message", "invalid request");
+		assertThat(attributes).containsEntry("exception", RuntimeException.class.getName());
 		assertThat(this.errorAttributes.getError(serverRequest)).isSameAs(error);
 		assertThat(serverRequest.attribute(ErrorAttributes.ERROR_ATTRIBUTE)).containsSame(error);
 	}
@@ -190,9 +190,9 @@ class DefaultErrorAttributesTests {
 		ServerRequest serverRequest = buildServerRequest(request, error);
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(serverRequest,
 				ErrorAttributeOptions.of(Include.EXCEPTION, Include.MESSAGE));
-		assertThat(attributes.get("status")).isEqualTo(406);
-		assertThat(attributes.get("message")).isEqualTo("could not process request");
-		assertThat(attributes.get("exception")).isEqualTo(ResponseStatusException.class.getName());
+		assertThat(attributes).containsEntry("status", 406);
+		assertThat(attributes).containsEntry("message", "could not process request");
+		assertThat(attributes).containsEntry("exception", ResponseStatusException.class.getName());
 		assertThat(this.errorAttributes.getError(serverRequest)).isSameAs(error);
 		assertThat(serverRequest.attribute(ErrorAttributes.ERROR_ATTRIBUTE)).containsSame(error);
 	}
@@ -203,7 +203,7 @@ class DefaultErrorAttributesTests {
 		MockServerHttpRequest request = MockServerHttpRequest.get("/test").build();
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(buildServerRequest(request, ex),
 				ErrorAttributeOptions.defaults());
-		assertThat(attributes.get("trace")).isNull();
+		assertThat(attributes).doesNotContainKey("trace");
 	}
 
 	@Test
@@ -220,7 +220,7 @@ class DefaultErrorAttributesTests {
 		MockServerHttpRequest request = MockServerHttpRequest.get("/test").build();
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(buildServerRequest(request, NOT_FOUND),
 				ErrorAttributeOptions.defaults());
-		assertThat(attributes.get("path")).isEqualTo("/test");
+		assertThat(attributes).containsEntry("path", "/test");
 	}
 
 	@Test
@@ -229,7 +229,7 @@ class DefaultErrorAttributesTests {
 		ServerRequest serverRequest = buildServerRequest(request, NOT_FOUND);
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(serverRequest,
 				ErrorAttributeOptions.defaults());
-		assertThat(attributes.get("requestId")).isEqualTo(serverRequest.exchange().getRequest().getId());
+		assertThat(attributes).containsEntry("requestId", serverRequest.exchange().getRequest().getId());
 	}
 
 	@Test
@@ -246,7 +246,7 @@ class DefaultErrorAttributesTests {
 				.startsWith("Validation failed for argument at index 0 in method: "
 						+ "int org.springframework.boot.web.reactive.error.DefaultErrorAttributesTests"
 						+ ".method(java.lang.String), with 1 error(s)");
-		assertThat(attributes.get("errors")).isEqualTo(bindingResult.getAllErrors());
+		assertThat(attributes).containsEntry("errors", bindingResult.getAllErrors());
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/server/CertificateParserTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/server/CertificateParserTests.java
@@ -34,7 +34,7 @@ class CertificateParserTests {
 	void parseCertificate() {
 		X509Certificate[] certificates = CertificateParser.parse("classpath:test-cert.pem");
 		assertThat(certificates).isNotNull();
-		assertThat(certificates.length).isEqualTo(1);
+		assertThat(certificates).hasSize(1);
 		assertThat(certificates[0].getType()).isEqualTo("X.509");
 	}
 
@@ -42,7 +42,7 @@ class CertificateParserTests {
 	void parseCertificateChain() {
 		X509Certificate[] certificates = CertificateParser.parse("classpath:test-cert-chain.pem");
 		assertThat(certificates).isNotNull();
-		assertThat(certificates.length).isEqualTo(2);
+		assertThat(certificates).hasSize(2);
 		assertThat(certificates[0].getType()).isEqualTo("X.509");
 		assertThat(certificates[1].getType()).isEqualTo("X.509");
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/MultipartConfigFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/MultipartConfigFactoryTests.java
@@ -35,10 +35,10 @@ class MultipartConfigFactoryTests {
 	void sensibleDefaults() {
 		MultipartConfigFactory factory = new MultipartConfigFactory();
 		MultipartConfigElement config = factory.createMultipartConfig();
-		assertThat(config.getLocation()).isEqualTo("");
+		assertThat(config.getLocation()).isEmpty();
 		assertThat(config.getMaxFileSize()).isEqualTo(-1L);
 		assertThat(config.getMaxRequestSize()).isEqualTo(-1L);
-		assertThat(config.getFileSizeThreshold()).isEqualTo(0);
+		assertThat(config.getFileSizeThreshold()).isZero();
 	}
 
 	@Test
@@ -48,7 +48,7 @@ class MultipartConfigFactoryTests {
 		factory.setMaxRequestSize(DataSize.ofKilobytes(2));
 		factory.setFileSizeThreshold(DataSize.ofMegabytes(3));
 		MultipartConfigElement config = factory.createMultipartConfig();
-		assertThat(config.getMaxFileSize()).isEqualTo(1L);
+		assertThat(config.getMaxFileSize()).isOne();
 		assertThat(config.getMaxRequestSize()).isEqualTo(2 * 1024L);
 		assertThat(config.getFileSizeThreshold()).isEqualTo(3 * 1024 * 1024);
 	}
@@ -62,7 +62,7 @@ class MultipartConfigFactoryTests {
 		MultipartConfigElement config = factory.createMultipartConfig();
 		assertThat(config.getMaxFileSize()).isEqualTo(-1L);
 		assertThat(config.getMaxRequestSize()).isEqualTo(-1);
-		assertThat(config.getFileSizeThreshold()).isEqualTo(0);
+		assertThat(config.getFileSizeThreshold()).isZero();
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/ServletContextInitializerBeansTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/ServletContextInitializerBeansTests.java
@@ -48,7 +48,7 @@ class ServletContextInitializerBeansTests {
 		load(ServletConfiguration.class);
 		ServletContextInitializerBeans initializerBeans = new ServletContextInitializerBeans(
 				this.context.getBeanFactory());
-		assertThat(initializerBeans.size()).isEqualTo(1);
+		assertThat(initializerBeans).hasSize(1);
 		assertThat(initializerBeans.iterator()).toIterable().hasOnlyElementsOfType(TestServlet.class);
 	}
 
@@ -57,7 +57,7 @@ class ServletContextInitializerBeansTests {
 		load(FilterConfiguration.class);
 		ServletContextInitializerBeans initializerBeans = new ServletContextInitializerBeans(
 				this.context.getBeanFactory());
-		assertThat(initializerBeans.size()).isEqualTo(1);
+		assertThat(initializerBeans).hasSize(1);
 		assertThat(initializerBeans.iterator()).toIterable().hasOnlyElementsOfType(TestFilter.class);
 	}
 
@@ -66,7 +66,7 @@ class ServletContextInitializerBeansTests {
 		load(TestConfiguration.class);
 		ServletContextInitializerBeans initializerBeans = new ServletContextInitializerBeans(
 				this.context.getBeanFactory(), TestServletContextInitializer.class);
-		assertThat(initializerBeans.size()).isEqualTo(1);
+		assertThat(initializerBeans).hasSize(1);
 		assertThat(initializerBeans.iterator()).toIterable().hasOnlyElementsOfType(TestServletContextInitializer.class);
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContextTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContextTests.java
@@ -140,7 +140,7 @@ class ServletWebServerApplicationContextTests {
 		assertThat(events).hasSize(2).extracting("class").containsExactly(ServletWebServerInitializedEvent.class,
 				ContextRefreshedEvent.class);
 		ServletWebServerInitializedEvent initializedEvent = (ServletWebServerInitializedEvent) events.get(0);
-		assertThat(initializedEvent.getSource().getPort() >= 0).isTrue();
+		assertThat(initializedEvent.getSource().getPort()).isGreaterThanOrEqualTo(0);
 		assertThat(initializedEvent.getApplicationContext()).isEqualTo(this.context);
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/error/DefaultErrorAttributesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/error/DefaultErrorAttributesTests.java
@@ -68,16 +68,16 @@ class DefaultErrorAttributesTests {
 		this.request.setAttribute("jakarta.servlet.error.status_code", 404);
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(this.webRequest,
 				ErrorAttributeOptions.defaults());
-		assertThat(attributes.get("error")).isEqualTo(HttpStatus.NOT_FOUND.getReasonPhrase());
-		assertThat(attributes.get("status")).isEqualTo(404);
+		assertThat(attributes).containsEntry("error", HttpStatus.NOT_FOUND.getReasonPhrase());
+		assertThat(attributes).containsEntry("status", 404);
 	}
 
 	@Test
 	void missingStatusCode() {
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(this.webRequest,
 				ErrorAttributeOptions.defaults());
-		assertThat(attributes.get("error")).isEqualTo("None");
-		assertThat(attributes.get("status")).isEqualTo(999);
+		assertThat(attributes).containsEntry("error", "None");
+		assertThat(attributes).containsEntry("status", 999);
 	}
 
 	@Test
@@ -92,7 +92,7 @@ class DefaultErrorAttributesTests {
 				.isSameAs(ex);
 		assertThat(modelAndView).isNull();
 		assertThat(attributes).doesNotContainKey("exception");
-		assertThat(attributes.get("message")).isEqualTo("Test");
+		assertThat(attributes).containsEntry("message", "Test");
 	}
 
 	@Test
@@ -105,7 +105,7 @@ class DefaultErrorAttributesTests {
 		assertThat(this.webRequest.getAttribute(ErrorAttributes.ERROR_ATTRIBUTE, WebRequest.SCOPE_REQUEST))
 				.isSameAs(ex);
 		assertThat(attributes).doesNotContainKey("exception");
-		assertThat(attributes.get("message")).isEqualTo("Test");
+		assertThat(attributes).containsEntry("message", "Test");
 	}
 
 	@Test
@@ -127,7 +127,7 @@ class DefaultErrorAttributesTests {
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(this.webRequest,
 				ErrorAttributeOptions.of(Include.MESSAGE));
 		assertThat(attributes).doesNotContainKey("exception");
-		assertThat(attributes.get("message")).isEqualTo("Test");
+		assertThat(attributes).containsEntry("message", "Test");
 	}
 
 	@Test
@@ -146,7 +146,7 @@ class DefaultErrorAttributesTests {
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(this.webRequest,
 				ErrorAttributeOptions.of(Include.MESSAGE));
 		assertThat(attributes).doesNotContainKey("exception");
-		assertThat(attributes.get("message")).isEqualTo("Test");
+		assertThat(attributes).containsEntry("message", "Test");
 	}
 
 	@Test
@@ -155,7 +155,7 @@ class DefaultErrorAttributesTests {
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(this.webRequest,
 				ErrorAttributeOptions.of(Include.MESSAGE));
 		assertThat(attributes).doesNotContainKey("exception");
-		assertThat(attributes.get("message")).isEqualTo("No message available");
+		assertThat(attributes).containsEntry("message", "No message available");
 	}
 
 	@Test
@@ -169,7 +169,7 @@ class DefaultErrorAttributesTests {
 		assertThat(this.webRequest.getAttribute(ErrorAttributes.ERROR_ATTRIBUTE, WebRequest.SCOPE_REQUEST))
 				.isSameAs(wrapped);
 		assertThat(attributes).doesNotContainKey("exception");
-		assertThat(attributes.get("message")).isEqualTo("Test");
+		assertThat(attributes).containsEntry("message", "Test");
 	}
 
 	@Test
@@ -182,7 +182,7 @@ class DefaultErrorAttributesTests {
 		assertThat(this.webRequest.getAttribute(ErrorAttributes.ERROR_ATTRIBUTE, WebRequest.SCOPE_REQUEST))
 				.isSameAs(error);
 		assertThat(attributes).doesNotContainKey("exception");
-		assertThat(attributes.get("message")).isEqualTo("Test error");
+		assertThat(attributes).containsEntry("message", "Test error");
 	}
 
 	@Test
@@ -215,14 +215,14 @@ class DefaultErrorAttributesTests {
 		this.request.setAttribute("jakarta.servlet.error.exception", ex);
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(this.webRequest, options);
 		if (options.isIncluded(Include.MESSAGE)) {
-			assertThat(attributes.get("message"))
-					.isEqualTo("Validation failed for object='objectName'. Error count: 1");
+			assertThat(attributes).containsEntry("message",
+					"Validation failed for object='objectName'. Error count: 1");
 		}
 		else {
 			assertThat(attributes).doesNotContainKey("message");
 		}
 		if (options.isIncluded(Include.BINDING_ERRORS)) {
-			assertThat(attributes.get("errors")).isEqualTo(bindingResult.getAllErrors());
+			assertThat(attributes).containsEntry("errors", bindingResult.getAllErrors());
 		}
 		else {
 			assertThat(attributes).doesNotContainKey("errors");
@@ -236,8 +236,8 @@ class DefaultErrorAttributesTests {
 		this.request.setAttribute("jakarta.servlet.error.exception", ex);
 		Map<String, Object> attributes = errorAttributes.getErrorAttributes(this.webRequest,
 				ErrorAttributeOptions.of(Include.EXCEPTION, Include.MESSAGE));
-		assertThat(attributes.get("exception")).isEqualTo(RuntimeException.class.getName());
-		assertThat(attributes.get("message")).isEqualTo("Test");
+		assertThat(attributes).containsEntry("exception", RuntimeException.class.getName());
+		assertThat(attributes).containsEntry("message", "Test");
 	}
 
 	@Test
@@ -263,7 +263,7 @@ class DefaultErrorAttributesTests {
 		this.request.setAttribute("jakarta.servlet.error.request_uri", "path");
 		Map<String, Object> attributes = this.errorAttributes.getErrorAttributes(this.webRequest,
 				ErrorAttributeOptions.defaults());
-		assertThat(attributes.get("path")).isEqualTo("path");
+		assertThat(attributes).containsEntry("path", "path");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
@@ -280,9 +280,9 @@ public abstract class AbstractServletWebServerFactoryTests {
 		final InitCountingServlet servlet = new InitCountingServlet();
 		this.webServer = factory
 				.getWebServer((servletContext) -> servletContext.addServlet("test", servlet).setLoadOnStartup(1));
-		assertThat(servlet.getInitCount()).isEqualTo(0);
+		assertThat(servlet.getInitCount()).isZero();
 		this.webServer.start();
-		assertThat(servlet.getInitCount()).isEqualTo(1);
+		assertThat(servlet.getInitCount()).isOne();
 	}
 
 	@Test
@@ -380,7 +380,7 @@ public abstract class AbstractServletWebServerFactoryTests {
 		this.webServer = factory.getWebServer();
 		this.webServer.start();
 		ClientHttpResponse response = getClientResponse(getLocalUrl("/test.xxcss"));
-		assertThat(response.getHeaders().getContentType().toString()).isEqualTo("text/css");
+		assertThat(response.getHeaders().getContentType()).hasToString("text/css");
 		response.close();
 	}
 
@@ -772,8 +772,8 @@ public abstract class AbstractServletWebServerFactoryTests {
 	void getValidSessionStoreWhenSessionStoreNotSet() {
 		AbstractServletWebServerFactory factory = getFactory();
 		File dir = factory.getValidSessionStoreDir(false);
-		assertThat(dir.getName()).isEqualTo("servlet-sessions");
-		assertThat(dir.getParentFile()).isEqualTo(new ApplicationTemp().getDir());
+		assertThat(dir).hasName("servlet-sessions");
+		assertThat(dir).hasParent(new ApplicationTemp().getDir());
 	}
 
 	@Test
@@ -781,8 +781,8 @@ public abstract class AbstractServletWebServerFactoryTests {
 		AbstractServletWebServerFactory factory = getFactory();
 		factory.getSession().setStoreDir(new File("sessions"));
 		File dir = factory.getValidSessionStoreDir(false);
-		assertThat(dir.getName()).isEqualTo("sessions");
-		assertThat(dir.getParentFile()).isEqualTo(new ApplicationHome().getDir());
+		assertThat(dir).hasName("sessions");
+		assertThat(dir).hasParent(new ApplicationHome().getDir());
 	}
 
 	@Test
@@ -939,7 +939,7 @@ public abstract class AbstractServletWebServerFactoryTests {
 		for (MimeMappings.Mapping mapping : expectedMimeMappings) {
 			assertThat(configuredMimeMappings).containsEntry(mapping.getExtension(), mapping.getMimeType());
 		}
-		assertThat(configuredMimeMappings.size()).isEqualTo(expectedMimeMappings.size());
+		assertThat(configuredMimeMappings).hasSameSizeAs(expectedMimeMappings);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/StaticResourceJarsTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/StaticResourceJarsTests.java
@@ -66,7 +66,7 @@ class StaticResourceJarsTests {
 	void excludeJarWithoutStaticResources() throws Exception {
 		File jarFile = createJar("dependency.jar");
 		List<URL> staticResourceJarUrls = new StaticResourceJars().getUrlsFrom(jarFile.toURI().toURL());
-		assertThat(staticResourceJarUrls).hasSize(0);
+		assertThat(staticResourceJarUrls).isEmpty();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/support/ErrorPageFilterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/support/ErrorPageFilterTests.java
@@ -208,7 +208,7 @@ class ErrorPageFilterTests {
 		assertThat(this.request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE)).isEqualTo(500);
 		assertThat(this.request.getAttribute(RequestDispatcher.ERROR_MESSAGE)).isEqualTo("BAD");
 		Map<String, Object> requestAttributes = getAttributesForDispatch("/500");
-		assertThat(requestAttributes.get(RequestDispatcher.ERROR_EXCEPTION_TYPE)).isEqualTo(RuntimeException.class);
+		assertThat(requestAttributes).containsEntry(RequestDispatcher.ERROR_EXCEPTION_TYPE, RuntimeException.class);
 		assertThat(requestAttributes.get(RequestDispatcher.ERROR_EXCEPTION)).isInstanceOf(RuntimeException.class);
 		assertThat(this.request.getAttribute(RequestDispatcher.ERROR_EXCEPTION_TYPE)).isNull();
 		assertThat(this.request.getAttribute(RequestDispatcher.ERROR_EXCEPTION)).isNull();
@@ -248,8 +248,8 @@ class ErrorPageFilterTests {
 		assertThat(this.request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE)).isEqualTo(500);
 		assertThat(this.request.getAttribute(RequestDispatcher.ERROR_MESSAGE)).isEqualTo("BAD");
 		Map<String, Object> requestAttributes = getAttributesForDispatch("/500");
-		assertThat(requestAttributes.get(RequestDispatcher.ERROR_EXCEPTION_TYPE))
-				.isEqualTo(IllegalStateException.class);
+		assertThat(requestAttributes).containsEntry(RequestDispatcher.ERROR_EXCEPTION_TYPE,
+				IllegalStateException.class);
 		assertThat(requestAttributes.get(RequestDispatcher.ERROR_EXCEPTION)).isInstanceOf(IllegalStateException.class);
 		assertThat(this.request.getAttribute(RequestDispatcher.ERROR_EXCEPTION_TYPE)).isNull();
 		assertThat(this.request.getAttribute(RequestDispatcher.ERROR_EXCEPTION)).isNull();
@@ -377,7 +377,7 @@ class ErrorPageFilterTests {
 		assertThat(this.request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE)).isEqualTo(500);
 		assertThat(this.request.getAttribute(RequestDispatcher.ERROR_MESSAGE)).isEqualTo("BAD");
 		Map<String, Object> requestAttributes = getAttributesForDispatch("/500");
-		assertThat(requestAttributes.get(RequestDispatcher.ERROR_EXCEPTION_TYPE)).isEqualTo(RuntimeException.class);
+		assertThat(requestAttributes).containsEntry(RequestDispatcher.ERROR_EXCEPTION_TYPE, RuntimeException.class);
 		assertThat(requestAttributes.get(RequestDispatcher.ERROR_EXCEPTION)).isInstanceOf(RuntimeException.class);
 		assertThat(this.request.getAttribute(RequestDispatcher.ERROR_EXCEPTION_TYPE)).isNull();
 		assertThat(this.request.getAttribute(RequestDispatcher.ERROR_EXCEPTION)).isNull();
@@ -399,8 +399,8 @@ class ErrorPageFilterTests {
 		assertThat(this.request.getAttribute(RequestDispatcher.ERROR_MESSAGE))
 				.isEqualTo("Required request parameter 'test' for method parameter type string is not present");
 		Map<String, Object> requestAttributes = getAttributesForDispatch("/500");
-		assertThat(requestAttributes.get(RequestDispatcher.ERROR_EXCEPTION_TYPE))
-				.isEqualTo(MissingServletRequestParameterException.class);
+		assertThat(requestAttributes).containsEntry(RequestDispatcher.ERROR_EXCEPTION_TYPE,
+				MissingServletRequestParameterException.class);
 		assertThat(requestAttributes.get(RequestDispatcher.ERROR_EXCEPTION))
 				.isInstanceOf(MissingServletRequestParameterException.class);
 		assertThat(this.request.getAttribute(RequestDispatcher.ERROR_EXCEPTION_TYPE)).isNull();

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/support/SpringBootServletInitializerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/support/SpringBootServletInitializerTests.java
@@ -125,7 +125,7 @@ class SpringBootServletInitializerTests {
 		WebServer webServer = new UndertowServletWebServerFactory(0).getWebServer((servletContext) -> {
 			try (AbstractApplicationContext context = (AbstractApplicationContext) new WithErrorPageFilterNotRegistered()
 					.createRootApplicationContext(servletContext)) {
-				assertThat(context.getBeansOfType(ErrorPageFilter.class)).hasSize(0);
+				assertThat(context.getBeansOfType(ErrorPageFilter.class)).isEmpty();
 			}
 		});
 		try {
@@ -182,7 +182,7 @@ class SpringBootServletInitializerTests {
 	@Test
 	void executableWarThatUsesServletInitializerDoesNotHaveErrorPageFilterConfigured() {
 		try (ConfigurableApplicationContext context = new SpringApplication(ExecutableWar.class).run()) {
-			assertThat(context.getBeansOfType(ErrorPageFilter.class)).hasSize(0);
+			assertThat(context.getBeansOfType(ErrorPageFilter.class)).isEmpty();
 		}
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/AbstractManagementPortAndPathSampleActuatorApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/AbstractManagementPortAndPathSampleActuatorApplicationTests.java
@@ -51,7 +51,7 @@ abstract class AbstractManagementPortAndPathSampleActuatorApplicationTests {
 		ResponseEntity<Map<String, Object>> entity = asMapEntity(
 				new TestRestTemplate("user", "password").getForEntity("http://localhost:" + this.port, Map.class));
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-		assertThat(entity.getBody().get("message")).isEqualTo("Hello Phil");
+		assertThat(entity.getBody()).containsEntry("message", "Hello Phil");
 	}
 
 	@Test
@@ -101,7 +101,7 @@ abstract class AbstractManagementPortAndPathSampleActuatorApplicationTests {
 		ResponseEntity<Map<String, Object>> entity = asMapEntity(new TestRestTemplate("user", "password")
 				.getForEntity("http://localhost:" + this.port + "/error", Map.class));
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-		assertThat(entity.getBody().get("status")).isEqualTo(999);
+		assertThat(entity.getBody()).containsEntry("status", 999);
 	}
 
 	@Test
@@ -109,7 +109,7 @@ abstract class AbstractManagementPortAndPathSampleActuatorApplicationTests {
 		ResponseEntity<Map<String, Object>> entity = asMapEntity(new TestRestTemplate("user", "password")
 				.getForEntity("http://localhost:" + this.managementPort + "/error", Map.class));
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-		assertThat(entity.getBody().get("status")).isEqualTo(999);
+		assertThat(entity.getBody()).containsEntry("status", 999);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/EndpointsPropertiesSampleActuatorApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/EndpointsPropertiesSampleActuatorApplicationTests.java
@@ -48,8 +48,8 @@ class EndpointsPropertiesSampleActuatorApplicationTests {
 				this.restTemplate.withBasicAuth("user", "password").getForEntity("/oops", Map.class));
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
 		Map<String, Object> body = entity.getBody();
-		assertThat(body.get("error")).isEqualTo("None");
-		assertThat(body.get("status")).isEqualTo(999);
+		assertThat(body).containsEntry("error", "None");
+		assertThat(body).containsEntry("status", 999);
 	}
 
 	@Test

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/ManagementPortSampleActuatorApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/ManagementPortSampleActuatorApplicationTests.java
@@ -62,7 +62,7 @@ class ManagementPortSampleActuatorApplicationTests {
 		ResponseEntity<Map<String, Object>> entity = asMapEntity(
 				new TestRestTemplate("user", "password").getForEntity("http://localhost:" + this.port, Map.class));
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-		assertThat(entity.getBody().get("message")).isEqualTo("Hello Phil");
+		assertThat(entity.getBody()).containsEntry("message", "Hello Phil");
 	}
 
 	@Test
@@ -88,7 +88,7 @@ class ManagementPortSampleActuatorApplicationTests {
 		ResponseEntity<Map<String, Object>> entity = asMapEntity(new TestRestTemplate("user", "password")
 				.getForEntity("http://localhost:" + this.managementPort + "/error", Map.class));
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-		assertThat(entity.getBody().get("status")).isEqualTo(999);
+		assertThat(entity.getBody()).containsEntry("status", 999);
 	}
 
 	@Test
@@ -98,7 +98,7 @@ class ManagementPortSampleActuatorApplicationTests {
 				.getForEntity("http://localhost:" + this.managementPort + "/404", Map.class));
 		assertThat(this.errorAttributes.securityContext.getAuthentication()).isNotNull();
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
-		assertThat(entity.getBody().get("status")).isEqualTo(404);
+		assertThat(entity.getBody()).containsEntry("status", 404);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/NoManagementSampleActuatorApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/NoManagementSampleActuatorApplicationTests.java
@@ -45,7 +45,7 @@ class NoManagementSampleActuatorApplicationTests {
 		ResponseEntity<Map<String, Object>> entity = asMapEntity(
 				this.restTemplate.withBasicAuth("user", "password").getForEntity("/", Map.class));
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-		assertThat(entity.getBody().get("message")).isEqualTo("Hello Phil");
+		assertThat(entity.getBody()).containsEntry("message", "Hello Phil");
 	}
 
 	@Test

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/SampleActuatorApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/SampleActuatorApplicationTests.java
@@ -78,7 +78,7 @@ class SampleActuatorApplicationTests {
 		ResponseEntity<Map<String, Object>> entity = asMapEntity(
 				this.restTemplate.withBasicAuth("user", "password").getForEntity("/", Map.class));
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-		assertThat(entity.getBody().get("message")).isEqualTo("Hello Phil");
+		assertThat(entity.getBody()).containsEntry("message", "Hello Phil");
 	}
 
 	@Test
@@ -136,8 +136,8 @@ class SampleActuatorApplicationTests {
 		ResponseEntity<Map<String, Object>> entity = asMapEntity(
 				this.restTemplate.withBasicAuth("user", "password").getForEntity("/error", Map.class));
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-		assertThat(entity.getBody().get("error")).isEqualTo("None");
-		assertThat(entity.getBody().get("status")).isEqualTo(999);
+		assertThat(entity.getBody()).containsEntry("error", "None");
+		assertThat(entity.getBody()).containsEntry("status", 999);
 	}
 
 	@Test

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/ServletPathSampleActuatorApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/ServletPathSampleActuatorApplicationTests.java
@@ -45,8 +45,8 @@ class ServletPathSampleActuatorApplicationTests {
 		ResponseEntity<Map<String, Object>> entity = asMapEntity(
 				this.restTemplate.withBasicAuth("user", "password").getForEntity("/spring/error", Map.class));
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-		assertThat(entity.getBody().get("error")).isEqualTo("None");
-		assertThat(entity.getBody().get("status")).isEqualTo(999);
+		assertThat(entity.getBody()).containsEntry("error", "None");
+		assertThat(entity.getBody()).containsEntry("status", 999);
 	}
 
 	@Test

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/ShutdownSampleActuatorApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/ShutdownSampleActuatorApplicationTests.java
@@ -52,7 +52,7 @@ class ShutdownSampleActuatorApplicationTests {
 				this.restTemplate.withBasicAuth("user", "password").getForEntity("/", Map.class));
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
 		Map<String, Object> body = entity.getBody();
-		assertThat(body.get("message")).isEqualTo("Hello Phil");
+		assertThat(body).containsEntry("message", "Hello Phil");
 	}
 
 	@Test

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-ant/src/test/java/smoketest/ant/SampleAntApplicationIT.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-ant/src/test/java/smoketest/ant/SampleAntApplicationIT.java
@@ -41,7 +41,7 @@ public class SampleAntApplicationIT {
 		Process process = new JavaExecutable().processBuilder("-jar", "spring-boot-smoke-test-ant.jar").directory(libs)
 				.start();
 		process.waitFor(5, TimeUnit.MINUTES);
-		assertThat(process.exitValue()).isEqualTo(0);
+		assertThat(process.exitValue()).isZero();
 		String output = FileCopyUtils.copyToString(new InputStreamReader(process.getInputStream()));
 		assertThat(output).contains("Spring Boot Ant Example");
 	}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-batch/src/test/java/smoketest/batch/SampleBatchApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-batch/src/test/java/smoketest/batch/SampleBatchApplicationTests.java
@@ -30,7 +30,7 @@ class SampleBatchApplicationTests {
 
 	@Test
 	void testDefaultSettings(CapturedOutput output) {
-		assertThat(SpringApplication.exit(SpringApplication.run(SampleBatchApplication.class))).isEqualTo(0);
+		assertThat(SpringApplication.exit(SpringApplication.run(SampleBatchApplication.class))).isZero();
 		assertThat(output).contains("completed with the following parameters");
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jpa/src/test/java/smoketest/jpa/repository/JpaNoteRepositoryIntegrationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jpa/src/test/java/smoketest/jpa/repository/JpaNoteRepositoryIntegrationTests.java
@@ -44,7 +44,7 @@ class JpaNoteRepositoryIntegrationTests {
 		List<Note> notes = this.repository.findAll();
 		assertThat(notes).hasSize(4);
 		for (Note note : notes) {
-			assertThat(note.getTags().size()).isGreaterThan(0);
+			assertThat(note.getTags()).isNotEmpty();
 		}
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jpa/src/test/java/smoketest/jpa/repository/JpaTagRepositoryIntegrationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jpa/src/test/java/smoketest/jpa/repository/JpaTagRepositoryIntegrationTests.java
@@ -44,7 +44,7 @@ class JpaTagRepositoryIntegrationTests {
 		List<Tag> tags = this.repository.findAll();
 		assertThat(tags).hasSize(3);
 		for (Tag tag : tags) {
-			assertThat(tag.getNotes().size()).isGreaterThan(0);
+			assertThat(tag.getNotes()).isNotEmpty();
 		}
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-liquibase/src/test/java/smoketest/liquibase/SampleLiquibaseApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-liquibase/src/test/java/smoketest/liquibase/SampleLiquibaseApplicationTests.java
@@ -29,6 +29,7 @@ import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.core.NestedCheckedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 @ExtendWith(OutputCaptureExtension.class)
 class SampleLiquibaseApplicationTests {
@@ -52,9 +53,7 @@ class SampleLiquibaseApplicationTests {
 			SampleLiquibaseApplication.main(new String[] { "--server.port=0" });
 		}
 		catch (IllegalStateException ex) {
-			if (serverNotRunning(ex)) {
-				return;
-			}
+			assumeThat(serverNotRunning(ex)).isFalse();
 		}
 		assertThat(output).contains("Successfully acquired change log lock")
 				.contains("Creating database history table with name: PUBLIC.DATABASECHANGELOG")

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-secure/src/test/java/smoketest/secure/SampleSecureApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-secure/src/test/java/smoketest/secure/SampleSecureApplicationTests.java
@@ -65,13 +65,13 @@ class SampleSecureApplicationTests {
 	void authenticated() {
 		SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken("user", "N/A",
 				AuthorityUtils.commaSeparatedStringToAuthorityList("ROLE_USER")));
-		assertThat("Hello Security").isEqualTo(this.service.secure());
+		assertThat(this.service.secure()).isEqualTo("Hello Security");
 	}
 
 	@Test
 	void preauth() {
 		SecurityContextHolder.getContext().setAuthentication(this.authentication);
-		assertThat("Hello World").isEqualTo(this.service.authorized());
+		assertThat(this.service.authorized()).isEqualTo("Hello World");
 	}
 
 	@Test

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-session-hazelcast/src/test/java/smoketest/session/hazelcast/SampleSessionHazelcastApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-session-hazelcast/src/test/java/smoketest/session/hazelcast/SampleSessionHazelcastApplicationTests.java
@@ -60,7 +60,7 @@ class SampleSessionHazelcastApplicationTests {
 		assertThat(entity).isNotNull();
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
 		List<Map<String, Object>> sessions = (List<Map<String, Object>>) entity.getBody().get("sessions");
-		assertThat(sessions.size()).isEqualTo(1);
+		assertThat(sessions).hasSize(1);
 	}
 
 	private String performLogin() {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-session-jdbc/src/test/java/smoketest/session/SampleSessionJdbcApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-session-jdbc/src/test/java/smoketest/session/SampleSessionJdbcApplicationTests.java
@@ -87,7 +87,7 @@ class SampleSessionJdbcApplicationTests {
 		assertThat(response).isNotNull();
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 		List<Map<String, Object>> sessions = (List<Map<String, Object>>) response.getBody().get("sessions");
-		assertThat(sessions.size()).isEqualTo(1);
+		assertThat(sessions).hasSize(1);
 	}
 
 	private ResponseEntity<String> performRequest(URI uri, String cookie) {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-session-mongo/src/test/java/smoketest/session/mongodb/SampleSessionMongoApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-session-mongo/src/test/java/smoketest/session/mongodb/SampleSessionMongoApplicationTests.java
@@ -79,7 +79,7 @@ class SampleSessionMongoApplicationTests {
 		assertThat(response).isNotNull();
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 		List<Map<String, Object>> sessions = (List<Map<String, Object>>) response.getBody().get("sessions");
-		assertThat(sessions.size()).isEqualTo(1);
+		assertThat(sessions).hasSize(1);
 	}
 
 	@Test

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-session-redis/src/test/java/smoketest/session/redis/SampleSessionRedisApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-session-redis/src/test/java/smoketest/session/redis/SampleSessionRedisApplicationTests.java
@@ -73,7 +73,7 @@ class SampleSessionRedisApplicationTests {
 		assertThat(response).isNotNull();
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 		List<Map<String, Object>> sessions = (List<Map<String, Object>>) response.getBody().get("sessions");
-		assertThat(sessions.size()).isEqualTo(1);
+		assertThat(sessions).hasSize(1);
 	}
 
 	private String performLogin() {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-test/src/test/java/smoketest/test/domain/VehicleIdentificationNumberTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-test/src/test/java/smoketest/test/domain/VehicleIdentificationNumberTests.java
@@ -54,7 +54,7 @@ class VehicleIdentificationNumberTests {
 	@Test
 	void toStringShouldReturnVin() {
 		VehicleIdentificationNumber vin = new VehicleIdentificationNumber(SAMPLE_VIN);
-		assertThat(vin.toString()).isEqualTo(SAMPLE_VIN);
+		assertThat(vin).hasToString(SAMPLE_VIN);
 	}
 
 	@Test
@@ -62,7 +62,7 @@ class VehicleIdentificationNumberTests {
 		VehicleIdentificationNumber vin1 = new VehicleIdentificationNumber(SAMPLE_VIN);
 		VehicleIdentificationNumber vin2 = new VehicleIdentificationNumber(SAMPLE_VIN);
 		VehicleIdentificationNumber vin3 = new VehicleIdentificationNumber("00000000000000000");
-		assertThat(vin1.hashCode()).isEqualTo(vin2.hashCode());
+		assertThat(vin1).hasSameHashCodeAs(vin2);
 		assertThat(vin1).isEqualTo(vin1).isEqualTo(vin2).isNotEqualTo(vin3);
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/test/java/smoketest/websocket/jetty/SampleWebSocketsApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/test/java/smoketest/websocket/jetty/SampleWebSocketsApplicationTests.java
@@ -59,7 +59,7 @@ class SampleWebSocketsApplicationTests {
 		long count = context.getBean(ClientConfiguration.class).latch.getCount();
 		AtomicReference<String> messagePayloadReference = context.getBean(ClientConfiguration.class).messagePayload;
 		context.close();
-		assertThat(count).isEqualTo(0);
+		assertThat(count).isZero();
 		assertThat(messagePayloadReference.get()).isEqualTo("Did you say \"Hello world!\"?");
 	}
 
@@ -72,7 +72,7 @@ class SampleWebSocketsApplicationTests {
 		long count = context.getBean(ClientConfiguration.class).latch.getCount();
 		AtomicReference<String> messagePayloadReference = context.getBean(ClientConfiguration.class).messagePayload;
 		context.close();
-		assertThat(count).isEqualTo(0);
+		assertThat(count).isZero();
 		assertThat(messagePayloadReference.get()).isEqualTo("Reversed: !dlrow olleH");
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/test/java/smoketest/websocket/jetty/echo/CustomContainerWebSocketsApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/test/java/smoketest/websocket/jetty/echo/CustomContainerWebSocketsApplicationTests.java
@@ -64,7 +64,7 @@ class CustomContainerWebSocketsApplicationTests {
 		long count = context.getBean(ClientConfiguration.class).latch.getCount();
 		AtomicReference<String> messagePayloadReference = context.getBean(ClientConfiguration.class).messagePayload;
 		context.close();
-		assertThat(count).isEqualTo(0);
+		assertThat(count).isZero();
 		assertThat(messagePayloadReference.get()).isEqualTo("Did you say \"Hello world!\"?");
 	}
 
@@ -77,7 +77,7 @@ class CustomContainerWebSocketsApplicationTests {
 		long count = context.getBean(ClientConfiguration.class).latch.getCount();
 		AtomicReference<String> messagePayloadReference = context.getBean(ClientConfiguration.class).messagePayload;
 		context.close();
-		assertThat(count).isEqualTo(0);
+		assertThat(count).isZero();
 		assertThat(messagePayloadReference.get()).isEqualTo("Reversed: !dlrow olleH");
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/test/java/smoketest/websocket/jetty/snake/SnakeTimerTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/test/java/smoketest/websocket/jetty/snake/SnakeTimerTests.java
@@ -34,7 +34,7 @@ class SnakeTimerTests {
 		SnakeTimer.addSnake(snake);
 
 		SnakeTimer.broadcast("");
-		assertThat(SnakeTimer.getSnakes()).hasSize(0);
+		assertThat(SnakeTimer.getSnakes()).isEmpty();
 	}
 
 }

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/test/java/smoketest/websocket/tomcat/SampleWebSocketsApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/test/java/smoketest/websocket/tomcat/SampleWebSocketsApplicationTests.java
@@ -59,7 +59,7 @@ class SampleWebSocketsApplicationTests {
 		long count = context.getBean(ClientConfiguration.class).latch.getCount();
 		AtomicReference<String> messagePayloadReference = context.getBean(ClientConfiguration.class).messagePayload;
 		context.close();
-		assertThat(count).isEqualTo(0);
+		assertThat(count).isZero();
 		assertThat(messagePayloadReference.get()).isEqualTo("Did you say \"Hello world!\"?");
 	}
 
@@ -72,7 +72,7 @@ class SampleWebSocketsApplicationTests {
 		long count = context.getBean(ClientConfiguration.class).latch.getCount();
 		AtomicReference<String> messagePayloadReference = context.getBean(ClientConfiguration.class).messagePayload;
 		context.close();
-		assertThat(count).isEqualTo(0);
+		assertThat(count).isZero();
 		assertThat(messagePayloadReference.get()).isEqualTo("Reversed: !dlrow olleH");
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/test/java/smoketest/websocket/tomcat/echo/CustomContainerWebSocketsApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/test/java/smoketest/websocket/tomcat/echo/CustomContainerWebSocketsApplicationTests.java
@@ -64,7 +64,7 @@ class CustomContainerWebSocketsApplicationTests {
 		long count = context.getBean(ClientConfiguration.class).latch.getCount();
 		AtomicReference<String> messagePayloadReference = context.getBean(ClientConfiguration.class).messagePayload;
 		context.close();
-		assertThat(count).isEqualTo(0);
+		assertThat(count).isZero();
 		assertThat(messagePayloadReference.get()).isEqualTo("Did you say \"Hello world!\"?");
 	}
 
@@ -77,7 +77,7 @@ class CustomContainerWebSocketsApplicationTests {
 		long count = context.getBean(ClientConfiguration.class).latch.getCount();
 		AtomicReference<String> messagePayloadReference = context.getBean(ClientConfiguration.class).messagePayload;
 		context.close();
-		assertThat(count).isEqualTo(0);
+		assertThat(count).isZero();
 		assertThat(messagePayloadReference.get()).isEqualTo("Reversed: !dlrow olleH");
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/test/java/smoketest/websocket/tomcat/snake/SnakeTimerTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/test/java/smoketest/websocket/tomcat/snake/SnakeTimerTests.java
@@ -33,7 +33,7 @@ class SnakeTimerTests {
 		willThrow(new IOException()).given(snake).sendMessage(anyString());
 		SnakeTimer.addSnake(snake);
 		SnakeTimer.broadcast("");
-		assertThat(SnakeTimer.getSnakes()).hasSize(0);
+		assertThat(SnakeTimer.getSnakes()).isEmpty();
 	}
 
 }

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/test/java/smoketest/websocket/undertow/SampleWebSocketsApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/test/java/smoketest/websocket/undertow/SampleWebSocketsApplicationTests.java
@@ -59,7 +59,7 @@ class SampleWebSocketsApplicationTests {
 		long count = context.getBean(ClientConfiguration.class).latch.getCount();
 		AtomicReference<String> messagePayloadReference = context.getBean(ClientConfiguration.class).messagePayload;
 		context.close();
-		assertThat(count).isEqualTo(0);
+		assertThat(count).isZero();
 		assertThat(messagePayloadReference.get()).isEqualTo("Did you say \"Hello world!\"?");
 	}
 
@@ -72,7 +72,7 @@ class SampleWebSocketsApplicationTests {
 		long count = context.getBean(ClientConfiguration.class).latch.getCount();
 		AtomicReference<String> messagePayloadReference = context.getBean(ClientConfiguration.class).messagePayload;
 		context.close();
-		assertThat(count).isEqualTo(0);
+		assertThat(count).isZero();
 		assertThat(messagePayloadReference.get()).isEqualTo("Reversed: !dlrow olleH");
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/test/java/smoketest/websocket/undertow/echo/CustomContainerWebSocketsApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/test/java/smoketest/websocket/undertow/echo/CustomContainerWebSocketsApplicationTests.java
@@ -64,7 +64,7 @@ class CustomContainerWebSocketsApplicationTests {
 		long count = context.getBean(ClientConfiguration.class).latch.getCount();
 		AtomicReference<String> messagePayloadReference = context.getBean(ClientConfiguration.class).messagePayload;
 		context.close();
-		assertThat(count).isEqualTo(0);
+		assertThat(count).isZero();
 		assertThat(messagePayloadReference.get()).isEqualTo("Did you say \"Hello world!\"?");
 	}
 
@@ -77,7 +77,7 @@ class CustomContainerWebSocketsApplicationTests {
 		long count = context.getBean(ClientConfiguration.class).latch.getCount();
 		AtomicReference<String> messagePayloadReference = context.getBean(ClientConfiguration.class).messagePayload;
 		context.close();
-		assertThat(count).isEqualTo(0);
+		assertThat(count).isZero();
 		assertThat(messagePayloadReference.get()).isEqualTo("Reversed: !dlrow olleH");
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/test/java/smoketest/websocket/undertow/snake/SnakeTimerTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/test/java/smoketest/websocket/undertow/snake/SnakeTimerTests.java
@@ -33,7 +33,7 @@ class SnakeTimerTests {
 		willThrow(new IOException()).given(snake).sendMessage(anyString());
 		SnakeTimer.addSnake(snake);
 		SnakeTimer.broadcast("");
-		assertThat(SnakeTimer.getSnakes()).hasSize(0);
+		assertThat(SnakeTimer.getSnakes()).isEmpty();
 	}
 
 }


### PR DESCRIPTION
Simplified AssertJ assertions (e.g. instead of doing `assertThat(list.size()).isEqualTo(2)` one can do `assertThat(list).hasSize(2)` which provides cleaner error message and makes the test slightly more readable).
Change was mostly automated using "Concise AssertJ Optimizing Nitpicker ​(Cajon)​", with some manual work where it made incorrect changes.
