### PR TITLE
Tomcat warns about a missing +/- prefix when enabling multiple protocols through server.ssl.enabled-protocols

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/SslConnectorCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/SslConnectorCustomizer.java
@@ -96,7 +96,7 @@ class SslConnectorCustomizer implements TomcatConnectorCustomizer {
 	private void configureEnabledProtocols(AbstractHttp11JsseProtocol<?> protocol) {
 		SslOptions options = this.sslBundle.getOptions();
 		if (options.getEnabledProtocols() != null) {
-			String enabledProtocols = StringUtils.arrayToCommaDelimitedString(options.getEnabledProtocols());
+			String enabledProtocols = StringUtils.arrayToDelimitedString(options.getEnabledProtocols(), "+");
 			for (SSLHostConfig sslHostConfig : protocol.findSslHostConfigs()) {
 				sslHostConfig.setProtocols(enabledProtocols);
 			}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
When configuring SSL with Tomcat, the following message is being logged in warning level by [SSLHostConfig](https://github.com/apache/tomcat/blob/a2615d18d686af9a17376017bad8dde22678f3a9/java/org/apache/tomcat/util/net/SSLHostConfig.java#L482):

`"The protocol [{0}] was added to the list of protocols on the SSLHostConfig named [{1}]. Check if a +/- prefix is missing."`

This is because Tomcat's [SSLHostConfig semantics](https://github.com/apache/tomcat/blob/a2615d18d686af9a17376017bad8dde22678f3a9/java/org/apache/tomcat/util/net/SSLHostConfig.java#L446) for protocol string is:
```
        // List of protocol names, separated by ",", "+" or "-".
        // Semantics is adding ("+") or removing ("-") from left
        // to right, starting with an empty protocol set.
        // Tokens are individual protocol names or "all" for a
        // default set of supported protocols.
        // Separator "," is only kept for compatibility and has the
        // same semantics as "+", except that it warns about a potentially
        // missing "+" or "-".
```

