### PR TITLE
Improve Kubernetes liveness and readiness probes customization documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/endpoints.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/endpoints.adoc
@@ -904,10 +904,8 @@ This can be done by setting the following property:
 	management.endpoint.health.probes.add-additional-paths=true
 ----
 
-This would make `liveness` available at `/livez` and `readiness` at `readyz` on the main server port.
-
-
-
+This would make `liveness` group available at `/livez` and `readiness` group at `readyz` on the main server port.
+Paths could be customized using `additional-path` property on each group, see <<actuator#actuator.endpoints.health.groups, health groups>> for more detail.
 
 [[actuator.endpoints.kubernetes-probes.external-state]]
 ==== Checking External State With Kubernetes Probes

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/AbstractManagementPortAvailabilityProbesTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/AbstractManagementPortAvailabilityProbesTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.actuator;
+
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Base class for integration tests for adding Health probes additional paths.
+ *
+ * @author Ivo Smid
+ */
+abstract class AbstractManagementPortAvailabilityProbesTests {
+
+	@LocalServerPort
+	protected int port;
+
+	@LocalManagementPort
+	protected int managementPort;
+
+	@Test
+	void testLiveness() {
+		ResponseEntity<String> entity = callHttpGetManagement("/actuator/health/liveness");
+		assertUp(entity);
+	}
+
+	@Test
+	void testReadiness() {
+		ResponseEntity<String> entity = callHttpGetManagement("/actuator/health/readiness");
+		assertUp(entity);
+	}
+
+	protected ResponseEntity<String> callHttpGetManagement(String urlPath) {
+		return callHttpGet(urlPath, this.managementPort, Function.identity());
+	}
+
+	protected ResponseEntity<String> callHttpGetServer(String urlPath) {
+		return callHttpGet(urlPath, this.port, (it) -> it.withBasicAuth("user", "password"));
+	}
+
+	private ResponseEntity<String> callHttpGet(String urlPath, int port,
+			Function<TestRestTemplate, TestRestTemplate> customizer) {
+		var testRestTemplate = customizer.apply(new TestRestTemplate());
+		return testRestTemplate.getForEntity("http://localhost:" + port + urlPath, String.class);
+	}
+
+	protected static void assertUp(ResponseEntity<String> entity) {
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(entity.getBody()).contains("\"status\":\"UP\"");
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/ManagementPortAvailabilityProbesCustomPathTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/ManagementPortAvailabilityProbesCustomPathTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.actuator;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for adding Health probes additional paths.
+ *
+ * @author Ivo Smid
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT,
+		properties = { "management.server.port=0", "management.endpoint.health.probes.enabled=true",
+				"management.endpoint.health.probes.add-additional-paths=true",
+				"management.endpoint.health.group.liveness.additional-path=server:/live-custom",
+				"management.endpoint.health.group.readiness.additional-path=server:/ready-custom" })
+class ManagementPortAvailabilityProbesCustomPathTests extends AbstractManagementPortAvailabilityProbesTests {
+
+	@Test
+	void testCustomLivez() {
+		ResponseEntity<String> entity = callHttpGetServer("/live-custom");
+		assertUp(entity);
+	}
+
+	@Test
+	void testDefaultLivezNotFound() {
+		ResponseEntity<String> entity = callHttpGetServer("/livez");
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	void testCustomReadyz() {
+		ResponseEntity<String> entity = callHttpGetServer("/ready-custom");
+		assertUp(entity);
+	}
+
+	@Test
+	void testDefaultReadyzNotFound() {
+		ResponseEntity<String> entity = callHttpGetServer("/readyz");
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/ManagementPortAvailabilityProbesCustomPathWithoutFlagEnabledTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/ManagementPortAvailabilityProbesCustomPathWithoutFlagEnabledTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.actuator;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for adding Health probes additional paths.
+ *
+ * @author Ivo Smid
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT,
+		properties = { "management.server.port=0", "management.endpoint.health.probes.enabled=true",
+				"management.endpoint.health.probes.add-additional-paths=false",
+				"management.endpoint.health.group.liveness.additional-path=server:/live-custom",
+				"management.endpoint.health.group.readiness.additional-path=server:/ready-custom" })
+class ManagementPortAvailabilityProbesCustomPathWithoutFlagEnabledTests
+		extends AbstractManagementPortAvailabilityProbesTests {
+
+	@Test
+	void testCustomLivez() {
+		ResponseEntity<String> entity = callHttpGetServer("/live-custom");
+		assertUp(entity);
+	}
+
+	@Test
+	void testDefaultLivezNotFound() {
+		ResponseEntity<String> entity = callHttpGetServer("/livez");
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	void testCustomReadyz() {
+		ResponseEntity<String> entity = callHttpGetServer("/ready-custom");
+		assertUp(entity);
+	}
+
+	@Test
+	void testDefaultReadyzNotFound() {
+		ResponseEntity<String> entity = callHttpGetServer("/readyz");
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/ManagementPortAvailabilityProbesDefaultPathTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/ManagementPortAvailabilityProbesDefaultPathTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.actuator;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Integration tests for adding Health probes additional paths.
+ *
+ * @author Ivo Smid
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT,
+		properties = { "management.server.port=0", "management.endpoint.health.probes.enabled=true",
+				"management.endpoint.health.probes.add-additional-paths=true" })
+class ManagementPortAvailabilityProbesDefaultPathTests extends AbstractManagementPortAvailabilityProbesTests {
+
+	@Test
+	void testLivez() {
+		ResponseEntity<String> entity = callHttpGetServer("/livez");
+		assertUp(entity);
+	}
+
+	@Test
+	void testReadyz() {
+		ResponseEntity<String> entity = callHttpGetServer("/readyz");
+		assertUp(entity);
+	}
+
+}


### PR DESCRIPTION
Hi,
when I was looking into docs how to customize k8s liveness and readiness probes, I was not able to find it explicitly how to do it.
This PR add tests and improves documentation little bit.
What do you think?
Thx
Ivos