### PR TITLE
Add Micrometer Tracing's CompositeSpanExporter

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfiguration.java
@@ -20,6 +20,10 @@ import java.util.Collections;
 import java.util.List;
 
 import io.micrometer.tracing.SpanCustomizer;
+import io.micrometer.tracing.exporter.SpanExportingPredicate;
+import io.micrometer.tracing.exporter.SpanFilter;
+import io.micrometer.tracing.exporter.SpanReporter;
+import io.micrometer.tracing.otel.bridge.CompositeSpanExporter;
 import io.micrometer.tracing.otel.bridge.EventListener;
 import io.micrometer.tracing.otel.bridge.EventPublishingContextWrapper;
 import io.micrometer.tracing.otel.bridge.OtelBaggageManager;
@@ -117,12 +121,8 @@ public class OpenTelemetryAutoConfiguration {
 	}
 
 	@Bean
-	SpanProcessor otelSpanProcessor(ObjectProvider<SpanExporter> spanExporters) {
-		return SpanProcessor.composite(spanExporters.orderedStream().map(this::buildBatchSpanProcessor).toList());
-	}
-
-	private SpanProcessor buildBatchSpanProcessor(SpanExporter exporter) {
-		return BatchSpanProcessor.builder(exporter).build();
+	SpanProcessor otelSpanProcessor(ObjectProvider<SpanExporter> spanExporters, ObjectProvider<SpanExportingPredicate> spanExportingPredicates, ObjectProvider<SpanReporter> spanReporters, ObjectProvider<SpanFilter> spanFilters) {
+		return BatchSpanProcessor.builder(new CompositeSpanExporter(spanExporters.orderedStream().toList(), spanExportingPredicates.orderedStream().toList(), spanReporters.orderedStream().toList(), spanFilters.orderedStream().toList())).build();
 	}
 
 	@Bean


### PR DESCRIPTION
Micrometer Tracing comes with 3 generic interfaces, `SpanExportingPredicate`, `SpanReporter` and `SpanFilter`, thanks to which you can decide whether you want to export a span, how you want to report it and how to mutate it regardless of which tracer library you are using.

Without this change usage of these 3 interfaces is not possible for OpenTelemetry.

With this change we're putting all `SpanExporters` to the `CompositeSpanExporter` and apply the exporters only after predicates, filtering and reporting took place.

fixes https://github.com/spring-projects/spring-boot/issues/31469