### PR TITLE
Support JDK HttpClient in ClientHttpRequestFactories

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 
 kotlinVersion=1.8.22
 nativeBuildToolsVersion=0.9.23
-springFrameworkVersion=6.1.0-M1
+springFrameworkVersion=6.1.0-SNAPSHOT
 tomcatVersion=10.1.10
 
 kotlin.stdlib.default.dependency=false

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/ClientHttpRequestFactoriesHttpComponentsTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/ClientHttpRequestFactoriesHttpComponentsTests.java
@@ -39,7 +39,7 @@ class ClientHttpRequestFactoriesHttpComponentsTests
 
 	@Override
 	protected long connectTimeout(HttpComponentsClientHttpRequestFactory requestFactory) {
-		return (int) ReflectionTestUtils.getField(requestFactory, "connectTimeout");
+		return (long) ReflectionTestUtils.getField(requestFactory, "connectTimeout");
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/ClientHttpRequestFactoriesJdkClientTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/ClientHttpRequestFactoriesJdkClientTests.java
@@ -24,7 +24,7 @@ import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
- * Tests for {@link ClientHttpRequestFactories} when Apache Http Components is the
+ * Tests for {@link ClientHttpRequestFactories} when JDK HttpClient is the
  * predominant HTTP client.
  *
  * @author Andy Wilkinson

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/ClientHttpRequestFactoriesJdkClientTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/ClientHttpRequestFactoriesJdkClientTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.client;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Tests for {@link ClientHttpRequestFactories} when Apache Http Components is the
+ * predominant HTTP client.
+ *
+ * @author Andy Wilkinson
+ */
+@ClassPathExclusions({ "httpclient5-*.jar", "okhttp-*.jar" })
+class ClientHttpRequestFactoriesJdkClientTests
+		extends AbstractClientHttpRequestFactoriesTests<JdkClientHttpRequestFactory> {
+
+	ClientHttpRequestFactoriesJdkClientTests() {
+		super(JdkClientHttpRequestFactory.class);
+	}
+
+	@Override
+	protected long connectTimeout(JdkClientHttpRequestFactory requestFactory) {
+		HttpClient httpClient = (HttpClient) ReflectionTestUtils.getField(requestFactory, "httpClient");
+		return httpClient.connectTimeout().map(Duration::toMillis).orElse(-1L);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected long readTimeout(JdkClientHttpRequestFactory requestFactory) {
+		return (int) ReflectionTestUtils.getField(requestFactory, "readTimeout");
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/ClientHttpRequestFactoriesJdkClientTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/ClientHttpRequestFactoriesJdkClientTests.java
@@ -46,7 +46,7 @@ class ClientHttpRequestFactoriesJdkClientTests
 	@Override
 	@SuppressWarnings("unchecked")
 	protected long readTimeout(JdkClientHttpRequestFactory requestFactory) {
-		return (int) ReflectionTestUtils.getField(requestFactory, "readTimeout");
+		return ((Duration) ReflectionTestUtils.getField(requestFactory, "readTimeout")).toMillis();
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/ClientHttpRequestFactoriesSimpleTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/ClientHttpRequestFactoriesSimpleTests.java
@@ -26,7 +26,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  *
  * @author Andy Wilkinson
  */
-@ClassPathExclusions({ "httpclient5-*.jar", "okhttp-*.jar" })
+@ClassPathExclusions(value = {"httpclient5-*.jar", "okhttp-*.jar"}, packages = "java.net.http")
 class ClientHttpRequestFactoriesSimpleTests
 		extends AbstractClientHttpRequestFactoriesTests<SimpleClientHttpRequestFactory> {
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/webservices/client/HttpWebServiceMessageSenderBuilderSimpleIntegrationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/webservices/client/HttpWebServiceMessageSenderBuilderSimpleIntegrationTests.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Stephane Nicoll
  */
-@ClassPathExclusions({ "httpclient5-*.jar", "okhttp*.jar" })
+@ClassPathExclusions(value = {"httpclient5-*.jar", "okhttp-*.jar"}, packages = "java.net.http")
 class HttpWebServiceMessageSenderBuilderSimpleIntegrationTests {
 
 	private final HttpWebServiceMessageSenderBuilder builder = new HttpWebServiceMessageSenderBuilder();


### PR DESCRIPTION
This commit introduces support for the JdkClientHttpRequestFactory in ClientHttpRequestFactories.

Notes:
- On Java 11+, `JdkClientHttpRequestFactory` is preferred to the  `SimpleClientHttpRequestFactory` if the `java.net.http` module is loaded. As a consequence, several tests that expect `SimpleClientHttpRequestFactory` fail, and because `@ClassPathExclusions` cannot be used in this situation, I am unsure how to proceed. Perhaps a new `@ModuleExclusions` annotation is necessary?
- As with #36116, this PR uses code that will be in Spring Framework 6.1-M2, hence the snapshot version change in gradle.properties.