### PR TITLE
addresses #33748 validate default table on jdbc session init

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionDataSourceScriptDatabaseInitializer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/JdbcSessionDataSourceScriptDatabaseInitializer.java
@@ -88,7 +88,7 @@ public class JdbcSessionDataSourceScriptDatabaseInitializer extends DataSourceSc
 		super.runScripts(scripts);
 	}
 
-	private void validateConfiguration() {
+	void validateConfiguration() {
 		if (properties == null) return; // cannot validate without this
 		JdbcSessionProperties defaults = new JdbcSessionProperties();
 		boolean willHappen = switch (properties.getInitializeSchema()) {


### PR DESCRIPTION
Refuses to start when jdbc session is initialized and custom table is specified, but default script is specified. default scripts are not currently customizable for a custom table name, so this configuration will result in a schema being defined for one table name, but sessions being stored in another table. this is almost definitely not the intended the end result. so we will ask the user to specify the schema (or set the initialization to never).

this is the intermediate solution to restore functionality lost in a merge as discussed in #33748

implementation notes:

I'm not sure whether i should have used the "customize" protected method, which can be overridden, and occurs close enough in the general execution workflow, that an exception thrown there or in my overridden runScripts method. But it seems that customization logic should live there, not validation logic? I can override the other method instead of runScripts if that is at all preferable.

it seems there is already an architectural decision in place here - to deal with the configuring the different implementations - all the implementations of `DataSourceScriptDatabaseInitializer` need to call the super constructor taking `DataSource` and `DatabaseInitializationSettings` as the second argument. perhaps it makes sense to augment the database initialization settings to add the necessary information to perform this particular kind of validation... then this solution will more easily translate to other implementations. otherwise it is less than ideal to hook into the constructors and store the implementation-specific ConfigurationProperties object.