### PR TITLE
Add metadata for default for spring.jmx.registration-policy

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -3076,6 +3076,10 @@
       ]
     },
     {
+      "name": "spring.jmx.registration-policy",
+      "defaultValue": "fail-on-existing"
+    },
+    {
       "name": "spring.jmx.server",
       "providers": [
         {


### PR DESCRIPTION
This PR adds configuration metadata for default value for `spring.jmx.registration-policy` property.

See gh-32573