### PR TITLE
Enable debug option for Kotlin in Gradle Plugin tests

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-test-support/src/main/java/org/springframework/boot/testsupport/gradle/testkit/GradleBuild.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-test-support/src/main/java/org/springframework/boot/testsupport/gradle/testkit/GradleBuild.java
@@ -236,8 +236,8 @@ public class GradleBuild {
 		GradleRunner gradleRunner = GradleRunner.create()
 			.withProjectDir(this.projectDir)
 			.withPluginClasspath(pluginClasspath());
-		if (this.dsl != Dsl.KOTLIN && !this.configurationCache) {
-			// see https://github.com/gradle/gradle/issues/6862
+		if (!this.configurationCache) {
+			// See https://github.com/gradle/gradle/issues/14125
 			gradleRunner.withDebug(true);
 		}
 		if (this.gradleVersion != null) {


### PR DESCRIPTION
Hi,

this PR enables `GradleRunner.withDebug(true)` for Kotlin tests as https://github.com/gradle/gradle/issues/6862 seems to be fixed by now. 

https://github.com/gradle/gradle/issues/14125 on the other hand still seems to be broken, so I updated the comment accordingly.

Cheers,
Christoph