### PR TITLE
Fix a typo in the ExitCodeGenerator documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/spring-application.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/spring-application.adoc
@@ -335,7 +335,7 @@ include::code:MyApplication[]
 Also, the `ExitCodeGenerator` interface may be implemented by exceptions.
 When such an exception is encountered, Spring Boot returns the exit code provided by the implemented `getExitCode()` method.
 
-If there is more than `ExitCodeGenerator`, the first non-zero exit code that is generated is used.
+If there is more than one `ExitCodeGenerator`, the first non-zero exit code that is generated is used.
 To control the order in which the generators are called, additionally implement the `org.springframework.core.Ordered` interface or use the `org.springframework.core.annotation.Order` annotation.
 
 


### PR DESCRIPTION
This PR fixes a small typo in the `ExitCodeGenerator` documentation in the `Core Freatures/SpringApplication/Application Exit` section.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
