### PR TITLE
Offer a way to customize the converters used by Spring Batch without extending DefaultBatchConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.boot.autoconfigure.batch;
+
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -44,6 +46,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.jdbc.datasource.init.DatabasePopulator;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Isolation;
@@ -115,11 +118,15 @@ public class BatchAutoConfiguration {
 
 		private final BatchProperties properties;
 
+		private final List<BatchConversionServiceCustomizer> batchConversionServiceCustomizers;
+
 		SpringBootBatchConfiguration(DataSource dataSource, @BatchDataSource ObjectProvider<DataSource> batchDataSource,
-				PlatformTransactionManager transactionManager, BatchProperties properties) {
+				PlatformTransactionManager transactionManager, BatchProperties properties,
+				List<BatchConversionServiceCustomizer> batchConversionServiceCustomizers) {
 			this.dataSource = batchDataSource.getIfAvailable(() -> dataSource);
 			this.transactionManager = transactionManager;
 			this.properties = properties;
+			this.batchConversionServiceCustomizers = batchConversionServiceCustomizers;
 		}
 
 		@Override
@@ -142,6 +149,15 @@ public class BatchAutoConfiguration {
 		protected Isolation getIsolationLevelForCreate() {
 			Isolation isolation = this.properties.getJdbc().getIsolationLevelForCreate();
 			return (isolation != null) ? isolation : super.getIsolationLevelForCreate();
+		}
+
+		@Override
+		protected ConfigurableConversionService getConversionService() {
+			ConfigurableConversionService conversionService = super.getConversionService();
+			for (BatchConversionServiceCustomizer customizer : this.batchConversionServiceCustomizers) {
+				customizer.customize(conversionService);
+			}
+			return conversionService;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchConversionServiceCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchConversionServiceCustomizer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.batch;
+
+import org.springframework.core.convert.support.ConfigurableConversionService;
+
+/**
+ * Callback interface that can be implemented by beans wishing to further customize the
+ * {@link ConfigurableConversionService} used in
+ * {@link org.springframework.batch.core.configuration.support.DefaultBatchConfiguration}
+ * retaining its default auto-configuration.
+ *
+ * @author Claudio Nave
+ * @since 3.1.0
+ */
+@FunctionalInterface
+public interface BatchConversionServiceCustomizer {
+
+	/**
+	 * Customize the {@link ConfigurableConversionService}.
+	 * @param configurableConversionService the ConfigurableConversionService to customize
+	 */
+	void customize(ConfigurableConversionService configurableConversionService);
+
+}


### PR DESCRIPTION
Hi, I'm trying to use the new feature of Spring Batch 5 that let you set a job parameter of any kind of type.

The problem is that you have to provide a `Converter` from your custom parameter type to `String` because Spring Batch needs it, but the only way to register this new converter is extending `DefaultBatchConfiguration` and overriding the `getConverterService()` method. This however switches off the spring boot autoconfiguration for Spring Batch, which seems a bit extreme just to register a simple converter.

I created a small project to demonstrate my situation https://github.com/EvaristeGalois11/spring-batch-parameter

In this small project i rely on the spring boot autoconfiguration to initialize the database schema needed by Spring Batch.

The `WithoutConverterTest` test case fails because the converter isn't registered, but the `WithConverterTest` test case fails too because the spring boot autoconfiguration isn't activated and the tables aren't being created.

### Possible solution ###
My simple idea to resolve the problem is to provide a bean similar to `Jackson2ObjectMapperBuilderCustomizer`.
If the spring boot autoconfiguration finds some beans of this type, the `ConfigurableConversionService` returned from `DefaultBatchConfiguration:getConverterService()` is enriched accordingly. This will permit registering a new converter without disrupting the autoconfiguration execution.

Let me know what you think, bye!