### PR TITLE
Add documentation tip showing how to configure publishRegistry Maven properties from the command line

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging-oci-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging-oci-image.adoc
@@ -363,6 +363,25 @@ The `publish` option can be specified on the command line as well, as shown in t
 	$ mvn spring-boot:build-image -Dspring-boot.build-image.imageName=docker.example.com/library/my-app:v1 -Dspring-boot.build-image.publish=true
 ----
 
+If you intend to invoke the `publish` option on the command line, with authentication, you'll need the combination of this command line:
+
+[indent=0]
+----
+	$ mvn spring-boot:build-image \
+          -Ddocker.publishRegistry.username=user \
+          -Ddocker.publishRegistry.password=secret \
+          -Ddocker.publishRegistry.url=docker.example.com \
+          -Dspring-boot.build-image.publish=true \
+          -Dspring-boot.build-image.imageName=docker.example.com/library/my-app:v1 \
+----
+
+and this XML configuration:
+
+[source,xml,indent=0,subs="verbatim,attributes",tabsize=4]
+----
+include::../maven/packaging-oci-image/docker-pom-authentication-command-line.xml[tags=docker]
+----
+
 [[build-image.examples.caches]]
 === Builder Cache Configuration
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/maven/packaging-oci-image/docker-pom-authentication-command-line.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/maven/packaging-oci-image/docker-pom-authentication-command-line.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- tag::docker[] -->
+<project>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<docker>
+						<publishRegistry>
+							<url>${docker.publishRegistry.url}</url>
+							<username>${docker.publishRegistry.username}</username>
+							<password>${docker.publishRegistry.password}</password>
+						</publishRegistry>
+					</docker>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>
+<!-- end::docker[] -->


### PR DESCRIPTION
* the publishRegistry element has to be configured via a combination of maven command line arguments and maven variables in the pom

Fixes #31024
