### PR TITLE
Add Javadoc since for JavaVersion.TWENTY_ONE

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/JavaVersion.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/JavaVersion.java
@@ -58,6 +58,7 @@ public enum JavaVersion {
 
 	/**
 	 * Java 21.
+	 * @since 3.2.0
 	 */
 	TWENTY_ONE("21", SortedSet.class, "getFirst");
 


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `JavaVersion.TWENTY_ONE`.

See gh-35892