### PR TITLE
Update RestTemplateBuilder#defaultHeader javadoc to reference correct client-side HTTP request class

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RestTemplateBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/RestTemplateBuilder.java
@@ -30,8 +30,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import reactor.netty.http.client.HttpClientRequest;
-
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.ssl.SslBundle;
 import org.springframework.http.client.ClientHttpRequest;
@@ -399,7 +397,7 @@ public class RestTemplateBuilder {
 
 	/**
 	 * Add a default header that will be set if not already present on the outgoing
-	 * {@link HttpClientRequest}.
+	 * {@link ClientHttpRequest}.
 	 * @param name the name of the header
 	 * @param values the header values
 	 * @return a new builder instance


### PR DESCRIPTION
The Javadoc of `org.springframework.boot.web.client.RestTemplateBuilder#defaultHeader` incorrectly references `reactor.netty.http.client.HttpClientRequest`. This is now replaced with the correct `org.springframework.http.client.ClientHttpRequest`.