### PR TITLE
Support custom token validators for OAuth2 Resource Server auto-configuration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerJwkConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerJwkConfiguration.java
@@ -110,6 +110,9 @@ class ReactiveOAuth2ResourceServerJwkConfiguration {
 				validators.add(new JwtClaimValidator<List<String>>(JwtClaimNames.AUD,
 						(aud) -> aud != null && !Collections.disjoint(aud, audiences)));
 			}
+			if (validators.size() == 1) {
+				return validators.get(0);
+			}
 			return new DelegatingOAuth2TokenValidator<>(validators);
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
@@ -110,6 +110,9 @@ class OAuth2ResourceServerJwtConfiguration {
 				validators.add(new JwtClaimValidator<List<String>>(JwtClaimNames.AUD,
 						(aud) -> aud != null && !Collections.disjoint(aud, audiences)));
 			}
+			if (validators.size() == 1) {
+				return validators.get(0);
+			}
 			return new DelegatingOAuth2TokenValidator<>(validators);
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
@@ -62,6 +62,7 @@ import static org.springframework.security.config.Customizer.withDefaults;
  * @author Artsiom Yudovin
  * @author HaiTao Zhang
  * @author Mushtaq Ahmed
+ * @author Roman Golovin
  */
 @Configuration(proxyBeanMethods = false)
 class OAuth2ResourceServerJwtConfiguration {
@@ -72,8 +73,12 @@ class OAuth2ResourceServerJwtConfiguration {
 
 		private final OAuth2ResourceServerProperties.Jwt properties;
 
-		JwtDecoderConfiguration(OAuth2ResourceServerProperties properties) {
+		private final List<OAuth2TokenValidator<Jwt>> customOAuth2TokenValidators;
+
+		JwtDecoderConfiguration(OAuth2ResourceServerProperties properties,
+				List<OAuth2TokenValidator<Jwt>> customOAuth2TokenValidators) {
 			this.properties = properties.getJwt();
+			this.customOAuth2TokenValidators = customOAuth2TokenValidators;
 		}
 
 		@Bean
@@ -97,14 +102,14 @@ class OAuth2ResourceServerJwtConfiguration {
 		}
 
 		private OAuth2TokenValidator<Jwt> getValidators(OAuth2TokenValidator<Jwt> defaultValidator) {
-			List<String> audiences = this.properties.getAudiences();
-			if (CollectionUtils.isEmpty(audiences)) {
-				return defaultValidator;
-			}
 			List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
 			validators.add(defaultValidator);
-			validators.add(new JwtClaimValidator<List<String>>(JwtClaimNames.AUD,
-					(aud) -> aud != null && !Collections.disjoint(aud, audiences)));
+			validators.addAll(this.customOAuth2TokenValidators);
+			List<String> audiences = this.properties.getAudiences();
+			if (!CollectionUtils.isEmpty(audiences)) {
+				validators.add(new JwtClaimValidator<List<String>>(JwtClaimNames.AUD,
+						(aud) -> aud != null && !Collections.disjoint(aud, audiences)));
+			}
 			return new DelegatingOAuth2TokenValidator<>(validators);
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
@@ -476,10 +476,6 @@ class OAuth2ResourceServerAutoConfigurationTests {
 				JwtDecoder jwtDecoder = context.getBean(JwtDecoder.class);
 				assertThat(jwtDecoder).extracting("jwtValidator.tokenValidators")
 					.asInstanceOf(InstanceOfAssertFactories.collection(OAuth2TokenValidator.class))
-					.hasSize(1)
-					.first()
-					.extracting("tokenValidators")
-					.asInstanceOf(InstanceOfAssertFactories.collection(OAuth2TokenValidator.class))
 					.hasAtLeastOneElementOfType(JwtIssuerValidator.class);
 			});
 	}
@@ -498,10 +494,6 @@ class OAuth2ResourceServerAutoConfigurationTests {
 				assertThat(context).hasSingleBean(JwtDecoder.class);
 				JwtDecoder jwtDecoder = context.getBean(JwtDecoder.class);
 				assertThat(jwtDecoder).extracting("jwtValidator.tokenValidators")
-					.asInstanceOf(InstanceOfAssertFactories.collection(OAuth2TokenValidator.class))
-					.hasSize(1)
-					.first()
-					.extracting("tokenValidators")
 					.asInstanceOf(InstanceOfAssertFactories.collection(OAuth2TokenValidator.class))
 					.hasExactlyElementsOfTypes(JwtTimestampValidator.class)
 					.doesNotHaveAnyElementsOfTypes(JwtClaimValidator.class)
@@ -794,7 +786,6 @@ class OAuth2ResourceServerAutoConfigurationTests {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@EnableWebSecurity
 	static class CustomTokenValidatorsConfig {
 
 		@Bean


### PR DESCRIPTION
Added injections of `OAuth2TokenValidator<Jwt>` beans to `ReactiveOAuth2ResourceServerJwkConfiguration`and `OAuth2ResourceServerJwtConfiguration` to provide an easy way to add custom validations and still use auto-configuration (#35783)

Closes gh-35783