### PR TITLE
Add Javadoc since to new PemSslStoreBundle constructor

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/PemSslStoreBundle.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/PemSslStoreBundle.java
@@ -70,6 +70,7 @@ public class PemSslStoreBundle implements SslStoreBundle {
 	 * @param trustStoreDetails the trust store details
 	 * @param keyAlias the key alias to use or {@code null} to use a default alias
 	 * @param keyPassword the password to use for the key
+	 * @since 3.2.0
 	 */
 	public PemSslStoreBundle(PemSslStoreDetails keyStoreDetails, PemSslStoreDetails trustStoreDetails, String keyAlias,
 			String keyPassword) {


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag to a new constructor for the `PemSslStoreBundle`.

See gh-35983