### PR TITLE
Harmonize use of Stream in ConfigDataLocationBindHandler

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLocationBindHandler.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLocationBindHandler.java
@@ -57,13 +57,10 @@ class ConfigDataLocationBindHandler extends AbstractBindHandler {
 			return list;
 		}
 		if (result instanceof ConfigDataLocation[] unfilteredLocations) {
-			ConfigDataLocation[] locations = Arrays.stream(unfilteredLocations)
+			return Arrays.stream(unfilteredLocations)
 				.filter(Objects::nonNull)
+				.map(e -> withOrigin(context, e))
 				.toArray(ConfigDataLocation[]::new);
-			for (int i = 0; i < locations.length; i++) {
-				locations[i] = withOrigin(context, locations[i]);
-			}
-			return locations;
 		}
 		return result;
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLocationBindHandler.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataLocationBindHandler.java
@@ -45,16 +45,10 @@ class ConfigDataLocationBindHandler extends AbstractBindHandler {
 			return withOrigin(context, location);
 		}
 		if (result instanceof List) {
-			List<Object> list = ((List<Object>) result).stream()
+			return ((List<Object>) result).stream()
 				.filter(Objects::nonNull)
+				.map(e -> (e instanceof ConfigDataLocation location) ? withOrigin(context, location) : e)
 				.collect(Collectors.toCollection(ArrayList::new));
-			for (int i = 0; i < list.size(); i++) {
-				Object element = list.get(i);
-				if (element instanceof ConfigDataLocation location) {
-					list.set(i, withOrigin(context, location));
-				}
-			}
-			return list;
 		}
 		if (result instanceof ConfigDataLocation[] unfilteredLocations) {
 			return Arrays.stream(unfilteredLocations)


### PR DESCRIPTION
Changed a little bit of code in ConfigDataLocationBindHandler.onSuccess method. I thought there's no reason to separate Stream and for logic, and that this way would be better to read.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
