### PR TITLE
Descriptions of started and ready time metrics contain time units but the unit may change when the metrics are exported

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/startup/StartupTimeMetricsListener.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/startup/StartupTimeMetricsListener.java
@@ -103,12 +103,12 @@ public class StartupTimeMetricsListener implements SmartApplicationListener {
 	}
 
 	private void onApplicationStarted(ApplicationStartedEvent event) {
-		registerGauge(this.startedTimeMetricName, "Time taken (ms) to start the application", event.getTimeTaken(),
+		registerGauge(this.startedTimeMetricName, "Time taken to start the application", event.getTimeTaken(),
 				event.getSpringApplication());
 	}
 
 	private void onApplicationReady(ApplicationReadyEvent event) {
-		registerGauge(this.readyTimeMetricName, "Time taken (ms) for the application to be ready to service requests",
+		registerGauge(this.readyTimeMetricName, "Time taken for the application to be ready to service requests",
 				event.getTimeTaken(), event.getSpringApplication());
 	}
 


### PR DESCRIPTION
When using this metric in Grafana/Prometheus, it is a bit confusing, because as the screenshot below shows, it is `application_started_time_seconds` (ends with "seconds"), and the value is really measured in seconds, but the hint text say it is "ms" not "s".

I guess this is because micrometer is smart enough to convert ms to s, since spring already tells micrometer it is ms.

![image](https://github.com/spring-projects/spring-boot/assets/5236035/a811a74e-2d84-4e03-a947-60446ad6c311)
