### PR TITLE
Remove unused XADataSourceAutoConfigurationTests.JdbcConnectionDetailsConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/XADataSourceAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/XADataSourceAutoConfigurationTests.java
@@ -126,16 +126,6 @@ class XADataSourceAutoConfigurationTests {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	static class JdbcConnectionDetailsConfiguration {
-
-		@Bean
-		JdbcConnectionDetails jdbcConnectionDetails() {
-			return new TestJdbcConnectionDetails();
-		}
-
-	}
-
-	@Configuration(proxyBeanMethods = false)
 	static class WrapExisting {
 
 		@Bean


### PR DESCRIPTION
This PR removes the unused `XADataSourceAutoConfigurationTests.JdbcConnectionDetailsConfiguration` since d69335d94a40164b1f64184bc26f569b80e936cc.