### PR TITLE
org.springframework.boot.web.embedded.jetty.GracefulShutdown uses the wrong class to create its logger

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/GracefulShutdown.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/GracefulShutdown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import org.springframework.util.ReflectionUtils;
  */
 final class GracefulShutdown {
 
-	private static final Log logger = LogFactory.getLog(JettyWebServer.class);
+	private static final Log logger = LogFactory.getLog(GracefulShutdown.class);
 
 	private final Server server;
 


### PR DESCRIPTION
Polishing: Update this logger to use "GracefulShutdown.class".