### PR TITLE
Optimizing the ConfigurationPropertyCaching strategy

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SoftReferenceConfigurationPropertyCache.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SoftReferenceConfigurationPropertyCache.java
@@ -28,10 +28,11 @@ import java.util.function.UnaryOperator;
  *
  * @param <T> the value type
  * @author Phillip Webb
+ * @author Zhuozhi Ji
  */
 class SoftReferenceConfigurationPropertyCache<T> implements ConfigurationPropertyCaching {
 
-	private static final Duration UNLIMITED = Duration.ZERO;
+	private static final Duration DEFAULT = Duration.ofSeconds(30);
 
 	private final boolean neverExpire;
 
@@ -43,11 +44,14 @@ class SoftReferenceConfigurationPropertyCache<T> implements ConfigurationPropert
 
 	SoftReferenceConfigurationPropertyCache(boolean neverExpire) {
 		this.neverExpire = neverExpire;
+		if (!neverExpire) {
+			enable();
+		}
 	}
 
 	@Override
 	public void enable() {
-		this.timeToLive = UNLIMITED;
+		this.timeToLive = DEFAULT;
 	}
 
 	@Override
@@ -96,11 +100,15 @@ class SoftReferenceConfigurationPropertyCache<T> implements ConfigurationPropert
 		if (timeToLive == null || lastAccessed == null) {
 			return true;
 		}
-		return !UNLIMITED.equals(timeToLive) && now().isAfter(lastAccessed.plus(timeToLive));
+		return now().isAfter(lastAccessed.plus(timeToLive));
 	}
 
 	protected Instant now() {
 		return Instant.now();
+	}
+
+	protected Duration getTimeToLive() {
+		return this.timeToLive;
 	}
 
 	protected T getValue() {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SoftReferenceConfigurationPropertyCacheTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SoftReferenceConfigurationPropertyCacheTests.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link SoftReferenceConfigurationPropertyCache}.
  *
  * @author Phillip Webb
+ * @author Zhuozhi Ji
  */
 class SoftReferenceConfigurationPropertyCacheTests {
 
@@ -42,13 +43,6 @@ class SoftReferenceConfigurationPropertyCacheTests {
 	private TestSoftReferenceConfigurationPropertyCache cache = new TestSoftReferenceConfigurationPropertyCache(false);
 
 	@Test
-	void getReturnsValueWithCorrectCounts() {
-		get(this.cache).assertCounts(0, 0);
-		get(this.cache).assertCounts(0, 1);
-		get(this.cache).assertCounts(0, 2);
-	}
-
-	@Test
 	void getWhenNeverExpireReturnsValueWithCorrectCounts() {
 		this.cache = new TestSoftReferenceConfigurationPropertyCache(true);
 		get(this.cache).assertCounts(0, 0);
@@ -57,11 +51,21 @@ class SoftReferenceConfigurationPropertyCacheTests {
 	}
 
 	@Test
-	void enableEnablesCachingWithUnlimitedTimeToLive() {
+	void enableEnablesCachingWithDefaultTimeToLive() {
 		this.cache.enable();
-		get(this.cache).assertCounts(0, 0);
-		tick(Duration.ofDays(300));
-		get(this.cache).assertCounts(0, 0);
+		assertThat(this.cache.getTimeToLive()).hasSeconds(30);
+	}
+
+	@Test
+	void neverExpireTrueWithNullTimeToLive(){
+		SoftReferenceConfigurationPropertyCache<?> cache = new SoftReferenceConfigurationPropertyCache<>(true);
+		assertThat(cache.getTimeToLive()).isNull();
+	}
+
+	@Test
+	void neverExpireFalseWithDefaultTimeToLive(){
+		SoftReferenceConfigurationPropertyCache<?> cache = new SoftReferenceConfigurationPropertyCache<>(false);
+		assertThat(cache.getTimeToLive()).hasSeconds(30);
 	}
 
 	@Test


### PR DESCRIPTION
In this commit, first tried enabling caching by default, if `neverExpire` is false.

Unlimited caching is not a good idea for any dynamic application, especially dynamic configuration. So next tried turning the default duration when enabled, 30s is a reasonable default value. It will neither cause memory pressure nor cause long-term reading of expired configuration.

See [gh-34172](https://github.com/spring-projects/spring-boot/issues/34172)
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
