### PR TITLE
Support Prometheus exemplars with OpenTelemetry agent

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAgentExemplarAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAgentExemplarAutoConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.springframework.boot.actuate.autoconfigure.tracing;
+
+import io.prometheus.client.exemplars.tracer.otel_agent.OpenTelemetryAgentSpanContextSupplier;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusMetricsExportAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * This {@link EnableAutoConfiguration Auto-configuration} runs if the
+ * application has been started with the OpenTelemetry agent.
+ * <p>
+ * Currently, it provides an Exemplar Sampler for Prometheus
+ * based on the agent's tracing, which is why it needs to run
+ * before {@link PrometheusMetricsExportAutoConfiguration}.
+ */
+@AutoConfiguration(before = PrometheusMetricsExportAutoConfiguration.class)
+@ConditionalOnEnabledTracing
+@ConditionalOnClass(name = "io.opentelemetry.javaagent.shaded.io.opentelemetry.api.trace.Span")
+class OpenTelemetryAgentExemplarAutoConfiguration {
+	@Bean
+	OpenTelemetryAgentSpanContextSupplier openTelemetryAgentSpanContextSupplier() {
+		return new OpenTelemetryAgentSpanContextSupplier();
+	}
+}


### PR DESCRIPTION
When running the Spring Boot Application with the OpenTelemetry Java Agent as follows ([see also](https://opentelemetry.io/docs/instrumentation/java/automatic/))
```
java -javaagent:opentelemetry-agent.jar -jar spring-boot-app.jar
```
the Spring Boot Application must include the following configuration to enable support for Prometheus exemplars when the usual Actuator endpoint is used:
```
@Configuration
class PrometheusExemplarSamplerConfiguration {
    @Bean
    @ConditionalOnClass(name = "io.opentelemetry.javaagent.shaded.io.opentelemetry.api.trace.Span")
    OpenTelemetryAgentSpanContextSupplier openTelemetryAgentSpanContextSupplier() {
        return new OpenTelemetryAgentSpanContextSupplier();
    }
}
```
Support for Prometheus exemplars was added in #30472 and this PR essentially makes this above extra configuration unnecessary. Tests are missing (but will be added) once you agree that this is a meaningful addition to Spring Boot's auto-configuration. In particular, I'm not sure if you agree with the way how I detect the Java agent being present, that is by having a hard-coded condition on the (shaded) Opentelemetry API class of the agent. 

I appreciate any feedback.
