### PR TITLE
Added toString method for EndpointRequestMatcher #33647

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
@@ -278,7 +278,7 @@ public final class EndpointRequest {
 			StringBuilder sb = new StringBuilder();
 			sb.append("EndpointRequest [includes='").append(this.includes).append("'");
 			sb.append(", Excludes='").append(this.excludes).append("'");
-			sb.append(", IncludeLinks=").append(this.includeLinks).append("'");
+			sb.append(", IncludeLinks='").append(this.includeLinks).append("'");
 			sb.append("]");
 			return sb.toString();
 		}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
@@ -277,8 +277,8 @@ public final class EndpointRequest {
 		public String toString() {
 			StringBuilder sb = new StringBuilder();
 			sb.append("EndpointRequest [includes='").append(this.includes).append("'");
-			sb.append(", [Excludes='").append(this.excludes).append("'");
-			sb.append(", [IncludeLinks=]").append(this.includeLinks).append("'");
+			sb.append(", Excludes='").append(this.excludes).append("'");
+			sb.append(", IncludeLinks=").append(this.includeLinks).append("'");
 			sb.append("]");
 			return sb.toString();
 		}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
@@ -273,6 +273,16 @@ public final class EndpointRequest {
 					.collect(Collectors.toCollection(ArrayList::new));
 		}
 
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder();
+			sb.append("EndpointRequest [includes='").append(this.includes).append("'");
+			sb.append(", [Excludes='").append(this.excludes).append("'");
+			sb.append(", [IncludeLinks=]").append(this.includeLinks).append("'");
+			sb.append("]");
+			return sb.toString();
+		}
+
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
@@ -276,8 +276,16 @@ public final class EndpointRequest {
 		@Override
 		public String toString() {
 			StringBuilder sb = new StringBuilder();
-			sb.append("EndpointRequest [includes='").append(this.includes).append("'");
-			sb.append(", Excludes='").append(this.excludes).append("'");
+			if (this.includes.isEmpty()) {
+				sb.append("EndpointRequest [includes='[").append("*").append("]'");
+			}
+			else {
+				sb.append("EndpointRequest [includes='")
+						.append(this.includes.stream().map(this::getEndpointId).collect(Collectors.toList()))
+						.append("'");
+			}
+			sb.append(", Excludes='")
+					.append(this.excludes.stream().map(this::getEndpointId).collect(Collectors.toList())).append("'");
 			sb.append(", IncludeLinks='").append(this.includeLinks).append("'");
 			sb.append("]");
 			return sb.toString();

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
@@ -24,7 +24,6 @@ import org.assertj.core.api.AssertDelegateTarget;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
-import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest.EndpointRequestMatcher;
 import org.springframework.boot.actuate.endpoint.EndpointId;
 import org.springframework.boot.actuate.endpoint.ExposableEndpoint;
 import org.springframework.boot.actuate.endpoint.Operation;

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
@@ -222,12 +222,12 @@ class EndpointRequestTests {
 				.isEqualTo("EndpointRequest [includes='[/foo, /bar]', Excludes='[]', IncludeLinks='false']");
 	}
 
-    @Test
-    void toStringIncludedExcludedEndpoints() {
-        RequestMatcher matcher = EndpointRequest.to("/foo").excluding("/bar");
-        assertThat(matcher.toString())
-                .isEqualTo("EndpointRequest [includes='[/foo]', Excludes='[/bar]', IncludeLinks='false']");
-    }
+	@Test
+	void toStringIncludedExcludedEndpoints() {
+		RequestMatcher matcher = EndpointRequest.to("/foo").excluding("/bar");
+		assertThat(matcher.toString())
+				.isEqualTo("EndpointRequest [includes='[/foo]', Excludes='[/bar]', IncludeLinks='false']");
+	}
 
 	private RequestMatcherAssert assertMatcher(RequestMatcher matcher) {
 		return assertMatcher(matcher, mockPathMappedEndpoints("/actuator"));

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
@@ -24,6 +24,7 @@ import org.assertj.core.api.AssertDelegateTarget;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest.EndpointRequestMatcher;
 import org.springframework.boot.actuate.endpoint.EndpointId;
 import org.springframework.boot.actuate.endpoint.ExposableEndpoint;
 import org.springframework.boot.actuate.endpoint.Operation;
@@ -213,6 +214,13 @@ class EndpointRequestTests {
 		RequestMatcher matcher = EndpointRequest.toAnyEndpoint();
 		assertMatcher(matcher, (PathMappedEndpoints) null).doesNotMatch("/actuator/foo");
 		assertMatcher(matcher, (PathMappedEndpoints) null).doesNotMatch("/actuator/bar");
+	}
+
+	@Test
+	void toStringEndpoint() {
+		RequestMatcher matcher = EndpointRequest.to("/foo", "/bar");
+		assertThat(matcher.toString())
+				.isEqualTo("EndpointRequest [includes='[/foo, /bar]', Excludes='[]', IncludeLinks='false']");
 	}
 
 	private RequestMatcherAssert assertMatcher(RequestMatcher matcher) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
@@ -217,16 +217,30 @@ class EndpointRequestTests {
 
 	@Test
 	void toStringIncludedEndpoints() {
-		RequestMatcher matcher = EndpointRequest.to("/foo", "/bar");
+		RequestMatcher matcher = EndpointRequest.to("foo", "bar");
 		assertThat(matcher.toString())
-				.isEqualTo("EndpointRequest [includes='[/foo, /bar]', Excludes='[]', IncludeLinks='false']");
+				.isEqualTo("EndpointRequest [includes='[foo, bar]', Excludes='[]', IncludeLinks='false']");
+	}
+
+	@Test
+	void toStringEmptyIncludedEndpoints() {
+		RequestMatcher matcher = EndpointRequest.toAnyEndpoint();
+		assertThat(matcher.toString())
+				.isEqualTo("EndpointRequest [includes='[*]', Excludes='[]', IncludeLinks='true']");
+	}
+
+	@Test
+	void toStringIncludedEndpointsClasses() {
+		RequestMatcher matcher = EndpointRequest.to(FooEndpoint.class).excluding("bar");
+		assertThat(matcher.toString())
+				.isEqualTo("EndpointRequest [includes='[foo]', Excludes='[bar]', IncludeLinks='false']");
 	}
 
 	@Test
 	void toStringIncludedExcludedEndpoints() {
-		RequestMatcher matcher = EndpointRequest.to("/foo").excluding("/bar");
+		RequestMatcher matcher = EndpointRequest.toAnyEndpoint().excluding("bar").excludingLinks();
 		assertThat(matcher.toString())
-				.isEqualTo("EndpointRequest [includes='[/foo]', Excludes='[/bar]', IncludeLinks='false']");
+				.isEqualTo("EndpointRequest [includes='[*]', Excludes='[bar]', IncludeLinks='false']");
 	}
 
 	private RequestMatcherAssert assertMatcher(RequestMatcher matcher) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
@@ -216,11 +216,18 @@ class EndpointRequestTests {
 	}
 
 	@Test
-	void toStringEndpoint() {
+	void toStringIncludedEndpoints() {
 		RequestMatcher matcher = EndpointRequest.to("/foo", "/bar");
 		assertThat(matcher.toString())
 				.isEqualTo("EndpointRequest [includes='[/foo, /bar]', Excludes='[]', IncludeLinks='false']");
 	}
+
+    @Test
+    void toStringIncludedExcludedEndpoints() {
+        RequestMatcher matcher = EndpointRequest.to("/foo").excluding("/bar");
+        assertThat(matcher.toString())
+                .isEqualTo("EndpointRequest [includes='[/foo]', Excludes='[/bar]', IncludeLinks='false']");
+    }
 
 	private RequestMatcherAssert assertMatcher(RequestMatcher matcher) {
 		return assertMatcher(matcher, mockPathMappedEndpoints("/actuator"));


### PR DESCRIPTION
Changes:

This PR add `toString()`method in `EndpointRequest.EndpointRequestMatcher`  as per the bug #33647. 
Added Test Cases for `toString()` method in `EndpointRequestTest`
Thanks