### PR TITLE
Avoid repeated class lookups in tests

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/RestDocsTestExecutionListener.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/RestDocsTestExecutionListener.java
@@ -33,7 +33,9 @@ import org.springframework.util.ClassUtils;
  */
 public class RestDocsTestExecutionListener extends AbstractTestExecutionListener {
 
-	private static final String REST_DOCS_CLASS = "org.springframework.restdocs.ManualRestDocumentation";
+	private static final boolean REST_DOCS_PRESENT = ClassUtils.isPresent(
+			"org.springframework.restdocs.ManualRestDocumentation",
+			RestDocsTestExecutionListener.class.getClassLoader());
 
 	@Override
 	public int getOrder() {
@@ -42,20 +44,16 @@ public class RestDocsTestExecutionListener extends AbstractTestExecutionListener
 
 	@Override
 	public void beforeTestMethod(TestContext testContext) throws Exception {
-		if (restDocsIsPresent()) {
+		if (REST_DOCS_PRESENT) {
 			new DocumentationHandler().beforeTestMethod(testContext);
 		}
 	}
 
 	@Override
 	public void afterTestMethod(TestContext testContext) throws Exception {
-		if (restDocsIsPresent()) {
+		if (REST_DOCS_PRESENT) {
 			new DocumentationHandler().afterTestMethod(testContext);
 		}
-	}
-
-	private boolean restDocsIsPresent() {
-		return ClassUtils.isPresent(REST_DOCS_CLASS, getClass().getClassLoader());
 	}
 
 	private static class DocumentationHandler {


### PR DESCRIPTION
Hi 👋 

I've been profiling our test suites these days and noticed a very small, but probably avoidable, overhead in `RestDocsTestExecutionListener`

<img width="1676" alt="image" src="https://user-images.githubusercontent.com/6304496/225370506-474202a5-c3f9-4402-8c42-7a4a8ad1c047.png">

Feel free to decline if this is problematic in any scenario I'm currently not seeing. It's really minor.

Cheers,
Christoph