### PR TITLE
Close #34505: Ignore other loggers print logs until logback configuration is complete.

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -285,6 +285,8 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 	private void stopAndReset(LoggerContext loggerContext) {
 		loggerContext.stop();
 		loggerContext.reset();
+		// Ignore other loggers print messages until logback configuration is complete.
+		loggerContext.getTurboFilterList().add(FILTER);
 		if (isBridgeHandlerInstalled()) {
 			addLevelChangePropagator(loggerContext);
 		}


### PR DESCRIPTION
- Logback INFO messages are always reported if other loggers are still printing logs before logback configuration is complete.
- I have found an issue in the `org.springframework.boot.logging.logback.LogbackLoggingSystem` class, specifically on line 280. At this point, all initial default states (including appenders and filters) of loggerContext have been cleared. If other loggers are still printing logs (such as `org.springframework.jndi.JndiTemplate` which reads environment variable values from `<springProperty scope="context" ...>`), a warning `noAppenderDefinedWarning` will be issued, causing `StatusPrinter.printInCaseOfErrorsOrWarnings(loggerContext)` to be executed. This will ultimately result in a large amount of unimportant logs being printed before SpringBoot completes startup.

Fixes https://github.com/spring-projects/spring-boot/issues/34505