### PR TITLE
Remove unnecessary exclude from spring-restdocs-mockmvc

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -174,9 +174,7 @@ dependencies {
 	testImplementation("org.springframework:spring-orm")
 	testImplementation("org.springframework.data:spring-data-rest-webmvc")
 	testImplementation("org.springframework.integration:spring-integration-jmx")
-	testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc") {
-		exclude group: "javax.servlet", module: "javax.servlet-api"
-	}
+	testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
 	testImplementation("org.springframework.restdocs:spring-restdocs-webtestclient")
 	testImplementation("org.springframework.security:spring-security-test")
 	testImplementation("org.yaml:snakeyaml")

--- a/spring-boot-project/spring-boot-docs/build.gradle
+++ b/spring-boot-project/spring-boot-docs/build.gradle
@@ -151,9 +151,7 @@ dependencies {
 	implementation("org.springframework.graphql:spring-graphql-test")
 	implementation("org.springframework.kafka:spring-kafka")
 	implementation("org.springframework.kafka:spring-kafka-test")
-	implementation("org.springframework.restdocs:spring-restdocs-mockmvc") {
-		exclude group: "javax.servlet", module: "javax.servlet-api"
-	}
+	implementation("org.springframework.restdocs:spring-restdocs-mockmvc")
 	implementation("org.springframework.restdocs:spring-restdocs-restassured")
 	implementation("org.springframework.restdocs:spring-restdocs-webtestclient")
 	implementation("org.springframework.security:spring-security-config")

--- a/spring-boot-project/spring-boot-test-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-test-autoconfigure/build.gradle
@@ -48,9 +48,7 @@ dependencies {
 	optional("org.springframework.data:spring-data-r2dbc")
 	optional("org.springframework.data:spring-data-redis")
 	optional("org.springframework.graphql:spring-graphql-test")
-	optional("org.springframework.restdocs:spring-restdocs-mockmvc") {
-		exclude group: "javax.servlet", module: "javax.servlet-api"
-	}
+	optional("org.springframework.restdocs:spring-restdocs-mockmvc")
 	optional("org.springframework.restdocs:spring-restdocs-restassured")
 	optional("org.springframework.restdocs:spring-restdocs-webtestclient")
 	optional("org.springframework.security:spring-security-config")


### PR DESCRIPTION
Hi,

this PR removes the `javax.servlet-api` exclusion from `spring-restdocs-mockmvc`. This doesn't seem to be necessary anymore, but I might me missing something more deeply nested...

Cheers,
Christoph