### PR TITLE
Auto-configured JacksonJsonpMapper is conditional on an ObjectMapper bean but does not use such a bean

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchClientAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchClientAutoConfiguration.java
@@ -23,7 +23,6 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchClientConfigurations.ElasticsearchClientConfiguration;
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchClientConfigurations.ElasticsearchTransportConfiguration;
-import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.autoconfigure.jsonb.JsonbAutoConfiguration;
 import org.springframework.context.annotation.Import;
 
@@ -33,8 +32,7 @@ import org.springframework.context.annotation.Import;
  * @author Andy Wilkinson
  * @since 3.0.0
  */
-@AutoConfiguration(after = { JacksonAutoConfiguration.class, JsonbAutoConfiguration.class,
-		ElasticsearchRestClientAutoConfiguration.class })
+@AutoConfiguration(after = { JsonbAutoConfiguration.class, ElasticsearchRestClientAutoConfiguration.class })
 @ConditionalOnClass(ElasticsearchClient.class)
 @Import({ ElasticsearchTransportConfiguration.class, ElasticsearchClientConfiguration.class })
 public class ElasticsearchClientAutoConfiguration {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchClientConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchClientConfigurations.java
@@ -31,6 +31,7 @@ import org.elasticsearch.client.RestClient;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -44,7 +45,7 @@ import org.springframework.context.annotation.Import;
 class ElasticsearchClientConfigurations {
 
 	@ConditionalOnMissingBean(JsonpMapper.class)
-	@ConditionalOnBean(ObjectMapper.class)
+	@ConditionalOnClass(ObjectMapper.class)
 	@Configuration(proxyBeanMethods = false)
 	static class JacksonJsonpMapperConfiguration {
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchClientAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchClientAutoConfigurationTests.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.autoconfigure.jsonb.JsonbAutoConfiguration;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -64,14 +65,16 @@ class ElasticsearchClientAutoConfigurationTests {
 
 	@Test
 	void withoutJsonbOrJacksonShouldDefineSimpleMapper() {
-		this.contextRunner.withUserConfiguration(RestClientConfiguration.class)
+		this.contextRunner.withClassLoader(new FilteredClassLoader(ObjectMapper.class))
+			.withUserConfiguration(RestClientConfiguration.class)
 			.run((context) -> assertThat(context).hasSingleBean(JsonpMapper.class)
 				.hasSingleBean(SimpleJsonpMapper.class));
 	}
 
 	@Test
 	void withJsonbShouldDefineJsonbMapper() {
-		this.contextRunner.withConfiguration(AutoConfigurations.of(JsonbAutoConfiguration.class))
+		this.contextRunner.withClassLoader(new FilteredClassLoader(ObjectMapper.class))
+			.withConfiguration(AutoConfigurations.of(JsonbAutoConfiguration.class))
 			.withUserConfiguration(RestClientConfiguration.class)
 			.run((context) -> assertThat(context).hasSingleBean(JsonpMapper.class)
 				.hasSingleBean(JsonbJsonpMapper.class));


### PR DESCRIPTION
# Spring Boot version
3.1.1

# Bug description
The autoconfigured [JacksonJsonpMapper bean](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchClientConfigurations.java#L52C22-L52C40) used to depend on a global `ObjectMapper` bean before SpringBoot version v3.0.3. 

After this [commit](https://github.com/spring-projects/spring-boot/commit/3af30b0a114be586e3cdfa0d49d5c5385753c511) introduced by SpringBoot version v3.0.3, the global `ObjectMapper` bean is not required when creating `JacksonJsonpMapper` bean.

However, the `JacksonJsonpMapper` bean creation condition `@ConditionalOnBean(ObjectMapper.class)` is not changed, resulting in `JacksonJsonpMapper` bean can be created only when ObjectMapper bean is present instead of the ObjectMapper class.

# Bug resolving solution
Change `@ConditionalOnBean(ObjectMapper.class)` to `@ConditionalOnClass(ObjectMapper.class)`
