### PR TITLE
Make DebugAgentEnvironmentPostProcessor playing nice with compile time enhancement

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/reactor/DebugAgentEnvironmentPostProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/reactor/DebugAgentEnvironmentPostProcessor.java
@@ -37,11 +37,13 @@ public class DebugAgentEnvironmentPostProcessor implements EnvironmentPostProces
 
 	private static final String REACTOR_DEBUGAGENT_CLASS = "reactor.tools.agent.ReactorDebugAgent";
 
+	private static final String BYTE_BUDDYAGENT_CLASS = "net.bytebuddy.agent.ByteBuddyAgent";
+
 	private static final String DEBUGAGENT_ENABLED_CONFIG_KEY = "spring.reactor.debug-agent.enabled";
 
 	@Override
 	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
-		if (ClassUtils.isPresent(REACTOR_DEBUGAGENT_CLASS, null)) {
+		if (ClassUtils.isPresent(REACTOR_DEBUGAGENT_CLASS, null) && ClassUtils.isPresent(BYTE_BUDDYAGENT_CLASS, null)) {
 			Boolean agentEnabled = environment.getProperty(DEBUGAGENT_ENABLED_CONFIG_KEY, Boolean.class);
 			if (agentEnabled != Boolean.FALSE) {
 				try {


### PR DESCRIPTION
https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/reactor/DebugAgentEnvironmentPostProcessor.java#L44

- If compile time reactor debug is enabled as described here: https://github.com/reactor/reactor-core/blob/main/docs/asciidoc/debugging.adoc#running-reactordebugagent-at-build-time
- Then the reactor-tools library is on the classpath 
- However the class ByteBuddyAgent isn't since this is compile time

Suggestion: make the loading also conditional on the class `net.bytebuddy.agent.ByteBuddyAgent` to detect when the user wants compile or runtime/agent-based enhancement.



Stack trace:
```
10:59:09.028 [main] ERROR org.springframework.boot.SpringApplication -- Application run failed                                                                                                                                                                                                         
java.lang.RuntimeException: Failed to init Reactor's debug agent                                                                                                                                                                                                                                       
        at org.springframework.boot.reactor.DebugAgentEnvironmentPostProcessor.postProcessEnvironment(DebugAgentEnvironmentPostProcessor.java:52)                                                                                                                                                      
        at org.springframework.boot.env.EnvironmentPostProcessorApplicationListener.onApplicationEnvironmentPreparedEvent(EnvironmentPostProcessorApplicationListener.java:109)                                                                                                                        
        at org.springframework.boot.env.EnvironmentPostProcessorApplicationListener.onApplicationEvent(EnvironmentPostProcessorApplicationListener.java:94)                                                                                                                                            
        at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:176)                                                                                                                                                            
        at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:169)                                                                                                                                                              
        at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:143)                                                                                                                                                              
        at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:131)                                                                                                                                                              
        at org.springframework.boot.context.event.EventPublishingRunListener.multicastInitialEvent(EventPublishingRunListener.java:136)                                                                                                                                                                
        at org.springframework.boot.context.event.EventPublishingRunListener.environmentPrepared(EventPublishingRunListener.java:81)                                                                                                                                                                   
        at org.springframework.boot.SpringApplicationRunListeners.lambda$environmentPrepared$2(SpringApplicationRunListeners.java:64)                                                                                                                                                                  
        at java.base/java.lang.Iterable.forEach(Unknown Source)                                                                                                                                                                                                                                        
        at org.springframework.boot.SpringApplicationRunListeners.doWithListeners(SpringApplicationRunListeners.java:118)                                                                                                                                                                              
        at org.springframework.boot.SpringApplicationRunListeners.doWithListeners(SpringApplicationRunListeners.java:112)
        at org.springframework.boot.SpringApplicationRunListeners.environmentPrepared(SpringApplicationRunListeners.java:63)
        at org.springframework.boot.SpringApplication.prepareEnvironment(SpringApplication.java:354)
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:305)               
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:1304)              
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:1293)              
        at com.example.Service.main(LspReportingServiceApplication.java:26)
Caused by: java.lang.reflect.InvocationTargetException: null                                                                                       
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)           
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)        
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)    
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)                                                                               
        at org.springframework.boot.reactor.DebugAgentEnvironmentPostProcessor.postProcessEnvironment(DebugAgentEnvironmentPostProcessor.java:49)
        ... 18 common frames omitted                                                                                                               
Caused by: java.lang.NoClassDefFoundError: net/bytebuddy/agent/ByteBuddyAgent                     
        at reactor.tools.agent.ReactorDebugAgent.init(ReactorDebugAgent.java:56)                    
        ... 23 common frames omitted                   
Caused by: java.lang.ClassNotFoundException: net.bytebuddy.agent.ByteBuddyAgent                   
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(Unknown Source)               
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(Unknown Source)      
        at java.base/java.lang.ClassLoader.loadClass(Unknown Source)                                                                               
        ... 24 common frames omitted        
```