### PR TITLE
server.max-http-request-header-size doesn't affect Netty server with http2 enabled

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizer.java
@@ -85,19 +85,25 @@ public class NettyWebServerFactoryCustomizer
 	private void customizeRequestDecoder(NettyReactiveWebServerFactory factory, PropertyMapper propertyMapper) {
 		factory.addServerCustomizers((httpServer) -> httpServer.httpRequestDecoder((httpRequestDecoderSpec) -> {
 			propertyMapper.from(this.serverProperties.getMaxHttpRequestHeaderSize())
+				.whenNonNull()
 				.to((maxHttpRequestHeader) -> httpRequestDecoderSpec
 					.maxHeaderSize((int) maxHttpRequestHeader.toBytes()));
 			ServerProperties.Netty nettyProperties = this.serverProperties.getNetty();
 			maxChunkSize(propertyMapper, httpRequestDecoderSpec, nettyProperties);
 			propertyMapper.from(nettyProperties.getMaxInitialLineLength())
+				.whenNonNull()
 				.to((maxInitialLineLength) -> httpRequestDecoderSpec
 					.maxInitialLineLength((int) maxInitialLineLength.toBytes()));
 			propertyMapper.from(nettyProperties.getH2cMaxContentLength())
+				.whenNonNull()
 				.to((h2cMaxContentLength) -> httpRequestDecoderSpec
 					.h2cMaxContentLength((int) h2cMaxContentLength.toBytes()));
 			propertyMapper.from(nettyProperties.getInitialBufferSize())
+				.whenNonNull()
 				.to((initialBufferSize) -> httpRequestDecoderSpec.initialBufferSize((int) initialBufferSize.toBytes()));
-			propertyMapper.from(nettyProperties.isValidateHeaders()).to(httpRequestDecoderSpec::validateHeaders);
+			propertyMapper.from(nettyProperties.isValidateHeaders())
+				.whenNonNull()
+				.to(httpRequestDecoderSpec::validateHeaders);
 			return httpRequestDecoderSpec;
 		}));
 	}
@@ -106,6 +112,7 @@ public class NettyWebServerFactoryCustomizer
 	private void maxChunkSize(PropertyMapper propertyMapper, HttpRequestDecoderSpec httpRequestDecoderSpec,
 			ServerProperties.Netty nettyProperties) {
 		propertyMapper.from(nettyProperties.getMaxChunkSize())
+			.whenNonNull()
 			.to((maxChunkSize) -> httpRequestDecoderSpec.maxChunkSize((int) maxChunkSize.toBytes()));
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizer.java
@@ -64,6 +64,8 @@ public class NettyWebServerFactoryCustomizer
 		map.from(nettyProperties::getIdleTimeout).to((idleTimeout) -> customizeIdleTimeout(factory, idleTimeout));
 		map.from(nettyProperties::getMaxKeepAliveRequests)
 			.to((maxKeepAliveRequests) -> customizeMaxKeepAliveRequests(factory, maxKeepAliveRequests));
+		map.from(this.serverProperties.getMaxHttpRequestHeaderSize())
+			.to((maxHttpRequestHeaderSize) -> customizeHttp2MaxHeaderSize(factory, maxHttpRequestHeaderSize.toBytes()));
 		customizeRequestDecoder(factory, map);
 	}
 
