### PR TITLE
Use kebab-case for property default values in metadata

### DIFF
--- a/spring-boot-project/spring-boot-docker-compose/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -4,23 +4,23 @@
   "properties": [
     {
       "name": "spring.docker.compose.lifecycle-management",
-      "defaultValue": "START_AND_STOP"
+      "defaultValue": "start-and-stop"
     },
     {
       "name": "spring.docker.compose.readiness.wait",
-      "defaultValue": "ALWAYS"
+      "defaultValue": "always"
     },
     {
       "name": "spring.docker.compose.start.command",
-      "defaultValue": "UP"
+      "defaultValue": "up"
     },
     {
       "name": "spring.docker.compose.start.log-level",
-      "defaultValue": "INFO"
+      "defaultValue": "info"
     },
     {
       "name": "spring.docker.compose.stop.command",
-      "defaultValue": "STOP"
+      "defaultValue": "stop"
     }
   ]
 }


### PR DESCRIPTION
This PR changes to use kebab-case for property default values in metadata for consistency.