### PR TITLE
Fix issue with 'springProperty' not loaded from context scope when initializing with 'playSaxEvents' in logback

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringPropertyAction.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringPropertyAction.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.logging.logback;
 
+import ch.qos.logback.core.joran.action.ActionUtil;
 import ch.qos.logback.core.joran.action.BaseModelAction;
 import ch.qos.logback.core.joran.spi.SaxEventInterpretationContext;
 import ch.qos.logback.core.model.Model;
@@ -46,6 +47,10 @@ class SpringPropertyAction extends BaseModelAction {
 		model.setSource(attributes.getValue(SOURCE_ATTRIBUTE));
 		model.setScope(attributes.getValue(SCOPE_ATTRIBUTE));
 		model.setDefaultValue(attributes.getValue(DEFAULT_VALUE_ATTRIBUTE));
+
+		if (ActionUtil.stringToScope(model.getScope()) == ActionUtil.Scope.CONTEXT) {
+			interpretationContext.getContext().putProperty(model.getName(), model.getSourceOrDefaultValue());
+		}
 		return model;
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringPropertyModel.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringPropertyModel.java
@@ -58,4 +58,11 @@ class SpringPropertyModel extends NamedModel {
 		this.source = source;
 	}
 
+	String getSourceOrDefaultValue() {
+		if (this.source == null) {
+			return this.defaultValue;
+		}
+		return this.source;
+	}
+	
 }


### PR DESCRIPTION
related issue : https://github.com/spring-projects/spring-boot/issues/35664

I fixed an issue that worked in boot 2.7 but has been happening since boot 3.x.

I think this issue was caused by the deletion of this line in this [commit](https://github.com/spring-projects/spring-boot/commit/0bfa9cd7049b70134f3e352db70a55af8f31458e#diff-ebdfb5ded3ac62a268b27edb59cd910349ffdd305f65cb133ce844ea452d7e54L58).
(And while I'm not entirely certain, I think this might also be due to the effects of updating logback to version 1.4.x)

### [Causes and actions]
Looking at the `doConfigure(...)` function in `ch.qos.logback.core.joranGenericXMLConfigurator.java`, it works like this. 

```
        Model top = buildModelFromSaxEventList(recorder.getSaxEventList());
        if (top == null) {
            addError(ErrorCodes.EMPTY_MODEL_STACK);
            return;
        }
        sanityCheck(top);
        processModel(top);
```

In the current situation, the `processModel` is lagging behind, and `buildModelFromSaxEventList(...)` isn't loading the `springProperty`.

Hence, I've injected `springProperty` into the `context` using a `SpringPropertyAction`, which is a part of the flow executed by `playSaxEvents(...)`.

(Referring to the previously mentioned commit, it appears that initialization was done via `SpringPropertyAction` in the past.)

### Additional comments 

I haven't given much thought to this revision, as I'm unaware of the historical context.
However, this issue has prevented me from upgrading the current project to boot 3.x. 
It would be truly beneficial if this issue could be resolved.

I'm always using Spring-Boot well. Thank you for your efforts.