### PR TITLE
Remove final from ProblemDetailsExceptionHandler classes to allow proxying

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-autoconfigure/build.gradle
@@ -221,6 +221,7 @@ dependencies {
 	testImplementation("com.querydsl:querydsl-core")
 	testImplementation("com.squareup.okhttp3:mockwebserver")
 	testImplementation("com.sun.xml.messaging.saaj:saaj-impl")
+	testImplementation("com.tngtech.archunit:archunit-junit5:0.22.0")
 	testImplementation("io.projectreactor:reactor-test")
 	testImplementation("io.r2dbc:r2dbc-h2")
 	testImplementation("jakarta.json:jakarta.json-api")

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/ProblemDetailsExceptionHandler.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/ProblemDetailsExceptionHandler.java
@@ -26,6 +26,6 @@ import org.springframework.web.reactive.result.method.annotation.ResponseEntityE
  * @author Brian Clozel
  */
 @ControllerAdvice
-final class ProblemDetailsExceptionHandler extends ResponseEntityExceptionHandler {
+class ProblemDetailsExceptionHandler extends ResponseEntityExceptionHandler {
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/ProblemDetailsExceptionHandler.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/ProblemDetailsExceptionHandler.java
@@ -26,6 +26,6 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
  * @author Brian Clozel
  */
 @ControllerAdvice
-final class ProblemDetailsExceptionHandler extends ResponseEntityExceptionHandler {
+class ProblemDetailsExceptionHandler extends ResponseEntityExceptionHandler {
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/SpringArchUnitTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/SpringArchUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/SpringArchUnitTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/SpringArchUnitTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.core.importer.Location;
+
+import java.util.regex.Pattern;
+
+/**
+ * @author Volkan Yazıcı
+ */
+public final class SpringArchUnitTests {
+
+	public static final class ExcludeTestsOption implements ImportOption {
+
+		@Override
+		public boolean includes(Location location) {
+			return !location.matches(Pattern.compile(".*Tests\\.class"));
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/ResponseEntityExceptionHandlerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/ResponseEntityExceptionHandlerTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.web.reactive;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import org.springframework.boot.autoconfigure.SpringArchUnitTests;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.reactive.result.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.List;
+
+import static com.tngtech.archunit.base.DescribedPredicate.greaterThanOrEqualTo;
+
+/**
+ * Tests for {@link ProblemDetailsExceptionHandler} using {@link SpringBootTest}.
+ *
+ * @author Volkan Yazıcı
+ */
+@AnalyzeClasses(packages = "org.springframework.boot.autoconfigure.web.reactive",
+		importOptions = SpringArchUnitTests.ExcludeTestsOption.class)
+class ResponseEntityExceptionHandlerTests {
+
+	@ArchTest
+	void exceptionHandlerShouldNotBeFinal(JavaClasses classes) { // gh-34426
+		int minMatchingClassCount = List.of(ProblemDetailsExceptionHandler.class).size();
+		ArchRuleDefinition.classes()
+			.that()
+			.areAssignableTo(ResponseEntityExceptionHandler.class)
+			.should()
+			// Ensure we are not working against an empty set:
+			.containNumberOfElements(greaterThanOrEqualTo(minMatchingClassCount))
+			// Avoid `final` modifiers:
+			.andShould()
+			.notHaveModifier(JavaModifier.FINAL)
+			.check(classes);
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/ResponseEntityExceptionHandlerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/ResponseEntityExceptionHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ResponseEntityExceptionHandlerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ResponseEntityExceptionHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ResponseEntityExceptionHandlerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ResponseEntityExceptionHandlerTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.web.servlet;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import org.springframework.boot.autoconfigure.SpringArchUnitTests;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.reactive.result.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.List;
+
+import static com.tngtech.archunit.base.DescribedPredicate.greaterThanOrEqualTo;
+
+/**
+ * Tests for {@link ProblemDetailsExceptionHandler} using {@link SpringBootTest}.
+ *
+ * @author Volkan Yazıcı
+ */
+@AnalyzeClasses(packages = "org.springframework.boot.autoconfigure.web.servlet",
+		importOptions = SpringArchUnitTests.ExcludeTestsOption.class)
+class ResponseEntityExceptionHandlerTests {
+
+	@ArchTest
+	void exceptionHandlerShouldNotBeFinal(JavaClasses classes) { // gh-34426
+		int minMatchingClassCount = List.of(ProblemDetailsExceptionHandler.class).size();
+		ArchRuleDefinition.classes()
+			.that()
+			.areAssignableTo(ResponseEntityExceptionHandler.class)
+			.should()
+			// Ensure we are not working against an empty set:
+			.containNumberOfElements(greaterThanOrEqualTo(minMatchingClassCount))
+			// Avoid `final` modifiers:
+			.andShould()
+			.notHaveModifier(JavaModifier.FINAL)
+			.check(classes);
+	}
+
+}


### PR DESCRIPTION
Removes `final` modifier from `ProblemDetailsExceptionHandler` implementations to allow proxying these beans. See #34426 for the issue.