### PR TITLE
Add RabbitTemplateCustomizer to allow customization of RabbitTemplates

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -154,10 +154,9 @@ public class RabbitAutoConfiguration {
 		@Bean
 		@ConditionalOnSingleCandidate(ConnectionFactory.class)
 		@ConditionalOnMissingBean(RabbitOperations.class)
-		public RabbitTemplate rabbitTemplate(RabbitTemplateConfigurer configurer
-				, ConnectionFactory connectionFactory
-				, ObjectProvider<RabbitTemplate.ConfirmCallback> confirmCallback
-				, ObjectProvider<RabbitTemplate.ReturnsCallback> returnsCallback) {
+		public RabbitTemplate rabbitTemplate(RabbitTemplateConfigurer configurer, ConnectionFactory connectionFactory,
+				ObjectProvider<RabbitTemplate.ConfirmCallback> confirmCallback,
+				ObjectProvider<RabbitTemplate.ReturnsCallback> returnsCallback) {
 			RabbitTemplate template = new RabbitTemplate();
 			configurer.configure(template, connectionFactory);
 			confirmCallback.ifAvailable(ccb -> template.setConfirmCallback(ccb));

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -154,9 +154,14 @@ public class RabbitAutoConfiguration {
 		@Bean
 		@ConditionalOnSingleCandidate(ConnectionFactory.class)
 		@ConditionalOnMissingBean(RabbitOperations.class)
-		public RabbitTemplate rabbitTemplate(RabbitTemplateConfigurer configurer, ConnectionFactory connectionFactory) {
+		public RabbitTemplate rabbitTemplate(RabbitTemplateConfigurer configurer
+				, ConnectionFactory connectionFactory
+				, ObjectProvider<RabbitTemplate.ConfirmCallback> confirmCallback
+				, ObjectProvider<RabbitTemplate.ReturnsCallback> returnsCallback) {
 			RabbitTemplate template = new RabbitTemplate();
 			configurer.configure(template, connectionFactory);
+			confirmCallback.ifAvailable(ccb -> template.setConfirmCallback(ccb));
+			returnsCallback.ifAvailable(rcb -> template.setReturnsCallback(rcb));
 			return template;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -155,12 +155,10 @@ public class RabbitAutoConfiguration {
 		@ConditionalOnSingleCandidate(ConnectionFactory.class)
 		@ConditionalOnMissingBean(RabbitOperations.class)
 		public RabbitTemplate rabbitTemplate(RabbitTemplateConfigurer configurer, ConnectionFactory connectionFactory,
-				ObjectProvider<RabbitTemplate.ConfirmCallback> confirmCallback,
-				ObjectProvider<RabbitTemplate.ReturnsCallback> returnsCallback) {
+				ObjectProvider<RabbitTemplateCustomizer> rabbitTemplateCustomizers) {
 			RabbitTemplate template = new RabbitTemplate();
 			configurer.configure(template, connectionFactory);
-			confirmCallback.ifAvailable((ccb) -> template.setConfirmCallback(ccb));
-			returnsCallback.ifAvailable((rcb) -> template.setReturnsCallback(rcb));
+			rabbitTemplateCustomizers.orderedStream().forEach((customizer) -> customizer.customize(template));
 			return template;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfiguration.java
@@ -159,8 +159,8 @@ public class RabbitAutoConfiguration {
 				ObjectProvider<RabbitTemplate.ReturnsCallback> returnsCallback) {
 			RabbitTemplate template = new RabbitTemplate();
 			configurer.configure(template, connectionFactory);
-			confirmCallback.ifAvailable(ccb -> template.setConfirmCallback(ccb));
-			returnsCallback.ifAvailable(rcb -> template.setReturnsCallback(rcb));
+			confirmCallback.ifAvailable((ccb) -> template.setConfirmCallback(ccb));
+			returnsCallback.ifAvailable((rcb) -> template.setReturnsCallback(rcb));
 			return template;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitTemplateCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitTemplateCustomizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.amqp;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+/**
+ * Callback interface that can be used to customize a {@link RabbitTemplate}.
+ *
+ * @author dang zhicairang
+ * @since 2.3.0
+ */
+@FunctionalInterface
+public interface RabbitTemplateCustomizer {
+
+	/**
+	 * Customize the {@link RabbitTemplate}.
+	 * @param rabbitTemplate the rabbitTemplate to customize
+	 */
+	void customize(RabbitTemplate rabbitTemplate);
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitTemplateCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitTemplateCustomizer.java
@@ -28,7 +28,8 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 public interface RabbitTemplateCustomizer {
 
 	/**
-	 * Customize the {@link RabbitTemplate}.
+	 * Customize the {@link RabbitTemplate}, such as used in
+	 * {@link RabbitAutoConfiguration}.
 	 * @param rabbitTemplate the rabbitTemplate to customize
 	 */
 	void customize(RabbitTemplate rabbitTemplate);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
@@ -29,7 +29,6 @@ import com.rabbitmq.client.impl.CredentialsProvider;
 import com.rabbitmq.client.impl.CredentialsRefreshService;
 import com.rabbitmq.client.impl.DefaultCredentialsProvider;
 import org.aopalliance.aop.Advice;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
@@ -80,6 +79,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -378,11 +378,11 @@ class RabbitAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(RabbitTemplateConfirmCallbackAndReturnsCallbackConfiguration.class)
 				.run((context) -> {
 					RabbitTemplate rabbitTemplate = context.getBean(RabbitTemplate.class);
-					Assertions.assertThatExceptionOfType(IllegalStateException.class)
+					assertThatIllegalStateException()
 							.isThrownBy(
 									() -> rabbitTemplate.setConfirmCallback(mock(RabbitTemplate.ConfirmCallback.class)))
 							.withMessage("Only one ConfirmCallback is supported by each RabbitTemplate");
-					Assertions.assertThatExceptionOfType(IllegalStateException.class)
+					assertThatIllegalStateException()
 							.isThrownBy(
 									() -> rabbitTemplate.setReturnsCallback(mock(RabbitTemplate.ReturnsCallback.class)))
 							.withMessage("Only one ReturnCallback is supported by each RabbitTemplate");
@@ -1000,7 +1000,7 @@ class RabbitAutoConfigurationTests {
 
 		@Bean
 		RabbitTemplate.ReturnsCallback returnsCallback() {
-			return returned -> {
+			return (returned) -> {
 			};
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
@@ -379,10 +379,12 @@ class RabbitAutoConfigurationTests {
 				.run((context) -> {
 					RabbitTemplate rabbitTemplate = context.getBean(RabbitTemplate.class);
 					Assertions.assertThatExceptionOfType(IllegalStateException.class)
-							.isThrownBy(() -> rabbitTemplate.setConfirmCallback(mock(RabbitTemplate.ConfirmCallback.class)))
+							.isThrownBy(
+									() -> rabbitTemplate.setConfirmCallback(mock(RabbitTemplate.ConfirmCallback.class)))
 							.withMessage("Only one ConfirmCallback is supported by each RabbitTemplate");
 					Assertions.assertThatExceptionOfType(IllegalStateException.class)
-							.isThrownBy(() -> rabbitTemplate.setReturnsCallback(mock(RabbitTemplate.ReturnsCallback.class)))
+							.isThrownBy(
+									() -> rabbitTemplate.setReturnsCallback(mock(RabbitTemplate.ReturnsCallback.class)))
 							.withMessage("Only one ReturnCallback is supported by each RabbitTemplate");
 				});
 	}


### PR DESCRIPTION
If there has a more convenient way to configure `ConfirmCallback` and `ReturnsCallback` for `RabbitTemplate` by auto-configure , like declare a bean of `ConfirmCallback` or `ReturnsCallback`, so we need not to declare a new bean of `RabbitTemplate` in extra `ConfigClass`.