### PR TITLE
Update two references to old APIs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/sql.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/data/sql.adoc
@@ -298,7 +298,7 @@ For more advanced queries, a `@Query` annotation is provided.
 
 Spring Boot will auto-configure Spring Data's JDBC repositories when the necessary dependencies are on the classpath.
 They can be added to your project with a single dependency on `spring-boot-starter-data-jdbc`.
-If necessary, you can take control of Spring Data JDBC's configuration by adding the `@EnableJdbcRepositories` annotation or a `JdbcConfiguration` subclass to your application.
+If necessary, you can take control of Spring Data JDBC's configuration by adding the `@EnableJdbcRepositories` annotation or a `AbstractJdbcConfiguration` subclass to your application.
 
 TIP: For complete details of Spring Data JDBC, see the {spring-data-jdbc-docs}[reference documentation].
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/spring-application.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/spring-application.adoc
@@ -287,7 +287,7 @@ The algorithm used to determine a `WebApplicationType` is the following:
 This means that if you are using Spring MVC and the new `WebClient` from Spring WebFlux in the same application, Spring MVC will be used by default.
 You can override that easily by calling `setWebApplicationType(WebApplicationType)`.
 
-It is also possible to take complete control of the `ApplicationContext` type that is used by calling `setApplicationContextClass(...)`.
+It is also possible to take complete control of the `ApplicationContext` type that is used by calling `setApplicationContextFactory(...)`.
 
 TIP: It is often desirable to call `setWebApplicationType(WebApplicationType.NONE)` when using `SpringApplication` within a JUnit test.
 


### PR DESCRIPTION
- `JdbcConfiguration` has been removed in this [commit](https://github.com/spring-projects/spring-data-relational/commit/2b6f7b2b480650ed594e04c0838d4e06005f19c5). 
- `setApplicationContextClass` has been removed in this [commit](https://github.com/spring-projects/spring-boot/commit/dc5acb00191c2eac09907c39e4d890343bf9848d). 