### PR TITLE
Rename MultipleConnectionPoolConfigurationsFailureAnalzyer

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/MultipleConnectionPoolConfigurationsFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/MultipleConnectionPoolConfigurationsFailureAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.springframework.boot.diagnostics.FailureAnalyzer;
  *
  * @author Andy Wilkinson
  */
-class MultipleConnectionPoolConfigurationsFailureAnalzyer
+class MultipleConnectionPoolConfigurationsFailureAnalyzer
 		extends AbstractFailureAnalyzer<MultipleConnectionPoolConfigurationsException> {
 
 	@Override

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -31,7 +31,7 @@ org.springframework.boot.autoconfigure.jdbc.HikariDriverConfigurationFailureAnal
 org.springframework.boot.autoconfigure.jooq.NoDslContextBeanFailureAnalyzer,\
 org.springframework.boot.autoconfigure.r2dbc.ConnectionFactoryBeanCreationFailureAnalyzer,\
 org.springframework.boot.autoconfigure.r2dbc.MissingR2dbcPoolDependencyFailureAnalyzer,\
-org.springframework.boot.autoconfigure.r2dbc.MultipleConnectionPoolConfigurationsFailureAnalzyer,\
+org.springframework.boot.autoconfigure.r2dbc.MultipleConnectionPoolConfigurationsFailureAnalyzer,\
 org.springframework.boot.autoconfigure.r2dbc.NoConnectionFactoryBeanFailureAnalyzer
 
 # Template availability providers

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/r2dbc/MultipleConnectionPoolConfigurationsFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/r2dbc/MultipleConnectionPoolConfigurationsFailureAnalyzerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,13 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link MultipleConnectionPoolConfigurationsFailureAnalzyer}
+ * Tests for {@link MultipleConnectionPoolConfigurationsFailureAnalyzer}
  *
  * @author Andy Wilkinson
  */
-class MultipleConnectionPoolConfigurationsFailureAnalzyerTests {
+class MultipleConnectionPoolConfigurationsFailureAnalyzerTests {
 
-	private final MultipleConnectionPoolConfigurationsFailureAnalzyer failureAnalyzer = new MultipleConnectionPoolConfigurationsFailureAnalzyer();
+	private final MultipleConnectionPoolConfigurationsFailureAnalyzer failureAnalyzer = new MultipleConnectionPoolConfigurationsFailureAnalyzer();
 
 	@Test
 	void analyzeWhenDifferentFailureShouldReturnNull() {


### PR DESCRIPTION
Rename `MultipleConnectionPoolConfigurationsFailureAnalzyer` to `MultipleConnectionPoolConfigurationsFailureAnalyzer`.