### PR TITLE
Add Javadoc since to ImageReference.inTaglessForm()

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/ImageReference.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/ImageReference.java
@@ -157,6 +157,7 @@ public final class ImageReference {
 	/**
 	 * Return an {@link ImageReference} without the tag.
 	 * @return the image reference in tagless form
+	 * @since 2.7.12
 	 */
 	public ImageReference inTaglessForm() {
 		if (this.tag == null) {


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag to the `ImageReference.inTaglessForm()`.

See gh-35358