### PR TITLE
Add Redis application properties example

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/nosql.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/nosql.adoc
@@ -48,7 +48,20 @@ If you add your own `@Bean` of any of the auto-configured types, it replaces the
 
 By default, a pooled connection factory is auto-configured if `commons-pool2` is on the classpath.
 
+Alternatively, you can specify connection details using discrete properties.
+For example, you might declare the following settings in your `application.properties`:
 
+[source,yaml,indent=0,subs="verbatim",configprops,configblocks]
+----
+	spring:
+	  data:
+	    redis:
+	      host: "localhost"
+	      port: 6379
+	      database: 0
+	      username: "user"
+	      password: "secret"
+----
 
 [[data.nosql.mongodb]]
 === MongoDB


### PR DESCRIPTION
After updating the [Spring-Session documentation](https://github.com/spring-projects/spring-session/pull/2229#event-8343880753) with regards to connecting to Redis, this PR aims to provide further options in the `Connect to Redis` section of the Spring-Boot documentation itself.

A new section is added that explains how to setup the connection via application properties in addition to the existing methods.