### PR TITLE
Add support for detecting the precense of a Neo4j `AuthTokenManager` bean

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jAutoConfigurationIntegrationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/neo4j/Neo4jAutoConfigurationIntegrationTests.java
@@ -18,7 +18,11 @@ package org.springframework.boot.autoconfigure.neo4j;
 
 import java.time.Duration;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokenManager;
+import org.neo4j.driver.AuthTokenManagers;
+import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
@@ -31,6 +35,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testsupport.testcontainers.DockerImageNames;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -43,7 +48,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Michael J. Simons
  * @author Stephane Nicoll
  */
-@SpringBootTest
 @Testcontainers(disabledWithoutDocker = true)
 class Neo4jAutoConfigurationIntegrationTests {
 
@@ -52,28 +56,71 @@ class Neo4jAutoConfigurationIntegrationTests {
 		.withStartupAttempts(5)
 		.withStartupTimeout(Duration.ofMinutes(10));
 
-	@DynamicPropertySource
-	static void neo4jProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.neo4j.uri", neo4jServer::getBoltUrl);
-		registry.add("spring.neo4j.authentication.username", () -> "neo4j");
-		registry.add("spring.neo4j.authentication.password", neo4jServer::getAdminPassword);
-	}
+	@SpringBootTest
+	@Nested
+	class DriverWithDefaultAuthToken {
 
-	@Autowired
-	private Driver driver;
-
-	@Test
-	void driverCanHandleRequest() {
-		try (Session session = this.driver.session(); Transaction tx = session.beginTransaction()) {
-			Result statementResult = tx.run("MATCH (n:Thing) RETURN n LIMIT 1");
-			assertThat(statementResult.hasNext()).isFalse();
-			tx.commit();
+		@DynamicPropertySource
+		static void neo4jProperties(DynamicPropertyRegistry registry) {
+			registry.add("spring.neo4j.uri", neo4jServer::getBoltUrl);
+			registry.add("spring.neo4j.authentication.username", () -> "neo4j");
+			registry.add("spring.neo4j.authentication.password", neo4jServer::getAdminPassword);
 		}
+
+		@Autowired
+		private Driver driver;
+
+		@Test
+		void driverCanHandleRequest() {
+			try (Session session = this.driver.session(); Transaction tx = session.beginTransaction()) {
+				Result statementResult = tx.run("MATCH (n:Thing) RETURN n LIMIT 1");
+				assertThat(statementResult.hasNext()).isFalse();
+				tx.commit();
+			}
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		@ImportAutoConfiguration(Neo4jAutoConfiguration.class)
+		static class TestConfiguration {
+
+		}
+
 	}
 
-	@Configuration(proxyBeanMethods = false)
-	@ImportAutoConfiguration(Neo4jAutoConfiguration.class)
-	static class TestConfiguration {
+	@SpringBootTest
+	@Nested
+	class DriverWithDynamicAuthToken {
+
+		@DynamicPropertySource
+		static void neo4jProperties(DynamicPropertyRegistry registry) {
+			registry.add("spring.neo4j.uri", neo4jServer::getBoltUrl);
+			registry.add("spring.neo4j.authentication.username", () -> "wrong");
+			registry.add("spring.neo4j.authentication.password", () -> "alsowrong");
+		}
+
+		@Autowired
+		private Driver driver;
+
+		@Test
+		void driverCanHandleRequest() {
+			try (Session session = this.driver.session(); Transaction tx = session.beginTransaction()) {
+				Result statementResult = tx.run("MATCH (n:Thing) RETURN n LIMIT 1");
+				assertThat(statementResult.hasNext()).isFalse();
+				tx.commit();
+			}
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		@ImportAutoConfiguration(Neo4jAutoConfiguration.class)
+		static class TestConfiguration {
+
+			@Bean
+			AuthTokenManager authTokenManager() {
+				return AuthTokenManagers.expirationBased(() -> AuthTokens.basic("neo4j", neo4jServer.getAdminPassword())
+					.expiringAt(System.currentTimeMillis() + 5_000));
+			}
+
+		}
 
 	}
 


### PR DESCRIPTION
Neo4j Java driver introduced support for an `AuthTokenManager` that can be used to define expiring tokens to be used as authentication with a database.

This commit adds a  `ObjectProvider<AuthTokenManager> authTokenManagers` parameter to the corresponding auto configuration class. If the provider resolves to a unique object, that `AuthTokenManager` will have precedence over any static token.

The usecase for Neo4j users is to be able to define expiring tokens and the like. Without this addition, they must configure the driver bean completely on their own. The config customiser will not help them as the token manager is configured in parallel. This leads to a lot of unnecessary duplicated code and some things are not even obvious that they won't work anymore (such as the integration with Spring logging).

The `AuthTokenManager` interface is marked as preview as it will probably receive more methods, it't won't go away however the code does not depend on specifics.

I tried adding the tests into unit scope, but the least bloated way is just running them as an integration test. To avoid having to start multiple containers, I used two nested tests in `Neo4jAutoConfigurationIntegrationTests`.