### PR TITLE
fix CentralDirectoryFileHeader class omit Cloneable

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/CentralDirectoryFileHeader.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/CentralDirectoryFileHeader.java
@@ -34,7 +34,7 @@ import org.springframework.boot.loader.data.RandomAccessData;
  * @see <a href="https://en.wikipedia.org/wiki/Zip_%28file_format%29">Zip File Format</a>
  */
 
-final class CentralDirectoryFileHeader implements FileHeader {
+final class CentralDirectoryFileHeader implements FileHeader, Cloneable {
 
 	private static final AsciiBytes SLASH = new AsciiBytes("/");
 


### PR DESCRIPTION
The CentralDirectoryFileHeader class override Object.clone() method but does not implement Cloneable. 
I'm not sure if this was intentionally not done by the developer, or if it was a mistake.
pls check it.