### PR TITLE
Hints for including Liquibase changelogs in a native image are unnecessarily narrow 

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -175,7 +175,7 @@ public class LiquibaseAutoConfiguration {
 
 		@Override
 		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
-			hints.resources().registerPattern("db/changelog/db.changelog-master.yaml");
+			hints.resources().registerPattern("db/changelog/*");
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
@@ -423,8 +423,11 @@ class LiquibaseAutoConfigurationTests {
 	void shouldRegisterHints() {
 		RuntimeHints hints = new RuntimeHints();
 		new LiquibaseAutoConfigurationRuntimeHints().registerHints(hints, getClass().getClassLoader());
+		assertThat(RuntimeHintsPredicates.resource().forResource("db/changelog/")).accepts(hints);
 		assertThat(RuntimeHintsPredicates.resource().forResource("db/changelog/db.changelog-master.yaml"))
 			.accepts(hints);
+		assertThat(RuntimeHintsPredicates.resource().forResource("db/changelog/tables/init.sql"))
+				.accepts(hints);
 	}
 
 	private ContextConsumer<AssertableApplicationContext> assertLiquibase(Consumer<SpringLiquibase> consumer) {


### PR DESCRIPTION
gh-34678

