### PR TITLE
Replace calls to verifyComplete() with expectComplete().verify(Duration) to avoid blocking indefinitely

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveCloudFoundrySecurityInterceptorTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveCloudFoundrySecurityInterceptorTests.java
@@ -33,6 +33,8 @@ import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.util.Base64Utils;
 
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -66,7 +68,7 @@ class ReactiveCloudFoundrySecurityInterceptorTests {
 			.build());
 		StepVerifier.create(this.interceptor.preHandle(request, "/a"))
 			.consumeNextWith((response) -> assertThat(response.getStatus()).isEqualTo(HttpStatus.OK))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -75,7 +77,7 @@ class ReactiveCloudFoundrySecurityInterceptorTests {
 		StepVerifier.create(this.interceptor.preHandle(request, "/a"))
 			.consumeNextWith(
 					(response) -> assertThat(response.getStatus()).isEqualTo(Reason.MISSING_AUTHORIZATION.getStatus()))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -85,7 +87,7 @@ class ReactiveCloudFoundrySecurityInterceptorTests {
 		StepVerifier.create(this.interceptor.preHandle(request, "/a"))
 			.consumeNextWith(
 					(response) -> assertThat(response.getStatus()).isEqualTo(Reason.MISSING_AUTHORIZATION.getStatus()))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -121,7 +123,7 @@ class ReactiveCloudFoundrySecurityInterceptorTests {
 			.build());
 		StepVerifier.create(this.interceptor.preHandle(request, "/a"))
 			.consumeNextWith((response) -> assertThat(response.getStatus()).isEqualTo(Reason.ACCESS_DENIED.getStatus()))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -135,7 +137,7 @@ class ReactiveCloudFoundrySecurityInterceptorTests {
 		StepVerifier.create(this.interceptor.preHandle(exchange, "/a")).consumeNextWith((response) -> {
 			assertThat(response.getStatus()).isEqualTo(HttpStatus.OK);
 			assertThat((AccessLevel) exchange.getAttribute("cloudFoundryAccessLevel")).isEqualTo(AccessLevel.FULL);
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -151,7 +153,7 @@ class ReactiveCloudFoundrySecurityInterceptorTests {
 			assertThat(response.getStatus()).isEqualTo(HttpStatus.OK);
 			assertThat((AccessLevel) exchange.getAttribute("cloudFoundryAccessLevel"))
 				.isEqualTo(AccessLevel.RESTRICTED);
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	private String mockAccessToken() {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveTokenValidatorTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/ReactiveTokenValidatorTests.java
@@ -25,6 +25,7 @@ import java.security.PrivateKey;
 import java.security.Signature;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -121,7 +122,7 @@ class ReactiveTokenValidatorTests {
 		String claims = "{\"exp\": 2147483647, \"iss\": \"http://localhost:8080/uaa/oauth/token\", \"scope\": [\"actuator.read\"]}";
 		StepVerifier
 			.create(this.tokenValidator.validate(new Token(getSignedToken(header.getBytes(), claims.getBytes()))))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 		assertThat(this.tokenValidator).hasFieldOrPropertyWithValue("cachedTokenKeys", VALID_KEYS);
 		fetchTokenKeys.assertWasSubscribed();
 	}
@@ -135,7 +136,7 @@ class ReactiveTokenValidatorTests {
 		String claims = "{\"exp\": 2147483647, \"iss\": \"http://localhost:8080/uaa/oauth/token\", \"scope\": [\"actuator.read\"]}";
 		StepVerifier
 			.create(this.tokenValidator.validate(new Token(getSignedToken(header.getBytes(), claims.getBytes()))))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 		assertThat(this.tokenValidator).hasFieldOrPropertyWithValue("cachedTokenKeys", VALID_KEYS);
 		fetchTokenKeys.assertWasSubscribed();
 	}
@@ -167,7 +168,7 @@ class ReactiveTokenValidatorTests {
 		String claims = "{\"exp\": 2147483647, \"iss\": \"http://localhost:8080/uaa/oauth/token\", \"scope\": [\"actuator.read\"]}";
 		StepVerifier
 			.create(this.tokenValidator.validate(new Token(getSignedToken(header.getBytes(), claims.getBytes()))))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 		fetchTokenKeys.assertWasNotSubscribed();
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/cassandra/CassandraDriverReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/cassandra/CassandraDriverReactiveHealthIndicatorTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.cassandra;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -61,7 +62,7 @@ class CassandraDriverReactiveHealthIndicatorTests {
 		Mono<Health> health = healthIndicator.health();
 		StepVerifier.create(health)
 			.consumeNextWith((h) -> assertThat(h.getStatus()).isEqualTo(Status.UP))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -71,7 +72,7 @@ class CassandraDriverReactiveHealthIndicatorTests {
 		Mono<Health> health = healthIndicator.health();
 		StepVerifier.create(health)
 			.consumeNextWith((h) -> assertThat(h.getStatus()).isEqualTo(Status.DOWN))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -81,7 +82,7 @@ class CassandraDriverReactiveHealthIndicatorTests {
 		Mono<Health> health = healthIndicator.health();
 		StepVerifier.create(health)
 			.consumeNextWith((h) -> assertThat(h.getStatus()).isEqualTo(Status.DOWN))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -91,7 +92,7 @@ class CassandraDriverReactiveHealthIndicatorTests {
 		Mono<Health> health = healthIndicator.health();
 		StepVerifier.create(health)
 			.consumeNextWith((h) -> assertThat(h.getStatus()).isEqualTo(Status.DOWN))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -101,7 +102,7 @@ class CassandraDriverReactiveHealthIndicatorTests {
 		Mono<Health> health = healthIndicator.health();
 		StepVerifier.create(health)
 			.consumeNextWith((h) -> assertThat(h.getStatus()).isEqualTo(Status.UP))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -111,7 +112,7 @@ class CassandraDriverReactiveHealthIndicatorTests {
 		Mono<Health> health = healthIndicator.health();
 		StepVerifier.create(health)
 			.consumeNextWith((h) -> assertThat(h.getStatus()).isEqualTo(Status.UP))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -121,7 +122,7 @@ class CassandraDriverReactiveHealthIndicatorTests {
 		Mono<Health> health = healthIndicator.health();
 		StepVerifier.create(health)
 			.consumeNextWith((h) -> assertThat(h.getStatus()).isEqualTo(Status.UP))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -139,7 +140,7 @@ class CassandraDriverReactiveHealthIndicatorTests {
 			assertThat(h.getStatus()).isEqualTo(Status.UP);
 			assertThat(h.getDetails()).containsOnlyKeys("version");
 			assertThat(h.getDetails().get("version")).isEqualTo(Version.V4_0_0);
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -150,7 +151,7 @@ class CassandraDriverReactiveHealthIndicatorTests {
 		StepVerifier.create(health).consumeNextWith((h) -> {
 			assertThat(h.getStatus()).isEqualTo(Status.UP);
 			assertThat(h.getDetails().get("version")).isNull();
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -165,7 +166,7 @@ class CassandraDriverReactiveHealthIndicatorTests {
 			assertThat(h.getDetails()).containsOnlyKeys("error");
 			assertThat(h.getDetails().get("error"))
 				.isEqualTo(DriverTimeoutException.class.getName() + ": Test Exception");
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	private CqlSession mockCqlSessionWithNodeState(NodeState... nodeStates) {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthIndicatorReactiveAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthIndicatorReactiveAdapterTests.java
@@ -37,7 +37,7 @@ class HealthIndicatorReactiveAdapterTests {
 		HealthIndicatorReactiveAdapter adapter = new HealthIndicatorReactiveAdapter(delegate);
 		Health status = Health.up().build();
 		given(delegate.health()).willReturn(status);
-		StepVerifier.create(adapter.health()).expectNext(status).verifyComplete();
+		StepVerifier.create(adapter.health()).expectNext(status).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -55,7 +55,7 @@ class HealthIndicatorReactiveAdapterTests {
 			.status(Thread.currentThread().getName().equals(currentThread) ? Status.DOWN : Status.UP)
 			.build();
 		HealthIndicatorReactiveAdapter adapter = new HealthIndicatorReactiveAdapter(delegate);
-		StepVerifier.create(adapter.health()).expectNext(Health.status(Status.UP).build()).verifyComplete();
+		StepVerifier.create(adapter.health()).expectNext(Health.status(Status.UP).build()).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/ReactiveHealthIndicatorImplementationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/ReactiveHealthIndicatorImplementationTests.java
@@ -25,6 +25,8 @@ import org.springframework.boot.actuate.health.Health.Builder;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -40,7 +42,7 @@ class ReactiveHealthIndicatorImplementationTests {
 	void healthUp(CapturedOutput output) {
 		StepVerifier.create(new SimpleReactiveHealthIndicator().health())
 			.consumeNextWith((health) -> assertThat(health).isEqualTo(Health.up().build()))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 		assertThat(output).doesNotContain("Health check failed for simple");
 	}
 
@@ -49,7 +51,7 @@ class ReactiveHealthIndicatorImplementationTests {
 		StepVerifier.create(new CustomErrorMessageReactiveHealthIndicator().health())
 			.consumeNextWith(
 					(health) -> assertThat(health).isEqualTo(Health.down(new UnsupportedOperationException()).build()))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 		assertThat(output).contains("Health check failed for custom");
 	}
 
@@ -57,7 +59,7 @@ class ReactiveHealthIndicatorImplementationTests {
 	void healthDownWithCustomErrorMessageFunction(CapturedOutput output) {
 		StepVerifier.create(new CustomErrorMessageFunctionReactiveHealthIndicator().health())
 			.consumeNextWith((health) -> assertThat(health).isEqualTo(Health.down(new RuntimeException()).build()))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 		assertThat(output).contains("Health check failed with RuntimeException");
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/r2dbc/ConnectionPoolMetricsTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/metrics/r2dbc/ConnectionPoolMetricsTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.metrics.r2dbc;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.UUID;
 
@@ -59,7 +60,7 @@ class ConnectionPoolMetricsTests {
 	@AfterEach
 	void close() {
 		if (this.connectionFactory != null) {
-			StepVerifier.create(this.connectionFactory.close()).verifyComplete();
+			StepVerifier.create(this.connectionFactory.close()).expectComplete().verify(Duration.ofSeconds(5));
 		}
 	}
 
@@ -72,8 +73,8 @@ class ConnectionPoolMetricsTests {
 				Tags.of(testTag, regionTag));
 		metrics.bindTo(registry);
 		// acquire two connections
-		connectionPool.create().as(StepVerifier::create).expectNextCount(1).verifyComplete();
-		connectionPool.create().as(StepVerifier::create).expectNextCount(1).verifyComplete();
+		connectionPool.create().as(StepVerifier::create).expectNextCount(1).expectComplete().verify(Duration.ofSeconds(5));
+		connectionPool.create().as(StepVerifier::create).expectNextCount(1).expectComplete().verify(Duration.ofSeconds(5));
 		assertGauge(registry, "r2dbc.pool.acquired", 2);
 		assertGauge(registry, "r2dbc.pool.allocated", 3);
 		assertGauge(registry, "r2dbc.pool.idle", 1);

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/mongo/MongoReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/mongo/MongoReactiveHealthIndicatorTests.java
@@ -26,6 +26,8 @@ import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -50,7 +52,7 @@ class MongoReactiveHealthIndicatorTests {
 			assertThat(h.getStatus()).isEqualTo(Status.UP);
 			assertThat(h.getDetails()).containsOnlyKeys("version");
 			assertThat(h.getDetails().get("version")).isEqualTo("2.6.4");
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -65,7 +67,7 @@ class MongoReactiveHealthIndicatorTests {
 			assertThat(h.getStatus()).isEqualTo(Status.DOWN);
 			assertThat(h.getDetails()).containsOnlyKeys("error");
 			assertThat(h.getDetails().get("error")).isEqualTo(MongoException.class.getName() + ": Connection failed");
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/neo4j/Neo4jReactiveHealthIndicatorTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.neo4j;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,7 @@ class Neo4jReactiveHealthIndicatorTests {
 			assertThat(health.getStatus()).isEqualTo(Status.UP);
 			assertThat(health.getDetails()).containsEntry("server", "4711@My Home");
 			assertThat(health.getDetails()).containsEntry("edition", "ultimate collectors edition");
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -80,7 +81,7 @@ class Neo4jReactiveHealthIndicatorTests {
 			assertThat(health.getStatus()).isEqualTo(Status.UP);
 			assertThat(health.getDetails()).containsEntry("server", "4711@My Home");
 			assertThat(health.getDetails()).containsEntry("edition", "some edition");
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 		then(session).should(times(2)).close();
 	}
 
@@ -92,7 +93,7 @@ class Neo4jReactiveHealthIndicatorTests {
 		healthIndicator.health().as(StepVerifier::create).consumeNextWith((health) -> {
 			assertThat(health.getStatus()).isEqualTo(Status.DOWN);
 			assertThat(health.getDetails()).containsKeys("error");
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	private RxResult mockStatementResult(ResultSummary resultSummary, String version, String edition) {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/r2dbc/ConnectionFactoryHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/r2dbc/ConnectionFactoryHealthIndicatorTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.r2dbc;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.UUID;
 
@@ -56,10 +57,10 @@ class ConnectionFactoryHealthIndicatorTests {
 				assertThat(actual.getStatus()).isEqualTo(Status.UP);
 				assertThat(actual.getDetails()).containsOnly(entry("database", "H2"),
 						entry("validationQuery", "validate(REMOTE)"));
-			}).verifyComplete();
+			}).expectComplete().verify(Duration.ofSeconds(5));
 		}
 		finally {
-			StepVerifier.create(connectionFactory.close()).verifyComplete();
+			StepVerifier.create(connectionFactory.close()).expectComplete().verify(Duration.ofSeconds(5));
 		}
 	}
 
@@ -74,7 +75,7 @@ class ConnectionFactoryHealthIndicatorTests {
 			assertThat(actual.getStatus()).isEqualTo(Status.DOWN);
 			assertThat(actual.getDetails()).containsOnly(entry("database", "mock"),
 					entry("validationQuery", "validate(REMOTE)"), entry("error", "java.lang.RuntimeException: test"));
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -90,7 +91,7 @@ class ConnectionFactoryHealthIndicatorTests {
 			assertThat(actual.getStatus()).isEqualTo(Status.DOWN);
 			assertThat(actual.getDetails()).containsOnly(entry("database", "mock"),
 					entry("validationQuery", "validate(REMOTE)"));
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -104,17 +105,17 @@ class ConnectionFactoryHealthIndicatorTests {
 					.flatMap(Result::getRowsUpdated)
 					.thenMany(it.close()))
 				.as(StepVerifier::create)
-				.verifyComplete();
+				.expectComplete().verify(Duration.ofSeconds(5));
 			ReactiveHealthIndicator healthIndicator = new ConnectionFactoryHealthIndicator(connectionFactory,
 					customValidationQuery);
 			healthIndicator.health().as(StepVerifier::create).assertNext((actual) -> {
 				assertThat(actual.getStatus()).isEqualTo(Status.UP);
 				assertThat(actual.getDetails()).containsOnly(entry("database", "H2"), entry("result", 0L),
 						entry("validationQuery", customValidationQuery));
-			}).verifyComplete();
+			}).expectComplete().verify(Duration.ofSeconds(5));
 		}
 		finally {
-			StepVerifier.create(connectionFactory.close()).verifyComplete();
+			StepVerifier.create(connectionFactory.close()).expectComplete().verify(Duration.ofSeconds(5));
 		}
 
 	}
@@ -131,10 +132,10 @@ class ConnectionFactoryHealthIndicatorTests {
 				assertThat(actual.getDetails()).contains(entry("database", "H2"),
 						entry("validationQuery", invalidValidationQuery));
 				assertThat(actual.getDetails()).containsOnlyKeys("database", "error", "validationQuery");
-			}).verifyComplete();
+			}).expectComplete().verify(Duration.ofSeconds(5));
 		}
 		finally {
-			StepVerifier.create(connectionFactory.close()).verifyComplete();
+			StepVerifier.create(connectionFactory.close()).expectComplete().verify(Duration.ofSeconds(5));
 		}
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicatorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/redis/RedisReactiveHealthIndicatorTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.redis;
 
+import java.time.Duration;
 import java.util.Properties;
 
 import io.lettuce.core.RedisConnectionException;
@@ -62,7 +63,7 @@ class RedisReactiveHealthIndicatorTests {
 			assertThat(h.getStatus()).isEqualTo(Status.UP);
 			assertThat(h.getDetails()).containsOnlyKeys("version");
 			assertThat(h.getDetails().get("version")).isEqualTo("2.8.9");
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 		then(redisConnection).should().closeLater();
 	}
 
@@ -76,7 +77,7 @@ class RedisReactiveHealthIndicatorTests {
 			assertThat(h.getDetails().get("cluster_size")).isEqualTo(4L);
 			assertThat(h.getDetails().get("slots_up")).isEqualTo(4L);
 			assertThat(h.getDetails().get("slots_fail")).isEqualTo(0L);
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 		then(redisConnectionFactory.getReactiveConnection()).should().closeLater();
 	}
 
@@ -90,7 +91,7 @@ class RedisReactiveHealthIndicatorTests {
 			assertThat(h.getDetails().get("cluster_size")).isEqualTo(4L);
 			assertThat(h.getDetails().get("slots_up")).isEqualTo(4L);
 			assertThat(h.getDetails().get("slots_fail")).isEqualTo(0L);
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -102,7 +103,7 @@ class RedisReactiveHealthIndicatorTests {
 			assertThat(h.getStatus()).isEqualTo(Status.DOWN);
 			assertThat(h.getDetails().get("slots_up")).isEqualTo(3L);
 			assertThat(h.getDetails().get("slots_fail")).isEqualTo(1L);
-		}).verifyComplete();
+		}).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test
@@ -115,7 +116,7 @@ class RedisReactiveHealthIndicatorTests {
 		Mono<Health> health = healthIndicator.health();
 		StepVerifier.create(health)
 			.consumeNextWith((h) -> assertThat(h.getStatus()).isEqualTo(Status.DOWN))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 		then(redisConnection).should().closeLater();
 	}
 
@@ -128,7 +129,7 @@ class RedisReactiveHealthIndicatorTests {
 		Mono<Health> health = healthIndicator.health();
 		StepVerifier.create(health)
 			.consumeNextWith((h) -> assertThat(h.getStatus()).isEqualTo(Status.DOWN))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	private RedisReactiveHealthIndicator createHealthIndicator(ReactiveRedisConnection redisConnection,

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/http/reactive/HttpTraceWebFilterTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/trace/http/reactive/HttpTraceWebFilterTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.actuate.trace.http.reactive;
 
 import java.security.Principal;
+import java.time.Duration;
 import java.util.EnumSet;
 
 import org.junit.jupiter.api.Test;
@@ -105,7 +106,7 @@ class HttpTraceWebFilterTests {
 	private void executeFilter(ServerWebExchange exchange, WebFilterChain chain) {
 		StepVerifier
 			.create(this.filter.filter(exchange, chain).then(Mono.defer(() -> exchange.getResponse().setComplete())))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/r2dbc/R2dbcRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/r2dbc/R2dbcRepositoriesAutoConfigurationTests.java
@@ -39,6 +39,8 @@ import org.springframework.data.repository.Repository;
 import org.springframework.r2dbc.connection.init.ResourceDatabasePopulator;
 import org.springframework.r2dbc.core.DatabaseClient;
 
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -80,7 +82,7 @@ class R2dbcRepositoriesAutoConfigurationTests {
 					.findById(2000L)
 					.as(StepVerifier::create)
 					.expectNextCount(1)
-					.verifyComplete();
+					.expectComplete().verify(Duration.ofSeconds(5));
 			});
 	}
 
@@ -103,7 +105,7 @@ class R2dbcRepositoriesAutoConfigurationTests {
 					.findById(2000L)
 					.as(StepVerifier::create)
 					.expectNextCount(1)
-					.verifyComplete();
+					.expectComplete().verify(Duration.ofSeconds(5));
 			});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcTransactionManagerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcTransactionManagerAutoConfigurationTests.java
@@ -33,6 +33,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.reactive.TransactionSynchronizationManager;
 import org.springframework.transaction.reactive.TransactionalOperator;
 
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -65,7 +67,7 @@ class R2dbcTransactionManagerAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(SingleConnectionFactoryConfiguration.class, BaseConfiguration.class)
 			.run((context) -> {
 				TransactionalService bean = context.getBean(TransactionalService.class);
-				bean.isTransactionActive().as(StepVerifier::create).expectNext(true).verifyComplete();
+				bean.isTransactionActive().as(StepVerifier::create).expectNext(true).expectComplete().verify(Duration.ofSeconds(5));
 			});
 	}
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/neo4j/DataNeo4jTestReactiveIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/neo4j/DataNeo4jTestReactiveIntegrationTests.java
@@ -83,8 +83,8 @@ class DataNeo4jTestReactiveIntegrationTests {
 			.flatMap(this.exampleRepository::save)
 			.as(StepVerifier::create)
 			.expectNextCount(1)
-			.verifyComplete();
-		StepVerifier.create(this.neo4jTemplate.count(ExampleGraph.class)).expectNext(1L).verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
+		StepVerifier.create(this.neo4jTemplate.count(ExampleGraph.class)).expectNext(1L).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/r2dbc/DataR2dbcTestIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/r2dbc/DataR2dbcTestIntegrationTests.java
@@ -24,6 +24,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.r2dbc.core.DatabaseClient;
 
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -46,7 +48,7 @@ class DataR2dbcTestIntegrationTests {
 
 	@Test
 	void testDatabaseClient() {
-		this.databaseClient.sql("SELECT * FROM example").fetch().all().as(StepVerifier::create).verifyComplete();
+		this.databaseClient.sql("SELECT * FROM example").fetch().all().as(StepVerifier::create).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestReactiveIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/redis/DataRedisTestReactiveIntegrationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.test.autoconfigure.data.redis;
 
+import java.time.Duration;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -62,11 +63,11 @@ class DataRedisTestReactiveIntegrationTests {
 		String id = UUID.randomUUID().toString();
 		StepVerifier.create(this.operations.opsForValue().set(id, "Hello World"))
 			.expectNext(Boolean.TRUE)
-			.verifyComplete();
-		StepVerifier.create(this.operations.opsForValue().get(id)).expectNext("Hello World").verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
+		StepVerifier.create(this.operations.opsForValue().get(id)).expectNext("Hello World").expectComplete().verify(Duration.ofSeconds(5));
 		StepVerifier.create(this.operations.execute((action) -> action.serverCommands().flushDb()))
 			.expectNext("OK")
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/rsocket/netty/NettyRSocketServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/rsocket/netty/NettyRSocketServerFactoryTests.java
@@ -18,6 +18,7 @@ package org.springframework.boot.rsocket.netty;
 
 import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 
@@ -194,7 +195,7 @@ class NettyRSocketServerFactoryTests {
 	private void checkEchoRequest() {
 		String payload = "test payload";
 		Mono<String> response = this.requester.route("test").data(payload).retrieveMono(String.class);
-		StepVerifier.create(response).expectNext(payload).verifyComplete();
+		StepVerifier.create(response).expectNext(payload).expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	private void testBasicSslWithKeyStore(String keyStore, String keyPassword, Transport transport) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/netty/NettyReactiveWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/netty/NettyReactiveWebServerFactoryTests.java
@@ -110,7 +110,7 @@ class NettyReactiveWebServerFactoryTests extends AbstractReactiveWebServerFactor
 	void whenSslIsConfiguredWithAValidAliasARequestSucceeds() {
 		Mono<String> result = testSslWithAlias("test-alias");
 		StepVerifier.setDefaultTimeout(Duration.ofSeconds(30));
-		StepVerifier.create(result).expectNext("Hello World").verifyComplete();
+		StepVerifier.create(result).expectNext("Hello World").expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/result/view/MustacheViewTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/result/view/MustacheViewTests.java
@@ -55,7 +55,7 @@ class MustacheViewTests {
 			.block(Duration.ofSeconds(30));
 		StepVerifier.create(exchange.getResponse().getBodyAsString())
 			.assertNext((body) -> assertThat(body).isEqualToIgnoringWhitespace("Hello Spring"))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/server/AbstractReactiveWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/reactive/server/AbstractReactiveWebServerFactoryTests.java
@@ -194,7 +194,7 @@ public abstract class AbstractReactiveWebServerFactoryTests {
 			.bodyToMono(String.class);
 
 		StepVerifier.setDefaultTimeout(Duration.ofSeconds(30));
-		StepVerifier.create(result).expectNext("Hello World").verifyComplete();
+		StepVerifier.create(result).expectNext("Hello World").expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	@Test

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-r2dbc-flyway/src/test/java/smoketest/data/r2dbc/CityRepositoryTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-r2dbc-flyway/src/test/java/smoketest/data/r2dbc/CityRepositoryTests.java
@@ -28,6 +28,8 @@ import org.springframework.boot.testsupport.testcontainers.DockerImageNames;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -60,7 +62,7 @@ class CityRepositoryTests {
 	void databaseHasBeenInitialized() {
 		StepVerifier.create(this.repository.findByState("DC").filter((city) -> city.getName().equals("Washington")))
 			.consumeNextWith((city) -> assertThat(city.getId()).isNotNull())
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	private static String r2dbcUrl() {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-r2dbc-liquibase/src/test/java/smoketest/data/r2dbc/CityRepositoryTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-r2dbc-liquibase/src/test/java/smoketest/data/r2dbc/CityRepositoryTests.java
@@ -28,6 +28,8 @@ import org.springframework.boot.testsupport.testcontainers.DockerImageNames;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -60,7 +62,7 @@ class CityRepositoryTests {
 	void databaseHasBeenInitialized() {
 		StepVerifier.create(this.repository.findByState("DC").filter((city) -> city.getName().equals("Washington")))
 			.consumeNextWith((city) -> assertThat(city.getId()).isNotNull())
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 	private static String r2dbcUrl() {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-rsocket/src/test/java/smoketest/rsocket/SampleRSocketApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-rsocket/src/test/java/smoketest/rsocket/SampleRSocketApplicationTests.java
@@ -30,6 +30,8 @@ import org.springframework.security.rsocket.metadata.SimpleAuthenticationEncoder
 import org.springframework.security.rsocket.metadata.UsernamePasswordMetadata;
 import org.springframework.util.MimeTypeUtils;
 
+import java.time.Duration;
+
 @SpringBootTest(properties = "spring.rsocket.server.port=0")
 class SampleRSocketApplicationTests {
 
@@ -56,7 +58,7 @@ class SampleRSocketApplicationTests {
 		Mono<Project> result = requester.route("find.project.spring-boot").retrieveMono(Project.class);
 		StepVerifier.create(result)
 			.assertNext((project) -> Assertions.assertThat(project.getName()).isEqualTo("spring-boot"))
-			.verifyComplete();
+			.expectComplete().verify(Duration.ofSeconds(5));
 	}
 
 }


### PR DESCRIPTION
This pull request addresses the issue #35791, where it was required to replace `verifyComplete()` with `expectComplete().verify(Duration)` in test cases across multiple files. 

Changes made:

1. Replaced `verifyComplete()` with `expectComplete().verify(Duration.ofSeconds(5))` in all the necessary places. The decision to use `Duration.ofSeconds(5)` was influenced by its existing usage in another part of the project, ensuring consistency across the codebase.
2. Added `import java.time.Duration;` where it was not already imported.

I have successfully made changes to 23 files and built the project without any errors. All the tests ran successfully after the changes.