### PR TITLE
refactor: Change loop code

### DIFF
--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DefaultDockerCompose.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DefaultDockerCompose.java
@@ -76,13 +76,11 @@ class DefaultDockerCompose implements DockerCompose {
 			return Collections.emptyList();
 		}
 		DockerComposeFile dockerComposeFile = this.cli.getDockerComposeFile();
-		List<RunningService> result = new ArrayList<>();
 		Map<String, DockerCliInspectResponse> inspected = inspect(runningPsResponses);
-		for (DockerCliComposePsResponse psResponse : runningPsResponses) {
-			DockerCliInspectResponse inspectResponse = inspected.get(psResponse.id());
-			result.add(new DefaultRunningService(this.hostname, dockerComposeFile, psResponse, inspectResponse));
-		}
-		return Collections.unmodifiableList(result);
+		return runningPsResponses.stream()
+			.map(psResponse -> new DefaultRunningService(this.hostname, dockerComposeFile, psResponse,
+				inspected.get(psResponse.id())))
+			.toList()
 	}
 
 	private Map<String, DockerCliInspectResponse> inspect(List<DockerCliComposePsResponse> runningPsResponses) {


### PR DESCRIPTION
method was using stream and foreach together.
We changed foreach to stream

Also, using stream's toList() eliminates the need to use Collections.unmodifiableList().
