### PR TITLE
fix(src): check if the session timeout is negative before setting the value

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/server/Session.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/server/Session.java
@@ -53,7 +53,9 @@ public class Session {
 	}
 
 	public void setTimeout(Duration timeout) {
-		this.timeout = timeout;
+		if(timeout != null && !timeout.isNegative()) {
+			this.timeout = timeout;
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

  - Add check condition to determine if the session duration is negative.
  - If the provided session duration is negative, let the timeout be set to default 30 mins.

#.
-->