@@ -83,25 +85,19 @@ public class NettyWebServerFactoryCustomizer
 	private void customizeRequestDecoder(NettyReactiveWebServerFactory factory, PropertyMapper propertyMapper) {
 		factory.addServerCustomizers((httpServer) -> httpServer.httpRequestDecoder((httpRequestDecoderSpec) -> {
 			propertyMapper.from(this.serverProperties.getMaxHttpRequestHeaderSize())
-				.whenNonNull()
 				.to((maxHttpRequestHeader) -> httpRequestDecoderSpec
 					.maxHeaderSize((int) maxHttpRequestHeader.toBytes()));
 			ServerProperties.Netty nettyProperties = this.serverProperties.getNetty();
 			maxChunkSize(propertyMapper, httpRequestDecoderSpec, nettyProperties);
 			propertyMapper.from(nettyProperties.getMaxInitialLineLength())
-				.whenNonNull()
 				.to((maxInitialLineLength) -> httpRequestDecoderSpec
 					.maxInitialLineLength((int) maxInitialLineLength.toBytes()));
 			propertyMapper.from(nettyProperties.getH2cMaxContentLength())
-				.whenNonNull()
 				.to((h2cMaxContentLength) -> httpRequestDecoderSpec
 					.h2cMaxContentLength((int) h2cMaxContentLength.toBytes()));
 			propertyMapper.from(nettyProperties.getInitialBufferSize())
-				.whenNonNull()
 				.to((initialBufferSize) -> httpRequestDecoderSpec.initialBufferSize((int) initialBufferSize.toBytes()));
-			propertyMapper.from(nettyProperties.isValidateHeaders())
-				.whenNonNull()
-				.to(httpRequestDecoderSpec::validateHeaders);
+			propertyMapper.from(nettyProperties.isValidateHeaders()).to(httpRequestDecoderSpec::validateHeaders);
 			return httpRequestDecoderSpec;
 		}));
 	}
@@ -110,7 +106,6 @@ public class NettyWebServerFactoryCustomizer
 	private void maxChunkSize(PropertyMapper propertyMapper, HttpRequestDecoderSpec httpRequestDecoderSpec,
 			ServerProperties.Netty nettyProperties) {
 		propertyMapper.from(nettyProperties.getMaxChunkSize())
-			.whenNonNull()
 			.to((maxChunkSize) -> httpRequestDecoderSpec.maxChunkSize((int) maxChunkSize.toBytes()));
 	}
 
@@ -120,6 +115,11 @@ public class NettyWebServerFactoryCustomizer
 
 	private void customizeMaxKeepAliveRequests(NettyReactiveWebServerFactory factory, int maxKeepAliveRequests) {
 		factory.addServerCustomizers((httpServer) -> httpServer.maxKeepAliveRequests(maxKeepAliveRequests));
+	}
+
+	private void customizeHttp2MaxHeaderSize(NettyReactiveWebServerFactory factory, long maxHttpRequestHeaderSize) {
+		factory.addServerCustomizers(((httpServer) -> httpServer.http2Settings(
+				(http2SettingsSpecBuilder) -> http2SettingsSpecBuilder.maxHeaderListSize(maxHttpRequestHeaderSize))));
 	}
 
 }


### PR DESCRIPTION
Setting `server.max-http-request-header-size` doesn't work when http2 is enabled on Netty server.

I have created a small repro project https://github.com/NersesAM/netty-http2-bug

Steps to reproduce:

