### PR TITLE
ConfigurationPropertyName#equals is not symmetric when element has trailing dashes

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -406,7 +406,7 @@ public final class ConfigurationPropertyName implements Comparable<Configuration
 		int i2 = 0;
 		while (i1 < l1) {
 			if (i2 >= l2) {
-				return false;
+				return remainderIsNotAlphanumeric(e1, i, i1);
 			}
 			char ch1 = e1.charAt(i, i1);
 			char ch2 = e2.charAt(i, i2);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/ConfigurationPropertyNameTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/ConfigurationPropertyNameTests.java
@@ -702,6 +702,14 @@ class ConfigurationPropertyNameTests {
 	}
 
 	@Test
+	void equalsSymmetricWhenNameMatchesDueToRemovalOfTrailingDashes() {
+		ConfigurationPropertyName n1 = ConfigurationPropertyName.of("foobar");
+		ConfigurationPropertyName n2 = ConfigurationPropertyName.of("foobar--");
+		assertThat(n1).isEqualTo(n2);
+		assertThat(n2).isEqualTo(n1);
+	}
+
+	@Test
 	void isValidWhenValidShouldReturnTrue() {
 		assertThat(ConfigurationPropertyName.isValid("")).isTrue();
 		assertThat(ConfigurationPropertyName.isValid("foo")).isTrue();


### PR DESCRIPTION
...with trailing dashes in an element. 

See also: #30393
