### PR TITLE
jOOQ DefaultConfiguration does not use TransactionProvider

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfiguration.java
@@ -87,11 +87,13 @@ public class JooqAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean(org.jooq.Configuration.class)
 		public DefaultConfiguration jooqConfiguration(JooqProperties properties, ConnectionProvider connectionProvider,
-				DataSource dataSource, ObjectProvider<ExecuteListenerProvider> executeListenerProviders,
+				DataSource dataSource, ObjectProvider<TransactionProvider> transactionProvider,
+				ObjectProvider<ExecuteListenerProvider> executeListenerProviders,
 				ObjectProvider<DefaultConfigurationCustomizer> configurationCustomizers) {
 			DefaultConfiguration configuration = new DefaultConfiguration();
 			configuration.set(properties.determineSqlDialect(dataSource));
 			configuration.set(connectionProvider);
+			transactionProvider.ifAvailable(configuration::set);
 			configuration.set(executeListenerProviders.orderedStream().toArray(ExecuteListenerProvider[]::new));
 			configurationCustomizers.orderedStream().forEach((customizer) -> customizer.customize(configuration));
 			return configuration;

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfigurationTests.java
@@ -114,6 +114,16 @@ class JooqAutoConfigurationTests {
 	}
 
 	@Test
+	void jooqWithDefaultTransactionProvider() {
+		this.contextRunner.withUserConfiguration(JooqDataSourceConfiguration.class, TxManagerConfiguration.class).run((context) -> {
+			DSLContext dsl = context.getBean(DSLContext.class);
+			TransactionProvider expectedTransactionProvider = context.getBean(TransactionProvider.class);
+			TransactionProvider transactionProvider = dsl.configuration().transactionProvider();
+			assertThat(transactionProvider).isSameAs(expectedTransactionProvider);
+		});
+	}
+
+	@Test
 	void jooqWithDefaultExecuteListenerProvider() {
 		this.contextRunner.withUserConfiguration(JooqDataSourceConfiguration.class).run((context) -> {
 			DSLContext dsl = context.getBean(DSLContext.class);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/JooqAutoConfigurationTests.java
@@ -115,12 +115,13 @@ class JooqAutoConfigurationTests {
 
 	@Test
 	void jooqWithDefaultTransactionProvider() {
-		this.contextRunner.withUserConfiguration(JooqDataSourceConfiguration.class, TxManagerConfiguration.class).run((context) -> {
-			DSLContext dsl = context.getBean(DSLContext.class);
-			TransactionProvider expectedTransactionProvider = context.getBean(TransactionProvider.class);
-			TransactionProvider transactionProvider = dsl.configuration().transactionProvider();
-			assertThat(transactionProvider).isSameAs(expectedTransactionProvider);
-		});
+		this.contextRunner.withUserConfiguration(JooqDataSourceConfiguration.class, TxManagerConfiguration.class)
+				.run((context) -> {
+					DSLContext dsl = context.getBean(DSLContext.class);
+					TransactionProvider expectedTransactionProvider = context.getBean(TransactionProvider.class);
+					TransactionProvider transactionProvider = dsl.configuration().transactionProvider();
+					assertThat(transactionProvider).isSameAs(expectedTransactionProvider);
+				});
 	}
 
 	@Test


### PR DESCRIPTION
# Problem
A jOOQ `TransactionProvider` bean is created, but is not configured to be used by the `DefaultConfiguration`. This applies to Spring Boot 3.0.0, 3.0.1, 3.0.2.
A recent commit (https://github.com/spring-projects/spring-boot/commit/51df7813a594822ae39b4e8ba042f9133c080eb2) removed the `DefaultConfigurationCustomizer` that configured `DefaultConfiguration` to use the `TransactionProvider` if such a bean was available.

# Solution
This PR sets the `TransactionProvider` (if available) when creating the `DefaultConfiguration`.