### PR TITLE
Short circuit @Value injection when using a source already covered by ConfigurationPropertySourcesPropertySource

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/ConfigurationPropertySourcesPlaceholderConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/ConfigurationPropertySourcesPlaceholderConfigurer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.context;
+
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.core.env.ConfigurablePropertyResolver;
+import org.springframework.core.env.MutablePropertySources;
+
+/**
+ * Placeholder configurer that resolves using the optimized
+ * {@link ConfigurablePropertyResolver}.
+ *
+ * @author Guirong Hu
+ */
+class ConfigurationPropertySourcesPlaceholderConfigurer extends PropertySourcesPlaceholderConfigurer {
+
+	@Override
+	protected ConfigurablePropertyResolver createPropertyResolver(MutablePropertySources propertySources) {
+		return ConfigurationPropertySources.createPropertyResolver(propertySources);
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/PropertyPlaceholderAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/PropertyPlaceholderAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public class PropertyPlaceholderAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(search = SearchStrategy.CURRENT)
 	public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
-		return new PropertySourcesPlaceholderConfigurer();
+		return new ConfigurationPropertySourcesPlaceholderConfigurer();
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/context/ConfigurationPropertySourcesPlaceholderConfigurerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/context/ConfigurationPropertySourcesPlaceholderConfigurerTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.context;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurablePropertyResolver;
+import org.springframework.core.env.MutablePropertySources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConfigurationPropertySourcesPlaceholderConfigurer}.
+ *
+ * @author Guirong Hu
+ */
+class ConfigurationPropertySourcesPlaceholderConfigurerTests {
+
+	@Test
+	void propertyResolverIsOptimizedForPropertyPlaceholder() {
+		ConfigurablePropertyResolver expected = ConfigurationPropertySources
+				.createPropertyResolver(new MutablePropertySources());
+
+		new ApplicationContextRunner().withUserConfiguration(GetPropertyResolverPlaceholderConfigurerConfig.class)
+				.run((context) -> assertThat(
+						context.getBean(GetPropertyResolverPlaceholderConfigurer.class).getPropertyResolver())
+								.hasSameClassAs(expected));
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class GetPropertyResolverPlaceholderConfigurerConfig {
+
+		@Bean
+		static GetPropertyResolverPlaceholderConfigurer getPropertyResolverPlaceholderConfigurer() {
+			return new GetPropertyResolverPlaceholderConfigurer();
+		}
+
+	}
+
+	static class GetPropertyResolverPlaceholderConfigurer extends ConfigurationPropertySourcesPlaceholderConfigurer {
+
+		private ConfigurablePropertyResolver propertyResolver;
+
+		@Override
+		protected void processProperties(ConfigurableListableBeanFactory beanFactoryToProcess,
+				ConfigurablePropertyResolver propertyResolver) throws BeansException {
+			this.propertyResolver = propertyResolver;
+			super.processProperties(beanFactoryToProcess, propertyResolver);
+		}
+
+		public ConfigurablePropertyResolver getPropertyResolver() {
+			return this.propertyResolver;
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/context/PropertyPlaceholderAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/context/PropertyPlaceholderAutoConfigurationTests.java
@@ -118,7 +118,7 @@ class PropertyPlaceholderAutoConfigurationTests {
 
 		@Bean
 		static PropertySourcesPlaceholderConfigurer morePlaceholders() {
-			PropertySourcesPlaceholderConfigurer configurer = new PropertySourcesPlaceholderConfigurer();
+			PropertySourcesPlaceholderConfigurer configurer = new ConfigurationPropertySourcesPlaceholderConfigurer();
 			configurer
 				.setProperties(StringUtils.splitArrayElementsIntoProperties(new String[] { "fruit=orange" }, "="));
 			configurer.setLocalOverride(true);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
@@ -21,11 +21,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
 import org.springframework.boot.system.ApplicationPid;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.ConfigurablePropertyResolver;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertyResolver;
-import org.springframework.core.env.PropertySourcesPropertyResolver;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -217,8 +218,8 @@ public class LoggingSystemProperties {
 
 	private PropertyResolver getPropertyResolver() {
 		if (this.environment instanceof ConfigurableEnvironment configurableEnvironment) {
-			PropertySourcesPropertyResolver resolver = new PropertySourcesPropertyResolver(
-					configurableEnvironment.getPropertySources());
+			ConfigurablePropertyResolver resolver = ConfigurationPropertySources
+					.createPropertyResolver(configurableEnvironment.getPropertySources());
 			resolver.setConversionService(((ConfigurableEnvironment) this.environment).getConversionService());
 			resolver.setIgnoreUnresolvableNestedPlaceholders(true);
 			return resolver;


### PR DESCRIPTION
Hi, I found that `PropertySourcesPropertyResolver` (a resolver that does not support short-circuiting) is used in these places:

* `LoggingSystemProperties`

https://github.com/spring-projects/spring-boot/blob/08ce0919cd7895a9551018c072985d014b8cd295/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java#L165

* When the key is not a property name, such as when it is a SpEL expression:

https://github.com/spring-projects/spring-boot/blob/5817c8441d4a24ca0ad6efe70bec64d22875b652/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ErrorProperties.java#L35

In this case `ConfigurationPropertyName.of(key, true)` will return null, and then `defaultResolver` (inherited from `PropertySourcesPropertyResolver`) will be used for resolution.

https://github.com/spring-projects/spring-boot/blob/5817c8441d4a24ca0ad6efe70bec64d22875b652/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertySourcesPropertyResolver.java#L87-L97

However the entire process property value will only be retrieved once, the current implementation is fine and we don't need to make any changes.

https://github.com/spring-projects/spring-boot/blob/5817c8441d4a24ca0ad6efe70bec64d22875b652/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertySourcesPropertySource.java#L66-L68

* As @philwebb  [commented](https://github.com/spring-projects/spring-boot/issues/28687#issuecomment-990148089), Boot auto-configures `PropertySourcesPlaceholderConfigurer`, may need to wait spring-projects/spring-framework#30304 to fix

https://github.com/spring-projects/spring-boot/blob/5817c8441d4a24ca0ad6efe70bec64d22875b652/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/context/PropertyPlaceholderAutoConfiguration.java#L43






Closes gh-28687

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
