### PR TITLE
Defining a zipkin2.reporter.Reporter results in two reporter beans as the auto-configured AsyncReporter does not back off

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
@@ -129,7 +129,7 @@ class ZipkinConfigurations {
 		@Bean
 		@ConditionalOnMissingBean
 		@ConditionalOnBean(Sender.class)
-		AsyncReporter<Span> spanReporter(Sender sender, BytesEncoder<Span> encoder) {
+		Reporter<Span> spanReporter(Sender sender, BytesEncoder<Span> encoder) {
 			return AsyncReporter.builder(sender).build(encoder);
 		}
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsReporterConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsReporterConfigurationTests.java
@@ -56,10 +56,11 @@ class ZipkinConfigurationsReporterConfigurationTests {
 
 	@Test
 	void shouldBackOffOnCustomBeans() {
-		this.contextRunner.withUserConfiguration(CustomConfiguration.class).run((context) -> {
-			assertThat(context).hasBean("customReporter");
-			assertThat(context).hasSingleBean(Reporter.class);
-		});
+		this.contextRunner.withUserConfiguration(SenderConfiguration.class, CustomConfiguration.class)
+			.run((context) -> {
+				assertThat(context).hasBean("customReporter");
+				assertThat(context).hasSingleBean(Reporter.class);
+			});
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
from this PR: https://github.com/spring-projects/spring-boot/pull/35424

## Modifications

### ZipkinConfigurations.ReporterConfiguration

I want to use a `Reporter<Span>` that I created myself(bean configuration).

For some reason, the current `AsyncReporter<Span>` is used, so if I configure the bean by myself, two `Reporter<Span>`  are created.
