### PR TITLE
Add property for base time unit in OTLP registry

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.actuate.autoconfigure.metrics.export.otlp;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import io.micrometer.registry.otlp.AggregationTemporality;
 
@@ -55,6 +56,11 @@ public class OtlpProperties extends StepRegistryProperties {
 	 */
 	private Map<String, String> headers;
 
+	/**
+	 * Time unit for exported metrics.
+	 */
+	private TimeUnit baseTimeUnit = TimeUnit.MILLISECONDS;
+
 	public String getUrl() {
 		return this.url;
 	}
@@ -85,6 +91,14 @@ public class OtlpProperties extends StepRegistryProperties {
 
 	public void setHeaders(Map<String, String> headers) {
 		this.headers = headers;
+	}
+
+	public TimeUnit getBaseTimeUnit() {
+		return this.baseTimeUnit;
+	}
+
+	public void setBaseTimeUnit(TimeUnit baseTimeUnit) {
+		this.baseTimeUnit = baseTimeUnit;
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesConfigAdapter.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.actuate.autoconfigure.metrics.export.otlp;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import io.micrometer.registry.otlp.AggregationTemporality;
 import io.micrometer.registry.otlp.OtlpConfig;
@@ -58,6 +59,11 @@ class OtlpPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<Ot
 	@Override
 	public Map<String, String> headers() {
 		return get(OtlpProperties::getHeaders, OtlpConfig.super::headers);
+	}
+
+	@Override
+	public TimeUnit baseTimeUnit() {
+		return get(OtlpProperties::getBaseTimeUnit, OtlpConfig.super::baseTimeUnit);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesConfigAdapterTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.actuate.autoconfigure.metrics.export.otlp;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import io.micrometer.registry.otlp.AggregationTemporality;
 import org.junit.jupiter.api.Test;
@@ -65,6 +66,19 @@ class OtlpPropertiesConfigAdapterTests {
 		OtlpProperties properties = new OtlpProperties();
 		properties.setHeaders(Map.of("header", "value"));
 		assertThat(new OtlpPropertiesConfigAdapter(properties).headers()).containsEntry("header", "value");
+	}
+
+	@Test
+	void whenPropertiesBaseTimeUnitIsNotSetAdapterBaseTimeUnitReturnsMillis() {
+		OtlpProperties properties = new OtlpProperties();
+		assertThat(new OtlpPropertiesConfigAdapter(properties).baseTimeUnit()).isSameAs(TimeUnit.MILLISECONDS);
+	}
+
+	@Test
+	void whenPropertiesBaseTimeUnitIsSetAdapterBaseTimeUnitReturnsIt() {
+		OtlpProperties properties = new OtlpProperties();
+		properties.setBaseTimeUnit(TimeUnit.SECONDS);
+		assertThat(new OtlpPropertiesConfigAdapter(properties).baseTimeUnit()).isSameAs(TimeUnit.SECONDS);
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpPropertiesTests.java
@@ -37,6 +37,7 @@ class OtlpPropertiesTests extends StepRegistryPropertiesTests {
 		assertStepRegistryDefaultValues(properties, config);
 		assertThat(properties.getUrl()).isEqualTo(config.url());
 		assertThat(properties.getAggregationTemporality()).isSameAs(config.aggregationTemporality());
+		assertThat(properties.getBaseTimeUnit()).isSameAs(config.baseTimeUnit());
 	}
 
 }


### PR DESCRIPTION
Micrometer added a new configuration option to its OTLP registry to enable configuring the base time unit. These changes add Boot property support to it.

See gh-36200