### PR TITLE
Add properties to support device grant with Spring Authorization Server

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerProperties.java
@@ -100,6 +100,16 @@ public class OAuth2AuthorizationServerProperties implements InitializingBean {
 		private String authorizationUri;
 
 		/**
+		 * Authorization Server's OAuth 2.0 Device Authorization Endpoint.
+		 */
+		private String deviceAuthorizationUri;
+
+		/**
+		 * Authorization Server's OAuth 2.0 Device Verification Endpoint.
+		 */
+		private String deviceVerificationUri;
+
+		/**
 		 * Authorization Server's OAuth 2.0 Token Endpoint.
 		 */
 		private String tokenUri;
@@ -131,6 +141,22 @@ public class OAuth2AuthorizationServerProperties implements InitializingBean {
 
 		public void setAuthorizationUri(String authorizationUri) {
 			this.authorizationUri = authorizationUri;
+		}
+
+		public String getDeviceAuthorizationUri() {
+			return this.deviceAuthorizationUri;
+		}
+
+		public void setDeviceAuthorizationUri(String deviceAuthorizationUri) {
+			this.deviceAuthorizationUri = deviceAuthorizationUri;
+		}
+
+		public String getDeviceVerificationUri() {
+			return this.deviceVerificationUri;
+		}
+
+		public void setDeviceVerificationUri(String deviceVerificationUri) {
+			this.deviceVerificationUri = deviceVerificationUri;
 		}
 
 		public String getTokenUri() {
@@ -431,6 +457,11 @@ public class OAuth2AuthorizationServerProperties implements InitializingBean {
 		private String accessTokenFormat;
 
 		/**
+		 * Time-to-live for a device code.
+		 */
+		private Duration deviceCodeTimeToLive;
+
+		/**
 		 * Whether refresh tokens are reused or a new refresh token is issued when
 		 * returning the access token response.
 		 */
@@ -468,6 +499,14 @@ public class OAuth2AuthorizationServerProperties implements InitializingBean {
 
 		public void setAccessTokenFormat(String accessTokenFormat) {
 			this.accessTokenFormat = accessTokenFormat;
+		}
+
+		public Duration getDeviceCodeTimeToLive() {
+			return this.deviceCodeTimeToLive;
+		}
+
+		public void setDeviceCodeTimeToLive(Duration deviceCodeTimeToLive) {
+			this.deviceCodeTimeToLive = deviceCodeTimeToLive;
 		}
 
 		public boolean isReuseRefreshTokens() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerPropertiesMapper.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerPropertiesMapper.java
@@ -53,6 +53,8 @@ final class OAuth2AuthorizationServerPropertiesMapper {
 		AuthorizationServerSettings.Builder builder = AuthorizationServerSettings.builder();
 		map.from(this.properties::getIssuer).to(builder::issuer);
 		map.from(endpoint::getAuthorizationUri).to(builder::authorizationEndpoint);
+		map.from(endpoint::getDeviceAuthorizationUri).to(builder::deviceAuthorizationEndpoint);
+		map.from(endpoint::getDeviceVerificationUri).to(builder::deviceVerificationEndpoint);
 		map.from(endpoint::getTokenUri).to(builder::tokenEndpoint);
 		map.from(endpoint::getJwkSetUri).to(builder::jwkSetEndpoint);
 		map.from(endpoint::getTokenRevocationUri).to(builder::tokenRevocationEndpoint);
@@ -111,6 +113,7 @@ final class OAuth2AuthorizationServerPropertiesMapper {
 		map.from(token::getAuthorizationCodeTimeToLive).to(builder::authorizationCodeTimeToLive);
 		map.from(token::getAccessTokenTimeToLive).to(builder::accessTokenTimeToLive);
 		map.from(token::getAccessTokenFormat).as(OAuth2TokenFormat::new).to(builder::accessTokenFormat);
+		map.from(token::getDeviceCodeTimeToLive).to(builder::deviceCodeTimeToLive);
 		map.from(token::isReuseRefreshTokens).to(builder::reuseRefreshTokens);
 		map.from(token::getRefreshTokenTimeToLive).to(builder::refreshTokenTimeToLive);
 		map.from(token::getIdTokenSignatureAlgorithm)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerAutoConfigurationTests.java
@@ -124,6 +124,8 @@ class OAuth2AuthorizationServerAutoConfigurationTests {
 		this.contextRunner
 			.withPropertyValues(PROPERTIES_PREFIX + ".issuer=https://example.com",
 					PROPERTIES_PREFIX + ".endpoint.authorization-uri=/authorize",
+					PROPERTIES_PREFIX + ".endpoint.device-authorization-uri=/device_authorization",
+					PROPERTIES_PREFIX + ".endpoint.device-verification-uri=/device_verification",
 					PROPERTIES_PREFIX + ".endpoint.token-uri=/token", PROPERTIES_PREFIX + ".endpoint.jwk-set-uri=/jwks",
 					PROPERTIES_PREFIX + ".endpoint.token-revocation-uri=/revoke",
 					PROPERTIES_PREFIX + ".endpoint.token-introspection-uri=/introspect",
@@ -134,6 +136,8 @@ class OAuth2AuthorizationServerAutoConfigurationTests {
 				AuthorizationServerSettings settings = context.getBean(AuthorizationServerSettings.class);
 				assertThat(settings.getIssuer()).isEqualTo("https://example.com");
 				assertThat(settings.getAuthorizationEndpoint()).isEqualTo("/authorize");
+				assertThat(settings.getDeviceAuthorizationEndpoint()).isEqualTo("/device_authorization");
+				assertThat(settings.getDeviceVerificationEndpoint()).isEqualTo("/device_verification");
 				assertThat(settings.getTokenEndpoint()).isEqualTo("/token");
 				assertThat(settings.getJwkSetEndpoint()).isEqualTo("/jwks");
 				assertThat(settings.getTokenRevocationEndpoint()).isEqualTo("/revoke");

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerPropertiesMapperTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerPropertiesMapperTests.java
@@ -89,6 +89,7 @@ class OAuth2AuthorizationServerPropertiesMapperTests {
 		token.setAccessTokenFormat("reference");
 		token.setAccessTokenTimeToLive(Duration.ofSeconds(300));
 		token.setRefreshTokenTimeToLive(Duration.ofHours(24));
+		token.setDeviceCodeTimeToLive(Duration.ofMinutes(30));
 		token.setReuseRefreshTokens(true);
 		token.setIdTokenSignatureAlgorithm("rs512");
 		return client;
@@ -99,6 +100,8 @@ class OAuth2AuthorizationServerPropertiesMapperTests {
 		this.properties.setIssuer("https://example.com");
 		OAuth2AuthorizationServerProperties.Endpoint endpoints = this.properties.getEndpoint();
 		endpoints.setAuthorizationUri("/authorize");
+		endpoints.setDeviceAuthorizationUri("/device_authorization");
+		endpoints.setDeviceVerificationUri("/device_verification");
 		endpoints.setTokenUri("/token");
 		endpoints.setJwkSetUri("/jwks");
 		endpoints.setTokenRevocationUri("/revoke");
@@ -110,6 +113,8 @@ class OAuth2AuthorizationServerPropertiesMapperTests {
 		AuthorizationServerSettings settings = this.mapper.asAuthorizationServerSettings();
 		assertThat(settings.getIssuer()).isEqualTo("https://example.com");
 		assertThat(settings.getAuthorizationEndpoint()).isEqualTo("/authorize");
+		assertThat(settings.getDeviceAuthorizationEndpoint()).isEqualTo("/device_authorization");
+		assertThat(settings.getDeviceVerificationEndpoint()).isEqualTo("/device_verification");
 		assertThat(settings.getTokenEndpoint()).isEqualTo("/token");
 		assertThat(settings.getJwkSetEndpoint()).isEqualTo("/jwks");
 		assertThat(settings.getTokenRevocationEndpoint()).isEqualTo("/revoke");


### PR DESCRIPTION
Adds the following properties under `spring.security.oauth2.authorizationserver.client.[registration-id]`:

* `endpoint.device-authorization-uri`
* `endpoint.device-verification-uri`
* `token.device-code-time-to-live`

Closes gh-34843

CC: @mbhave 

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
