### PR TITLE
JobLauncherApplicationRunner returns a success exit code even when no jobs have been run

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunner.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunner.java
@@ -66,6 +66,7 @@ import org.springframework.util.StringUtils;
  * @author Jean-Pierre Bergamin
  * @author Mahmoud Ben Hassine
  * @author Stephane Nicoll
+ * @author Akshay Dubey
  * @since 2.3.0
  */
 public class JobLauncherApplicationRunner implements ApplicationRunner, Ordered, ApplicationEventPublisherAware {
@@ -187,6 +188,9 @@ public class JobLauncherApplicationRunner implements ApplicationRunner, Ordered,
 				}
 				catch (NoSuchJobException ex) {
 					logger.debug(LogMessage.format("No job found in registry for job name: %s", jobName));
+					if(this.jobExplorer != null && this.jobExplorer.getLastJobInstance(jobName) == null) {
+						throw ex;
+					}
 				}
 			}
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfigurationTests.java
@@ -38,6 +38,7 @@ import org.springframework.batch.core.configuration.support.JobRegistryBeanPostP
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.job.AbstractJob;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -71,6 +72,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -80,6 +82,7 @@ import static org.mockito.Mockito.mock;
  * @author Stephane Nicoll
  * @author Vedran Pavic
  * @author Kazuki Shimizu
+ * @author Akshay Dubey
  */
 @ExtendWith(OutputCaptureExtension.class)
 class BatchAutoConfigurationTests {
@@ -372,6 +375,21 @@ class BatchAutoConfigurationTests {
 					DataSourceTransactionManagerAutoConfiguration.class))
 			.run((context) -> assertThat(context).hasSingleBean(BatchDataSourceScriptDatabaseInitializer.class)
 				.hasBean("customInitializer"));
+	}
+
+	@Test
+	void testExecuteLocalAndNonConfiguredJob() {
+		this.contextRunner
+		.withUserConfiguration(NamedJobConfigurationWithLocalJob.class, EmbeddedDataSourceConfiguration.class)
+		.withPropertyValues("spring.batch.job.names:discreteLocalJob,nonConfiguredJob")
+		.run((context) -> {
+			assertThat(context).hasSingleBean(JobLauncher.class);
+			assertThrows(NoSuchJobException.class,()->{
+				context.getBean(JobLauncherApplicationRunner.class).run();
+			});
+			assertThat(context.getBean(JobRepository.class)
+				.getLastJobExecution("discreteLocalJob", new JobParameters())).isNotNull();
+		});
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
JobLauncherApplicationRunner returns a success exit code even when no jobs have been run.
fix: Rethrowing exception when NoSuchJobException is caught for non configured jobs.
Closes: https://github.com/spring-projects/spring-boot/issues/35940
