### PR TITLE
Include setter-only properties in metadata

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/JavaBeanPropertyDescriptor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/JavaBeanPropertyDescriptor.java
@@ -36,7 +36,7 @@ class JavaBeanPropertyDescriptor extends PropertyDescriptor<ExecutableElement> {
 	@Override
 	protected boolean isProperty(MetadataGenerationEnvironment env) {
 		boolean isCollection = env.getTypeUtils().isCollectionOrMap(getType());
-		return !env.isExcluded(getType()) && getGetter() != null && (getSetter() != null || isCollection);
+		return !env.isExcluded(getType()) && (getSetter() != null || isCollection);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeElementMembers.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeElementMembers.java
@@ -113,7 +113,7 @@ class TypeElementMembers {
 		return getMatchingAccessor(candidates, type, ExecutableElement::getReturnType);
 	}
 
-	private ExecutableElement getMatchingSetter(List<ExecutableElement> candidates, TypeMirror type) {
+	ExecutableElement getMatchingSetter(List<ExecutableElement> candidates, TypeMirror type) {
 		return getMatchingAccessor(candidates, type, (candidate) -> candidate.getParameters().get(0).asType());
 	}
 
@@ -195,6 +195,10 @@ class TypeElementMembers {
 
 	Map<String, List<ExecutableElement>> getPublicGetters() {
 		return Collections.unmodifiableMap(this.publicGetters);
+	}
+
+	Map<String, List<ExecutableElement>> getPublicSetters() {
+		return Collections.unmodifiableMap(this.publicSetters);
 	}
 
 	ExecutableElement getPublicGetter(String name, TypeMirror type) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -113,9 +113,8 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 			.withDescription("A simple flag.")
 			.withDeprecation(null, null));
 		assertThat(metadata).has(Metadata.withProperty("simple.number", Long.class)
-				.fromSource(SimpleProperties.class)
-				.withDescription("A setter-only property.")
-		);
+			.fromSource(SimpleProperties.class)
+			.withDescription("A setter-only property."));
 		assertThat(metadata).has(Metadata.withProperty("simple.comparator"));
 		assertThat(metadata).doesNotHave(Metadata.withProperty("simple.size"));
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -112,8 +112,11 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 			.fromSource(SimpleProperties.class)
 			.withDescription("A simple flag.")
 			.withDeprecation(null, null));
+		assertThat(metadata).has(Metadata.withProperty("simple.number", Long.class)
+				.fromSource(SimpleProperties.class)
+				.withDescription("A setter-only property.")
+		);
 		assertThat(metadata).has(Metadata.withProperty("simple.comparator"));
-		assertThat(metadata).doesNotHave(Metadata.withProperty("simple.counter"));
 		assertThat(metadata).doesNotHave(Metadata.withProperty("simple.size"));
 	}
 
