### PR TITLE
bump io.github.git-commit-id from 5.0.0 to 5.0.1

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -299,7 +299,7 @@ bom {
 			]
 		}
 	}
-	library("Git Commit ID Maven Plugin", "5.0.0") {
+	library("Git Commit ID Maven Plugin", "5.0.1") {
 		group("io.github.git-commit-id") {
 			plugins = [
 				"git-commit-id-maven-plugin"


### PR DESCRIPTION
The 5.0.1 release avoids Maven 3.9.2 warnings since it declares `org.apache.maven:maven-plugin-api` and `org.apache.maven:maven-core` as `<scope>provided</scope>`

Related to the discussion in https://github.com/spring-projects/spring-boot/issues/35605 and https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/630


:warning: just changing files over the github GUI interface I'm not sure if this represents all the places where the plugin is configured/referenced :-)

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
