### PR TITLE
Clarify servlet container compatibility

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/getting-started/system-requirements.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/getting-started/system-requirements.adoc
@@ -37,4 +37,4 @@ Spring Boot supports the following embedded servlet containers:
 | 4.0
 |===
 
-Spring Boot {spring-boot-version} `.war` applications can also be deployed in web containers compatible with Servlet Spec 3.1 or above, up to and including 4.0. Web containers with Servlet Spec 5.0 and above are not compatible, due to breaking changes in this Servlet Spec version.
+You can also deploy Spring Boot applications to any Servlet 3.1 or 4.0 compatible container.

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/getting-started/system-requirements.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/getting-started/system-requirements.adoc
@@ -37,4 +37,4 @@ Spring Boot supports the following embedded servlet containers:
 | 4.0
 |===
 
-You can also deploy Spring Boot applications to any servlet 3.1+ compatible container.
+Spring Boot {spring-boot-version} `.war` applications can also be deployed in web containers compatible with Servlet Spec 3.1 or above, up to and including 4.0. Web containers with Servlet Spec 5.0 and above are not compatible, due to breaking changes in this Servlet Spec version.


### PR DESCRIPTION
Fix documentation section on web container requirements for 2.7.x.

This is relevant for teams and companies that are planning upgrade to Spring Boot 3, upgrade the web container used, and so on.