### PR TITLE
Implement validity check to spring.rabbitmq.host config property

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -27,6 +27,7 @@ import org.springframework.amqp.rabbit.connection.AbstractConnectionFactory.Addr
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.CacheMode;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.ConfirmType;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
 import org.springframework.boot.convert.DurationUnit;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -43,6 +44,7 @@ import org.springframework.util.StringUtils;
  * @author Artsiom Yudovin
  * @author Franjo Zilic
  * @author Eddú Meléndez
+ * @author Rafael Carvalho
  * @since 1.0.0
  */
 @ConfigurationProperties(prefix = "spring.rabbitmq")
@@ -203,6 +205,10 @@ public class RabbitProperties {
 	 */
 	public String determineAddresses() {
 		if (CollectionUtils.isEmpty(this.parsedAddresses)) {
+			if (this.host.contains(",")) {
+				throw new InvalidConfigurationPropertyValueException("spring.rabbitmq.host", this.host,
+						"Invalid character ','. Value must be a single host. For multiple hosts, use property 'spring.rabbitmq.addresses' instead.");
+			}
 			return this.host + ":" + determinePort();
 		}
 		List<String> addressStrings = new ArrayList<>();

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
@@ -22,8 +22,10 @@ import org.springframework.amqp.rabbit.config.DirectRabbitListenerContainerFacto
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.listener.DirectMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link RabbitProperties}.
@@ -31,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Dave Syer
  * @author Andy Wilkinson
  * @author Stephane Nicoll
+ * @author Rafael Carvalho
  */
 class RabbitPropertiesTests {
 
@@ -336,6 +339,15 @@ class RabbitPropertiesTests {
 		this.properties.setAddresses("user@rabbit1.example.com:1234/alpha");
 		assertThat(this.properties.determineUsername()).isEqualTo("user");
 		assertThat(this.properties.determinePassword()).isEqualTo("guest");
+	}
+
+	@Test
+	void hostPropertyMustBeSingleHost() {
+		this.properties.setHost("my-rmq-host.net,my-rmq-host-2.net");
+		assertThat(this.properties.getHost()).isEqualTo("my-rmq-host.net,my-rmq-host-2.net");
+		assertThatThrownBy(this.properties::determineAddresses)
+			.isInstanceOf(InvalidConfigurationPropertyValueException.class)
+			.hasMessageContaining("spring.rabbitmq.host");
 	}
 
 }


### PR DESCRIPTION
As discussed on issue #35628, at some point the host property accepted multiple comma-separated hosts. However, this was not intended, and for better clarification, it was decided to implement a clearer error message for this situation.

This PR adds an extra check in `org.springframework.boot.autoconfigure.amqp.RabbitProperties#determineAddresses` for commas in the host property, throwing an `InvalidConfigurationPropertyValueException` if any is found.