### PR TITLE
SSL configuration overwrites other WebClient customization

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/function/client/ReactorClientHttpConnectorFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/function/client/ReactorClientHttpConnectorFactory.java
@@ -59,10 +59,9 @@ class ReactorClientHttpConnectorFactory implements ClientHttpConnectorFactory<Re
 			.reduce((before, after) -> (client) -> after.configure(before.configure(client)))
 			.orElse((client) -> client);
 		if (sslBundle != null) {
-			mapper = new SslConfigurer(sslBundle)::configure;
+			mapper = (client) -> new SslConfigurer(sslBundle).configure(mapper.configure(client));
 		}
 		return new ReactorClientHttpConnector(this.reactorResourceFactory, mapper::configure);
-
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/function/client/ReactorClientHttpConnectorFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/function/client/ReactorClientHttpConnectorFactory.java
@@ -55,12 +55,13 @@ class ReactorClientHttpConnectorFactory implements ClientHttpConnectorFactory<Re
 
 	@Override
 	public ReactorClientHttpConnector createClientHttpConnector(SslBundle sslBundle) {
-		ReactorNettyHttpClientMapper mapper = this.mappers.get()
-			.reduce((before, after) -> (client) -> after.configure(before.configure(client)))
-			.orElse((client) -> client);
-		if (sslBundle != null) {
-			mapper = (client) -> new SslConfigurer(sslBundle).configure(mapper.configure(client));
-		}
+		final ReactorNettyHttpClientMapper mapper =
+				Stream.concat(
+					this.mappers.get(),
+					Stream.ofNullable(sslBundle != null ? (ReactorNettyHttpClientMapper) new SslConfigurer(sslBundle)::configure : null))
+				.reduce((before, after) -> (client) -> after.configure(before.configure(client)))
+				.orElse((client) -> client);
+
 		return new ReactorClientHttpConnector(this.reactorResourceFactory, mapper::configure);
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/function/client/ClientHttpConnectorFactoryConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/function/client/ClientHttpConnectorFactoryConfigurationTests.java
@@ -24,6 +24,10 @@ import org.eclipse.jetty.util.thread.Scheduler;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.ssl.SslBundle;
+import org.springframework.boot.ssl.SslBundleKey;
+import org.springframework.boot.ssl.jks.JksSslStoreBundle;
+import org.springframework.boot.ssl.jks.JksSslStoreDetails;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -80,11 +84,14 @@ class ClientHttpConnectorFactoryConfigurationTests {
 
 	@Test
 	void shouldApplyHttpClientMapper() {
+		JksSslStoreDetails storeDetails = JksSslStoreDetails.forLocation("classpath:test.jks");
+		JksSslStoreBundle stores = new JksSslStoreBundle(storeDetails, storeDetails);
+		SslBundle sslBundle = SslBundle.of(stores, SslBundleKey.of("password"));
 		new ReactiveWebApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(ClientHttpConnectorFactoryConfiguration.ReactorNetty.class))
 			.withUserConfiguration(CustomHttpClientMapper.class)
 			.run((context) -> {
-				context.getBean(ReactorClientHttpConnectorFactory.class).createClientHttpConnector();
+				context.getBean(ReactorClientHttpConnectorFactory.class).createClientHttpConnector(sslBundle);
 				assertThat(CustomHttpClientMapper.called).isTrue();
 			});
 	}


### PR DESCRIPTION
Issue: Whenever you are configuring TLS on a webclient, any other custom configuration of HttpClient is lost and not applied to the final instance.

Example:
```java
  @Bean
  public WebClient webClient(
      ...
    return WebClient.builder().apply(clientSsl.fromBundle(sslBundle)).build();
  }

  @Bean
  public ReactorNettyHttpClientMapper httpClient() {
   // This is not applied to the WebClient instance generated by the builder on webclient()
    return client ->
        client.compress(true)
```

Check the code being changed, where we can see that mapper is being reassigned to only consider configurations from SslConfigurer. It should be just added to the map stream, so everything is applied