### PR TITLE
Add aggregation temporality to OtlpProperties

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpProperties.java
@@ -18,6 +18,8 @@ package org.springframework.boot.actuate.autoconfigure.metrics.export.otlp;
 
 import java.util.Map;
 
+import io.micrometer.registry.otlp.AggregationTemporality;
+
 import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -26,6 +28,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * export.
  *
  * @author Eddú Meléndez
+ * @author Jonatan Ivanov
  * @since 3.0.0
  */
 @ConfigurationProperties(prefix = "management.otlp.metrics.export")
@@ -35,6 +38,12 @@ public class OtlpProperties extends StepRegistryProperties {
 	 * URI of the OLTP server.
 	 */
 	private String url = "http://localhost:4318/v1/metrics";
+
+	/**
+	 * Aggregation temporality of sums. It defines the way additive values are expressed.
+	 * This setting depends on the backend you use, some only support one temporality.
+	 */
+	private AggregationTemporality aggregationTemporality = AggregationTemporality.CUMULATIVE;
 
 	/**
 	 * Monitored resource's attributes.
@@ -52,6 +61,14 @@ public class OtlpProperties extends StepRegistryProperties {
 
 	public void setUrl(String url) {
 		this.url = url;
+	}
+
+	public AggregationTemporality getAggregationTemporality() {
+		return this.aggregationTemporality;
+	}
+
+	public void setAggregationTemporality(AggregationTemporality aggregationTemporality) {
+		this.aggregationTemporality = aggregationTemporality;
 	}
 
 	public Map<String, String> getResourceAttributes() {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesConfigAdapter.java
@@ -18,6 +18,7 @@ package org.springframework.boot.actuate.autoconfigure.metrics.export.otlp;
 
 import java.util.Map;
 
+import io.micrometer.registry.otlp.AggregationTemporality;
 import io.micrometer.registry.otlp.OtlpConfig;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.StepRegistryPropertiesConfigAdapter;
@@ -26,6 +27,7 @@ import org.springframework.boot.actuate.autoconfigure.metrics.export.properties.
  * Adapter to convert {@link OtlpProperties} to an {@link OtlpConfig}.
  *
  * @author Eddú Meléndez
+ * @author Jonatan Ivanov
  */
 class OtlpPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<OtlpProperties> implements OtlpConfig {
 
@@ -41,6 +43,11 @@ class OtlpPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<Ot
 	@Override
 	public String url() {
 		return get(OtlpProperties::getUrl, OtlpConfig.super::url);
+	}
+
+	@Override
+	public AggregationTemporality aggregationTemporality() {
+		return get(OtlpProperties::getAggregationTemporality, OtlpConfig.super::aggregationTemporality);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesConfigAdapterTests.java
@@ -18,6 +18,7 @@ package org.springframework.boot.actuate.autoconfigure.metrics.export.otlp;
 
 import java.util.Map;
 
+import io.micrometer.registry.otlp.AggregationTemporality;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +35,21 @@ class OtlpPropertiesConfigAdapterTests {
 		OtlpProperties properties = new OtlpProperties();
 		properties.setUrl("http://another-url:4318/v1/metrics");
 		assertThat(new OtlpPropertiesConfigAdapter(properties).url()).isEqualTo("http://another-url:4318/v1/metrics");
+	}
+
+	@Test
+	void whenPropertiesAggregationTemporalityIsNotSetAdapterAggregationTemporalityReturnsCumulative() {
+		OtlpProperties properties = new OtlpProperties();
+		assertThat(new OtlpPropertiesConfigAdapter(properties).aggregationTemporality())
+			.isSameAs(AggregationTemporality.CUMULATIVE);
+	}
+
+	@Test
+	void whenPropertiesAggregationTemporalityIsSetAdapterAggregationTemporalityReturnsIt() {
+		OtlpProperties properties = new OtlpProperties();
+		properties.setAggregationTemporality(AggregationTemporality.DELTA);
+		assertThat(new OtlpPropertiesConfigAdapter(properties).aggregationTemporality())
+			.isSameAs(AggregationTemporality.DELTA);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesTests.java
@@ -36,6 +36,7 @@ class OtlpPropertiesTests extends StepRegistryPropertiesTests {
 		OtlpConfig config = OtlpConfig.DEFAULT;
 		assertStepRegistryDefaultValues(properties, config);
 		assertThat(properties.getUrl()).isEqualTo(config.url());
+		assertThat(properties.getAggregationTemporality()).isSameAs(config.aggregationTemporality());
 	}
 
 }


### PR DESCRIPTION
In Micrometer 1.11.0-RC1, a new property was introduced in OtlpConfig to define aggregation temporality.
See https://github.com/micrometer-metrics/micrometer/pull/3625
