### PR TITLE
Refine `SpringApplication.Augmented.with` Kotlin extension

### DIFF
--- a/spring-boot-project/spring-boot/src/main/kotlin/org/springframework/boot/SpringApplicationExtensions.kt
+++ b/spring-boot-project/spring-boot/src/main/kotlin/org/springframework/boot/SpringApplicationExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,11 +68,12 @@ inline fun <reified T : Any> fromApplication(): SpringApplication.Augmented {
 }
 
 /**
- * Extension function that allows `SpringApplication.Augmented.with` to work with Kotlin classes.
+ * Extension function that allows [SpringApplication.Augmented.with] to work with Kotlin classes.
  *
  * @author Phillip Webb
+ * @author Sebastien Deleuze
  * @since 3.1.1
  */
-fun SpringApplication.Augmented.with(type: KClass<*>): SpringApplication.Augmented {
-	return this.with(type.java)!!
+fun SpringApplication.Augmented.with(vararg types: KClass<*>): SpringApplication.Augmented {
+	return this.with(*types.map(KClass<*>::java).toTypedArray())!!
 }

--- a/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/SpringApplicationExtensionsTests.kt
+++ b/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/SpringApplicationExtensionsTests.kt
@@ -37,7 +37,7 @@ class SpringApplicationExtensionsTests {
 	@Test
 	fun `Kotlin runApplication() top level function`() {
 		val context = runApplication<ExampleWebConfig>()
-		assertThat(context).isNotNull
+		assertThat(context).isNotNull()
 	}
 
 	@Test
@@ -46,7 +46,7 @@ class SpringApplicationExtensionsTests {
 		val context = runApplication<ExampleWebConfig> {
 			setEnvironment(environment)
 		}
-		assertThat(context).isNotNull
+		assertThat(context).isNotNull()
 		assertThat(environment).isEqualTo(context.environment)
 	}
 
@@ -55,7 +55,7 @@ class SpringApplicationExtensionsTests {
 		val context = runApplication<ExampleWebConfig>("--debug", "spring", "boot")
 		val args = context.getBean<ApplicationArguments>()
 		assertThat(args.nonOptionArgs.toTypedArray()).containsExactly("spring", "boot")
-		assertThat(args.containsOption("debug")).isEqualTo(true)
+		assertThat(args.containsOption("debug")).isTrue()
 	}
 
 	@Test
@@ -66,21 +66,21 @@ class SpringApplicationExtensionsTests {
 		}
 		val args = context.getBean<ApplicationArguments>()
 		assertThat(args.nonOptionArgs.toTypedArray()).containsExactly("spring", "boot")
-		assertThat(args.containsOption("debug")).isEqualTo(true)
+		assertThat(args.containsOption("debug")).isTrue()
 		assertThat(environment).isEqualTo(context.environment)
 	}
 
 	@Test
 	fun `Kotlin fromApplication() top level function`() {
 		val context = fromApplication<TestKotlinApplication>().with(ExampleWebConfig::class).run().applicationContext
-		assertThat(context.getBean<MockServletWebServerFactory>()).isNotNull
+		assertThat(context.getBean<MockServletWebServerFactory>()).isNotNull()
 	}
 
 	@Test
 	fun `Kotlin fromApplication() top level function with multiple sources`() {
 		val context = fromApplication<TestKotlinApplication>().with(ExampleWebConfig::class, ExampleFilterConfig::class).run().applicationContext
-		assertThat(context.getBean<MockServletWebServerFactory>()).isNotNull
-		assertThat(context.getBean<MockFilter>()).isNotNull
+		assertThat(context.getBean<MockServletWebServerFactory>()).isNotNull()
+		assertThat(context.getBean<MockFilter>()).isNotNull()
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/SpringApplicationExtensionsTests.kt
+++ b/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/SpringApplicationExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test
 
 import org.springframework.beans.factory.getBean
 import org.springframework.boot.kotlinsample.TestKotlinApplication
+import org.springframework.boot.web.servlet.mock.MockFilter
 import org.springframework.boot.web.servlet.server.MockServletWebServerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -76,6 +77,13 @@ class SpringApplicationExtensionsTests {
 	}
 
 	@Test
+	fun `Kotlin fromApplication() top level function with multiple sources`() {
+		val context = fromApplication<TestKotlinApplication>().with(ExampleWebConfig::class, ExampleFilterConfig::class).run().applicationContext
+		assertThat(context.getBean<MockServletWebServerFactory>()).isNotNull
+		assertThat(context.getBean<MockFilter>()).isNotNull
+	}
+
+	@Test
 	fun `Kotlin fromApplication() top level function when no main`() {
 		assertThatIllegalStateException().isThrownBy { fromApplication<ExampleWebConfig>().run() }
 			.withMessage("Unable to use 'fromApplication' with org.springframework.boot.SpringApplicationExtensionsTests.ExampleWebConfig")
@@ -87,6 +95,16 @@ class SpringApplicationExtensionsTests {
 		@Bean
 		open fun webServer(): MockServletWebServerFactory {
 			return MockServletWebServerFactory()
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	internal open class ExampleFilterConfig {
+
+		@Bean
+		open fun filter(): MockFilter {
+			return MockFilter()
 		}
 
 	}


### PR DESCRIPTION
This PR refines `SpringApplication.Augmented.with` Kotlin extension to allow specifying multiple classes like the Java original method, and polish related tests (`isNotNull()` is an assert method, so the property syntax is likely not the best choice here).