### PR TITLE
Checking for invalid characters in SpringBootContextLoader.setActiveProfiles

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootContextLoader.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootContextLoader.java
@@ -236,7 +236,7 @@ public class SpringBootContextLoader extends AbstractContextLoader implements Ao
 	}
 
 	private boolean containsProhibitedCharacters(String str){
-		String regex = ".*[*&!|].*";
+		String regex = ".*[*&!|,].*";
 		return str.matches(regex);
 	}
 
@@ -247,7 +247,7 @@ public class SpringBootContextLoader extends AbstractContextLoader implements Ao
 		}
 		for (String profile : profiles) {
 			if (containsProhibitedCharacters(profile)) {
-				throw new IllegalArgumentException("Invalid profile: '" + profile + "'. Profile names can't contain '*', '&', '!' or '|'.");
+				throw new IllegalArgumentException("Invalid profile: '" + profile + "'. Profile names can't contain '*', '&', '!', ',' or '|'.");
 			}
 		}
 		if (!applicationEnvironment) {

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootContextLoader.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootContextLoader.java
@@ -235,10 +235,20 @@ public class SpringBootContextLoader extends AbstractContextLoader implements Ao
 		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(environment, getInlinedProperties(mergedConfig));
 	}
 
+	private boolean containsProhibitedCharacters(String str){
+		String regex = ".*[*&!|].*";
+		return str.matches(regex);
+	}
+
 	private void setActiveProfiles(ConfigurableEnvironment environment, String[] profiles,
 			boolean applicationEnvironment) {
 		if (ObjectUtils.isEmpty(profiles)) {
 			return;
+		}
+		for (String profile : profiles) {
+			if (containsProhibitedCharacters(profile)) {
+				throw new IllegalArgumentException("Invalid profile: '" + profile + "'. Profile names can't contain '*', '&', '!' or '|'.");
+			}
 		}
 		if (!applicationEnvironment) {
 			environment.setActiveProfiles(profiles);

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootContextLoaderTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootContextLoaderTests.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -49,8 +50,7 @@ import org.springframework.test.context.support.TestPropertySourceUtils;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.WebApplicationContext;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests for {@link SpringBootContextLoader}
@@ -128,6 +128,34 @@ class SpringBootContextLoaderTests {
 	@Test
 	void activeProfileWithComma() {
 		assertThat(getActiveProfiles(ActiveProfileWithComma.class)).containsExactly("profile1,2");
+	}
+
+	@Test
+	void activeProfileWithAsterisk() {
+		Assertions.assertThrows(Exception.class, () ->
+			assertThat(getActiveProfiles(ActiveProfileWithAsterisk.class)).containsExactly("foo*bar")
+		);
+	}
+
+	@Test
+	void activeProfileWithAmpersand() {
+		Assertions.assertThrows(Exception.class, () ->
+			assertThat(getActiveProfiles(ActiveProfileWithAmpersand.class)).containsExactly("foo&bar")
+		);
+	}
+
+	@Test
+	void activeProfileWithExclamationMark() {
+		Assertions.assertThrows(Exception.class, () ->
+			assertThat(getActiveProfiles(ActiveProfileWithExclamationMark.class)).containsExactly("!foobar")
+		);
+	}
+
+	@Test
+	void activeProfileWithPipe() {
+		Assertions.assertThrows(Exception.class, () ->
+			assertThat(getActiveProfiles(ActiveProfileWithPipe.class)).containsExactly("foobar|")
+		);
 	}
 
 	@Test // gh-28776
@@ -308,6 +336,30 @@ class SpringBootContextLoaderTests {
 	@SpringBootTest(classes = Config.class)
 	@ActiveProfiles({ "profile1,2" })
 	static class ActiveProfileWithComma {
+
+	}
+
+	@SpringBootTest(classes = Config.class)
+	@ActiveProfiles("foo*bar")
+	static class ActiveProfileWithAsterisk {
+
+	}
+
+	@SpringBootTest(classes = Config.class)
+	@ActiveProfiles("!foobar")
+	static class ActiveProfileWithExclamationMark {
+
+	}
+
+	@SpringBootTest(classes = Config.class)
+	@ActiveProfiles("foobar|")
+	static class ActiveProfileWithPipe {
+
+	}
+
+	@SpringBootTest(classes = Config.class)
+	@ActiveProfiles("foo&bar")
+	static class ActiveProfileWithAmpersand {
 
 	}
 

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootContextLoaderTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootContextLoaderTests.java
@@ -127,7 +127,9 @@ class SpringBootContextLoaderTests {
 
 	@Test
 	void activeProfileWithComma() {
-		assertThat(getActiveProfiles(ActiveProfileWithComma.class)).containsExactly("profile1,2");
+		Assertions.assertThrows(Exception.class, () ->
+			assertThat(getActiveProfiles(ActiveProfileWithComma.class)).containsExactly("profile1,2")
+		);
 	}
 
 	@Test
@@ -364,7 +366,7 @@ class SpringBootContextLoaderTests {
 	}
 
 	@SpringBootTest(properties = { "key=myValue" }, classes = Config.class)
-	@ActiveProfiles({ "profile1,2" })
+	@ActiveProfiles({ "profile1" })
 	static class ActiveProfileWithInlinedProperties {
 
 	}


### PR DESCRIPTION
This PR relates to #34062. I created a loop at the beginning of the method that goes through the list of profiles and checks if there are any of these invalid characters: `*` `&` `!` `|` `,`. If so, an exception is thrown informing which profile is invalid and which characters are prohibited. 
I also created the necessary tests to verify the method changes.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
