### PR TITLE
fix: issues-34505

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -285,6 +285,14 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 	private void stopAndReset(LoggerContext loggerContext) {
 		loggerContext.stop();
 		loggerContext.reset();
+
+		// FIXME: At this point, all initial default states (including appenders and filters) of loggerContext have been cleared.
+		// If other loggers are still printing logs (such as org.springframework.jndi.JndiTemplate which reads environment variable values from <springProperty scope="context" ...>),
+		// a warning noAppenderDefinedWarning will be issued, causing StatusPrinter.printInCaseOfErrorsOrWarnings(loggerContext) to be executed.
+		// This will ultimately result in a large amount of unimportant logs being printed before SpringBoot completes startup.
+
+		loggerContext.getTurboFilterList().add(FILTER);
+
 		if (isBridgeHandlerInstalled()) {
 			addLevelChangePropagator(loggerContext);
 		}


### PR DESCRIPTION
fix: Logback INFO messages are always reported if other loggers are still printing logs before SpringBoot completes startup

https://github.com/spring-projects/spring-boot/issues/34505