### PR TITLE
Allow DeprecatedConfigurationProperty on fields for Lombok

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/LombokPropertyDescriptor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/LombokPropertyDescriptor.java
@@ -75,7 +75,7 @@ class LombokPropertyDescriptor extends PropertyDescriptor<VariableElement> {
 	protected ItemDeprecation resolveItemDeprecation(MetadataGenerationEnvironment environment) {
 		boolean deprecated = environment.isDeprecated(getField()) || environment.isDeprecated(getGetter())
 				|| environment.isDeprecated(getFactoryMethod());
-		return deprecated ? environment.resolveItemDeprecation(getGetter()) : null;
+		return deprecated ? environment.resolveItemDeprecation(getField()) : null;
 	}
 
 	private boolean hasSetter(MetadataGenerationEnvironment env) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/LombokMetadataGenerationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/LombokMetadataGenerationTests.java
@@ -63,7 +63,7 @@ class LombokMetadataGenerationTests extends AbstractMetadataGenerationTests {
 	void lombokExplicitProperties() {
 		ConfigurationMetadata metadata = compile(LombokExplicitProperties.class);
 		assertSimpleLombokProperties(metadata, LombokExplicitProperties.class, "explicit");
-		assertThat(metadata.getItems()).hasSize(6);
+		assertThat(metadata.getItems()).hasSize(7);
 	}
 
 	@Test
@@ -143,6 +143,10 @@ class LombokMetadataGenerationTests extends AbstractMetadataGenerationTests {
 			.fromSource(source)
 			.withDefaultValue(0)
 			.withDeprecation(null, null));
+		assertThat(metadata).has(Metadata.withProperty(prefix + ".number2")
+			.fromSource(source)
+			.withDefaultValue(1)
+			.withDeprecation("true", "false"));
 		assertThat(metadata).has(Metadata.withProperty(prefix + ".items"));
 		assertThat(metadata).doesNotHave(Metadata.withProperty(prefix + ".ignored"));
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/PropertyDescriptorResolverTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/PropertyDescriptorResolverTests.java
@@ -90,25 +90,25 @@ class PropertyDescriptorResolverTests {
 	@Test
 	void propertiesWithLombokGetterSetterAtClassLevel() throws IOException {
 		process(LombokSimpleProperties.class, propertyNames(
-				(stream) -> assertThat(stream).containsExactly("name", "description", "counter", "number", "items")));
+				(stream) -> assertThat(stream).containsExactly("name", "description", "counter", "number", "number2", "items")));
 	}
 
 	@Test
 	void propertiesWithLombokGetterSetterAtFieldLevel() throws IOException {
 		process(LombokExplicitProperties.class, propertyNames(
-				(stream) -> assertThat(stream).containsExactly("name", "description", "counter", "number", "items")));
+				(stream) -> assertThat(stream).containsExactly("name", "description", "counter", "number", "number2", "items")));
 	}
 
 	@Test
 	void propertiesWithLombokDataClass() throws IOException {
 		process(LombokSimpleDataProperties.class, propertyNames(
-				(stream) -> assertThat(stream).containsExactly("name", "description", "counter", "number", "items")));
+				(stream) -> assertThat(stream).containsExactly("name", "description", "counter", "number", "number2", "items")));
 	}
 
 	@Test
 	void propertiesWithLombokValueClass() throws IOException {
 		process(LombokSimpleValueProperties.class, propertyNames(
-				(stream) -> assertThat(stream).containsExactly("name", "description", "counter", "number", "items")));
+				(stream) -> assertThat(stream).containsExactly("name", "description", "counter", "number", "number2", "items")));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/DeprecatedConfigurationProperty.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/DeprecatedConfigurationProperty.java
@@ -28,12 +28,13 @@ import java.lang.annotation.Target;
  * but it is used by the {@code spring-boot-configuration-processor} to add deprecation
  * meta-data.
  * <p>
- * This annotation <strong>must</strong> be used on the getter of the deprecated element.
+ * This annotation <strong>must</strong> be used on the getter of the deprecated element,
+ * or on the field, if Lombok is used.
  *
  * @author Phillip Webb
  * @since 1.3.0
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface DeprecatedConfigurationProperty {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokExplicitProperties.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokExplicitProperties.java
@@ -23,6 +23,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.DeprecatedConfigurationProperty;
 
 /**
  * Configuration properties using lombok @Getter/@Setter at field level.
@@ -54,6 +55,11 @@ public class LombokExplicitProperties {
 	@Getter
 	@Setter
 	private Integer number = 0;
+
+	@DeprecatedConfigurationProperty(reason = "true", replacement = "false")
+	@Getter
+	@Setter
+	private Integer number2 = 1;
 
 	@Getter
 	private final List<String> items = new ArrayList<>();

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokSimpleDataProperties.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokSimpleDataProperties.java
@@ -22,6 +22,7 @@ import java.util.List;
 import lombok.Data;
 
 import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.DeprecatedConfigurationProperty;
 
 /**
  * Configuration properties using lombok @Data.
@@ -46,6 +47,9 @@ public class LombokSimpleDataProperties {
 
 	@Deprecated
 	private Integer number = 0;
+
+	@DeprecatedConfigurationProperty(reason = "true", replacement = "false")
+	private Integer number2 = 1;
 
 	private final List<String> items = new ArrayList<>();
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokSimpleProperties.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokSimpleProperties.java
@@ -23,6 +23,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.DeprecatedConfigurationProperty;
 
 /**
  * Configuration properties using lombok @Getter/@Setter at class level.
@@ -48,6 +49,9 @@ public class LombokSimpleProperties {
 
 	@Deprecated
 	private Integer number = 0;
+
+	@DeprecatedConfigurationProperty(reason = "true", replacement = "false")
+	private Integer number2 = 1;
 
 	private final List<String> items = new ArrayList<>();
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokSimpleValueProperties.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokSimpleValueProperties.java
@@ -22,6 +22,7 @@ import java.util.List;
 import lombok.Value;
 
 import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.DeprecatedConfigurationProperty;
 
 /**
  * Configuration properties using Lombok {@code @Value}.
@@ -46,6 +47,9 @@ public class LombokSimpleValueProperties {
 
 	@Deprecated
 	private Integer number = 0;
+
+	@DeprecatedConfigurationProperty(reason = "true", replacement = "false")
+	private Integer number2 = 1;
 
 	private final List<String> items = new ArrayList<>();
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/DeprecatedConfigurationProperty.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/DeprecatedConfigurationProperty.java
@@ -28,12 +28,13 @@ import java.lang.annotation.Target;
  * but it is used by the {@code spring-boot-configuration-processor} to add deprecation
  * meta-data.
  * <p>
- * This annotation <strong>must</strong> be used on the getter of the deprecated element.
+ * This annotation <strong>must</strong> be used on the getter of the deprecated element,
+ * or on the field, if Lombok is used.
  *
  * @author Phillip Webb
  * @since 1.3.0
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface DeprecatedConfigurationProperty {


### PR DESCRIPTION
There is currently no elegant way to use `@DeprecatedConfigurationProperty` in order to provide additional deprecation metadata for a property when the `@ConfigurationProperties` class is built using Lombok.

This change allows `@DeprecatedConfigurationProperty` to be used directly on a field when using Lombok.

