### PR TITLE
Add DataSourceBuilderCustomizer

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBuilderCustomizer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jdbc;
+
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.ConnectionFactoryOptions.Builder;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+
+import javax.sql.DataSource;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize the
+ * {@link ConnectionFactoryOptions} through a {@link DataSourceBuilder} whilst retaining default
+ * auto-configuration.
+ *
+ * @author Eduan Bekker
+ * @since 3.2.0
+ */
+@FunctionalInterface
+public interface DataSourceBuilderCustomizer {
+
+	/**
+	 * Customize the {@link DataSourceBuilder}.
+	 * @param builder the builder to customize
+	 */
+	<T extends DataSource> void customize(DataSourceBuilder<T> builder);
+
+}


### PR DESCRIPTION
This PR introduces a DataSourceBuilderCustomizer. This allows customizing only parts of the DataSource without creating a full new DataSource. This is the JDBC equivalent to R2DBC's ConnectionFactoryOptionsBuilderCustomizer.

My real world use case is connecting to AWS Aurora using IAM. The AWS SDK can generate a password with the GenerateAuthenticationTokenRequest function.
https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/rds/RdsUtilities.html#generateAuthenticationToken(software.amazon.awssdk.services.rds.model.GenerateAuthenticationTokenRequest