### PR TITLE
Add MacOS `.DS_Store` file to  the`.gitignore`

### DIFF
--- a/ci/images/releasescripts/.gitignore
+++ b/ci/images/releasescripts/.gitignore
@@ -29,3 +29,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### MacOS ###
+**/.DS_Store


### PR DESCRIPTION
Every developer working on MacOS has to eventually add `.DS_Store` file to the `.gitignore` file because we don't want OS-specific files to be in repo. 
