### PR TITLE
Change server log message to have "port" or "ports" rather than "ports(s)"

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/docs/ApplicationRunner.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/docs/ApplicationRunner.java
@@ -105,8 +105,8 @@ public class ApplicationRunner extends DefaultTask {
 	}
 
 	public void normalizeTomcatPort() {
-		this.normalizations.put("(Tomcat started on port\\(s\\): )[\\d]+( \\(http\\))", "$18080$2");
-		this.normalizations.put("(Tomcat initialized with port\\(s\\): )[\\d]+( \\(http\\))", "$18080$2");
+		this.normalizations.put("(Tomcat started on port )[\\d]+( \\(http\\))", "$18080$2");
+		this.normalizations.put("(Tomcat initialized with port )[\\d]+( \\(http\\))", "$18080$2");
 	}
 
 	public void normalizeLiveReloadPort() {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/resources/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/sample.log
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/resources/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/sample.log
@@ -9,7 +9,7 @@
 2017-08-08 17:12:30.910  INFO 19866 --- [           main] s.f.SampleWebFreeMarkerApplication       : Starting SampleWebFreeMarkerApplication with PID 19866
 2017-08-08 17:12:30.913  INFO 19866 --- [           main] s.f.SampleWebFreeMarkerApplication       : No active profile set, falling back to default profiles: default
 2017-08-08 17:12:30.952  INFO 19866 --- [           main] ConfigServletWebServerApplicationContext : Refreshing org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@76b10754: startup date [Tue Aug 08 17:12:30 BST 2017]; root of context hierarchy
-2017-08-08 17:12:31.878  INFO 19866 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port: 8080 (http)
+2017-08-08 17:12:31.878  INFO 19866 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port 8080 (http)
 2017-08-08 17:12:31.889  INFO 19866 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
 2017-08-08 17:12:31.890  INFO 19866 --- [           main] org.apache.catalina.core.StandardEngine  : Starting Servlet Engine: Apache Tomcat/8.5.16
 2017-08-08 17:12:31.978  INFO 19866 --- [ost-startStop-1] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
@@ -27,5 +27,5 @@
 2017-08-08 17:12:32.471  INFO 19866 --- [           main] o.s.w.s.handler.SimpleUrlHandlerMapping  : Mapped URL path [/**/favicon.ico] onto handler of type [class org.springframework.web.servlet.resource.ResourceHttpRequestHandler]
 2017-08-08 17:12:32.600  INFO 19866 --- [           main] o.s.w.s.v.f.FreeMarkerConfigurer         : ClassTemplateLoader for Spring macros added to FreeMarker configuration
 2017-08-08 17:12:32.681  INFO 19866 --- [           main] o.s.j.e.a.AnnotationMBeanExporter        : Registering beans for JMX exposure on startup
-2017-08-08 17:12:32.744  INFO 19866 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port: 8080 (http)
+2017-08-08 17:12:32.744  INFO 19866 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port 8080 (http)
 2017-08-08 17:12:32.750  INFO 19866 --- [           main] s.f.SampleWebFreeMarkerApplication       : Started SampleWebFreeMarkerApplication in 2.172 seconds (JVM running for 2.479)

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/resources/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/sample.log
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/resources/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/sample.log
@@ -9,7 +9,7 @@
 2017-08-08 17:12:30.910  INFO 19866 --- [           main] s.f.SampleWebFreeMarkerApplication       : Starting SampleWebFreeMarkerApplication with PID 19866
 2017-08-08 17:12:30.913  INFO 19866 --- [           main] s.f.SampleWebFreeMarkerApplication       : No active profile set, falling back to default profiles: default
 2017-08-08 17:12:30.952  INFO 19866 --- [           main] ConfigServletWebServerApplicationContext : Refreshing org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@76b10754: startup date [Tue Aug 08 17:12:30 BST 2017]; root of context hierarchy
-2017-08-08 17:12:31.878  INFO 19866 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port(s): 8080 (http)
+2017-08-08 17:12:31.878  INFO 19866 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port: 8080 (http)
 2017-08-08 17:12:31.889  INFO 19866 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
 2017-08-08 17:12:31.890  INFO 19866 --- [           main] org.apache.catalina.core.StandardEngine  : Starting Servlet Engine: Apache Tomcat/8.5.16
 2017-08-08 17:12:31.978  INFO 19866 --- [ost-startStop-1] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
@@ -27,5 +27,5 @@
 2017-08-08 17:12:32.471  INFO 19866 --- [           main] o.s.w.s.handler.SimpleUrlHandlerMapping  : Mapped URL path [/**/favicon.ico] onto handler of type [class org.springframework.web.servlet.resource.ResourceHttpRequestHandler]
 2017-08-08 17:12:32.600  INFO 19866 --- [           main] o.s.w.s.v.f.FreeMarkerConfigurer         : ClassTemplateLoader for Spring macros added to FreeMarker configuration
 2017-08-08 17:12:32.681  INFO 19866 --- [           main] o.s.j.e.a.AnnotationMBeanExporter        : Registering beans for JMX exposure on startup
-2017-08-08 17:12:32.744  INFO 19866 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port(s): 8080 (http)
+2017-08-08 17:12:32.744  INFO 19866 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port: 8080 (http)
 2017-08-08 17:12:32.750  INFO 19866 --- [           main] s.f.SampleWebFreeMarkerApplication       : Started SampleWebFreeMarkerApplication in 2.172 seconds (JVM running for 2.479)

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/rsocket/netty/NettyRSocketServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/rsocket/netty/NettyRSocketServer.java
@@ -62,7 +62,7 @@ public class NettyRSocketServer implements RSocketServer {
 	@Override
 	public void start() throws RSocketServerException {
 		this.channel = block(this.starter, this.lifecycleTimeout);
-		logger.info("Netty RSocket started on port(s): " + address().getPort());
+		logger.info("Netty RSocket started on port: " + address().getPort());
 		startDaemonAwaitThread(this.channel);
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/rsocket/netty/NettyRSocketServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/rsocket/netty/NettyRSocketServer.java
@@ -62,7 +62,7 @@ public class NettyRSocketServer implements RSocketServer {
 	@Override
 	public void start() throws RSocketServerException {
 		this.channel = block(this.starter, this.lifecycleTimeout);
-		logger.info("Netty RSocket started on port: " + address().getPort());
+		logger.info("Netty RSocket started on port " + address().getPort());
 		startDaemonAwaitThread(this.channel);
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
@@ -168,8 +168,8 @@ public class JettyWebServer implements WebServer {
 					}
 				}
 				this.started = true;
-				logger.info("Jetty started on port" + (connectors.length == 1 ? "" : "s") + " "
-						+ getActualPortsDescription() + " with context path '" + getContextPath() + "'");
+				logger.info("Jetty started on " + getActualPortsDescription() + " with context path '"
+						+ getContextPath() + "'");
 			}
 			catch (WebServerException ex) {
 				stopSilently();
@@ -184,10 +184,18 @@ public class JettyWebServer implements WebServer {
 
 	private String getActualPortsDescription() {
 		StringBuilder ports = new StringBuilder();
-		for (Connector connector : this.server.getConnectors()) {
-			if (ports.length() != 0) {
+		Connector[] connectors = this.server.getConnectors();
+		ports.append("port");
+		if (connectors.length != 1) {
+			ports.append("s");
+		}
+		ports.append(" ");
+
+		for (int i = 0; i < connectors.length; i++) {
+			if (i != 0) {
 				ports.append(", ");
 			}
+			Connector connector = connectors[i];
 			ports.append(getLocalPort(connector)).append(getProtocols(connector));
 		}
 		return ports.toString();

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
@@ -168,8 +168,8 @@ public class JettyWebServer implements WebServer {
 					}
 				}
 				this.started = true;
-				logger.info("Jetty started on port(s) " + getActualPortsDescription() + " with context path '"
-						+ getContextPath() + "'");
+				logger.info("Jetty started on port" + (connectors.length == 1 ? "" : "s") + " "
+						+ getActualPortsDescription() + " with context path '" + getContextPath() + "'");
 			}
 			catch (WebServerException ex) {
 				stopSilently();

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
@@ -105,7 +105,8 @@ public class TomcatWebServer implements WebServer {
 	}
 
 	private void initialize() throws WebServerException {
-		logger.info("Tomcat initialized with port(s): " + getPortsDescription(false));
+		logger.info("Tomcat initialized with port" + (this.tomcat.getService().findConnectors().length == 1 ? "" : "s")
+				+ ": " + getPortsDescription(false));
 		synchronized (this.monitor) {
 			try {
 				addInstanceIdToEngineName();
@@ -218,8 +219,9 @@ public class TomcatWebServer implements WebServer {
 				}
 				checkThatConnectorsHaveStarted();
 				this.started = true;
-				logger.info("Tomcat started on port(s): " + getPortsDescription(true) + " with context path '"
-						+ getContextPath() + "'");
+				logger
+					.info("Tomcat started on port" + (this.tomcat.getService().findConnectors().length == 1 ? "" : "s")
+							+ ": " + getPortsDescription(true) + " with context path '" + getContextPath() + "'");
 			}
 			catch (ConnectorStartFailedException ex) {
 				stopSilently();

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
@@ -105,8 +105,7 @@ public class TomcatWebServer implements WebServer {
 	}
 
 	private void initialize() throws WebServerException {
-		logger.info("Tomcat initialized with port" + (this.tomcat.getService().findConnectors().length == 1 ? "" : "s")
-				+ ": " + getPortsDescription(false));
+		logger.info("Tomcat initialized with " + getPortsDescription(false));
 		synchronized (this.monitor) {
 			try {
 				addInstanceIdToEngineName();
@@ -219,9 +218,8 @@ public class TomcatWebServer implements WebServer {
 				}
 				checkThatConnectorsHaveStarted();
 				this.started = true;
-				logger
-					.info("Tomcat started on port" + (this.tomcat.getService().findConnectors().length == 1 ? "" : "s")
-							+ ": " + getPortsDescription(true) + " with context path '" + getContextPath() + "'");
+				logger.info("Tomcat started on " + getPortsDescription(true) + " with context path '" + getContextPath()
+						+ "'");
 			}
 			catch (ConnectorStartFailedException ex) {
 				stopSilently();
@@ -358,10 +356,14 @@ public class TomcatWebServer implements WebServer {
 
 	private String getPortsDescription(boolean localPort) {
 		StringBuilder ports = new StringBuilder();
-		for (Connector connector : this.tomcat.getService().findConnectors()) {
-			if (ports.length() != 0) {
-				ports.append(' ');
-			}
+		Connector[] connectors = this.tomcat.getService().findConnectors();
+		ports.append("port");
+		if (connectors.length != 1) {
+			ports.append("s");
+		}
+
+		for (Connector connector : connectors) {
+			ports.append(' ');
 			int port = localPort ? connector.getLocalPort() : connector.getPort();
 			ports.append(port).append(" (").append(connector.getScheme()).append(')');
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowWebServer.java
@@ -315,7 +315,7 @@ public class UndertowWebServer implements WebServer {
 	}
 
 	protected String getStartLogMessage() {
-		return "Undertow started on port(s) " + getPortsDescription();
+		return "Undertow started on port" + (getActualPorts().size() == 1 ? "" : "s") + " " + getPortsDescription();
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowWebServer.java
@@ -182,11 +182,21 @@ public class UndertowWebServer implements WebServer {
 	}
 
 	private String getPortsDescription() {
+		StringBuilder portsDescription = new StringBuilder();
 		List<UndertowWebServer.Port> ports = getActualPorts();
-		if (!ports.isEmpty()) {
-			return StringUtils.collectionToDelimitedString(ports, " ");
+		portsDescription.append("port");
+		if (ports.size() != 1) {
+			portsDescription.append("s");
 		}
-		return "unknown";
+		portsDescription.append(" ");
+
+		if (!ports.isEmpty()) {
+			portsDescription.append(StringUtils.collectionToDelimitedString(ports, " "));
+		}
+		else {
+			portsDescription.append("unknown");
+		}
+		return portsDescription.toString();
 	}
 
 	private List<Port> getActualPorts() {
@@ -315,7 +325,7 @@ public class UndertowWebServer implements WebServer {
 	}
 
 	protected String getStartLogMessage() {
-		return "Undertow started on port" + (getActualPorts().size() == 1 ? "" : "s") + " " + getPortsDescription();
+		return "Undertow started on " + getPortsDescription();
 	}
 
 	/**


### PR DESCRIPTION
There are some places in the logs, which says `ports(s)`.

I believe it would be better to say only `port` or `ports` according to the number of ports, if it is 1, then use the singular form, otherwise use the plural form.