### PR TITLE
Fix Javadoc in JobLauncherApplicationRunner

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunner.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunner.java
@@ -57,9 +57,9 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
- * {@link ApplicationRunner} to {@link JobLauncher launch} Spring Batch jobs. Runs all
- * jobs in the surrounding context by default. Can also be used to launch a specific job
- * by providing a jobName
+ * {@link ApplicationRunner} to {@link JobLauncher launch} Spring Batch jobs.
+ * If a single job is found in the context, it will be executed by default.
+ * If multiple jobs are found, launch a specific job by providing a jobName
  *
  * @author Dave Syer
  * @author Jean-Pierre Bergamin


### PR DESCRIPTION
The JobLauncherApplicationRunner does not launch multiple jobs by the commit - https://github.com/spring-projects/spring-boot/commit/55d6a87fefcd1f258a0ca5bc104b82b3bebf8aa1 .
The Javadoc in JobLauncherApplicationRunner was not updated, so this pr fixed it.