### PR TITLE
Configure maven.compiler.release in spring-boot-starter-parent to prevent impossible JDK API usage

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
@@ -23,6 +23,7 @@ publishing.publications.withType(MavenPublication) {
 				delegate."resource.delimiter"('@')
 				delegate."maven.compiler.source"('${java.version}')
 				delegate."maven.compiler.target"('${java.version}')
+				delegate."maven.compiler.release"('${java.version}')
 				delegate."project.build.sourceEncoding"('UTF-8')
 				delegate."project.reporting.outputEncoding"('UTF-8')
 			}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

When cross compiling with newer JDKs against an older JDK API, it might happen, that a JDK API is used, which is not available in the intended Java version. Using maven.compiler.release will migitate this.

- [Maven Compiler Plugin Documentation](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#release)
- [Baeldung Explanation for the release flag](https://www.baeldung.com/java-compiler-release-option)
