### PR TITLE
Improve OAuth2 Client section of docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/web/spring-security.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/web/spring-security.adoc
@@ -87,14 +87,24 @@ You can register multiple OAuth2 clients and providers under the `spring.securit
 	    oauth2:
 	      client:
 	        registration:
+	          my-login-client:
+	            client-id: "abcd"
+	            client-secret: "password"
+	            client-name: "Client for OpenID Connect"
+	            provider: "my-oauth-provider"
+	            scope: "openid,profile,email,phone,address"
+	            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+	            client-authentication-method: "client_secret_basic"
+	            authorization-grant-type: "authorization_code"
+
 	          my-client-1:
 	            client-id: "abcd"
 	            client-secret: "password"
 	            client-name: "Client for user scope"
 	            provider: "my-oauth-provider"
 	            scope: "user"
-	            redirect-uri: "https://my-redirect-uri.com"
-	            client-authentication-method: "basic"
+	            redirect-uri: "{baseUrl}/authorized/user"
+	            client-authentication-method: "client_secret_basic"
 	            authorization-grant-type: "authorization_code"
 
 	          my-client-2:
@@ -103,17 +113,17 @@ You can register multiple OAuth2 clients and providers under the `spring.securit
 	            client-name: "Client for email scope"
 	            provider: "my-oauth-provider"
 	            scope: "email"
-	            redirect-uri: "https://my-redirect-uri.com"
-	            client-authentication-method: "basic"
+	            redirect-uri: "{baseUrl}/authorized/email"
+	            client-authentication-method: "client_secret_basic"
 	            authorization-grant-type: "authorization_code"
 
 	        provider:
 	          my-oauth-provider:
-	            authorization-uri: "https://my-auth-server/oauth/authorize"
-	            token-uri: "https://my-auth-server/oauth/token"
-	            user-info-uri: "https://my-auth-server/userinfo"
+	            authorization-uri: "https://my-auth-server.com/oauth2/authorize"
+	            token-uri: "https://my-auth-server.com/oauth2/token"
+	            user-info-uri: "https://my-auth-server.com/userinfo"
 	            user-info-authentication-method: "header"
-	            jwk-set-uri: "https://my-auth-server/token_keys"
+	            jwk-set-uri: "https://my-auth-server.com/oauth2/jwks"
 	            user-name-attribute: "name"
 ----
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/web/security/oauth2/client/MyOAuthClientConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/web/security/oauth2/client/MyOAuthClientConfiguration.java
@@ -19,15 +19,26 @@ package org.springframework.boot.docs.web.security.oauth2.client;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration(proxyBeanMethods = false)
+@EnableWebSecurity
 public class MyOAuthClientConfiguration {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.authorizeHttpRequests((requests) -> requests.anyRequest().authenticated());
-		http.oauth2Login((login) -> login.redirectionEndpoint((endpoint) -> endpoint.baseUri("custom-callback")));
+		// @formatter:off
+		http
+			.authorizeHttpRequests((requests) -> requests
+				.anyRequest().authenticated()
+			)
+			.oauth2Login((login) -> login
+				.redirectionEndpoint((endpoint) -> endpoint
+					.baseUri("/login/oauth2/callback/*")
+				)
+			);
+		// @formatter:on
 		return http.build();
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/web/security/oauth2/client/MyOAuthClientConfiguration.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/web/security/oauth2/client/MyOAuthClientConfiguration.kt
@@ -19,15 +19,26 @@ package org.springframework.boot.docs.web.security.oauth2.client
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.invoke
 import org.springframework.security.web.SecurityFilterChain
 
 @Configuration(proxyBeanMethods = false)
-class MyOAuthClientConfiguration {
+@EnableWebSecurity
+open class MyOAuthClientConfiguration {
 
 	@Bean
-	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-		http.authorizeHttpRequests { requests -> requests.anyRequest().authenticated() }
-		http.oauth2Login { login -> login.redirectionEndpoint { redirectionEndpoint -> redirectionEndpoint.baseUri("custom-callback") } }
+	open fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+		http {
+			authorizeHttpRequests {
+				authorize(anyRequest, authenticated)
+			}
+			oauth2Login {
+				redirectionEndpoint {
+					baseUri = "/login/oauth2/callback/*"
+				}
+			}
+		}
 		return http.build()
 	}
 


### PR DESCRIPTION
With the release Spring Security 6, we should align docs between Spring Boot and Spring Security. This PR includes the following minor changes to the OAuth2 Client section of the docs:

* Add an OpenID Connect login client example
* Update [redirect-uri examples](https://docs.spring.io/spring-security/reference/servlet/oauth2/login/core.html#oauth2login-sample-redirect-uri) to match Security docs and not require any customization
* Update client-authentication-method for Spring Security 6 usage (`basic` and `post` matched constants which were [deprecated](https://github.com/spring-projects/spring-security/commit/58e32350931100e38265788f1a024bab5b890f5b) and subsequently [removed](https://github.com/spring-projects/spring-security/commit/be58e2ac49bb0d4b5996df0f8b830d08e6800571#diff-10f22fdd52ef116c50401d46f8d95362330ff198e55abb1addf731711088cb74))
* Update provider configuration example to align with Spring Authorization Server
* Format Java DSL according to Spring Security docs
* Use Kotlin DSL
* Update [redirection endpoint base uri](https://docs.spring.io/spring-security/reference/servlet/oauth2/login/advanced.html#oauth2login-advanced-redirection-endpoint) example to use ant pattern

