### PR TITLE
Add Javadoc since to OperationParameter.getAnnotation()

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/invoke/OperationParameter.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/invoke/OperationParameter.java
@@ -51,6 +51,7 @@ public interface OperationParameter {
 	 * @param annotation class of the annotation
 	 * @return annotation value
 	 * @param <T> type of the annotation
+	 * @since 2.7.8
 	 */
 	<T extends Annotation> T getAnnotation(Class<T> annotation);
 


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag to the `OperationParameter.getAnnotation()` method.

See gh-31240