### PR TITLE
Slice test annotations do not include SslAutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.data.cassandra.AutoConfigureDataCassandra.imports
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.data.cassandra.AutoConfigureDataCassandra.imports
@@ -4,3 +4,4 @@ org.springframework.boot.autoconfigure.data.cassandra.CassandraDataAutoConfigura
 org.springframework.boot.autoconfigure.data.cassandra.CassandraReactiveDataAutoConfiguration
 org.springframework.boot.autoconfigure.data.cassandra.CassandraReactiveRepositoriesAutoConfiguration
 org.springframework.boot.autoconfigure.data.cassandra.CassandraRepositoriesAutoConfiguration
+org.springframework.boot.autoconfigure.ssl.SslAutoConfiguration

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.data.couchbase.AutoConfigureDataCouchbase.imports
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.data.couchbase.AutoConfigureDataCouchbase.imports
@@ -5,3 +5,4 @@ org.springframework.boot.autoconfigure.data.couchbase.CouchbaseDataAutoConfigura
 org.springframework.boot.autoconfigure.data.couchbase.CouchbaseReactiveDataAutoConfiguration
 org.springframework.boot.autoconfigure.data.couchbase.CouchbaseReactiveRepositoriesAutoConfiguration
 org.springframework.boot.autoconfigure.data.couchbase.CouchbaseRepositoriesAutoConfiguration
+org.springframework.boot.autoconfigure.ssl.SslAutoConfiguration

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.data.elasticsearch.AutoConfigureDataElasticsearch.imports
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.data.elasticsearch.AutoConfigureDataElasticsearch.imports
@@ -7,3 +7,4 @@ org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAuto
 org.springframework.boot.autoconfigure.elasticsearch.ReactiveElasticsearchClientAutoConfiguration
 org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
 org.springframework.boot.autoconfigure.jsonb.JsonbAutoConfiguration
+org.springframework.boot.autoconfigure.ssl.SslAutoConfiguration

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo.imports
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo.imports
@@ -6,3 +6,4 @@ org.springframework.boot.autoconfigure.data.mongo.MongoRepositoriesAutoConfigura
 org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration
 org.springframework.boot.autoconfigure.mongo.MongoReactiveAutoConfiguration
 org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration
