### PR TITLE
Gradle 8.2 compatibility: replace usage of JavaPluginConvention with …

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/JavaPluginAction.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/JavaPluginAction.java
@@ -166,7 +166,7 @@ final class JavaPluginAction implements PluginApplicationAction {
 
 	@SuppressWarnings("deprecation")
 	private SourceSetContainer sourceSets(Project project) {
-		return project.getConvention().getPlugin(org.gradle.api.plugins.JavaPluginConvention.class).getSourceSets();
+		return project.getConvention().getPlugin(org.gradle.api.plugins.JavaPluginExtension.class).getSourceSets();
 	}
 
 	private void configureUtf8Encoding(Project evaluatedProject) {


### PR DESCRIPTION
Hello,

The upcoming release of Gradle 8.2 has introduced a warning around the use of Project.getConvention which is related to a part of Spring Boot 2.7.x (https://docs.gradle.org/8.2-rc-1/userguide/upgrading_version_8.html#deprecated_access_to_conventions).

This part of the code (https://github.com/spring-projects/spring-boot/blob/2.7.x/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/JavaPluginAction.java#L169) uses Project.getConvention and it raises a warning about the usage of this method, as it is scheduled to be removed in Gradle 9.0.

While this is not a problem with Spring Boot Gradle Plugin 3.x, this could impact users running with 2.7.x if Gradle 9.x comes out before they migrate to Spring Boot 3.x.

If 2.7.x is still receiving changes, it would make sense to change this usage from JavaPluginConvention to JavaPluginExtension. This Pull Request performs that change.