### PR TITLE
SDKMAN should not use repo.spring.io for releases

### DIFF
--- a/ci/images/releasescripts/src/main/java/io/spring/concourse/releasescripts/sdkman/SdkmanService.java
+++ b/ci/images/releasescripts/src/main/java/io/spring/concourse/releasescripts/sdkman/SdkmanService.java
@@ -40,7 +40,7 @@ public class SdkmanService {
 
 	private static final String SDKMAN_URL = "https://vendors.sdkman.io/";
 
-	private static final String DOWNLOAD_URL = "https://repo.spring.io/simple/libs-release-local/org/springframework/boot/spring-boot-cli/"
+	private static final String DOWNLOAD_URL = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-cli/"
 			+ "%s/spring-boot-cli-%s-bin.zip";
 
 	private static final String CHANGELOG_URL = "https://github.com/spring-projects/spring-boot/releases/tag/v%s";


### PR DESCRIPTION
As mention in #33705 , I have replace repo url to maven url. While going through the https://github.com/spring-projects/spring-boot/issues/33702 and [Jan 2023 spring notice](https://spring.io/blog/2022/12/14/notice-of-permissions-changes-to-repo-spring-io-january-2023).
Let me know If any issue.
Sorry for previous commit