### PR TITLE
fix InMemoryUserDetailsManager: encode password if encoder is available

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/UserDetailsServiceAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/UserDetailsServiceAutoConfiguration.java
@@ -89,8 +89,11 @@ public class UserDetailsServiceAutoConfiguration {
 							+ "production.%n",
 					user.getPassword()));
 		}
-		if (encoder != null || PASSWORD_ALGORITHM_PATTERN.matcher(password).matches()) {
+		if (PASSWORD_ALGORITHM_PATTERN.matcher(password).matches()) {
 			return password;
+		}
+		if (encoder != null) {
+			return encoder.encode(password);
 		}
 		return NOOP_PASSWORD_PREFIX + password;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/servlet/UserDetailsServiceAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/servlet/UserDetailsServiceAutoConfigurationTests.java
@@ -16,11 +16,13 @@
 
 package org.springframework.boot.autoconfigure.security.servlet;
 
+import java.util.Base64;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import org.mockito.stubbing.Answer;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -47,7 +49,9 @@ import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link UserDetailsServiceAutoConfiguration}.
@@ -146,7 +150,7 @@ class UserDetailsServiceAutoConfigurationTests {
 
 	@Test
 	void userDetailsServiceWhenPasswordEncoderBeanPresent() {
-		testPasswordEncoding(TestConfigWithPasswordEncoder.class, "secret", "secret");
+		testPasswordEncoding(TestConfigWithPasswordEncoder.class, "secret", "c2VjcmV0");
 	}
 
 	@Test
@@ -219,7 +223,9 @@ class UserDetailsServiceAutoConfigurationTests {
 
 		@Bean
 		PasswordEncoder passwordEncoder() {
-			return mock(PasswordEncoder.class);
+			PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+			when(passwordEncoder.encode(any())).thenAnswer((Answer<String>) invocation -> Base64.getEncoder().encodeToString(invocation.getArgument(0).toString().getBytes()));
+			return passwordEncoder;
 		}
 
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
The InMemoryUserDetailsManager should encode generated password if the password encoder is provided.