### PR TITLE
Added runtime hints for weaver-messages

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/aop/AopAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/aop/AopAutoConfiguration.java
@@ -18,7 +18,10 @@ package org.springframework.boot.autoconfigure.aop;
 
 import org.aspectj.weaver.Advice;
 
+import org.aspectj.weaver.WeaverMessages;
 import org.springframework.aop.config.AopConfigUtils;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -65,7 +68,14 @@ public class AopAutoConfiguration {
 		static class CglibAutoProxyConfiguration {
 
 		}
+	}
 
+	@ConditionalOnClass(WeaverMessages.class)
+	static class AspectJRuntimeHints implements RuntimeHintsRegistrar {
+		@Override
+		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+			hints.resources().registerResourceBundle("org.aspectj.weaver.weaver-messages");
+		}
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring/aot.factories
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring/aot.factories
@@ -1,5 +1,6 @@
 org.springframework.aot.hint.RuntimeHintsRegistrar=\
 org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration.JacksonAutoConfigurationRuntimeHints,\
+org.springframework.boot.autoconfigure.aop.AopAutoConfiguration.AspectJRuntimeHints,\
 org.springframework.boot.autoconfigure.template.TemplateRuntimeHints
 
 org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor=\


### PR DESCRIPTION
When the AOP is failling due to an exception, it uses the weaver-messages to print the exception. 
If the application is built native, another is excpetion is thrown because it cannot find the resources  for `org.aspectj.weaver.weaver-messages`. 

This PR will add a hint for the resources.


