### PR TITLE
Upgrade to AssertJ 3.24.2

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -56,10 +56,10 @@ bom {
 			]
 		}
 	}
-	library("AssertJ", "3.23.1") {
+	library("AssertJ", "3.24.2") {
 		group("org.assertj") {
-			modules = [
-				"assertj-core"
+			imports = [
+				"assertj-bom"
 			]
 		}
 	}


### PR DESCRIPTION
Aside from just upgrading the version, this also switches to the [AssertJ BOM](https://assertj.github.io/doc/#dependency-metadata-assertj-bom).
