### PR TITLE
Fix name for Implementation-Title in Spring Boot Gradle plugin

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootArchiveSupport.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootArchiveSupport.java
@@ -87,7 +87,7 @@ class BootArchiveSupport {
 	}
 
 	void configureManifest(Manifest manifest, String mainClass, String classes, String lib, String classPathIndex,
-			String layersIndex, String jdkVersion, String implementationName, Object implementationVersion) {
+			String layersIndex, String jdkVersion, String implementationTitle, Object implementationVersion) {
 		Attributes attributes = manifest.getAttributes();
 		attributes.putIfAbsent("Main-Class", this.loaderMainClass);
 		attributes.putIfAbsent("Start-Class", mainClass);
@@ -101,7 +101,7 @@ class BootArchiveSupport {
 			attributes.putIfAbsent("Spring-Boot-Layers-Index", layersIndex);
 		}
 		attributes.putIfAbsent("Build-Jdk-Spec", jdkVersion);
-		attributes.putIfAbsent("Implementation-Name", implementationName);
+		attributes.putIfAbsent("Implementation-Title", implementationTitle);
 		if (implementationVersion != null) {
 			String versionString = implementationVersion.toString();
 			if (!UNSPECIFIED_VERSION.equals(versionString)) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/AbstractBootArchiveTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/AbstractBootArchiveTests.java
@@ -132,7 +132,7 @@ abstract class AbstractBootArchiveTests<T extends Jar & BootArchive> {
 					.isEqualTo(this.classesPath);
 			assertThat(jarFile.getManifest().getMainAttributes().getValue("Spring-Boot-Lib")).isEqualTo(this.libPath);
 			assertThat(jarFile.getManifest().getMainAttributes().getValue("Spring-Boot-Version")).isNotNull();
-			assertThat(jarFile.getManifest().getMainAttributes().getValue("Implementation-Name"))
+			assertThat(jarFile.getManifest().getMainAttributes().getValue("Implementation-Title"))
 					.isEqualTo(this.project.getName());
 			assertThat(jarFile.getManifest().getMainAttributes().getValue("Implementation-Version")).isNull();
 		}
@@ -141,10 +141,10 @@ abstract class AbstractBootArchiveTests<T extends Jar & BootArchive> {
 	@Test
 	void whenImplementationNameIsCustomizedItShouldAppearInArchiveManifest() throws IOException {
 		this.task.getMainClass().set("com.example.Main");
-		this.task.getManifest().getAttributes().put("Implementation-Name", "Customized");
+		this.task.getManifest().getAttributes().put("Implementation-Title", "Customized");
 		executeTask();
 		try (JarFile jarFile = new JarFile(this.task.getArchiveFile().get().getAsFile())) {
-			assertThat(jarFile.getManifest().getMainAttributes().getValue("Implementation-Name"))
+			assertThat(jarFile.getManifest().getMainAttributes().getValue("Implementation-Title"))
 					.isEqualTo("Customized");
 		}
 	}


### PR DESCRIPTION
This PR fixes the name for the `Implementation-Title` manifest entry in the Spring Boot Gradle plugin as `Implementation-Name` seems to have been typed accidentally.

See gh-34059