### PR TITLE
Document that server.forward-headers-strategy property defaults to native when running on Kubernetes

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/webserver.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/webserver.adoc
@@ -443,7 +443,7 @@ You can register it as a servlet filter in your application by setting `server.f
 TIP: If you are using Tomcat and terminating SSL at the proxy, configprop:server.tomcat.redirect-context-root[] should be set to `false`.
 This allows the `X-Forwarded-Proto` header to be honored before any redirects are performed.
 
-NOTE: If your application runs in Cloud Foundry, Heroku or K8s, the configprop:server.forward-headers-strategy[] property defaults to `NATIVE`.
+NOTE: If your application runs in Cloud Foundry, Heroku or Kubernetes, the configprop:server.forward-headers-strategy[] property defaults to `NATIVE`.
 In all other instances, it defaults to `NONE`.
 
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/webserver.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/webserver.adoc
@@ -443,7 +443,7 @@ You can register it as a servlet filter in your application by setting `server.f
 TIP: If you are using Tomcat and terminating SSL at the proxy, configprop:server.tomcat.redirect-context-root[] should be set to `false`.
 This allows the `X-Forwarded-Proto` header to be honored before any redirects are performed.
 
-NOTE: If your application runs in Cloud Foundry or Heroku, the configprop:server.forward-headers-strategy[] property defaults to `NATIVE`.
+NOTE: If your application runs in Cloud Foundry, Heroku or K8s, the configprop:server.forward-headers-strategy[] property defaults to `NATIVE`.
 In all other instances, it defaults to `NONE`.
 
 


### PR DESCRIPTION
I found that my app on k8s has `server.forward-headers-strategy` NATIVE but the docs do not state so.
Hence I propose this quick fix.
Please confirm, I could not find the particular code line to control that behavior. 