### PR TITLE
Add Javadoc since to BuildInfoMojo.skip

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildInfoMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildInfoMojo.java
@@ -99,6 +99,7 @@ public class BuildInfoMojo extends AbstractMojo {
 
 	/**
 	 * Skip the execution.
+	 * @since 3.1.0
 	 */
 	@Parameter(property = "spring-boot.build-info.skip", defaultValue = "false")
 	private boolean skip;


### PR DESCRIPTION
This PR adds Javadoc `@since` tag to the `BuildInfoMojo.skip` parameter.

See gh-34393