### PR TITLE
Add management.wavefront.application.custom-tags property

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/wavefront/WavefrontAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/wavefront/WavefrontAutoConfiguration.java
@@ -54,6 +54,7 @@ public class WavefrontAutoConfiguration {
 		ApplicationTags.Builder builder = new ApplicationTags.Builder(application.getName(), serviceName);
 		map.from(application::getClusterName).to(builder::cluster);
 		map.from(application::getShardName).to(builder::shard);
+		map.from(application::getCustomTags).to(builder::customTags);
 		return builder.build();
 	}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/wavefront/WavefrontProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/wavefront/WavefrontProperties.java
@@ -20,6 +20,8 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.PushRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -173,6 +175,11 @@ public class WavefrontProperties {
 		 */
 		private String shardName;
 
+		/**
+		 * Wavefront custom tags used in ApplicationTags.
+		 */
+		private Map<String, String> customTags = new HashMap<>();
+
 		public String getServiceName() {
 			return this.serviceName;
 		}
@@ -203,6 +210,14 @@ public class WavefrontProperties {
 
 		public void setShardName(String shardName) {
 			this.shardName = shardName;
+		}
+
+		public Map<String, String> getCustomTags() {
+			return this.customTags;
+		}
+
+		public void setCustomTags(Map<String, String> customTags) {
+			this.customTags = customTags;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/wavefront/WavefrontAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/wavefront/WavefrontAutoConfigurationTests.java
@@ -55,12 +55,15 @@ class WavefrontAutoConfigurationTests {
 		properties.add("management.wavefront.application.service-name=test-service");
 		properties.add("management.wavefront.application.cluster-name=test-cluster");
 		properties.add("management.wavefront.application.shard-name=test-shard");
+		properties.add("management.wavefront.application.custom-tags.foo=FOO");
+		properties.add("management.wavefront.application.custom-tags.bar=BAR");
 		this.contextRunner.withPropertyValues(properties.toArray(String[]::new)).run((context) -> {
 			ApplicationTags tags = context.getBean(ApplicationTags.class);
 			assertThat(tags.getApplication()).isEqualTo("test-application");
 			assertThat(tags.getService()).isEqualTo("test-service");
 			assertThat(tags.getCluster()).isEqualTo("test-cluster");
 			assertThat(tags.getShard()).isEqualTo("test-shard");
+			assertThat(tags.getCustomTags()).hasSize(2).containsEntry("foo", "FOO").containsEntry("bar", "BAR");
 		});
 	}
 
@@ -72,6 +75,7 @@ class WavefrontAutoConfigurationTests {
 			assertThat(tags.getService()).isEqualTo("spring-app");
 			assertThat(tags.getCluster()).isNull();
 			assertThat(tags.getShard()).isNull();
+			assertThat(tags.getCustomTags()).isEmpty();
 		});
 	}
 


### PR DESCRIPTION
Currently, `ApplicationTags` auto configured in `WavefrontAutoConfiguration` does not populate custom tags.
This PR adds `management.wavefront.application.custom-tags` property to populate the corresponding custom tags in `ApplicationTags`.
