### PR TITLE
Add support for providing custom OTel IdGenerator

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfiguration.java
@@ -46,6 +46,7 @@ import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.extension.trace.propagation.B3Propagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.IdGenerator;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import io.opentelemetry.sdk.trace.SpanProcessor;
@@ -100,12 +101,13 @@ public class OpenTelemetryAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	SdkTracerProvider otelSdkTracerProvider(Environment environment, ObjectProvider<SpanProcessor> spanProcessors,
-			Sampler sampler) {
+	SdkTracerProvider otelSdkTracerProvider(Environment environment, ObjectProvider<IdGenerator> idGenerator,
+			ObjectProvider<SpanProcessor> spanProcessors, Sampler sampler) {
 		String applicationName = environment.getProperty("spring.application.name", DEFAULT_APPLICATION_NAME);
 		SdkTracerProviderBuilder builder = SdkTracerProvider.builder()
 			.setSampler(sampler)
 			.setResource(Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, applicationName)));
+		idGenerator.ifUnique(builder::setIdGenerator);
 		spanProcessors.orderedStream().forEach(builder::addSpanProcessor);
 		return builder.build();
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfigurationTests.java
@@ -33,6 +33,7 @@ import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.extension.trace.propagation.B3Propagator;
+import io.opentelemetry.sdk.trace.IdGenerator;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
@@ -54,6 +55,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Moritz Halbritter
  * @author Andy Wilkinson
+ * @author Vedran Pavic
  */
 class OpenTelemetryAutoConfigurationTests {
 
@@ -203,6 +205,16 @@ class OpenTelemetryAutoConfigurationTests {
 			.run((context) -> assertThat(context).hasBean("w3cTextMapPropagatorWithoutBaggage"));
 	}
 
+	@Test
+	void shouldAllowCustomIdGenerator() {
+		this.contextRunner.withUserConfiguration(CustomIdGeneratorConfiguration.class).run((context) -> {
+			IdGenerator customIdGenerator = context.getBean("customIdGenerator", IdGenerator.class);
+			assertThat(customIdGenerator).isNotNull();
+			assertThat(context).getBean(SdkTracerProvider.class).extracting("sharedState.idGenerator")
+					.isEqualTo(customIdGenerator);
+		});
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	private static class CustomConfiguration {
 
@@ -274,6 +286,16 @@ class OpenTelemetryAutoConfigurationTests {
 		@Bean
 		SpanCustomizer customSpanCustomizer() {
 			return mock(SpanCustomizer.class);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	private static class CustomIdGeneratorConfiguration {
+
+		@Bean
+		IdGenerator customIdGenerator() {
+			return mock(IdGenerator.class);
 		}
 
 	}


### PR DESCRIPTION
At present, `OpenTelemetryAutoConfiguration` offers no easy way of providing custom `IdGenerator`, which is necessary for some tracing systems (for example, AWS X-Ray). Consequently, user that need custom `IdGenerator` are forced to replace significant bits of `OpenTelemetryAutoConfiguration`.

This commit adds support for providing custom `IdGenerator` bean, that will be used in auto-configured `SdkTracerProvider`.

Closes gh-34787

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
