### PR TITLE
ImportsContextCustomizer does not support AliasFor

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/ImportsContextCustomizer.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/ImportsContextCustomizer.java
@@ -16,13 +16,13 @@
 
 package org.springframework.boot.test.context;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
@@ -42,7 +42,9 @@ import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.context.annotation.ImportSelector;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.core.Ordered;
-import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.annotation.MergedAnnotation;
+import org.springframework.core.annotation.MergedAnnotations;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.core.type.AnnotationMetadata;
@@ -214,80 +216,40 @@ class ImportsContextCustomizer implements ContextCustomizer {
 	 */
 	static class ContextCustomizerKey {
 
-		private static final Class<?>[] NO_IMPORTS = {};
+		private static final Predicate<String> IGNORE_ANNOTATION = or(packages("java.lang.annotation"),
+				packages("org.spockframework", "spock"),
+				or(Predicate.isEqual("kotlin.Metadata"), isInKotlinAnnotationPackage()), packages(("org.junit")));
 
-		private static final Set<AnnotationFilter> ANNOTATION_FILTERS;
-
-		static {
-			Set<AnnotationFilter> filters = new HashSet<>();
-			filters.add(new JavaLangAnnotationFilter());
-			filters.add(new KotlinAnnotationFilter());
-			filters.add(new SpockAnnotationFilter());
-			filters.add(new JUnitAnnotationFilter());
-			ANNOTATION_FILTERS = Collections.unmodifiableSet(filters);
-		}
-
-		private final Set<Object> key;
+		private final Object key;
 
 		ContextCustomizerKey(Class<?> testClass) {
-			Set<Annotation> annotations = new HashSet<>();
-			Set<Class<?>> seen = new HashSet<>();
-			collectClassAnnotations(testClass, annotations, seen);
-			Set<Object> determinedImports = determineImports(annotations, testClass);
-			this.key = Collections.unmodifiableSet((determinedImports != null) ? determinedImports : annotations);
-		}
-
-		private void collectClassAnnotations(Class<?> classType, Set<Annotation> annotations, Set<Class<?>> seen) {
-			if (seen.add(classType)) {
-				collectElementAnnotations(classType, annotations, seen);
-				for (Class<?> interfaceType : classType.getInterfaces()) {
-					collectClassAnnotations(interfaceType, annotations, seen);
-				}
-				if (classType.getSuperclass() != null) {
-					collectClassAnnotations(classType.getSuperclass(), annotations, seen);
-				}
+			var mergedAnnotations = MergedAnnotations.search(MergedAnnotations.SearchStrategy.TYPE_HIERARCHY)
+				.withAnnotationFilter(IGNORE_ANNOTATION::test)
+				.from(testClass);
+			var determinedImports = determineImports(mergedAnnotations, testClass);
+			if (determinedImports != null) {
+				this.key = determinedImports;
+			}
+			else {
+				this.key = AnnotatedElementUtils.findAllMergedAnnotations(testClass,
+						mergedAnnotations.stream().map(MergedAnnotation::getType).collect(Collectors.toSet()));
 			}
 		}
 
-		private void collectElementAnnotations(AnnotatedElement element, Set<Annotation> annotations,
-				Set<Class<?>> seen) {
-			for (Annotation annotation : element.getDeclaredAnnotations()) {
-				if (!isIgnoredAnnotation(annotation)) {
-					annotations.add(annotation);
-					collectClassAnnotations(annotation.annotationType(), annotations, seen);
-				}
-			}
-		}
-
-		private boolean isIgnoredAnnotation(Annotation annotation) {
-			for (AnnotationFilter annotationFilter : ANNOTATION_FILTERS) {
-				if (annotationFilter.isIgnored(annotation)) {
-					return true;
-				}
-			}
-			return false;
-		}
-
-		private Set<Object> determineImports(Set<Annotation> annotations, Class<?> testClass) {
-			Set<Object> determinedImports = new LinkedHashSet<>();
+		private Set<Object> determineImports(MergedAnnotations mergedAnnotations, Class<?> testClass) {
 			AnnotationMetadata testClassMetadata = AnnotationMetadata.introspect(testClass);
-			for (Annotation annotation : annotations) {
-				for (Class<?> source : getImports(annotation)) {
-					Set<Object> determinedSourceImports = determineImports(source, testClassMetadata);
-					if (determinedSourceImports == null) {
+			return mergedAnnotations.stream(Import.class)
+				.flatMap((ma) -> Stream.of(ma.getClassArray("value")))
+				.map((source) -> determineImports(source, testClassMetadata))
+				.reduce(new HashSet<>(), (a, b) -> {
+					if (a == null || b == null) {
 						return null;
 					}
-					determinedImports.addAll(determinedSourceImports);
-				}
-			}
-			return determinedImports;
-		}
-
-		private Class<?>[] getImports(Annotation annotation) {
-			if (annotation instanceof Import importAnnotation) {
-				return importAnnotation.value();
-			}
-			return NO_IMPORTS;
+					else {
+						a.add(b);
+						return a;
+					}
+				});
 		}
 
 		private Set<Object> determineImports(Class<?> source, AnnotationMetadata metadata) {
@@ -333,67 +295,25 @@ class ImportsContextCustomizer implements ContextCustomizer {
 			return this.key.toString();
 		}
 
-	}
-
-	/**
-	 * Filter used to limit considered annotations.
-	 */
-	private interface AnnotationFilter {
-
-		boolean isIgnored(Annotation annotation);
-
-	}
-
-	/**
-	 * {@link AnnotationFilter} for {@literal java.lang} annotations.
-	 */
-	private static final class JavaLangAnnotationFilter implements AnnotationFilter {
-
-		@Override
-		public boolean isIgnored(Annotation annotation) {
-			return AnnotationUtils.isInJavaLangAnnotationPackage(annotation);
+		private static Predicate<String> isInKotlinAnnotationPackage() {
+			return packages("kotlin.annotation");
 		}
 
-	}
-
-	/**
-	 * {@link AnnotationFilter} for Kotlin annotations.
-	 */
-	private static final class KotlinAnnotationFilter implements AnnotationFilter {
-
-		@Override
-		public boolean isIgnored(Annotation annotation) {
-			return "kotlin.Metadata".equals(annotation.annotationType().getName())
-					|| isInKotlinAnnotationPackage(annotation);
+		@SafeVarargs
+		private static <T> Predicate<T> or(Predicate<T>... predicates) {
+			return (x) -> {
+				for (var predicate : predicates) {
+					if (predicate.test(x)) {
+						return true;
+					}
+				}
+				return false;
+			};
 		}
 
-		private boolean isInKotlinAnnotationPackage(Annotation annotation) {
-			return annotation.annotationType().getName().startsWith("kotlin.annotation.");
-		}
-
-	}
-
-	/**
-	 * {@link AnnotationFilter} for Spock annotations.
-	 */
-	private static final class SpockAnnotationFilter implements AnnotationFilter {
-
-		@Override
-		public boolean isIgnored(Annotation annotation) {
-			return annotation.annotationType().getName().startsWith("org.spockframework.")
-					|| annotation.annotationType().getName().startsWith("spock.");
-		}
-
-	}
-
-	/**
-	 * {@link AnnotationFilter} for JUnit annotations.
-	 */
-	private static final class JUnitAnnotationFilter implements AnnotationFilter {
-
-		@Override
-		public boolean isIgnored(Annotation annotation) {
-			return annotation.annotationType().getName().startsWith("org.junit.");
+		private static Predicate<String> packages(String... packages) {
+			var starts = Stream.of(packages).map((p) -> p + ".").toList();
+			return (packageName) -> starts.stream().anyMatch(packageName::startsWith);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/ImportsContextCustomizerTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/ImportsContextCustomizerTests.java
@@ -33,6 +33,7 @@ import org.springframework.boot.context.annotation.DeterminableImports;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportSelector;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.core.type.AnnotationMetadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -78,6 +79,30 @@ class ImportsContextCustomizerTests {
 	void customizersForTestClassesWithDifferentJUnitAnnotationsAreEqual() {
 		assertThat(new ImportsContextCustomizer(FirstJUnitAnnotatedTestClass.class))
 			.isEqualTo(new ImportsContextCustomizer(SecondJUnitAnnotatedTestClass.class));
+	}
+
+	@Test
+	void customizersForClassesWithDifferentImportsAreNotEqual() {
+		assertThat(new ImportsContextCustomizer(FirstAnnotatedTestClass.class))
+			.isNotEqualTo(new ImportsContextCustomizer(SecondAnnotatedTestClass.class));
+	}
+
+	@Test
+	void customizersForClassesWithDifferentMetaImportsAreNotEqual() {
+		assertThat(new ImportsContextCustomizer(FirstMetaAnnotatedTestClass.class))
+			.isNotEqualTo(new ImportsContextCustomizer(SecondMetaAnnotatedTestClass.class));
+	}
+
+	@Test
+	void customizersForClassesWithDifferentAliasedImportsAreNotEqual() {
+		assertThat(new ImportsContextCustomizer(FirstAliasAnnotatedTestClass.class))
+			.isNotEqualTo(new ImportsContextCustomizer(SecondAliasAnnotatedTestClass.class));
+	}
+
+	@Test
+	void importsCanBeScatteredOnMultipleAnnotations() {
+		assertThat(new ImportsContextCustomizer(SingleImportAnnotationTestClass.class))
+			.isEqualTo(new ImportsContextCustomizer(MultipleImportAnnotationTestClass.class));
 	}
 
 	@Import(TestImportSelector.class)
@@ -152,6 +177,17 @@ class ImportsContextCustomizerTests {
 
 	}
 
+	@Import({ FirstImportedClass.class, SecondImportedClass.class })
+	static class SingleImportAnnotationTestClass {
+
+	}
+
+	@FirstMetaImport
+	@Import(SecondImportedClass.class)
+	static class MultipleImportAnnotationTestClass {
+
+	}
+
 	@Retention(RetentionPolicy.RUNTIME)
 	@interface Indicator1 {
 
@@ -159,6 +195,65 @@ class ImportsContextCustomizerTests {
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@interface Indicator2 {
+
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Import(AliasFor.class)
+	public @interface AliasedImport {
+
+		@AliasFor(annotation = Import.class)
+		Class<?>[] value();
+
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Import(FirstImportedClass.class)
+	public @interface FirstMetaImport {
+
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Import(SecondImportedClass.class)
+	public @interface SecondMetaImport {
+
+	}
+
+	static class FirstImportedClass {
+
+	}
+
+	static class SecondImportedClass {
+
+	}
+
+	@AliasedImport(FirstImportedClass.class)
+	static class FirstAliasAnnotatedTestClass {
+
+	}
+
+	@AliasedImport(SecondImportedClass.class)
+	static class SecondAliasAnnotatedTestClass {
+
+	}
+
+	@FirstMetaImport
+	static class FirstMetaAnnotatedTestClass {
+
+	}
+
+	@SecondMetaImport
+	static class SecondMetaAnnotatedTestClass {
+
+	}
+
+	@Import(FirstImportedClass.class)
+	static class FirstAnnotatedTestClass {
+
+	}
+
+	@Import(SecondImportedClass.class)
+	static class SecondAnnotatedTestClass {
 
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
Fixes https://github.com/spring-projects/spring-boot/issues/34854

Use `MergedAnnotations` in order to support `@AliasFor`.

I used plain `Predicate` instead of `AnnotationFilter` because it is much simpler and generic.
