### PR TITLE
defaultTracingObservationHandler is not ordered as documented

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/MicrometerTracingAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/MicrometerTracingAutoConfiguration.java
@@ -62,6 +62,7 @@ public class MicrometerTracingAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(Tracer.class)
+	@Order(DEFAULT_TRACING_OBSERVATION_HANDLER_ORDER)
 	public DefaultTracingObservationHandler defaultTracingObservationHandler(Tracer tracer) {
 		return new DefaultTracingObservationHandler(tracer);
 	}


### PR DESCRIPTION
The javadoc on `MicrometerTracingAutoConfiguration.DEFAULT_TRACING_OBSERVATION_HANDLER_ORDER` says it is a `@Order` value for the `defaultTracingObservationHandler` bean.
However, in the code, this constant is not applied to the `defaultTracingObservationHandler` bean definition.

This PR specifies the missing `@Order` on the `defaultTracingObservationHandler` bean.
