### PR TITLE
Default for spring.flway.execute-in-transaction is not aligned with Flyway's default

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayProperties.java
@@ -365,7 +365,7 @@ public class FlywayProperties {
 	/**
 	 * Whether Flyway should execute SQL within a transaction.
 	 */
-	private boolean executeInTransaction;
+	private boolean executeInTransaction = true;
 
 	public boolean isEnabled() {
 		return this.enabled;

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayPropertiesTests.java
@@ -92,6 +92,7 @@ class FlywayPropertiesTests {
 		assertThat(properties.getPlaceholderSeparator()).isEqualTo(configuration.getPlaceholderSeparator());
 		assertThat(properties.getScriptPlaceholderPrefix()).isEqualTo(configuration.getScriptPlaceholderPrefix());
 		assertThat(properties.getScriptPlaceholderSuffix()).isEqualTo(configuration.getScriptPlaceholderSuffix());
+		assertThat(properties.isExecuteInTransaction()).isEqualTo(configuration.isExecuteInTransaction());
 	}
 
 	@Test


### PR DESCRIPTION
FlywayProperties has executeInTransaction default as false, changing the org.flywaydb.core.api.configuration.Configuration#isExecuteInTransaction default. See also org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration.FlywayConfiguration#configureProperties

Tested in 3.1.0-RC2.

Prior to change with no `spring.flyway` configuration set 
```
Migrating schema "public" to version "0.0.1.0 - init-tables [non-transactional]"
```