### PR TITLE
Rename directories property into additionalClasspathElements

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractRunMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractRunMojo.java
@@ -165,12 +165,12 @@ public abstract class AbstractRunMojo extends AbstractDependencyFilterMojo {
 	private String mainClass;
 
 	/**
-	 * Additional directories besides the classes directory that should be added to the
+	 * Additional elements besides the classes directory that should be added to the
 	 * classpath.
 	 * @since 1.0.0
 	 */
-	@Parameter(property = "spring-boot.run.directories")
-	private String[] directories;
+	@Parameter(property = "spring-boot.run.additionalClasspathElements")
+	private String[] additionalClasspathElements;
 
 	/**
 	 * Directory containing the classes and resource files that should be used to run the
@@ -348,7 +348,7 @@ public abstract class AbstractRunMojo extends AbstractDependencyFilterMojo {
 	protected URL[] getClassPathUrls() throws MojoExecutionException {
 		try {
 			List<URL> urls = new ArrayList<>();
-			addUserDefinedDirectories(urls);
+			addAdditionalClasspathElements(urls);
 			addResources(urls);
 			addProjectClasses(urls);
 			addDependencies(urls);
@@ -359,10 +359,10 @@ public abstract class AbstractRunMojo extends AbstractDependencyFilterMojo {
 		}
 	}
 
-	private void addUserDefinedDirectories(List<URL> urls) throws MalformedURLException {
-		if (this.directories != null) {
-			for (String directory : this.directories) {
-				urls.add(new File(directory).toURI().toURL());
+	private void addAdditionalClasspathElements(List<URL> urls) throws MalformedURLException {
+		if (this.additionalClasspathElements != null) {
+			for (String element : this.additionalClasspathElements) {
+				urls.add(new File(element).toURI().toURL());
 			}
 		}
 	}


### PR DESCRIPTION
This PR is related to what was discussed in issue #35179. This code renames the ```spring-boot.run.directories``` property into ```spring-boot.run.additionalClasspathElements```.

Furthermore, it changes the code that appends the property's value to the classpath. Currently, the value goes through multiple conversions from ```String``` to ```File```, ```URI``` and ```URL```. This version only converts the string into a ```Path``` to treat non-absolute paths. However, it was commented that this may change as it is desirable to only append the string without any processing.