### PR TITLE
Order ProblemDetailsExceptionHandler beans

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfiguration.java
@@ -343,6 +343,7 @@ public class WebFluxAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(ResponseEntityExceptionHandler.class)
+		@Order(0)
 		ProblemDetailsExceptionHandler problemDetailsExceptionHandler() {
 			return new ProblemDetailsExceptionHandler();
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
@@ -662,6 +662,7 @@ public class WebMvcAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(ResponseEntityExceptionHandler.class)
+		@Order(0)
 		ProblemDetailsExceptionHandler problemDetailsExceptionHandler() {
 			return new ProblemDetailsExceptionHandler();
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -51,6 +52,8 @@ import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguratio
 import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
 import org.springframework.boot.autoconfigure.validation.ValidatorAdapter;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration.WebMvcAutoConfigurationAdapter;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfigurationTests.OrderedControllerAdviceBeansConfiguration.HighestOrderedControllerAdvice;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfigurationTests.OrderedControllerAdviceBeansConfiguration.LowestOrderedControllerAdvice;
 import org.springframework.boot.test.context.assertj.AssertableWebApplicationContext;
 import org.springframework.boot.test.context.runner.ContextConsumer;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
@@ -65,6 +68,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -89,6 +94,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.FormContentFilter;
 import org.springframework.web.filter.HiddenHttpMethodFilter;
 import org.springframework.web.filter.RequestContextFilter;
+import org.springframework.web.method.ControllerAdviceBean;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.FlashMap;
 import org.springframework.web.servlet.FlashMapManager;
@@ -972,6 +978,22 @@ class WebMvcAutoConfigurationTests {
 				.hasSingleBean(CustomExceptionHandler.class));
 	}
 
+	@Test
+	void problemDetailsIsOrderedBetweenLowestAndHighestOrderedControllerHandlers() {
+		this.contextRunner.withPropertyValues("spring.mvc.problemdetails.enabled:true")
+			.withUserConfiguration(OrderedControllerAdviceBeansConfiguration.class)
+			.run((context) -> {
+
+				List<Class<?>> controllerAdviceClasses = ControllerAdviceBean.findAnnotatedBeans(context)
+					.stream()
+					.map(ControllerAdviceBean::getBeanType)
+					.collect(Collectors.toList());
+
+				assertThat(controllerAdviceClasses).containsExactly(HighestOrderedControllerAdvice.class,
+						ProblemDetailsExceptionHandler.class, LowestOrderedControllerAdvice.class);
+			});
+	}
+
 	private void assertResourceHttpRequestHandler(AssertableWebApplicationContext context,
 			Consumer<ResourceHttpRequestHandler> handlerConsumer) {
 		Map<String, Object> handlerMap = getHandlerMap(context.getBean("resourceHandlerMapping", HandlerMapping.class));
@@ -1492,6 +1514,24 @@ class WebMvcAutoConfigurationTests {
 		@Bean
 		CustomExceptionHandler customExceptionHandler() {
 			return new CustomExceptionHandler();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Import({ LowestOrderedControllerAdvice.class, HighestOrderedControllerAdvice.class })
+	static class OrderedControllerAdviceBeansConfiguration {
+
+		@ControllerAdvice
+		@Order
+		static class LowestOrderedControllerAdvice {
+
+		}
+
+		@ControllerAdvice
+		@Order(Ordered.HIGHEST_PRECEDENCE)
+		static class HighestOrderedControllerAdvice {
+
 		}
 
 	}


### PR DESCRIPTION
In this pull request I added an explicit zero order to the ` ProblemDetailsExceptionHandler` beans for WebMVC and Webflux.

Without the order, it means these beans automatically have the lowest precedence, and they will usually be executed last. This can be problematic when someone would like to create a “catch-all” `@ExceptionHandler` in a `@ControllerAdvice` bean. Meaning an exception handler that should handle any exception that was not handled by any other exception handler with.
Such an exception handler should have the absolute lowest precedence, and the `ProblemDetailsExceptionHandler` must have a higher precedence. However, because both now have the same precedence, it is not a guarantee that this will be the case. In my tests, my own catch-all exception handler would always start handling those exceptions that should be handled by the `ProblemDetailsExceptionHandler`.

The workaround is to create custom beans that implement `ResponseEntityExceptionHandler` and give those an order that has a higher precedence then my catch-all exception handler. However, I don’t think this should be necessary.

Because the `ResponseEntityExceptionHandler` has a defined list of exceptions it is going to handle, there should be no issue in it having a specific order by default. If it has the order `0` then anyone can easily create an exception handler that has a higher or lower precedence. 

I created a test which shows the issue, and the current workaround:

https://github.com/mzeijen/spring-boot-problem-support/blob/main/src/test/java/com/example/demo/ResponseEntityExceptionHandlerOrderingTest.java

This test has nested test classes which show the difference in behavior for both WebMVC and Webflux, when the default `ResponseEntityExceptionHandler` are used or when the workaround is applied.

In the pull request I added a test that verifies that the ordering takes effect.