### PR TITLE
Use current Neo4j version in Testcontainers-based examples.

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/testcontainers/dynamicproperties/MyIntegrationTests.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/testcontainers/dynamicproperties/MyIntegrationTests.java
@@ -30,7 +30,7 @@ import org.springframework.test.context.DynamicPropertySource;
 class MyIntegrationTests {
 
 	@Container
-	static Neo4jContainer<?> neo4j = new Neo4jContainer<>("neo4j:4.2");
+	static Neo4jContainer<?> neo4j = new Neo4jContainer<>("neo4j:5");
 
 	@Test
 	void myTest() {

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/testcontainers/serviceconnections/MyIntegrationTests.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/testcontainers/serviceconnections/MyIntegrationTests.java
@@ -30,7 +30,7 @@ class MyIntegrationTests {
 
 	@Container
 	@Neo4jServiceConnection
-	static Neo4jContainer<?> neo4j = new Neo4jContainer<>("neo4j:4.2");
+	static Neo4jContainer<?> neo4j = new Neo4jContainer<>("neo4j:5");
 
 	@Test
 	void myTest() {

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/testcontainers/vanilla/MyIntegrationTests.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/testcontainers/vanilla/MyIntegrationTests.java
@@ -28,7 +28,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 class MyIntegrationTests {
 
 	@Container
-	static Neo4jContainer<?> neo4j = new Neo4jContainer<>("neo4j:4.2");
+	static Neo4jContainer<?> neo4j = new Neo4jContainer<>("neo4j:5");
 
 	@Test
 	void myTest() {

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/testing/testcontainers/dynamicproperties/MyIntegrationTests.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/testing/testcontainers/dynamicproperties/MyIntegrationTests.kt
@@ -36,7 +36,7 @@ internal class MyIntegrationTests {
 	companion object {
 
 		@Container
-		var neo4j: Neo4jContainer<*> = Neo4jContainer<Nothing>("neo4j:4.2")
+		var neo4j: Neo4jContainer<*> = Neo4jContainer<Nothing>("neo4j:5")
 
 		@DynamicPropertySource
 		fun neo4jProperties(registry: DynamicPropertyRegistry) {

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/testing/testcontainers/serviceconnections/MyIntegrationTests.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/testing/testcontainers/serviceconnections/MyIntegrationTests.kt
@@ -38,7 +38,7 @@ internal class MyIntegrationTests {
 
 		@Container
 		@Neo4jServiceConnection
-		var neo4j: Neo4jContainer<*> = Neo4jContainer<Nothing>("neo4j:4.2")
+		var neo4j: Neo4jContainer<*> = Neo4jContainer<Nothing>("neo4j:5")
 
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/testing/testcontainers/vanilla/MyIntegrationTests.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/testing/testcontainers/vanilla/MyIntegrationTests.kt
@@ -33,7 +33,7 @@ internal class MyIntegrationTests {
 
 	companion object {
 		@Container
-		var neo4j: Neo4jContainer<*> = Neo4jContainer<Nothing>("neo4j:4.2")
+		var neo4j: Neo4jContainer<*> = Neo4jContainer<Nothing>("neo4j:5")
 	}
 
 }


### PR DESCRIPTION
I just spotted an outdated Neo4j version in the docs.
From the commit message:
Version 4.2 went out of support May 16, 2022.
With the more general and supported tag 5, it is
a) up to date and
b) maintenance friendly until 6 arrives.