### PR TITLE
EmbeddedWebServerFactoryCustomizerAutoConfiguration should not run when embedded web server is not configured

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnNotWarDeployment.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnNotWarDeployment.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.condition;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Conditional;
+
+/**
+ * {@link Conditional @Conditional} that only matches when the application is a not
+ * traditional WAR deployment. For applications with embedded servers, this condition will
+ * return true.
+ *
+ * @author Guirong Hu
+ * @since 2.7.10
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Conditional(OnWarDeploymentCondition.class)
+public @interface ConditionalOnNotWarDeployment {
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnWarDeploymentCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnWarDeploymentCondition.java
@@ -29,20 +29,23 @@ import org.springframework.web.context.WebApplicationContext;
  * deployment.
  *
  * @author Madhura Bhave
+ * @see ConditionalOnWarDeployment
+ * @see ConditionalOnNotWarDeployment
  */
 class OnWarDeploymentCondition extends SpringBootCondition {
 
 	@Override
 	public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		boolean required = metadata.isAnnotated(ConditionalOnWarDeployment.class.getName());
 		ResourceLoader resourceLoader = context.getResourceLoader();
 		if (resourceLoader instanceof WebApplicationContext) {
 			WebApplicationContext applicationContext = (WebApplicationContext) resourceLoader;
 			ServletContext servletContext = applicationContext.getServletContext();
 			if (servletContext != null) {
-				return ConditionOutcome.match("Application is deployed as a WAR file.");
+				return new ConditionOutcome(required, "Application is deployed as a WAR file.");
 			}
 		}
-		return ConditionOutcome.noMatch(ConditionMessage.forCondition(ConditionalOnWarDeployment.class)
+		return new ConditionOutcome(!required, ConditionMessage.forCondition(ConditionalOnWarDeployment.class)
 			.because("the application is not deployed as a WAR file."));
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/EmbeddedWebServerFactoryCustomizerAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/EmbeddedWebServerFactoryCustomizerAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import reactor.netty.http.server.HttpServer;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnNotWarDeployment;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -43,6 +44,7 @@ import org.springframework.core.env.Environment;
  * @since 2.0.0
  */
 @AutoConfiguration
+@ConditionalOnNotWarDeployment
 @ConditionalOnWebApplication
 @EnableConfigurationProperties(ServerProperties.class)
 public class EmbeddedWebServerFactoryCustomizerAutoConfiguration {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnNotWarDeploymentTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnNotWarDeploymentTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.condition;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.web.servlet.context.AnnotationConfigServletWebApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConditionalOnNotWarDeployment @ConditionalOnNotWarDeployment}.
+ *
+ * @author Guirong Hu
+ */
+class ConditionalOnNotWarDeploymentTests {
+
+	@Test
+	void nonWebApplicationShouldMatch() {
+		ApplicationContextRunner contextRunner = new ApplicationContextRunner();
+		contextRunner.withUserConfiguration(NotWarDeploymentConfiguration.class)
+			.run((context) -> assertThat(context).hasBean("notForWar"));
+	}
+
+	@Test
+	void reactiveWebApplicationShouldMatch() {
+		ReactiveWebApplicationContextRunner contextRunner = new ReactiveWebApplicationContextRunner();
+		contextRunner.withUserConfiguration(NotWarDeploymentConfiguration.class)
+			.run((context) -> assertThat(context).hasBean("notForWar"));
+	}
+
+	@Test
+	void embeddedServletWebApplicationShouldMatch() {
+		WebApplicationContextRunner contextRunner = new WebApplicationContextRunner(
+				AnnotationConfigServletWebApplicationContext::new);
+		contextRunner.withUserConfiguration(NotWarDeploymentConfiguration.class)
+			.run((context) -> assertThat(context).hasBean("notForWar"));
+	}
+
+	@Test
+	void warDeployedServletWebApplicationShouldNotMatch() {
+		WebApplicationContextRunner contextRunner = new WebApplicationContextRunner();
+		contextRunner.withUserConfiguration(NotWarDeploymentConfiguration.class)
+			.run((context) -> assertThat(context).doesNotHaveBean("notForWar"));
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnNotWarDeployment
+	static class NotWarDeploymentConfiguration {
+
+		@Bean
+		String notForWar() {
+			return "notForWar";
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/developing-auto-configuration.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/developing-auto-configuration.adoc
@@ -129,7 +129,7 @@ The `@ConditionalOnWebApplication` and `@ConditionalOnNotWebApplication` annotat
 A servlet-based web application is any application that uses a Spring `WebApplicationContext`, defines a `session` scope, or has a `ConfigurableWebEnvironment`.
 A reactive web application is any application that uses a `ReactiveWebApplicationContext`, or has a `ConfigurableReactiveWebEnvironment`.
 
-The `@ConditionalOnWarDeployment` annotation lets configuration be included depending on whether the application is a traditional WAR application that is deployed to a container.
+The `@ConditionalOnWarDeployment` and `@ConditionalOnNotWarDeployment` annotation lets configuration be included depending on whether the application is a traditional WAR application that is deployed to a container.
 This condition will not match for applications that are run with an embedded server.
 
 


### PR DESCRIPTION
Disable auto-configure factory customizer when not using embedded web server.

Closes gh-34189

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
