### PR TITLE
Remove EnabledForJreRange.min in PaketoBuilderTests

### DIFF
--- a/spring-boot-system-tests/spring-boot-image-tests/src/systemTest/java/org/springframework/boot/image/paketo/PaketoBuilderTests.java
+++ b/spring-boot-system-tests/spring-boot-image-tests/src/systemTest/java/org/springframework/boot/image/paketo/PaketoBuilderTests.java
@@ -60,7 +60,7 @@ import static org.assertj.core.api.Assertions.entry;
  * @author Scott Frederick
  */
 @ExtendWith({ GradleBuildInjectionExtension.class, GradleBuildExtension.class })
-@EnabledForJreRange(min = JRE.JAVA_8, max = JRE.JAVA_18)
+@EnabledForJreRange(max = JRE.JAVA_18)
 class PaketoBuilderTests {
 
 	GradleBuild gradleBuild;


### PR DESCRIPTION
This PR removes unnecessary `@EnabledForJreRange` `min` attribute in the `PaketoBuilderTests`.