### PR TITLE
Remove dependencies in same stream chain without storing in intermediate list

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/classpath/CheckClasspathForUnnecessaryExclusions.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/classpath/CheckClasspathForUnnecessaryExclusions.java
@@ -107,14 +107,13 @@ public class CheckClasspathForUnnecessaryExclusions extends DefaultTask {
 		this.exclusionsByDependencyId.forEach((dependencyId, exclusions) -> {
 			if (!exclusions.isEmpty()) {
 				Dependency toCheck = this.dependencyById.get(dependencyId);
-				List<String> dependencies = this.configurations.detachedConfiguration(toCheck, this.platform)
+				this.configurations.detachedConfiguration(toCheck, this.platform)
 					.getIncoming()
 					.getArtifacts()
 					.getArtifacts()
 					.stream()
 					.map(this::getId)
-					.toList();
-				exclusions.removeAll(dependencies);
+					.forEach(exclusions::remove);
 				removeProfileExclusions(dependencyId, exclusions);
 				if (!exclusions.isEmpty()) {
 					unnecessaryExclusions.put(dependencyId, exclusions);


### PR DESCRIPTION
This PR is to improve the removal of dependencies in `CheckClasspathForUnnecessaryExclusions`.  

It enhances the code to use same stream chain to remove `dependencies` from `exclusions Set<String>` without storing/collecting in any intermediate list.

Also, `Set.removeAll(List)` call can be slow when the size of the argument is greater than or equal to the size of the set, and the set is a subclass of java.util.AbstractSet. In this case, List.contains() is called for each element in the set, which will perform a linear search.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
