### PR TITLE
Polish Javadoc since tags for gh-34324

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/DockerApi.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/DockerApi.java
@@ -284,6 +284,7 @@ public class DockerApi {
 		 * @param exports a consumer to receive the layer tar file paths (file can only be
 		 * accessed during the callback)
 		 * @throws IOException on IO error
+		 * @since 2.7.10
 		 */
 		public void exportLayerFiles(ImageReference reference, IOBiConsumer<String, Path> exports) throws IOException {
 			Assert.notNull(reference, "Reference must not be null");

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/ImageArchiveManifest.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/ImageArchiveManifest.java
@@ -31,7 +31,7 @@ import org.springframework.boot.buildpack.platform.json.MappedObject;
  * Image archive manifest information.
  *
  * @author Scott Frederick
- * @since 2.7.9
+ * @since 2.7.10
  */
 public class ImageArchiveManifest extends MappedObject {
 


### PR DESCRIPTION
This PR polishes Javadoc `@since` tags for gh-34324.

See gh-34324