### PR TITLE
Remove source and target as maven.compiler.release is already set

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
@@ -21,8 +21,6 @@ publishing.publications.withType(MavenPublication) {
 			properties {
 				delegate."java.version"('17')
 				delegate."resource.delimiter"('@')
-				delegate."maven.compiler.source"('${java.version}')
-				delegate."maven.compiler.target"('${java.version}')
 				delegate."maven.compiler.release"('${java.version}')
 				delegate."project.build.sourceEncoding"('UTF-8')
 				delegate."project.reporting.outputEncoding"('UTF-8')


### PR DESCRIPTION
Follow-up on #34365.

When the compiler's release argument is set, arguments source and target are not used. No need to keep them around.

See https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html#option-release
> Note: When using --release, you cannot also use the --source/-source or --target/-target options.

Maven actually allows setting both. But using both directly with javac would result in an error.