### PR TITLE
Remove redundant Files.delete() calls in tests

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ssl/KeyStoreFactoryTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ssl/KeyStoreFactoryTests.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.buildpack.platform.docker.ssl;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -60,7 +59,6 @@ class KeyStoreFactoryTests {
 		assertThat(keyStore.containsAlias("test-alias-1")).isTrue();
 		assertThat(keyStore.getCertificate("test-alias-1")).isNotNull();
 		assertThat(keyStore.getKey("test-alias-1", new char[] {})).isNull();
-		Files.delete(certPath);
 	}
 
 	@Test
@@ -72,8 +70,6 @@ class KeyStoreFactoryTests {
 		assertThat(keyStore.containsAlias("test-alias")).isTrue();
 		assertThat(keyStore.getCertificate("test-alias")).isNotNull();
 		assertThat(keyStore.getKey("test-alias", new char[] {})).isNotNull();
-		Files.delete(certPath);
-		Files.delete(keyPath);
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ssl/PrivateKeyParserTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ssl/PrivateKeyParserTests.java
@@ -19,7 +19,6 @@ package org.springframework.boot.buildpack.platform.docker.ssl;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.PrivateKey;
@@ -63,7 +62,6 @@ class PrivateKeyParserTests {
 		PrivateKey privateKey = PrivateKeyParser.parse(path);
 		assertThat(privateKey).isNotNull();
 		assertThat(privateKey.getFormat()).isEqualTo("PKCS#8");
-		Files.delete(path);
 	}
 
 	@ParameterizedTest
@@ -93,7 +91,6 @@ class PrivateKeyParserTests {
 		assertThat(privateKey).isNotNull();
 		// keys in PKCS#1 format are converted to PKCS#8 for parsing
 		assertThat(privateKey.getFormat()).isEqualTo("PKCS#8");
-		Files.delete(path);
 	}
 
 	@Test
@@ -103,7 +100,6 @@ class PrivateKeyParserTests {
 		assertThat(privateKey).isNotNull();
 		// keys in PKCS#1 format are converted to PKCS#8 for parsing
 		assertThat(privateKey.getFormat()).isEqualTo("PKCS#8");
-		Files.delete(path);
 	}
 
 	@Test
@@ -120,7 +116,6 @@ class PrivateKeyParserTests {
 		Path path = this.fileWriter.writeFile("text.pem", "plain text");
 		assertThatIllegalStateException().isThrownBy(() -> PrivateKeyParser.parse(path))
 			.withMessageContaining(path.toString());
-		Files.delete(path);
 	}
 
 	@Test


### PR DESCRIPTION
This PR adds missing `Files.delete()` calls in the `PrivateKeyParserTests`.