### PR TITLE
getting-started: move MyApplication.java to it's own package

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/getting-started/first-application.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/getting-started/first-application.adoc
@@ -134,10 +134,31 @@ If you run `mvn dependency:tree` again, you see that there are now a number of a
 
 [[getting-started.first-application.code]]
 === Writing the Code
-To finish our application, we need to create a single Java file.
-By default, Maven compiles sources from `src/main/java`, so you need to create that directory structure and then add a file named `src/main/java/MyApplication.java` to contain the following code:
+To finish our application, we need to create a single Java file in a package. We shall be creating a directory structure corresponding to this package.
+By default, Maven compiles sources from `src/main/java`. Our package is `com.example.myproject`, so, our directory will be `src/main/java/com/example/myproject`. We'll create a file named `src/main/java/com/example/myproject/MyApplication.java` to contain the following code:
 
-include::code:MyApplication[]
+```java
+package com.example.myproject;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@SpringBootApplication
+public class MyApplication {
+
+    @RequestMapping("/")
+    String home() {
+        return "Hello World!";
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(MyApplication.class, args);
+    }
+
+}
+```
 
 Although there is not much code here, quite a lot is going on.
 We step through the important parts in the next few sections.


### PR DESCRIPTION
In its current state, MyApplication.java does not have it's own package and exists in the default package which conflicts with SpringBootApplication. The changes here move the create com.example.myproject package and move MyApplication under it.
This also comes with creating a directory structure for the package and moving the code file under it. Fixes issue [#34827](https://github.com/spring-projects/spring-boot/issues/34827)
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
