### PR TITLE
Add build-info skip support

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildInfoMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildInfoMojo.java
@@ -97,8 +97,18 @@ public class BuildInfoMojo extends AbstractMojo {
 	@Parameter
 	private List<String> excludeInfoProperties;
 
+	/**
+	 * Skip the execution.
+	 */
+	@Parameter(property = "spring-boot.build-info.skip", defaultValue = "false")
+	private boolean skip;
+
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
+		if (this.skip) {
+			getLog().debug("skipping build-info as per configuration.");
+			return;
+		}
 		try {
 			ProjectDetails details = getProjectDetails();
 			new BuildPropertiesWriter(this.outputFile).writeBuildProperties(details);


### PR DESCRIPTION
Allow skip `build-info` maven goal via `-Dspring-boot.build-info.skip`, as other spring-boot maven goals do, e.g. `-Dspring-boot.repackage.skip`