### PR TITLE
Methods in KafkaConnectionDetails are named inconsistently

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfiguration.java
@@ -204,7 +204,7 @@ public class KafkaAutoConfiguration {
 
 	private void applyKafkaConnectionDetailsForAdmin(Map<String, Object> properties,
 			KafkaConnectionDetails connectionDetails) {
-		properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, connectionDetails.getAdminBootstrapNodes());
+		properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, connectionDetails.getAdminBootstrapServers());
 		if (!(connectionDetails instanceof PropertiesKafkaConnectionDetails)) {
 			properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "PLAINTEXT");
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaConnectionDetails.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaConnectionDetails.java
@@ -31,38 +31,38 @@ import org.springframework.boot.autoconfigure.service.connection.ConnectionDetai
 public interface KafkaConnectionDetails extends ConnectionDetails {
 
 	/**
-	 * Returns the list of bootstrap nodes.
-	 * @return the list of bootstrap nodes
+	 * Returns the list of bootstrap servers.
+	 * @return the list of bootstrap servers
 	 */
 	List<String> getBootstrapServers();
 
 	/**
-	 * Returns the list of bootstrap nodes used for consumers.
-	 * @return the list of bootstrap nodes used for consumers
+	 * Returns the list of bootstrap servers used for consumers.
+	 * @return the list of bootstrap servers used for consumers
 	 */
 	default List<String> getConsumerBootstrapServers() {
 		return getBootstrapServers();
 	}
 
 	/**
-	 * Returns the list of bootstrap nodes used for producers.
-	 * @return the list of bootstrap nodes used for producers
+	 * Returns the list of bootstrap servers used for producers.
+	 * @return the list of bootstrap servers used for producers
 	 */
 	default List<String> getProducerBootstrapServers() {
 		return getBootstrapServers();
 	}
 
 	/**
-	 * Returns the list of bootstrap nodes used for the admin.
-	 * @return the list of bootstrap nodes used for the admin
+	 * Returns the list of bootstrap servers used for the admin.
+	 * @return the list of bootstrap servers used for the admin
 	 */
-	default List<String> getAdminBootstrapNodes() {
+	default List<String> getAdminBootstrapServers() {
 		return getBootstrapServers();
 	}
 
 	/**
-	 * Returns the list of bootstrap nodes used for Kafka Streams.
-	 * @return the list of bootstrap nodes used for Kafka Streams
+	 * Returns the list of bootstrap servers used for Kafka Streams.
+	 * @return the list of bootstrap servers used for Kafka Streams
 	 */
 	default List<String> getStreamsBootstrapServers() {
 		return getBootstrapServers();


### PR DESCRIPTION
This PR polishes the changes made in gh-34770 a bit by completing renaming nodes to servers.

It contains a breaking change, but I didn't do anything for it as I don't know what the preference for it is here.