### PR TITLE
Documentation of spring.redis.url incorrectly states that it does not override spring.redis.user

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -42,7 +42,7 @@ public class RedisProperties {
 	private int database = 0;
 
 	/**
-	 * Connection URL. Overrides host, port, and password. User is ignored. Example:
+	 * Connection URL. Overrides host, port, username, and password. Example:
 	 * redis://user:password@example.com:6379
 	 */
 	private String url;


### PR DESCRIPTION
This PR updates Javadoc for the `RedisProperties.url` field to include username in override targets as it seems to override it.

[A Redis URI seems to be able to include other properties like database](https://github.com/lettuce-io/lettuce-core/wiki/Redis-URI-and-connection-details#uri-syntax), but they are not included in override targets. It seems to be inconsistent, but I'm not sure if it's intentional.