### PR TITLE
#34638 Added handling of bright ANSI colors in log4j and logback

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/ColorConverter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/ColorConverter.java
@@ -60,6 +60,16 @@ public final class ColorConverter extends LogEventPatternConverter {
 		ansiElements.put("blue", AnsiColor.BLUE);
 		ansiElements.put("magenta", AnsiColor.MAGENTA);
 		ansiElements.put("cyan", AnsiColor.CYAN);
+		ansiElements.put("black", AnsiColor.BLACK);
+		ansiElements.put("white", AnsiColor.WHITE);
+		ansiElements.put("bright_red", AnsiColor.BRIGHT_RED);
+		ansiElements.put("bright_green", AnsiColor.BRIGHT_GREEN);
+		ansiElements.put("bright_yellow", AnsiColor.BRIGHT_YELLOW);
+		ansiElements.put("bright_blue", AnsiColor.BRIGHT_BLUE);
+		ansiElements.put("bright_magenta", AnsiColor.BRIGHT_MAGENTA);
+		ansiElements.put("bright_cyan", AnsiColor.BRIGHT_CYAN);
+		ansiElements.put("bright_black", AnsiColor.BRIGHT_BLACK);
+		ansiElements.put("bright_white", AnsiColor.BRIGHT_WHITE);
 		ELEMENTS = Collections.unmodifiableMap(ansiElements);
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/ColorConverter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/ColorConverter.java
@@ -50,6 +50,16 @@ public class ColorConverter extends CompositeConverter<ILoggingEvent> {
 		ansiElements.put("blue", AnsiColor.BLUE);
 		ansiElements.put("magenta", AnsiColor.MAGENTA);
 		ansiElements.put("cyan", AnsiColor.CYAN);
+		ansiElements.put("black", AnsiColor.BLACK);
+		ansiElements.put("white", AnsiColor.WHITE);
+		ansiElements.put("bright_red", AnsiColor.BRIGHT_RED);
+		ansiElements.put("bright_green", AnsiColor.BRIGHT_GREEN);
+		ansiElements.put("bright_yellow", AnsiColor.BRIGHT_YELLOW);
+		ansiElements.put("bright_blue", AnsiColor.BRIGHT_BLUE);
+		ansiElements.put("bright_magenta", AnsiColor.BRIGHT_MAGENTA);
+		ansiElements.put("bright_cyan", AnsiColor.BRIGHT_CYAN);
+		ansiElements.put("bright_black", AnsiColor.BRIGHT_BLACK);
+		ansiElements.put("bright_white", AnsiColor.BRIGHT_WHITE);
 		ELEMENTS = Collections.unmodifiableMap(ansiElements);
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/ColorConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/ColorConverterTests.java
@@ -16,12 +16,17 @@
 
 package org.springframework.boot.logging.log4j2;
 
+import java.util.Map;
+import java.util.stream.Stream;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.AbstractLogEvent;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 
 import org.springframework.boot.ansi.AnsiOutput;
 
@@ -31,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link ColorConverter}.
  *
  * @author Vladimir Tsanev
+ * @author Krzysztof Krason
  */
 class ColorConverterTests {
 
@@ -57,53 +63,27 @@ class ColorConverterTests {
 		return ColorConverter.newInstance(null, new String[] { this.in, styling });
 	}
 
-	@Test
-	void faint() {
-		StringBuilder output = new StringBuilder();
-		newConverter("faint").format(this.event, output);
-		assertThat(output).hasToString("\033[2min\033[0;39m");
+	@TestFactory
+	Stream<DynamicTest> colors() {
+		return Map.ofEntries(Map.entry("faint", "\033[2min\033[0;39m"), Map.entry("cyan", "\033[36min\033[0;39m"),
+				Map.entry("magenta", "\033[35min\033[0;39m"), Map.entry("blue", "\033[34min\033[0;39m"),
+				Map.entry("yellow", "\033[33min\033[0;39m"), Map.entry("green", "\033[32min\033[0;39m"),
+				Map.entry("red", "\033[31min\033[0;39m"), Map.entry("black", "\033[30min\033[0;39m"),
+				Map.entry("white", "\033[37min\033[0;39m"), Map.entry("bright_cyan", "\033[96min\033[0;39m"),
+				Map.entry("bright_magenta", "\033[95min\033[0;39m"), Map.entry("bright_blue", "\033[94min\033[0;39m"),
+				Map.entry("bright_yellow", "\033[93min\033[0;39m"), Map.entry("bright_green", "\033[92min\033[0;39m"),
+				Map.entry("bright_red", "\033[91min\033[0;39m"), Map.entry("bright_black", "\033[90min\033[0;39m"),
+				Map.entry("bright_white", "\033[97min\033[0;39m"))
+			.entrySet()
+			.stream()
+			.map((entry) -> DynamicTest.dynamicTest("Test for %s".formatted(entry.getKey()),
+					() -> colorValidation(entry.getKey(), entry.getValue())));
 	}
 
-	@Test
-	void red() {
+	void colorValidation(String color, String escapeSeq) {
 		StringBuilder output = new StringBuilder();
-		newConverter("red").format(this.event, output);
-		assertThat(output).hasToString("\033[31min\033[0;39m");
-	}
-
-	@Test
-	void green() {
-		StringBuilder output = new StringBuilder();
-		newConverter("green").format(this.event, output);
-		assertThat(output).hasToString("\033[32min\033[0;39m");
-	}
-
-	@Test
-	void yellow() {
-		StringBuilder output = new StringBuilder();
-		newConverter("yellow").format(this.event, output);
-		assertThat(output).hasToString("\033[33min\033[0;39m");
-	}
-
-	@Test
-	void blue() {
-		StringBuilder output = new StringBuilder();
-		newConverter("blue").format(this.event, output);
-		assertThat(output).hasToString("\033[34min\033[0;39m");
-	}
-
-	@Test
-	void magenta() {
-		StringBuilder output = new StringBuilder();
-		newConverter("magenta").format(this.event, output);
-		assertThat(output).hasToString("\033[35min\033[0;39m");
-	}
-
-	@Test
-	void cyan() {
-		StringBuilder output = new StringBuilder();
-		newConverter("cyan").format(this.event, output);
-		assertThat(output).hasToString("\033[36min\033[0;39m");
+		newConverter(color).format(this.event, output);
+		assertThat(output).hasToString(escapeSeq);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/ColorConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/ColorConverterTests.java
@@ -17,12 +17,16 @@
 package org.springframework.boot.logging.logback;
 
 import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Stream;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 
 import org.springframework.boot.ansi.AnsiOutput;
 
@@ -32,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link ColorConverter}.
  *
  * @author Phillip Webb
+ * @author Krzysztof Krason
  */
 class ColorConverterTests {
 
@@ -51,53 +56,27 @@ class ColorConverterTests {
 		AnsiOutput.setEnabled(AnsiOutput.Enabled.DETECT);
 	}
 
-	@Test
-	void faint() {
-		this.converter.setOptionList(Collections.singletonList("faint"));
-		String out = this.converter.transform(this.event, this.in);
-		assertThat(out).isEqualTo("\033[2min\033[0;39m");
+	@TestFactory
+	Stream<DynamicTest> colors() {
+		return Map.ofEntries(Map.entry("faint", "\033[2min\033[0;39m"), Map.entry("cyan", "\033[36min\033[0;39m"),
+				Map.entry("magenta", "\033[35min\033[0;39m"), Map.entry("blue", "\033[34min\033[0;39m"),
+				Map.entry("yellow", "\033[33min\033[0;39m"), Map.entry("green", "\033[32min\033[0;39m"),
+				Map.entry("red", "\033[31min\033[0;39m"), Map.entry("black", "\033[30min\033[0;39m"),
+				Map.entry("white", "\033[37min\033[0;39m"), Map.entry("bright_cyan", "\033[96min\033[0;39m"),
+				Map.entry("bright_magenta", "\033[95min\033[0;39m"), Map.entry("bright_blue", "\033[94min\033[0;39m"),
+				Map.entry("bright_yellow", "\033[93min\033[0;39m"), Map.entry("bright_green", "\033[92min\033[0;39m"),
+				Map.entry("bright_red", "\033[91min\033[0;39m"), Map.entry("bright_black", "\033[90min\033[0;39m"),
+				Map.entry("bright_white", "\033[97min\033[0;39m"))
+			.entrySet()
+			.stream()
+			.map((entry) -> DynamicTest.dynamicTest("Test for %s".formatted(entry.getKey()),
+					() -> colorValidation(entry.getKey(), entry.getValue())));
 	}
 
-	@Test
-	void red() {
-		this.converter.setOptionList(Collections.singletonList("red"));
+	void colorValidation(String color, String escapeSeq) {
+		this.converter.setOptionList(Collections.singletonList(color));
 		String out = this.converter.transform(this.event, this.in);
-		assertThat(out).isEqualTo("\033[31min\033[0;39m");
-	}
-
-	@Test
-	void green() {
-		this.converter.setOptionList(Collections.singletonList("green"));
-		String out = this.converter.transform(this.event, this.in);
-		assertThat(out).isEqualTo("\033[32min\033[0;39m");
-	}
-
-	@Test
-	void yellow() {
-		this.converter.setOptionList(Collections.singletonList("yellow"));
-		String out = this.converter.transform(this.event, this.in);
-		assertThat(out).isEqualTo("\033[33min\033[0;39m");
-	}
-
-	@Test
-	void blue() {
-		this.converter.setOptionList(Collections.singletonList("blue"));
-		String out = this.converter.transform(this.event, this.in);
-		assertThat(out).isEqualTo("\033[34min\033[0;39m");
-	}
-
-	@Test
-	void magenta() {
-		this.converter.setOptionList(Collections.singletonList("magenta"));
-		String out = this.converter.transform(this.event, this.in);
-		assertThat(out).isEqualTo("\033[35min\033[0;39m");
-	}
-
-	@Test
-	void cyan() {
-		this.converter.setOptionList(Collections.singletonList("cyan"));
-		String out = this.converter.transform(this.event, this.in);
-		assertThat(out).isEqualTo("\033[36min\033[0;39m");
+		assertThat(out).isEqualTo(escapeSeq);
 	}
 
 	@Test


### PR DESCRIPTION
For #34638.
Added handling of "bright" variants of colors for logback and log4j ColorConverter. Added also black and white (with bright variants) as those were also missing.
