### PR TITLE
Create Add SslAutoConfiguration to slice test annotation.java

### DIFF
--- a/Add SslAutoConfiguration to slice test annotation.java
+++ b/Add SslAutoConfiguration to slice test annotation.java
@@ -1,0 +1,12 @@
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.data.mongodb.repository.config.MongoRepositoryConfigurationExtension;
+import org.springframework.data.mongodb.repository.config.MongoRepositoryConfigurationSupport;
+
+@Configuration
+@Import(SslAutoConfiguration.class) // Add this line to import SslAutoConfiguration
+@EnableMongoRepositories(repositoryBaseClass = MongoRepositoryConfigurationSupport.class)
+public class MyMongoConfiguration {
+    // Configuration code goes here
+}


### PR DESCRIPTION
In this example, the @Import(SslAutoConfiguration.class) annotation is added to import the SslAutoConfiguration class, which enables SSL configuration for MongoDB. Make sure to replace MyMongoConfiguration with your actual configuration class name.

Add SslAutoConfiguration to slice test annotations #35861 template

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
