### PR TITLE
BatchProperties has an outdated reference to JPA

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchProperties.java
@@ -69,7 +69,6 @@ public class BatchProperties {
 
 		/**
 		 * Transaction isolation level to use when creating job meta-data for new jobs.
-		 * Auto-detected based on whether JPA is being used or not.
 		 */
 		private Isolation isolationLevelForCreate;
 


### PR DESCRIPTION
Since [JpaBatchConfigurer.java](https://github.com/spring-projects/spring-boot/blob/2.7.x/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JpaBatchConfigurer.java) was removed, [BatchAutoConfiguration.getIsolationLevelForCreate()](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java#L142) is the only method  that determines the default value for `spring.batch.jdbc.isolation-level-for-create`.

`BatchAutoConfiguration.getIsolationLevelForCreate()` does not consider the use of JPA.

With this PR, it is expected that the following documents will be fixed as well.

https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#application-properties.integration.spring.batch.jdbc.isolation-level-for-create
