### PR TITLE
Add property `headers` in `OtlpProperties`

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpProperties.java
@@ -41,6 +41,11 @@ public class OtlpProperties extends StepRegistryProperties {
 	 */
 	private Map<String, String> resourceAttributes;
 
+	/**
+	 * Headers for the exported metrics.
+	 */
+	private Map<String, String> headers;
+
 	public String getUrl() {
 		return this.url;
 	}
@@ -57,4 +62,11 @@ public class OtlpProperties extends StepRegistryProperties {
 		this.resourceAttributes = resourceAttributes;
 	}
 
+	public Map<String, String> getHeaders() {
+		return this.headers;
+	}
+
+	public void setHeaders(Map<String, String> headers) {
+		this.headers = headers;
+	}
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesConfigAdapter.java
@@ -48,4 +48,9 @@ class OtlpPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<Ot
 		return get(OtlpProperties::getResourceAttributes, OtlpConfig.super::resourceAttributes);
 	}
 
+	@Override
+	public Map<String, String> headers() {
+		return get(OtlpProperties::getHeaders, OtlpConfig.super::headers);
+	}
+
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesConfigAdapterTests.java
@@ -44,4 +44,12 @@ class OtlpPropertiesConfigAdapterTests {
 				"boot-service");
 	}
 
+	@Test
+	void whenPropertiesHeadersIsSetAdapterHeadersReturnsIt() {
+		OtlpProperties properties = new OtlpProperties();
+		properties.setHeaders(Map.of("header", "value"));
+		assertThat(new OtlpPropertiesConfigAdapter(properties).headers()).containsEntry("header",
+				"value");
+	}
+
 }

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -932,7 +932,7 @@ bom {
 			]
 		}
 	}
-	library("Micrometer", "1.10.3") {
+	library("Micrometer", "1.11.0-SNAPSHOT") {
 		group("io.micrometer") {
 			modules = [
 				"micrometer-registry-stackdriver" {


### PR DESCRIPTION
In Micrometer 1.11, headers property has been introduced.
