### PR TITLE
Replaces deprecated snakeyaml Representer constructor

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/OriginTrackedYamlLoader.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/OriginTrackedYamlLoader.java
@@ -77,8 +77,8 @@ class OriginTrackedYamlLoader extends YamlProcessor {
 
 	private Yaml createYaml(LoaderOptions loaderOptions) {
 		BaseConstructor constructor = new OriginTrackingConstructor(loaderOptions);
-		Representer representer = new Representer();
 		DumperOptions dumperOptions = new DumperOptions();
+		Representer representer = new Representer(dumperOptions);
 		Resolver resolver = HAS_RESOLVER_LIMIT ? new NoTimestampResolverWithLimit() : new NoTimestampResolver();
 		return new Yaml(constructor, representer, dumperOptions, loaderOptions, resolver);
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Because of the recent CVEs in SnakeYAML, many projects need to bump snake-yaml version to 2.0 or higher.  But some deprecated codes in 1.33 have been removed in 2.0 which blocks the upgrade. This PR is about one of them which is used in Spring Boot 2.7.x source code. 

This is essentially the same change as [this commit](https://github.com/spring-projects/spring-boot/commit/bf5bd4f91c8b5617b589795b4db6a2371b26d5f5
) in 3.0 source but without dependency upgrade. 
