### PR TITLE
OpenTelemetryAutoConfiguration: allow to override SpanProcessor bean

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryAutoConfiguration.java
@@ -126,6 +126,7 @@ public class OpenTelemetryAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
 	SpanProcessor otelSpanProcessor(ObjectProvider<SpanExporter> spanExporters,
 			ObjectProvider<SpanExportingPredicate> spanExportingPredicates, ObjectProvider<SpanReporter> spanReporters,
 			ObjectProvider<SpanFilter> spanFilters) {


### PR DESCRIPTION
Allow to customize only SpanProcessor bean without the need to throw away all `OpenTelemetryAutoConfiguration` value.
This is the only one bean in this class which is not annotated with `@ConditionalOnMissingBean`.