### PR TITLE
Remove hints for Spring Integration Graph

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/integration/IntegrationGraphEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/integration/IntegrationGraphEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,34 +19,14 @@ package org.springframework.boot.actuate.integration;
 import java.util.Collection;
 import java.util.Map;
 
-import org.springframework.aot.hint.BindingReflectionHintsRegistrar;
-import org.springframework.aot.hint.RuntimeHints;
-import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.boot.actuate.endpoint.OperationResponseBody;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
-import org.springframework.boot.actuate.integration.IntegrationGraphEndpoint.IntegrationGraphEndpointRuntimeHints;
-import org.springframework.context.annotation.ImportRuntimeHints;
-import org.springframework.integration.graph.CompositeMessageHandlerNode;
-import org.springframework.integration.graph.DiscardingMessageHandlerNode;
-import org.springframework.integration.graph.EndpointNode;
-import org.springframework.integration.graph.ErrorCapableCompositeMessageHandlerNode;
-import org.springframework.integration.graph.ErrorCapableDiscardingMessageHandlerNode;
-import org.springframework.integration.graph.ErrorCapableEndpointNode;
-import org.springframework.integration.graph.ErrorCapableMessageHandlerNode;
-import org.springframework.integration.graph.ErrorCapableRoutingNode;
 import org.springframework.integration.graph.Graph;
 import org.springframework.integration.graph.IntegrationGraphServer;
 import org.springframework.integration.graph.IntegrationNode;
 import org.springframework.integration.graph.LinkNode;
-import org.springframework.integration.graph.MessageChannelNode;
-import org.springframework.integration.graph.MessageGatewayNode;
-import org.springframework.integration.graph.MessageHandlerNode;
-import org.springframework.integration.graph.MessageProducerNode;
-import org.springframework.integration.graph.MessageSourceNode;
-import org.springframework.integration.graph.PollableChannelNode;
-import org.springframework.integration.graph.RoutingMessageHandlerNode;
 
 /**
  * {@link Endpoint @Endpoint} to expose the Spring Integration graph.
@@ -55,7 +35,6 @@ import org.springframework.integration.graph.RoutingMessageHandlerNode;
  * @since 2.1.0
  */
 @Endpoint(id = "integrationgraph")
-@ImportRuntimeHints(IntegrationGraphEndpointRuntimeHints.class)
 public class IntegrationGraphEndpoint {
 
 	private final IntegrationGraphServer graphServer;
@@ -78,23 +57,6 @@ public class IntegrationGraphEndpoint {
 	@WriteOperation
 	public void rebuild() {
 		this.graphServer.rebuild();
-	}
-
-	static class IntegrationGraphEndpointRuntimeHints implements RuntimeHintsRegistrar {
-
-		private final BindingReflectionHintsRegistrar bindingRegistrar = new BindingReflectionHintsRegistrar();
-
-		@Override
-		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
-			this.bindingRegistrar.registerReflectionHints(hints.reflection(), Graph.class,
-					CompositeMessageHandlerNode.class, DiscardingMessageHandlerNode.class, EndpointNode.class,
-					ErrorCapableCompositeMessageHandlerNode.class, ErrorCapableDiscardingMessageHandlerNode.class,
-					ErrorCapableEndpointNode.class, ErrorCapableMessageHandlerNode.class, ErrorCapableRoutingNode.class,
-					MessageChannelNode.class, MessageGatewayNode.class, MessageHandlerNode.class,
-					MessageProducerNode.class, MessageSourceNode.class, PollableChannelNode.class,
-					RoutingMessageHandlerNode.class);
-		}
-
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/integration/IntegrationGraphEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/integration/IntegrationGraphEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,34 +20,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.aot.hint.MemberCategory;
-import org.springframework.aot.hint.RuntimeHints;
-import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
 import org.springframework.boot.actuate.integration.IntegrationGraphEndpoint.GraphDescriptor;
-import org.springframework.boot.actuate.integration.IntegrationGraphEndpoint.IntegrationGraphEndpointRuntimeHints;
-import org.springframework.integration.graph.CompositeMessageHandlerNode;
-import org.springframework.integration.graph.DiscardingMessageHandlerNode;
-import org.springframework.integration.graph.EndpointNode;
-import org.springframework.integration.graph.ErrorCapableCompositeMessageHandlerNode;
-import org.springframework.integration.graph.ErrorCapableDiscardingMessageHandlerNode;
-import org.springframework.integration.graph.ErrorCapableEndpointNode;
-import org.springframework.integration.graph.ErrorCapableMessageHandlerNode;
-import org.springframework.integration.graph.ErrorCapableRoutingNode;
 import org.springframework.integration.graph.Graph;
 import org.springframework.integration.graph.IntegrationGraphServer;
 import org.springframework.integration.graph.IntegrationNode;
 import org.springframework.integration.graph.LinkNode;
-import org.springframework.integration.graph.MessageChannelNode;
-import org.springframework.integration.graph.MessageGatewayNode;
-import org.springframework.integration.graph.MessageHandlerNode;
-import org.springframework.integration.graph.MessageProducerNode;
-import org.springframework.integration.graph.MessageSourceNode;
-import org.springframework.integration.graph.PollableChannelNode;
-import org.springframework.integration.graph.RoutingMessageHandlerNode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -87,23 +67,6 @@ class IntegrationGraphEndpointTests {
 	void writeOperationShouldRebuildGraph() {
 		this.endpoint.rebuild();
 		then(this.server).should().rebuild();
-	}
-
-	@Test
-	void shouldRegisterHints() {
-		RuntimeHints runtimeHints = new RuntimeHints();
-		new IntegrationGraphEndpointRuntimeHints().registerHints(runtimeHints, getClass().getClassLoader());
-		Set<Class<?>> bindingTypes = Set.of(Graph.class, EndpointNode.class, CompositeMessageHandlerNode.class,
-				DiscardingMessageHandlerNode.class, ErrorCapableCompositeMessageHandlerNode.class,
-				ErrorCapableDiscardingMessageHandlerNode.class, ErrorCapableEndpointNode.class,
-				ErrorCapableMessageHandlerNode.class, ErrorCapableRoutingNode.class, MessageGatewayNode.class,
-				MessageProducerNode.class, PollableChannelNode.class, MessageChannelNode.class,
-				MessageHandlerNode.class, MessageSourceNode.class, RoutingMessageHandlerNode.class);
-		for (Class<?> bindingType : bindingTypes) {
-			assertThat(RuntimeHintsPredicates.reflection().onType(bindingType)
-					.withMemberCategories(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.DECLARED_FIELDS))
-							.accepts(runtimeHints);
-		}
 	}
 
 }


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-integration/issues/3994

Spring Integration's `IntegrationGraphServer` can be used without actuator or even Spring Boot at all.
That is more natural to have respective reflection hints exposed by Spring Integration itself.
See related GH issue and its fix which just does a migration of the remove code from `IntegrationGraphEndpoint`

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
