### PR TITLE
Enable ANSI output on Windows automatically

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiOutput.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiOutput.java
@@ -37,8 +37,6 @@ public abstract class AnsiOutput {
 
 	private static Boolean ansiCapable;
 
-	private static final String OPERATING_SYSTEM_NAME = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
-
 	private static final String ENCODE_START = "\033[";
 
 	private static final String ENCODE_END = "m";
@@ -155,7 +153,7 @@ public abstract class AnsiOutput {
 			if ((consoleAvailable == null) && (System.console() == null)) {
 				return false;
 			}
-			return !(OPERATING_SYSTEM_NAME.contains("win"));
+			return true;
 		}
 		catch (Throwable ex) {
 			return false;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiOutput.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiOutput.java
@@ -16,8 +16,6 @@
 
 package org.springframework.boot.ansi;
 
-import java.util.Locale;
-
 import org.springframework.util.Assert;
 
 /**


### PR DESCRIPTION
Windows supports ANSI encoding since Windows 10 version 1909. All you need to do is call ENABLE_VIRTUAL_TERMINAL_PROCESSING when calling console API.

IntelliJ does this automatically.
![image](https://user-images.githubusercontent.com/2323565/229368101-0983a39f-59e4-46b5-935c-7a0ad8b06616.png)
All software running via the new Windows Terminal, including Java, does this as well.
![image](https://user-images.githubusercontent.com/2323565/229368082-5e2b0704-6f6b-467a-9d96-a17243395728.png)

Old Windows command prompt doesn't do this by default for compatibility reasons, but new Java versions will make it possible for workaround even for older Windows versions https://stackoverflow.com/questions/74319252/printing-ansi-color-codes-in-java-works-on-vs-code-terminal-but-not-in-cmd

My proposal is to enable ANSI coloring on Windows by default.

Patch should be compatible with both 3.x and 2.7.x branches.