### PR TITLE
Maven Plugin's PropertiesMergingResourceTransformer closes InputStream when it should not do so

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/PropertiesMergingResourceTransformer.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/PropertiesMergingResourceTransformer.java
@@ -69,7 +69,6 @@ public class PropertiesMergingResourceTransformer implements ReproducibleResourc
 			throws IOException {
 		Properties properties = new Properties();
 		properties.load(inputStream);
-		inputStream.close();
 		properties.forEach((name, value) -> process((String) name, (String) value));
 		if (time > this.time) {
 			this.time = time;


### PR DESCRIPTION
Hi,
This is a conformity fix, as the interface `ReproducibleResourceTransformer` requires that "An input stream for the resource, the implementation should *not* close this stream" :
```java
public interface ReproducibleResourceTransformer
    extends ResourceTransformer
{
    /**
     * Transform an individual resource
     * @param resource The resource name
     * @param is An input stream for the resource, the implementation should *not* close this stream
     * @param relocators  A list of relocators
     * @param time the time of the resource to process
     * @throws IOException When the IO blows up
     */
    void processResource( String resource, InputStream is, List<Relocator> relocators, long time )
        throws IOException;
}
```
I think that the implementation shouldn't close the input stream.
Thanks