@@ -404,7 +407,9 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 	void invalidAccessor() {
 		ConfigurationMetadata metadata = compile(InvalidAccessorProperties.class);
 		assertThat(metadata).has(Metadata.withGroup("config"));
-		assertThat(metadata.getItems()).hasSize(1);
+		// ensure valid property is still found
+		assertThat(metadata).has(Metadata.withProperty("config.flag").withDefaultValue(false));
+		assertThat(metadata.getItems()).hasSize(2);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/JavaBeanPropertyDescriptorTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/JavaBeanPropertyDescriptorTests.java
@@ -110,17 +110,17 @@ class JavaBeanPropertyDescriptorTests extends PropertyDescriptorTests {
 	}
 
 	@Test
-	void javaBeanSimplePropertyWithOnlySetterShouldNotBeExposed() throws IOException {
+	void javaBeanSimplePropertyWithOnlySetterShouldBeExposed() throws IOException {
 		process(SimpleProperties.class, (roundEnv, metadataEnv) -> {
 			TypeElement ownerElement = roundEnv.getRootElement(SimpleProperties.class);
-			VariableElement field = getField(ownerElement, "counter");
-			JavaBeanPropertyDescriptor property = new JavaBeanPropertyDescriptor(ownerElement, null, null, "counter",
-					field.asType(), field, getMethod(ownerElement, "setCounter"));
-			assertThat(property.getName()).isEqualTo("counter");
+			VariableElement field = getField(ownerElement, "number");
+			JavaBeanPropertyDescriptor property = new JavaBeanPropertyDescriptor(ownerElement, null, null, "number",
+					field.asType(), field, getMethod(ownerElement, "setNumber"));
+			assertThat(property.getName()).isEqualTo("number");
 			assertThat(property.getSource()).isSameAs(property.getGetter());
 			assertThat(property.getGetter()).isNull();
-			assertThat(property.getSetter().getSimpleName()).hasToString("setCounter");
-			assertThat(property.isProperty(metadataEnv)).isFalse();
+			assertThat(property.getSetter().getSimpleName()).hasToString("setNumber");
+			assertThat(property.isProperty(metadataEnv)).isTrue();
 			assertThat(property.isNested(metadataEnv)).isFalse();
 		});
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/MergeMetadataGenerationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/MergeMetadataGenerationTests.java
@@ -79,7 +79,7 @@ class MergeMetadataGenerationTests extends AbstractMetadataGenerationTests {
 			.withDescription("A simple flag.")
 			.withDeprecation(null, null)
 			.withDefaultValue(true));
-		assertThat(metadata.getItems()).hasSize(4);
+		assertThat(metadata.getItems()).hasSize(5);
 	}
 
 	@Test
@@ -88,7 +88,7 @@ class MergeMetadataGenerationTests extends AbstractMetadataGenerationTests {
 				true, null);
 		writeAdditionalMetadata(property);
 		ConfigurationMetadata metadata = compile(SimpleProperties.class, SimpleConflictingProperties.class);
-		assertThat(metadata.getItems()).hasSize(6);
+		assertThat(metadata.getItems()).hasSize(7);
 		List<ItemMetadata> items = metadata.getItems()
 			.stream()
 			.filter((item) -> item.getName().equals("simple.flag"))
@@ -121,7 +121,7 @@ class MergeMetadataGenerationTests extends AbstractMetadataGenerationTests {
 		assertThat(metadata).has(Metadata.withProperty("simple.comparator", "java.util.Comparator<?>")
 			.fromSource(SimpleProperties.class)
 			.withDescription("A nice comparator."));
-		assertThat(metadata.getItems()).hasSize(4);
+		assertThat(metadata.getItems()).hasSize(5);
 	}
 
 	@Test
@@ -133,7 +133,7 @@ class MergeMetadataGenerationTests extends AbstractMetadataGenerationTests {
 		assertThat(metadata).has(Metadata.withProperty("simple.comparator", "java.util.Comparator<?>")
 			.fromSource(SimpleProperties.class)
 			.withDeprecation("Don't use this.", "simple.complex-comparator", "error"));
-		assertThat(metadata.getItems()).hasSize(4);
+		assertThat(metadata.getItems()).hasSize(5);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/PropertyDescriptorResolverTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/PropertyDescriptorResolverTests.java
@@ -65,8 +65,8 @@ class PropertyDescriptorResolverTests {
 
 	@Test
 	void propertiesWithJavaBeanProperties() throws IOException {
-		process(SimpleProperties.class,
-				propertyNames((stream) -> assertThat(stream).containsExactly("theName", "flag", "comparator", "number")));
+		process(SimpleProperties.class, propertyNames(
+				(stream) -> assertThat(stream).containsExactly("theName", "flag", "comparator", "number")));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/PropertyDescriptorResolverTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/PropertyDescriptorResolverTests.java
@@ -66,7 +66,7 @@ class PropertyDescriptorResolverTests {
 	@Test
 	void propertiesWithJavaBeanProperties() throws IOException {
 		process(SimpleProperties.class,
-				propertyNames((stream) -> assertThat(stream).containsExactly("theName", "flag", "comparator")));
+				propertyNames((stream) -> assertThat(stream).containsExactly("theName", "flag", "comparator", "number")));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/SimpleProperties.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/SimpleProperties.java
@@ -47,8 +47,13 @@ public class SimpleProperties {
 	// ignored
 	private FeatureDescriptor featureDescriptor;
 
-	// There is only a setter on this "simple" property --> ignored
+	/**
+	 * A setter-only property.
+	 */
 	@SuppressWarnings("unused")
+	private Long number;
+
+	// There is no getter nor setter on this "simple" property --> ignored
 	private Long counter;
 
 	// There is only a getter on this "simple" property --> ignored
@@ -84,8 +89,8 @@ public class SimpleProperties {
 		return this.featureDescriptor;
 	}
 
-	public void setCounter(Long counter) {
-		this.counter = counter;
+	public void setNumber(Long number) {
+		this.number = number;
 	}
 
 	public Integer getSize() {


### PR DESCRIPTION
`@ConfigurationProperties` on a `@Bean` method allows to set properties based on setters, so those properties should also be included in metadata.

Fixes #34309.

It seems that not exposing setter-only properties is by design, some test actually test that; I have ~not~ adjusted them ~yet~, but intend to do that, still wanted I wanted to share my code early to get some feedback on this already, and not go to far before verifying this is actually wanted.

I started this mainly for collecting experience using this specific problem I have -- If there is already a alternative implementation in the works I have no problem stopping here. :)

I think this will expose a number of (leaf) properties that have no string representation (and thus are likely not useful for IDEs nor reports), I'll check if it is possible to exclude such properties in this scope, or if it is too big for this and needs to be done/discussed separately.

<!--

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
