### PR TITLE
 Use beanName as default name of @ServiceConnection

### DIFF
--- a/spring-boot-project/spring-boot-testcontainers/build.gradle
+++ b/spring-boot-project/spring-boot-testcontainers/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	testImplementation("org.springframework:spring-core-test")
 	testImplementation("org.springframework:spring-r2dbc")
 	testImplementation("org.springframework.amqp:spring-rabbit")
+	testImplementation("org.springframework.data:spring-data-redis")
 	testImplementation("org.springframework.kafka:spring-kafka")
 	testImplementation("org.testcontainers:junit-jupiter")
 

--- a/spring-boot-project/spring-boot-testcontainers/src/test/java/org/springframework/boot/testcontainers/service/connection/redis/RedisContainerConnectionDetailsFactoryIntegrationTests.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/test/java/org/springframework/boot/testcontainers/service/connection/redis/RedisContainerConnectionDetailsFactoryIntegrationTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.testcontainers.service.connection.redis;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisConnectionDetails;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnectionAutoConfiguration;
+import org.springframework.boot.testsupport.testcontainers.RedisContainer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link RedisContainerConnectionDetailsFactory}.
+ *
+ * @author Yanming Zhou
+ */
+@SpringJUnitConfig
+@Testcontainers(disabledWithoutDocker = true)
+class RedisContainerConnectionDetailsFactoryIntegrationTests {
+
+	@Autowired
+	private RedisConnectionDetails connectionDetails;
+
+	@Test
+	void connectionDetailsShouldBeCreatedByRedisContainerConnectionDetailsFactory() {
+		assertThat(this.connectionDetails.getClass().getEnclosingClass())
+			.isSameAs(RedisContainerConnectionDetailsFactory.class);
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportAutoConfiguration(ServiceConnectionAutoConfiguration.class)
+	static class ContainerConfig {
+
+		@Bean
+		@ServiceConnection
+		RedisContainer redis() {
+			return new RedisContainer();
+		}
+
+	}
+
+}


### PR DESCRIPTION
Before this commit, `ConnectionDetailsNotFoundException` will be raised if unnamed `@ServiceConnection` is annotated on `@Bean` method and `containerType` is not accepted by `ContainerConnectionSource`.

For example:
```java
	@Bean
	@ServiceConnection(name = "redis")
	GenericContainer<?> redis() {
		return new GenericContainer<>("redis").withExposedPorts(6379);
	}
```
After this commit, name of `@ServiceConnection` could be omitted.