1. checkout https://github.com/NersesAM/netty-http2-bug
2. Start the server NettyHttp2BugApplication. max-http-request-header-size in application.yml file is set to 16k
3. Hit it with the following curl command which has forced http2 and header size ~9k which is over default 8K size.
```
curl -IXGET --http2-prior-knowledge --location "http://localhost:8080" \
    -H "Accept: application/json" \
    -H "large-header1: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Id neque aliquam vestibulum morbi. Mattis vulputate enim nulla aliquet. Dignissim suspendisse in est ante in nibh mauris cursus mattis. Aliquet nec ullamcorper sit amet risus nullam eget felis. Nascetur ridiculus mus mauris vitae ultricies leo integer. Proin sagittis nisl rhoncus mattis rhoncus urna. Id diam vel quam elementum pulvinar etiam non. Ut venenatis tellus in metus vulputate eu scelerisque felis. Turpis egestas maecenas pharetra convallis posuere morbi. Tempor orci eu lobortis elementum nibh tellus molestie nunc. Mauris commodo quis imperdiet massa tincidunt. Et sollicitudin ac orci phasellus egestas. Consectetur lorem donec massa sapien faucibus et molestie ac feugiat. Pulvinar mattis nunc sed blandit libero volutpat sed. Nulla facilisi nullam vehicula ipsum a arcu cursus. Justo laoreet sit amet cursus sit amet.Eget lorem dolor sed viverra ipsum. Lacus sed turpis tincidunt id. Senectus et netus et malesuada fames ac turpis. Eget nullam non nisi est sit amet. Sed viverra ipsum nunc aliquet bibendum enim facilisis gravida. Cursus vitae congue mauris rhoncus aenean vel elit. Sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus. Nibh tortor id aliquet lectus proin nibh nisl condimentum. Risus viverra adipiscing at in tellus integer. Elit sed vulputate mi sit amet mauris commodo quis imperdiet. Arcu non odio euismod lacinia at quis risus. Purus gravida quis blandit turpis cursus. Dui sapien eget mi proin sed libero enim sed. Vel orci porta non pulvinar neque laoreet suspendisse interdum consectetur. Posuere urna nec tincidunt praesent semper feugiat. Tortor vitae purus faucibus ornare suspendisse sed. Risus commodo viverra maecenas accumsan lacus. Massa massa ultricies mi quis hendrerit dolor magna. Sed turpis tincidunt id aliquet risus feugiat in. Scelerisque felis imperdiet proin fermentum. Orci a scelerisque purus semper. Et molestie ac feugiat sed lectus. Amet nisl purus in mollis nunc. Dui sapien eget mi proin sed. Arcu odio ut sem nulla pharetra diam. Ipsum nunc aliquet bibendum enim. Tempor commodo ullamcorper a lacus vestibulum sed arcu non odio." \
    -H "large-header2: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Id neque aliquam vestibulum morbi. Mattis vulputate enim nulla aliquet. Dignissim suspendisse in est ante in nibh mauris cursus mattis. Aliquet nec ullamcorper sit amet risus nullam eget felis. Nascetur ridiculus mus mauris vitae ultricies leo integer. Proin sagittis nisl rhoncus mattis rhoncus urna. Id diam vel quam elementum pulvinar etiam non. Ut venenatis tellus in metus vulputate eu scelerisque felis. Turpis egestas maecenas pharetra convallis posuere morbi. Tempor orci eu lobortis elementum nibh tellus molestie nunc. Mauris commodo quis imperdiet massa tincidunt. Et sollicitudin ac orci phasellus egestas. Consectetur lorem donec massa sapien faucibus et molestie ac feugiat. Pulvinar mattis nunc sed blandit libero volutpat sed. Nulla facilisi nullam vehicula ipsum a arcu cursus. Justo laoreet sit amet cursus sit amet.Eget lorem dolor sed viverra ipsum. Lacus sed turpis tincidunt id. Senectus et netus et malesuada fames ac turpis. Eget nullam non nisi est sit amet. Sed viverra ipsum nunc aliquet bibendum enim facilisis gravida. Cursus vitae congue mauris rhoncus aenean vel elit. Sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus. Nibh tortor id aliquet lectus proin nibh nisl condimentum. Risus viverra adipiscing at in tellus integer. Elit sed vulputate mi sit amet mauris commodo quis imperdiet. Arcu non odio euismod lacinia at quis risus. Purus gravida quis blandit turpis cursus. Dui sapien eget mi proin sed libero enim sed. Vel orci porta non pulvinar neque laoreet suspendisse interdum consectetur. Posuere urna nec tincidunt praesent semper feugiat. Tortor vitae purus faucibus ornare suspendisse sed. Risus commodo viverra maecenas accumsan lacus. Massa massa ultricies mi quis hendrerit dolor magna. Sed turpis tincidunt id aliquet risus feugiat in. Scelerisque felis imperdiet proin fermentum. Orci a scelerisque purus semper. Et molestie ac feugiat sed lectus. Amet nisl purus in mollis nunc. Dui sapien eget mi proin sed. Arcu odio ut sem nulla pharetra diam. Ipsum nunc aliquet bibendum enim. Tempor commodo ullamcorper a lacus vestibulum sed arcu non odio." \
    -H "large-header3: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Id neque aliquam vestibulum morbi. Mattis vulputate enim nulla aliquet. Dignissim suspendisse in est ante in nibh mauris cursus mattis. Aliquet nec ullamcorper sit amet risus nullam eget felis. Nascetur ridiculus mus mauris vitae ultricies leo integer. Proin sagittis nisl rhoncus mattis rhoncus urna. Id diam vel quam elementum pulvinar etiam non. Ut venenatis tellus in metus vulputate eu scelerisque felis. Turpis egestas maecenas pharetra convallis posuere morbi. Tempor orci eu lobortis elementum nibh tellus molestie nunc. Mauris commodo quis imperdiet massa tincidunt. Et sollicitudin ac orci phasellus egestas. Consectetur lorem donec massa sapien faucibus et molestie ac feugiat. Pulvinar mattis nunc sed blandit libero volutpat sed. Nulla facilisi nullam vehicula ipsum a arcu cursus. Justo laoreet sit amet cursus sit amet.Eget lorem dolor sed viverra ipsum. Lacus sed turpis tincidunt id. Senectus et netus et malesuada fames ac turpis. Eget nullam non nisi est sit amet. Sed viverra ipsum nunc aliquet bibendum enim facilisis gravida. Cursus vitae congue mauris rhoncus aenean vel elit. Sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus. Nibh tortor id aliquet lectus proin nibh nisl condimentum. Risus viverra adipiscing at in tellus integer. Elit sed vulputate mi sit amet mauris commodo quis imperdiet. Arcu non odio euismod lacinia at quis risus. Purus gravida quis blandit turpis cursus. Dui sapien eget mi proin sed libero enim sed. Vel orci porta non pulvinar neque laoreet suspendisse interdum consectetur. Posuere urna nec tincidunt praesent semper feugiat. Tortor vitae purus faucibus ornare suspendisse sed. Risus commodo viverra maecenas accumsan lacus. Massa massa ultricies mi quis hendrerit dolor magna. Sed turpis tincidunt id aliquet risus feugiat in. Scelerisque felis imperdiet proin fermentum. Orci a scelerisque purus semper. Et molestie ac feugiat sed lectus. Amet nisl purus in mollis nunc. Dui sapien eget mi proin sed. Arcu odio ut sem nulla pharetra diam. Ipsum nunc aliquet bibendum enim. Tempor commodo ullamcorper a lacus vestibulum sed arcu non odio." \
    -H "large-header4: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Id neque aliquam vestibulum morbi. Mattis vulputate enim nulla aliquet. Dignissim suspendisse in est ante in nibh mauris cursus mattis. Aliquet nec ullamcorper sit amet risus nullam eget felis. Nascetur ridiculus mus mauris vitae ultricies leo integer. Proin sagittis nisl rhoncus mattis rhoncus urna. Id diam vel quam elementum pulvinar etiam non. Ut venenatis tellus in metus vulputate eu scelerisque felis. Turpis egestas maecenas pharetra convallis posuere morbi. Tempor orci eu lobortis elementum nibh tellus molestie nunc. Mauris commodo quis imperdiet massa tincidunt. Et sollicitudin ac orci phasellus egestas. Consectetur lorem donec massa sapien faucibus et molestie ac feugiat. Pulvinar mattis nunc sed blandit libero volutpat sed. Nulla facilisi nullam vehicula ipsum a arcu cursus. Justo laoreet sit amet cursus sit amet.Eget lorem dolor sed viverra ipsum. Lacus sed turpis tincidunt id. Senectus et netus et malesuada fames ac turpis. Eget nullam non nisi est sit amet. Sed viverra ipsum nunc aliquet bibendum enim facilisis gravida. Cursus vitae congue mauris rhoncus aenean vel elit. Sit amet luctus venenatis lectus magna fringilla urna porttitor rhoncus. Nibh tortor id aliquet lectus proin nibh nisl condimentum. Risus viverra adipiscing at in tellus integer. Elit sed vulputate mi sit amet mauris commodo quis imperdiet. Arcu non odio euismod lacinia at quis risus. Purus gravida quis blandit turpis cursus. Dui sapien eget mi proin sed libero enim sed. Vel orci porta non pulvinar neque laoreet suspendisse interdum consectetur. Posuere urna nec tincidunt praesent semper feugiat. Tortor vitae purus faucibus ornare suspendisse sed. Risus commodo viverra maecenas accumsan lacus. Massa massa ultricies mi quis hendrerit dolor magna. Sed turpis tincidunt id aliquet risus feugiat in. Scelerisque felis imperdiet proin fermentum. Orci a scelerisque purus semper. Et molestie ac feugiat sed lectus. Amet nisl purus in mollis nunc. Dui sapien eget mi proin sed. Arcu odio ut sem nulla pharetra diam. Ipsum nunc aliquet bibendum enim. Tempor commodo ullamcorper a lacus vestibulum sed arcu non odio."
```
4. Observe 431 status code returned instead of expected 200


