### PR TITLE
Fix test in `DataSourceTransactionManagerAutoConfigurationTests`

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/DataSourceTransactionManagerAutoConfigurationTests.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.mock;
  * @author Dave Syer
  * @author Stephane Nicoll
  * @author Kazuki Shimizu
+ * @author Davin Byeon
  */
 class DataSourceTransactionManagerAutoConfigurationTests {
 
@@ -76,7 +77,7 @@ class DataSourceTransactionManagerAutoConfigurationTests {
 
 	@Test
 	void transactionManagerWithExistingTransactionManagerIsNotOverridden() {
-		this.contextRunner
+		this.contextRunner.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
 			.withBean("myTransactionManager", TransactionManager.class, () -> mock(TransactionManager.class))
 			.run((context) -> assertThat(context).hasSingleBean(TransactionManager.class)
 				.hasBean("myTransactionManager"));


### PR DESCRIPTION
I fixed one existing test because it didn't configure `DataSourceAutoConfiguration`, which made the test vacuously true. (mentioned in #35261)