### PR TITLE
Revert accidental Javadoc since changes for ImageReference

### DIFF
--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/ImageReference.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/ImageReference.java
@@ -26,7 +26,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Phillip Webb
  * @author Scott Frederick
- * @since 2.3.0
+ * @since 3.1.0
  */
 public final class ImageReference {
 


### PR DESCRIPTION
This PR reverts the accidental Javadoc `@since` tag changes for the `org.springframework.boot.docker.compose.core.ImageReference`.

See 0f032c2