### PR TITLE
Avoid repeated loading of "META-INF/spring.factories"

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/StandardConfigDataLocationResolver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/StandardConfigDataLocationResolver.java
@@ -86,7 +86,7 @@ public class StandardConfigDataLocationResolver
 	public StandardConfigDataLocationResolver(Log logger, Binder binder, ResourceLoader resourceLoader) {
 		this.logger = logger;
 		this.propertySourceLoaders = SpringFactoriesLoader.loadFactories(PropertySourceLoader.class,
-				getClass().getClassLoader());
+				resourceLoader.getClassLoader() == null ? getClass().getClassLoader() : resourceLoader.getClassLoader());
 		this.configNames = getConfigNames(binder);
 		this.resourceLoader = new LocationResourceLoader(resourceLoader);
 	}


### PR DESCRIPTION
When I use a custom classloader I find duplicate loading spring.factories

```
@SpringBootApplication
public class TestApplication {

    public static void main(String[] args){
        URLClassLoader diskClassLoader = new URLClassLoader(urls("/work/lib"), TestApplication.class.getClassLoader());
        SpringApplication app = new SpringApplication(new DefaultResourceLoader(diskClassLoader),TestApplication.class);
        app.run(args);
    }

    private static URL[] urls(String dir){
        File file = new File(dir);
        List<URL> urls = new ArrayList<>();
        File[] files = file.listFiles();
        if(files != null){
            try{
                for (File listFile : files) {
                    if(listFile.isDirectory() || !listFile.getName().endsWith(".jar")){
                        continue;
                    }
                    urls.add(listFile.toURI().toURL());
                }
            }catch (MalformedURLException e){
                //ignore
            }
        }
        return urls.toArray(new URL[0]);
    }

}
```
