### PR TITLE
Revert accidental author changes in FlywayAutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
@@ -84,7 +84,7 @@ import org.springframework.util.StringUtils;
  * @author Dominic Gunn
  * @author Dan Zheng
  * @author András Deák
- * @author Semyon Danilo
+ * @author Semyon Danilov
  * @author Chris Bono
  * @author Moritz Halbritter
  * @author Andy Wilkinson


### PR DESCRIPTION
This PR reverts the author changes in the `FlywayAutoConfiguration` in 7ffacf43f317d9645117e01f678429ed92182a9b as it seems to be accidental based on its Git history.