Enabling Debug logging we can see following, at info level there are no logs printed 
```
2023-08-05 12:09:22,541 DEBUG [reactor-http-nio-2] i.n.c.DefaultChannelPipeline: Discarded message pipeline : [reactor.left.httpCodec, reactor.left.h2MultiplexHandler, DefaultChannelPipeline$TailContext#0]. Channel : [id: 0x84aa76b7, L:/127.0.0.1:8080 - R:/127.0.0.1:55365].
2023-08-05 12:09:22,546 DEBUG [reactor-http-nio-2] i.n.u.i.l.AbstractInternalLogger: Stream exception thrown for unknown stream 1.
io.netty.handler.codec.http2.Http2Exception$HeaderListSizeException: Header size exceeded max allowed size (8192)
	at io.netty.handler.codec.http2.Http2Exception.headerListSizeError(Http2Exception.java:195)
	at io.netty.handler.codec.http2.Http2CodecUtil.headerListSizeExceeded(Http2CodecUtil.java:233)
	at io.netty.handler.codec.http2.HpackDecoder$Http2HeadersSink.finish(HpackDecoder.java:543)
	at io.netty.handler.codec.http2.HpackDecoder.decode(HpackDecoder.java:136)
	at io.netty.handler.codec.http2.DefaultHttp2HeadersDecoder.decodeHeaders(DefaultHttp2HeadersDecoder.java:160)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$HeadersBlockBuilder.headers(DefaultHttp2FrameReader.java:733)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$2.processFragment(DefaultHttp2FrameReader.java:476)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:484)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:253)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:159)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:173)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:63)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:393)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:453)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:529)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:468)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
2023-08-05 12:09:22,554 DEBUG [reactor-http-nio-2] i.n.c.DefaultChannelPipeline: Discarded inbound message DefaultHttp2SettingsAckFrame that reached at the tail of the pipeline. Please check your pipeline configuration.
2023-08-05 12:09:22,554 DEBUG [reactor-http-nio-2] i.n.c.DefaultChannelPipeline: Discarded message pipeline : [reactor.left.httpCodec, reactor.left.h2MultiplexHandler, DefaultChannelPipeline$TailContext#0]. Channel : [id: 0x84aa76b7, L:/127.0.0.1:8080 - R:/127.0.0.1:55365].
```
Same curl will work if the curl request is done with http 1.1.

This can be fixed with a custom [NettyCustomizer](https://github.com/NersesAM/netty-http2-bug/blob/main/src/main/kotlin/com/example/nettyhttp2bug/NettyCustomizer.kt) uncomment `@Component` to validate it fixes the problem. But this is unexpected behaviour as the max header size setting should apply regardless which http protocol is used. So I suggest to fix it in Spring boot with this PR.