### PR TITLE
EndpointRequest.toLinks() does not match when management.endpoints.web.base-path is '/'

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointProperties.java
@@ -67,7 +67,7 @@ public class WebEndpointProperties {
 	}
 
 	private String cleanBasePath(String basePath) {
-		if (StringUtils.hasText(basePath) && basePath.endsWith("/")) {
+		if (StringUtils.hasText(basePath) && basePath.endsWith("/") && StringUtils.cleanPath(basePath).length() != 1) {
 			return basePath.substring(0, basePath.length() - 1);
 		}
 		return basePath;

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointPropertiesTests.java
@@ -107,7 +107,7 @@ class WebEndpointPropertiesTests {
 
 	@ParameterizedTest
 	@MethodSource("argumentsForExceptions")
-	void foo(String input, Class<Exception> expectedEx, String expectedExMsg) {
+	void basePathShouldThrowException(String input, Class<Exception> expectedEx, String expectedExMsg) {
 		Assertions.assertThrows(
 				expectedEx, () -> new WebEndpointProperties().setBasePath(input), expectedExMsg);
 	}


### PR DESCRIPTION
Fix for bug fix #34834. The code now allows for no cleanup of the "/" path to "". 
The rest of the test cases stay as is. 
Added new tests to verify behaviour 
