### PR TITLE
Fix metadata for logging.include-application-name

### DIFF
--- a/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -105,7 +105,7 @@
     },
     {
       "name": "logging.include-application-name",
-      "type": "java.lang.String>",
+      "type": "java.lang.Boolean",
       "description": "Whether to include the application name in the logs.",
       "sourceType": "org.springframework.boot.context.logging.LoggingApplicationListener",
       "defaultValue": true


### PR DESCRIPTION
This PR fixes metadata for the `logging.include-application-name` property.