### PR TITLE
Modify `@ConditionalOnMissingBean` of `transactionManager` in `JdbcTransactionManagerConfiguration`

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
@@ -45,7 +45,7 @@ import org.springframework.transaction.TransactionManager;
  * @author Stephane Nicoll
  * @author Andy Wilkinson
  * @author Kazuki Shimizu
- * @author davin111
+ * @author Davin Byeon
  * @since 1.0.0
  */
 @AutoConfiguration(before = TransactionAutoConfiguration.class)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
@@ -45,6 +45,7 @@ import org.springframework.transaction.TransactionManager;
  * @author Stephane Nicoll
  * @author Andy Wilkinson
  * @author Kazuki Shimizu
+ * @author davin111
  * @since 1.0.0
  */
 @AutoConfiguration(before = TransactionAutoConfiguration.class)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
@@ -36,7 +36,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionManager;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for {@link JdbcTransactionManager}.
@@ -49,7 +48,7 @@ import org.springframework.transaction.TransactionManager;
  * @since 1.0.0
  */
 @AutoConfiguration(before = TransactionAutoConfiguration.class)
-@ConditionalOnClass({ JdbcTemplate.class, TransactionManager.class })
+@ConditionalOnClass({ JdbcTemplate.class, PlatformTransactionManager.class })
 @AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
 @EnableConfigurationProperties(DataSourceProperties.class)
 public class DataSourceTransactionManagerAutoConfiguration {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.support.JdbcTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionManager;
 
 /**
@@ -57,7 +58,7 @@ public class DataSourceTransactionManagerAutoConfiguration {
 	static class JdbcTransactionManagerConfiguration {
 
 		@Bean
-		@ConditionalOnMissingBean(TransactionManager.class)
+		@ConditionalOnMissingBean(PlatformTransactionManager.class)
 		DataSourceTransactionManager transactionManager(Environment environment, DataSource dataSource,
 				ObjectProvider<TransactionManagerCustomizers> transactionManagerCustomizers) {
 			DataSourceTransactionManager transactionManager = createTransactionManager(environment, dataSource);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfigurationTests.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.mock;
  * @author Dave Syer
  * @author Stephane Nicoll
  * @author Kazuki Shimizu
- * @author davin111
+ * @author Davin Byeon
  */
 class DataSourceTransactionManagerAutoConfigurationTests {
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfigurationTests.java
@@ -27,6 +27,8 @@ import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfigu
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.support.JdbcTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.ReactiveTransactionManager;
 import org.springframework.transaction.TransactionManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,10 +78,21 @@ class DataSourceTransactionManagerAutoConfigurationTests {
 
 	@Test
 	void transactionManagerWithExistingTransactionManagerIsNotOverridden() {
-		this.contextRunner
-			.withBean("myTransactionManager", TransactionManager.class, () -> mock(TransactionManager.class))
+		this.contextRunner.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
+			.withBean("myTransactionManager", PlatformTransactionManager.class,
+					() -> mock(PlatformTransactionManager.class))
 			.run((context) -> assertThat(context).hasSingleBean(TransactionManager.class)
 				.hasBean("myTransactionManager"));
+	}
+
+	@Test
+	void transactionManagerWithExistingReactiveTransactionManagerIsConfigured() {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
+			.withBean("myReactiveTransactionManager", ReactiveTransactionManager.class,
+					() -> mock(ReactiveTransactionManager.class))
+			.run((context) -> assertThat(context)
+					.hasSingleBean(ReactiveTransactionManager.class).hasBean("myReactiveTransactionManager")
+					.hasSingleBean(PlatformTransactionManager.class).hasBean("transactionManager"));
 	}
 
 	@Test // gh-24321

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfigurationTests.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.mock;
  * @author Dave Syer
  * @author Stephane Nicoll
  * @author Kazuki Shimizu
+ * @author davin111
  */
 class DataSourceTransactionManagerAutoConfigurationTests {
 
@@ -90,9 +91,10 @@ class DataSourceTransactionManagerAutoConfigurationTests {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
 			.withBean("myReactiveTransactionManager", ReactiveTransactionManager.class,
 					() -> mock(ReactiveTransactionManager.class))
-			.run((context) -> assertThat(context)
-					.hasSingleBean(ReactiveTransactionManager.class).hasBean("myReactiveTransactionManager")
-					.hasSingleBean(PlatformTransactionManager.class).hasBean("transactionManager"));
+			.run((context) -> assertThat(context).hasSingleBean(ReactiveTransactionManager.class)
+				.hasBean("myReactiveTransactionManager")
+				.hasSingleBean(PlatformTransactionManager.class)
+				.hasBean("transactionManager"));
 	}
 
 	@Test // gh-24321


### PR DESCRIPTION
In `JdbcTransactionManagerConfiguration`, the `transactionManager` bean is registered if there is no bean of `TransactionManager` types. However, the autoconfiguration is responsible for jdbc transactionmanagers related with `PlatformTransactionManager`, not `ReactiveTransactionManager`. For now, with an existing `ReactiveTransactionManager`, this autoconfiguration doesn't register the expectable transactionmanager. I think the condition of the `transactionManager()` bean method should be modified.

I added a test related with it, and fixed one existing test because it didn't configure `DataSourceAutoConfiguration`, which made the test vacuously true.

* * *

After I made this PR, I checked the issue #22851 which is opposite. It said like below.
> Considering that framework expects a single bean of that type for unqualified `@Transactional` use, I think we should refine our auto-configuration to avoid that by default.

I also agreed with it, but I made this PR because when I develop a spring batch application with jdbc for `JobRepository` and r2dbc for main service and repository logic, I figured out this condition of the autoconfiguration prevents registering the required jdbc transactionmanager. Please give your opinion about this and I can close this PR or modify PR only for fixing the existing test.