### PR TITLE
Update com.gorylenko.gradle-git-properties version to 2.4.1 in doc

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/build.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/build.adoc
@@ -72,7 +72,7 @@ Gradle users can achieve the same result by using the https://plugins.gradle.org
 [source,gradle,indent=0,subs="verbatim"]
 ----
 	plugins {
-		id "com.gorylenko.gradle-git-properties" version "2.3.2"
+		id "com.gorylenko.gradle-git-properties" version "2.4.1"
 	}
 ----
 


### PR DESCRIPTION
This PR updates the `com.gorylenko.gradle-git-properties` Gradle plugin version to the latest (2.4.1) in the reference doc.