### PR TITLE
Skipping replace DataSource if has JdbcConnectionDetails not created by DataSourceAutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jdbc/TestDatabaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/jdbc/TestDatabaseAutoConfigurationTests.java
@@ -21,10 +21,13 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.JdbcConnectionDetails;
 import org.springframework.boot.test.autoconfigure.jdbc.TestDatabaseAutoConfiguration.EmbeddedDataSourceFactoryBean;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
@@ -36,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Stephane Nicoll
  * @author Andy Wilkinson
+ * @author Yanming Zhou
  */
 class TestDatabaseAutoConfigurationTests {
 
@@ -69,12 +73,45 @@ class TestDatabaseAutoConfigurationTests {
 			.run((context) -> assertThat(context).doesNotHaveBean(EmbeddedDataSourceFactoryBean.class));
 	}
 
+	@Test
+	void doesNotReplaceIfHasNonDefaultJdbcConnectionDetails() {
+		this.contextRunner.withUserConfiguration(ExistingJdbcConnectionDetailsConfiguration.class)
+			.run((context) -> assertThat(context).doesNotHaveBean(EmbeddedDataSourceFactoryBean.class));
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	static class ExistingDataSourceConfiguration {
 
 		@Bean
 		DataSource dataSource() {
 			return new EmbeddedDatabaseBuilder().generateUniqueName(true).setType(EmbeddedDatabaseType.HSQL).build();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Import(DataSourceAutoConfiguration.class)
+	static class ExistingJdbcConnectionDetailsConfiguration {
+
+		@Bean
+		JdbcConnectionDetails jdbcConnectionDetails() {
+			return new JdbcConnectionDetails() {
+
+				@Override
+				public String getUsername() {
+					return null;
+				}
+
+				@Override
+				public String getPassword() {
+					return null;
+				}
+
+				@Override
+				public String getJdbcUrl() {
+					return null;
+				}
+			};
 		}
 
 	}


### PR DESCRIPTION
before this commit, `@AutoConfigureTestDatabase(replace = NONE)` is required for
```java
@DataJpaTest
@Testcontainers
//@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
public class ApplicationDataJpaTests {

	@Container
	@ServiceConnection
	static MySQLContainer<?> container = ...

```

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