``` 
2023-03-10T06:42:43.871Z ERROR 1 --- [           main] o.s.boot.SpringApplication               : Application run failed
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'configurationPropertiesBeans': null
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:606) ~[com.deder.wol.WolApplicationKt:6.0.6]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:521) ~[com.deder.wol.WolApplicationKt:6.0.6]
        at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:326) ~[com.deder.wol.WolApplicationKt:6.0.6]
        at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) ~[com.deder.wol.WolApplicationKt:6.0.6]
        at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:324) ~[com.deder.wol.WolApplicationKt:6.0.6]
        at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:205) ~[com.deder.wol.WolApplicationKt:6.0.6]
        at org.springframework.context.support.PostProcessorRegistrationDelegate.registerBeanPostProcessors(PostProcessorRegistrationDelegate.java:273) ~[na:na]
        at org.springframework.context.support.AbstractApplicationContext.registerBeanPostProcessors(AbstractApplicationContext.java:763) ~[com.deder.wol.WolApplicationKt:6.0.6]
        at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:568) ~[com.deder.wol.WolApplicationKt:6.0.6]
        at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146) ~[com.deder.wol.WolApplicationKt:3.0.4]
        at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:732) ~[com.deder.wol.WolApplicationKt:3.0.4]
        at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:434) ~[com.deder.wol.WolApplicationKt:3.0.4]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:310) ~[com.deder.wol.WolApplicationKt:3.0.4]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:1304) ~[com.deder.wol.WolApplicationKt:3.0.4]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:1293) ~[com.deder.wol.WolApplicationKt:3.0.4]
        at com.deder.wol.WolApplicationKt.main(WolApplication.kt:13) ~[com.deder.wol.WolApplicationKt:na]
Caused by: java.lang.ExceptionInInitializerError: null
        at org.aspectj.weaver.patterns.ExactAnnotationTypePattern.verifyIsAnnotationType(ExactAnnotationTypePattern.java:354) ~[com.deder.wol.WolApplicationKt:na]
        at org.aspectj.weaver.patterns.ExactAnnotationTypePattern.resolveBindings(ExactAnnotationTypePattern.java:318) ~[com.deder.wol.WolApplicationKt:na]
        at org.aspectj.weaver.patterns.AnnotationPointcut.resolveBindings(AnnotationPointcut.java:184) ~[na:na]
        at org.aspectj.weaver.patterns.Pointcut.resolve(Pointcut.java:189) ~[com.deder.wol.WolApplicationKt:na]
        at org.aspectj.weaver.tools.PointcutParser.resolvePointcutExpression(PointcutParser.java:331) ~[com.deder.wol.WolApplicationKt:na]
        at org.aspectj.weaver.reflect.InternalUseOnlyPointcutParser.resolvePointcutExpression(InternalUseOnlyPointcutParser.java:36) ~[na:na]
        at org.aspectj.weaver.reflect.Java15ReflectionBasedReferenceTypeDelegate.getDeclaredPointcuts(Java15ReflectionBasedReferenceTypeDelegate.java:307) ~[na:na]
        at org.aspectj.weaver.ReferenceType.getDeclaredPointcuts(ReferenceType.java:890) ~[com.deder.wol.WolApplicationKt:1.9.19]
        at org.aspectj.weaver.ResolvedType$PointcutGetter.get(ResolvedType.java:261) ~[na:na]
        at org.aspectj.weaver.ResolvedType$PointcutGetter.get(ResolvedType.java:258) ~[na:na]
        at org.aspectj.weaver.Iterators$4$1.hasNext(Iterators.java:213) ~[na:na]
        at org.aspectj.weaver.Iterators$4.hasNext(Iterators.java:230) ~[na:na]
        at org.aspectj.weaver.ResolvedType.findPointcut(ResolvedType.java:767) ~[com.deder.wol.WolApplicationKt:1.9.19]
        at org.aspectj.weaver.patterns.ReferencePointcut.resolveBindings(ReferencePointcut.java:148) ~[na:na]
        at org.aspectj.weaver.patterns.OrPointcut.resolveBindings(OrPointcut.java:88) ~[na:na]
        at org.aspectj.weaver.patterns.Pointcut.resolve(Pointcut.java:189) ~[com.deder.wol.WolApplicationKt:na]
        at org.aspectj.weaver.tools.PointcutParser.resolvePointcutExpression(PointcutParser.java:331) ~[com.deder.wol.WolApplicationKt:na]
        at org.aspectj.weaver.tools.PointcutParser.parsePointcutExpression(PointcutParser.java:312) ~[com.deder.wol.WolApplicationKt:na]
        at org.springframework.aop.aspectj.AspectJExpressionPointcut.buildPointcutExpression(AspectJExpressionPointcut.java:222) ~[na:na]
        at org.springframework.aop.aspectj.AspectJExpressionPointcut.obtainPointcutExpression(AspectJExpressionPointcut.java:193) ~[na:na]
        at org.springframework.aop.aspectj.AspectJExpressionPointcut.getClassFilter(AspectJExpressionPointcut.java:172) ~[na:na]
        at org.springframework.aop.support.AopUtils.canApply(AopUtils.java:226) ~[na:na]
        at org.springframework.aop.support.AopUtils.canApply(AopUtils.java:288) ~[na:na]
        at org.springframework.aop.support.AopUtils.findAdvisorsThatCanApply(AopUtils.java:320) ~[na:na]
        at org.springframework.aop.framework.autoproxy.AbstractAdvisorAutoProxyCreator.findAdvisorsThatCanApply(AbstractAdvisorAutoProxyCreator.java:128) ~[com.deder.wol.WolApplicationKt:6.0.6]
        at org.springframework.aop.framework.autoproxy.AbstractAdvisorAutoProxyCreator.findEligibleAdvisors(AbstractAdvisorAutoProxyCreator.java:97) ~[com.deder.wol.WolApplicationKt:6.0.6]
        at org.springframework.aop.framework.autoproxy.AbstractAdvisorAutoProxyCreator.getAdvicesAndAdvisorsForBean(AbstractAdvisorAutoProxyCreator.java:78) ~[com.deder.wol.WolApplicationKt:6.0.6]
        at org.springframework.aop.framework.autoproxy.AbstractAutoProxyCreator.wrapIfNecessary(AbstractAutoProxyCreator.java:366) ~[com.deder.wol.WolApplicationKt:6.0.6]
        at org.springframework.aop.framework.autoproxy.AbstractAutoProxyCreator.postProcessAfterInitialization(AbstractAutoProxyCreator.java:318) ~[com.deder.wol.WolApplicationKt:6.0.6]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsAfterInitialization(AbstractAutowireCapableBeanFactory.java:435) ~[com.deder.wol.WolApplicationKt:6.0.6]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1765) ~[com.deder.wol.WolApplicationKt:6.0.6]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:599) ~[com.deder.wol.WolApplicationKt:6.0.6]
        ... 15 common frames omitted
Caused by: java.util.MissingResourceException: Can't find bundle for base name org.aspectj.weaver.weaver-messages, locale en_US
        at java.base@17.0.6/java.util.ResourceBundle.throwMissingResourceException(ResourceBundle.java:2045) ~[com.deder.wol.WolApplicationKt:na]
        at java.base@17.0.6/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1683) ~[com.deder.wol.WolApplicationKt:na]
        at java.base@17.0.6/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1586) ~[com.deder.wol.WolApplicationKt:na]
        at java.base@17.0.6/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1549) ~[com.deder.wol.WolApplicationKt:na]
        at java.base@17.0.6/java.util.ResourceBundle.getBundle(ResourceBundle.java:858) ~[com.deder.wol.WolApplicationKt:na]
        at org.aspectj.weaver.WeaverMessages.<clinit>(WeaverMessages.java:19) ~[na:na]
        ... 47 common frames omitted
``` 