### PR TITLE
Fix configuring replica set via PropertiesMongoConnectionDetails

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/PropertiesMongoConnectionDetails.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/PropertiesMongoConnectionDetails.java
@@ -66,7 +66,7 @@ public class PropertiesMongoConnectionDetails implements MongoConnectionDetails 
 			}
 			if (this.properties.getReplicaSetName() != null) {
 				builder.append("?");
-				builder.append("repliceSet=");
+				builder.append("replicaSet=");
 				builder.append(this.properties.getReplicaSetName());
 			}
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/PropertiesMongoConnectionDetailsTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/PropertiesMongoConnectionDetailsTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.mongo;
+
+import com.mongodb.ConnectionString;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link PropertiesMongoConnectionDetails}.
+ *
+ * @author Christoph Dreis
+ */
+class PropertiesMongoConnectionDetailsTests {
+
+	private final MongoProperties properties = new MongoProperties();
+
+	@Test
+	void replicaSetCanBeConfigured() {
+		this.properties.setReplicaSetName("test");
+		ConnectionString connectionString = getConnectionString();
+		assertThat(connectionString.getRequiredReplicaSetName()).isEqualTo("test");
+	}
+
+	private PropertiesMongoConnectionDetails createConnectionDetails() {
+		return new PropertiesMongoConnectionDetails(this.properties);
+	}
+
+	private ConnectionString getConnectionString() {
+		PropertiesMongoConnectionDetails connectionDetails = createConnectionDetails();
+		return connectionDetails.getConnectionString();
+	}
+
+}


### PR DESCRIPTION
Hi,

I was reviewing some of the new things in 3.1 and believe I found a typo leading to a bug when setting the `replicaSet` for MongoDB.

Cheers,
Christoph