### PR TITLE
Skip Duration to int to Duration conversion in ClientHttpRequestFactories.Jdk

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/ClientHttpRequestFactories.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/ClientHttpRequestFactories.java
@@ -285,7 +285,7 @@ public final class ClientHttpRequestFactories {
 			java.net.http.HttpClient httpClient = createHttpClient(settings.connectTimeout(), settings.sslBundle());
 			JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(httpClient);
 			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
-			map.from(settings::readTimeout).asInt(Duration::toMillis).to(requestFactory::setReadTimeout);
+			map.from(settings::readTimeout).to(requestFactory::setReadTimeout);
 			return requestFactory;
 		}
 


### PR DESCRIPTION
@poutsma added a `JdkClientHttpRequestFactory.setReadTimeout(Duration)` so the conversion to and from `int` is no longer needed.