### PR TITLE
Unlike @EnableBatchProcessing, auto-configuration for Spring Batch does not enable observability of steps and jobs

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id "java-library"
+	id "java-library"
 	id "org.asciidoctor.jvm.convert"
 	id "org.springframework.boot.auto-configuration"
 	id "org.springframework.boot.conventions"
 	id "org.springframework.boot.deployed"
-    id "org.springframework.boot.optional-dependencies"
+	id "org.springframework.boot.optional-dependencies"
 }
 
 description = "Spring Boot Actuator AutoConfigure"
@@ -116,6 +116,7 @@ dependencies {
 	optional("org.springframework:spring-webflux")
 	optional("org.springframework:spring-webmvc")
 	optional("org.springframework.amqp:spring-rabbit")
+	optional("org.springframework.batch:spring-batch-core")
 	optional("org.springframework.data:spring-data-cassandra") {
 		exclude group: "org.slf4j", module: "jcl-over-slf4j"
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/batch/BatchObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/batch/BatchObservationAutoConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.observation.batch;
+
+import io.micrometer.observation.ObservationRegistry;
+
+import org.springframework.batch.core.configuration.annotation.BatchObservabilityBeanPostProcessor;
+import org.springframework.boot.actuate.autoconfigure.observation.ObservationAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for instrumentation of Spring Batch.
+ * Jobs
+ *
+ * @author Mark Bonnekessel
+ * @since 3.0.3
+ */
+@AutoConfiguration(after = ObservationAutoConfiguration.class)
+@ConditionalOnBean(ObservationRegistry.class)
+@ConditionalOnClass({ ObservationRegistry.class, BatchObservabilityBeanPostProcessor.class })
+@SuppressWarnings("removal")
+public class BatchObservationAutoConfiguration {
+
+	@ConditionalOnMissingBean
+	@Bean
+	public BatchObservabilityBeanPostProcessor batchObservabilityBeanPostProcessor() {
+		return new BatchObservabilityBeanPostProcessor();
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/batch/package-info.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/batch/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Spring Batcn observations.
+ */
+package org.springframework.boot.actuate.autoconfigure.observation.batch;

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/batch/BatchObservationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/batch/BatchObservationAutoConfigurationTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.observation.batch;
+
+import io.micrometer.observation.tck.TestObservationRegistry;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.batch.core.configuration.annotation.BatchObservabilityBeanPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BatchObservationAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withBean(TestObservationRegistry.class, TestObservationRegistry::create)
+		.withConfiguration(AutoConfigurations.of(BatchObservationAutoConfiguration.class));
+
+	@Test
+	void backsOffWhenObservationRegistryIsMissing() {
+		new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(BatchObservationAutoConfiguration.class))
+			.run((context) -> assertThat(context).doesNotHaveBean(BatchObservabilityBeanPostProcessor.class));
+	}
+
+	@Test
+	void beanIsPresentWhenSpringBatchIsPresent() {
+		this.contextRunner
+			.run((context) -> assertThat(context).hasSingleBean(BatchObservabilityBeanPostProcessor.class));
+	}
+
+}


### PR DESCRIPTION
Tracing in Spring-Batch is supported by `BatchObservabilityBeanPostProcessor`.
It is imported by `@EnableBatchProcessing` and provided as a bean.

`@EnableBatchProcessing` is not used by the `BatchAutoConfiguration` in spring-boot. So `BatchObservabilityBeanPostProcessor` has to be provided by spring-boot to enable tracing for spring-batch.