+org.springframework.boot.autoconfigure.ssl.SslAutoConfiguration

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.data.redis.AutoConfigureDataRedis.imports
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.data.redis.AutoConfigureDataRedis.imports
@@ -2,3 +2,4 @@
 org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
 org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration
 org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+org.springframework.boot.autoconfigure.ssl.SslAutoConfiguration

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/build.gradle
@@ -7,6 +7,7 @@ description = "Spring Boot Data Cassandra smoke test"
 
 dependencies {
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-data-cassandra"))
+	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-data-cassandra-reactive"))
 
 	testImplementation(project(":spring-boot-project:spring-boot-test"))
 	testImplementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-test"))

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/src/test/java/smoketest/data/cassandra/SampleCassandraApplicationReactiveSslTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-cassandra/src/test/java/smoketest/data/cassandra/SampleCassandraApplicationReactiveSslTests.java
@@ -16,6 +16,7 @@
 
 package smoketest.data.cassandra;
 
+import java.time.Duration;
 import java.util.UUID;
 
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -25,37 +26,35 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.data.cassandra.DataCassandraTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.cassandra.core.CassandraTemplate;
+import org.springframework.data.cassandra.core.ReactiveCassandraTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Smoke tests for Cassandra with SSL.
  *
- * @author Scott Frederick
  * @author Eddú Meléndez
  */
 @Testcontainers(disabledWithoutDocker = true)
-@DataCassandraTest(properties = { "spring.cassandra.schema-action=create-if-not-exists",
+@SpringBootTest(properties = { "spring.cassandra.schema-action=create-if-not-exists",
 		"spring.cassandra.connection.connect-timeout=60s", "spring.cassandra.connection.init-query-timeout=60s",
 		"spring.cassandra.request.timeout=60s", "spring.cassandra.ssl.bundle=client",
 		"spring.ssl.bundle.jks.client.keystore.location=classpath:ssl/test-client.p12",
 		"spring.ssl.bundle.jks.client.keystore.password=password",
 		"spring.ssl.bundle.jks.client.truststore.location=classpath:ssl/test-ca.p12",
 		"spring.ssl.bundle.jks.client.truststore.password=password" })
-class SampleCassandraApplicationSslTests {
+class SampleCassandraApplicationReactiveSslTests {
 
 	@Container
 	@ServiceConnection
 	static final SecureCassandraContainer secureCassandra = new SecureCassandraContainer();
 
 	@Autowired
-	private CassandraTemplate cassandraTemplate;
+	private ReactiveCassandraTemplate cassandraTemplate;
 
 	@Autowired
 	private SampleRepository repository;
@@ -67,11 +66,11 @@ class SampleCassandraApplicationSslTests {
 		String id = UUID.randomUUID().toString();
 		entity.setId(id);
 		SampleEntity savedEntity = this.repository.save(entity);
-		SampleEntity getEntity = this.cassandraTemplate.selectOneById(id, SampleEntity.class);
+		SampleEntity getEntity = this.cassandraTemplate.selectOneById(id, SampleEntity.class)
+			.block(Duration.ofSeconds(30));
 		assertThat(getEntity).isNotNull();
 		assertThat(getEntity.getId()).isNotNull();
 		assertThat(getEntity.getId()).isEqualTo(savedEntity.getId());
-		this.repository.deleteAll();
 	}
 
 	@TestConfiguration(proxyBeanMethods = false)

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-couchbase/src/test/java/smoketest/data/couchbase/SampleCouchbaseApplicationSslTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-couchbase/src/test/java/smoketest/data/couchbase/SampleCouchbaseApplicationSslTests.java
@@ -23,6 +23,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.couchbase.DataCouchbaseTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.couchbase.core.CouchbaseTemplate;
@@ -35,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Scott Frederick
  */
 @Testcontainers(disabledWithoutDocker = true)
-@SpringBootTest(properties = { "spring.couchbase.env.ssl.bundle=client", "spring.couchbase.env.timeouts.connect=2m",
+@DataCouchbaseTest(properties = { "spring.couchbase.env.ssl.bundle=client", "spring.couchbase.env.timeouts.connect=2m",
 		"spring.data.couchbase.bucket-name=cbbucket",
 		"spring.ssl.bundle.pem.client.keystore.certificate=classpath:ssl/test-client.crt",
 		"spring.ssl.bundle.pem.client.keystore.private-key=classpath:ssl/test-client.key",

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-mongo/src/test/java/smoketest/data/mongo/SampleMongoApplicationSslTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-mongo/src/test/java/smoketest/data/mongo/SampleMongoApplicationSslTests.java
@@ -22,7 +22,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
@@ -32,9 +32,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Smoke tests for MongoDB with SSL.
  *
  * @author Scott Frederick
+ * @author Eddú Meléndez
  */
 @Testcontainers(disabledWithoutDocker = true)
-@SpringBootTest(properties = { "spring.data.mongodb.ssl.bundle=client",
+@DataMongoTest(properties = { "spring.data.mongodb.ssl.bundle=client",
 		"spring.ssl.bundle.pem.client.keystore.certificate=classpath:ssl/test-client.crt",
 		"spring.ssl.bundle.pem.client.keystore.private-key=classpath:ssl/test-client.key",
 		"spring.ssl.bundle.pem.client.truststore.certificate=classpath:ssl/test-ca.crt" })

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-redis/src/test/java/smoketest/data/redis/SampleRedisApplicationJedisSslTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-redis/src/test/java/smoketest/data/redis/SampleRedisApplicationJedisSslTests.java
@@ -24,6 +24,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
@@ -39,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @Testcontainers(disabledWithoutDocker = true)
 @ClassPathExclusions("lettuce-core-*.jar")
-@SpringBootTest(properties = { "spring.data.redis.ssl.bundle=client",
+@DataRedisTest(properties = { "spring.data.redis.ssl.bundle=client",
 		"spring.ssl.bundle.pem.client.keystore.certificate=classpath:ssl/test-client.crt",
 		"spring.ssl.bundle.pem.client.keystore.private-key=classpath:ssl/test-client.key",
 		"spring.ssl.bundle.pem.client.truststore.certificate=classpath:ssl/test-ca.crt" })


### PR DESCRIPTION
`SslAutoConfiguration` has been added to `cassandra`, `couchbase`,
`elasticsearch`, `mongo` and `redis` slice test annotations.

See gh-35861
