### PR TITLE
Correct list of annotations that are equivalent to @SpringBootApplication

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/SpringBootApplication.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/SpringBootApplication.java
@@ -40,7 +40,7 @@ import org.springframework.data.repository.Repository;
  * Indicates a {@link Configuration configuration} class that declares one or more
  * {@link Bean @Bean} methods and also triggers {@link EnableAutoConfiguration
  * auto-configuration} and {@link ComponentScan component scanning}. This is a convenience
- * annotation that is equivalent to declaring {@code @Configuration},
+ * annotation that is equivalent to declaring {@code @SpringBootConfiguration},
  * {@code @EnableAutoConfiguration} and {@code @ComponentScan}.
  *
  * @author Phillip Webb


### PR DESCRIPTION
In a working app I tested replacing `@SpringBootApplication` with
```
@Configuration
@EnableAutoConfiguration
@ComponentScan
```
and the Spring tests didn't work any more, I had to use `@SpringBootConfiguration` instead of `@Configuration`.
So I thought I fix the documentation.