### PR TITLE
liquibase-hibernate6 does not have version 4.17.2

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -779,7 +779,7 @@ bom {
 			]
 		}
 	}
-	library("Liquibase", "4.17.2") {
+	library("Liquibase", "4.19.0") {
 		group("org.liquibase") {
 			modules = [
 				"liquibase-cdi",


### PR DESCRIPTION
springboot 3 uses spring-orm6 thus, hibernate6 and liquibase-hibernate6 must be used. However, the first version of liquibase-hibernate6 is 4.19.0 and since liquibase recommend matching the version of liquibase with all the liquibase extension , i think it is wise for spring boot dependencies to use liquibase 4.19.0