### PR TITLE
Make CurrentTraceContext.Builder a bean

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfiguration.java
@@ -64,6 +64,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.context.properties.IncompatibleConfigurationException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
@@ -130,15 +131,22 @@ public class BraveAutoConfiguration {
 	}
 
 	@Bean
+	@Scope("prototype")
 	@ConditionalOnMissingBean
-	public CurrentTraceContext braveCurrentTraceContext(List<CurrentTraceContext.ScopeDecorator> scopeDecorators,
+	public CurrentTraceContext.Builder braveCurrentTraceContextBuilder() {
+		return ThreadLocalCurrentTraceContext.newBuilder();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public CurrentTraceContext braveCurrentTraceContext(CurrentTraceContext.Builder currentTraceContextBuilder,
+			List<CurrentTraceContext.ScopeDecorator> scopeDecorators,
 			List<CurrentTraceContextCustomizer> currentTraceContextCustomizers) {
-		ThreadLocalCurrentTraceContext.Builder builder = ThreadLocalCurrentTraceContext.newBuilder();
-		scopeDecorators.forEach(builder::addScopeDecorator);
+		scopeDecorators.forEach(currentTraceContextBuilder::addScopeDecorator);
 		for (CurrentTraceContextCustomizer currentTraceContextCustomizer : currentTraceContextCustomizers) {
-			currentTraceContextCustomizer.customize(builder);
+			currentTraceContextCustomizer.customize(currentTraceContextBuilder);
 		}
-		return builder.build();
+		return currentTraceContextBuilder.build();
 	}
 
 	@Bean

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
@@ -129,7 +129,7 @@ class ZipkinConfigurations {
 		@Bean
 		@ConditionalOnMissingBean
 		@ConditionalOnBean(Sender.class)
-		Reporter<Span> spanReporter(Sender sender, BytesEncoder<Span> encoder) {
+		AsyncReporter<Span> spanReporter(Sender sender, BytesEncoder<Span> encoder) {
 			return AsyncReporter.builder(sender).build(encoder);
 		}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
@@ -129,7 +129,7 @@ class ZipkinConfigurations {
 		@Bean
 		@ConditionalOnMissingBean
 		@ConditionalOnBean(Sender.class)
-		AsyncReporter<Span> spanReporter(Sender sender, BytesEncoder<Span> encoder) {
+		Reporter<Span> spanReporter(Sender sender, BytesEncoder<Span> encoder) {
 			return AsyncReporter.builder(sender).build(encoder);
 		}
 


### PR DESCRIPTION
When I did Micrometer Tracing/Observation support on my product, I noticed a part that I want to fix on the spring boot side, so I'm throwing a PR.
( I was wondering if I should start an issue first, but since it is a trivial fix, I will throw a PR directly. Sorry.)

## Modifications

### BraveAutoConfiguration.java

I would like to put CurrentTraceContext.Builder in the bean and use it.

Why: 
Because [the framework(armeria)](https://armeria.dev/docs/advanced-zipkin) I am using, requires the use of `RequestContextCurrentTraceContext` instead of `ThereadLocalCurrentTraceContext`.
This modification will help users who are using something other than the `ThreadLocalCurrentTraceContext`.

For example, it is also useful when you want to use `StrictCurrentTraceContext` for debugging purposes.
https://github.com/openzipkin/brave/blob/f4a2c7f7d0b8c2725ffef99fb4a5ccca222b6492/brave/src/main/java/brave/propagation/StrictCurrentTraceContext.java

### ZipkinConfigurations.ReporterConfiguration

I want to use a `Reporter<Span>` that I created myself(bean configuration).

For some reason, the current `AsyncReporter<Span>` is used, so if I configure the bean by myself, two `Reporter<Span>`  are created.

## ToDo

- [ ] If there is no problem with the modification, add the unit test