### PR TITLE
Polish "Add missing Micrometer PropertiesConfigAdapterTests"

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphitePropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/graphite/GraphitePropertiesConfigAdapterTests.java
@@ -55,8 +55,8 @@ class GraphitePropertiesConfigAdapterTests {
 	@Test
 	void whenPropertiesDurationUnitsIsSetAdapterDurationUnitsReturnsIt() {
 		GraphiteProperties properties = new GraphiteProperties();
-		properties.setRateUnits(TimeUnit.MINUTES);
-		assertThat(new GraphitePropertiesConfigAdapter(properties).rateUnits()).isEqualTo(TimeUnit.MINUTES);
+		properties.setDurationUnits(TimeUnit.MINUTES);
+		assertThat(new GraphitePropertiesConfigAdapter(properties).durationUnits()).isEqualTo(TimeUnit.MINUTES);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/newrelic/NewRelicPropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/newrelic/NewRelicPropertiesConfigAdapterTests.java
@@ -63,7 +63,7 @@ class NewRelicPropertiesConfigAdapterTests
 	}
 
 	@Test
-	void whenPropertiesApikeyIsSetAdapterApikeyReturnsIt() {
+	void whenPropertiesApiKeyIsSetAdapterApiKeyReturnsIt() {
 		NewRelicProperties properties = createProperties();
 		properties.setApiKey("my-key");
 		assertThat(createConfigAdapter(properties).apiKey()).isEqualTo("my-key");

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/signalfx/SignalFxPropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/signalfx/SignalFxPropertiesConfigAdapterTests.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Mirko Sobeck
  */
-class SignalFXPropertiesConfigAdapterTests
+class SignalFxPropertiesConfigAdapterTests
 		extends StepRegistryPropertiesConfigAdapterTests<SignalFxProperties, SignalFxPropertiesConfigAdapter> {
 
 	@Override

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimplePropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimplePropertiesConfigAdapterTests.java
@@ -21,12 +21,10 @@ import java.time.Duration;
 import io.micrometer.core.instrument.simple.CountingMode;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.boot.actuate.autoconfigure.metrics.export.signalfx.SignalFxPropertiesConfigAdapter;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link SignalFxPropertiesConfigAdapter}.
+ * Tests for {@link SimplePropertiesConfigAdapter}.
  *
  * @author Mirko Sobeck
  */
@@ -40,7 +38,7 @@ class SimplePropertiesConfigAdapterTests {
 	}
 
 	@Test
-	void whenPropertiesAccessTokenIsSetAdapterAccessTokenReturnsIt() {
+	void whenPropertiesModeIsSetAdapterModeReturnsIt() {
 		SimpleProperties properties = new SimpleProperties();
 		properties.setMode(CountingMode.STEP);
 		assertThat(new SimplePropertiesConfigAdapter(properties).mode()).isEqualTo(CountingMode.STEP);


### PR DESCRIPTION
This PR polishes "Add missing Micrometer PropertiesConfigAdapterTests" changes a bit.

See gh-34205