### PR TITLE
Polish spring-boot-smoke-test-data-mongo

### DIFF
--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-mongo/src/test/java/smoketest/data/mongo/SampleMongoApplicationSslTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-mongo/src/test/java/smoketest/data/mongo/SampleMongoApplicationSslTests.java
@@ -22,8 +22,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.ssl.SslAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -40,7 +38,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 		"spring.ssl.bundle.pem.client.keystore.certificate=classpath:ssl/test-client.crt",
 		"spring.ssl.bundle.pem.client.keystore.private-key=classpath:ssl/test-client.key",
 		"spring.ssl.bundle.pem.client.truststore.certificate=classpath:ssl/test-ca.crt" })
-@ImportAutoConfiguration(SslAutoConfiguration.class)
 class SampleMongoApplicationSslTests {
 
 	@Container


### PR DESCRIPTION
Remove `@ImportAutoConfiguration(SslAutoConfiguration.class)`.
`SslAutoConfiguration.class` is already provided as a auto-configuration
with `@SpringBootTest`
