### PR TITLE
Add auto-configuration for ObservedAspect

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationAutoConfiguration.java
@@ -27,9 +27,11 @@ import io.micrometer.observation.ObservationFilter;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationPredicate;
 import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.aop.ObservedAspect;
 import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.handler.TracingAwareMeterObservationHandler;
 import io.micrometer.tracing.handler.TracingObservationHandler;
+import org.aspectj.weaver.Advice;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
@@ -51,6 +53,7 @@ import org.springframework.core.annotation.Order;
  * @author Moritz Halbritter
  * @author Brian Clozel
  * @author Jonatan Ivanov
+ * @author Vedran Pavic
  * @since 3.0.0
  */
 @AutoConfiguration(after = { CompositeMeterRegistryAutoConfiguration.class, MicrometerTracingAutoConfiguration.class })
@@ -145,6 +148,18 @@ public class ObservationAutoConfiguration {
 				return new TracingAwareMeterObservationHandler<>(delegate, tracer);
 			}
 
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(Advice.class)
+	static class ObservedAspectConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean
+		ObservedAspect observedAspect(ObservationRegistry observationRegistry) {
+			return new ObservedAspect(observationRegistry);
 		}
 
 	}


### PR DESCRIPTION
This adds support for auto-configuring `ObservedAspect` when AspectJ is on the classpath, which enables the usage of `@Observed`.

---

Is it possible this gets considered for 3.1? I know the RC1 went out last week, but this is a change of small impact that IMO offers nice convenience for the users.

/cc @jonatan-ivanov