### PR TITLE
Deprecate DelegatingApplicationContextInitializer and DelegatingApplicationListener in favour of registering each delegate programatically or in spring.factories

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/DelegatingApplicationContextInitializer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/DelegatingApplicationContextInitializer.java
@@ -39,6 +39,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @since 1.0.0
  */
+@Deprecated
 public class DelegatingApplicationContextInitializer
 		implements ApplicationContextInitializer<ConfigurableApplicationContext>, Ordered {
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/DelegatingApplicationContextInitializer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/DelegatingApplicationContextInitializer.java
@@ -38,8 +38,10 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Phillip Webb
  * @since 1.0.0
+ *
+ * @deprecated since 3.2 for removal in 3.4 as property based initialization is no longer recommended
  */
-@Deprecated
+@Deprecated(since = "3.2.0", forRemoval = true)
 public class DelegatingApplicationContextInitializer
 		implements ApplicationContextInitializer<ConfigurableApplicationContext>, Ordered {
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/DelegatingApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/DelegatingApplicationListener.java
@@ -41,6 +41,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @since 1.0.0
  */
+@Deprecated
 public class DelegatingApplicationListener implements ApplicationListener<ApplicationEvent>, Ordered {
 
 	// NOTE: Similar to org.springframework.web.context.ContextLoader

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/DelegatingApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/DelegatingApplicationListener.java
@@ -40,8 +40,10 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Phillip Webb
  * @since 1.0.0
+ *
+ * @deprecated since 3.2 for removal in 3.4 as property based initialization is no longer recommended
  */
-@Deprecated
+@Deprecated(since = "3.2.0", forRemoval = true)
 public class DelegatingApplicationListener implements ApplicationListener<ApplicationEvent>, Ordered {
 
 	// NOTE: Similar to org.springframework.web.context.ContextLoader

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/DelegatingApplicationContextInitializerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/DelegatingApplicationContextInitializerTests.java
@@ -35,7 +35,10 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  * Tests for {@link DelegatingApplicationContextInitializer}.
  *
  * @author Phillip Webb
+ *
+ * @deprecated since 3.2 for removal in 3.4 as property based initialization is no longer recommended
  */
+@Deprecated(since = "3.2.0", forRemoval = true)
 class DelegatingApplicationContextInitializerTests {
 
 	private final DelegatingApplicationContextInitializer initializer = new DelegatingApplicationContextInitializer();

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/DelegatingApplicationListenerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/DelegatingApplicationListenerTests.java
@@ -36,7 +36,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link DelegatingApplicationListener}.
  *
  * @author Dave Syer
+ *
+ * @deprecated since 3.2 for removal in 3.4 as property based initialization is no longer recommended
  */
+@Deprecated(since = "3.2.0", forRemoval = true)
 class DelegatingApplicationListenerTests {
 
 	private final DelegatingApplicationListener listener = new DelegatingApplicationListener();


### PR DESCRIPTION
This PR is related to the issue #34779. I did what the issue suggested and deprecated `DelegatingApplicationContextInitializer` and `DelegatingApplicationListener`.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
