### PR TITLE
Artemis ConnectionFactory is not configured when CachingConnectionFactory is missing and enabled properties are false

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisConnectionFactoryConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisConnectionFactoryConfiguration.java
@@ -43,41 +43,40 @@ import org.springframework.jms.connection.CachingConnectionFactory;
 class ArtemisConnectionFactoryConfiguration {
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(CachingConnectionFactory.class)
 	@ConditionalOnProperty(prefix = "spring.artemis.pool", name = "enabled", havingValue = "false",
 			matchIfMissing = true)
 	static class SimpleConnectionFactoryConfiguration {
 
-		private final ArtemisProperties properties;
-
-		private final ListableBeanFactory beanFactory;
-
-		SimpleConnectionFactoryConfiguration(ArtemisProperties properties, ListableBeanFactory beanFactory) {
-			this.properties = properties;
-			this.beanFactory = beanFactory;
-		}
-
-		@Bean(name = "jmsConnectionFactory")
-		@ConditionalOnProperty(prefix = "spring.jms.cache", name = "enabled", havingValue = "true",
-				matchIfMissing = true)
-		CachingConnectionFactory cachingJmsConnectionFactory(JmsProperties jmsProperties) {
-			JmsProperties.Cache cacheProperties = jmsProperties.getCache();
-			CachingConnectionFactory connectionFactory = new CachingConnectionFactory(createConnectionFactory());
-			connectionFactory.setCacheConsumers(cacheProperties.isConsumers());
-			connectionFactory.setCacheProducers(cacheProperties.isProducers());
-			connectionFactory.setSessionCacheSize(cacheProperties.getSessionCacheSize());
-			return connectionFactory;
-		}
-
 		@Bean(name = "jmsConnectionFactory")
 		@ConditionalOnProperty(prefix = "spring.jms.cache", name = "enabled", havingValue = "false")
-		ActiveMQConnectionFactory jmsConnectionFactory() {
-			return createConnectionFactory();
+		ActiveMQConnectionFactory jmsConnectionFactory(ArtemisProperties properties, ListableBeanFactory beanFactory) {
+			return createConnectionFactory(properties, beanFactory);
 		}
 
-		private ActiveMQConnectionFactory createConnectionFactory() {
-			return new ArtemisConnectionFactoryFactory(this.beanFactory, this.properties)
+		private static ActiveMQConnectionFactory createConnectionFactory(ArtemisProperties properties,
+				ListableBeanFactory beanFactory) {
+			return new ArtemisConnectionFactoryFactory(beanFactory, properties)
 				.createConnectionFactory(ActiveMQConnectionFactory.class);
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		@ConditionalOnClass(CachingConnectionFactory.class)
+		@ConditionalOnProperty(prefix = "spring.jms.cache", name = "enabled", havingValue = "true",
+				matchIfMissing = true)
+		static class CachingConnectionFactoryConfiguration {
+
+			@Bean(name = "jmsConnectionFactory")
+			CachingConnectionFactory cachingJmsConnectionFactory(JmsProperties jmsProperties,
+					ArtemisProperties properties, ListableBeanFactory beanFactory) {
+				JmsProperties.Cache cacheProperties = jmsProperties.getCache();
+				CachingConnectionFactory connectionFactory = new CachingConnectionFactory(
+						createConnectionFactory(properties, beanFactory));
+				connectionFactory.setCacheConsumers(cacheProperties.isConsumers());
+				connectionFactory.setCacheProducers(cacheProperties.isProducers());
+				connectionFactory.setSessionCacheSize(cacheProperties.getSessionCacheSize());
+				return connectionFactory;
+			}
+
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisAutoConfigurationTests.java
@@ -46,6 +46,7 @@ import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jms.JmsAutoConfiguration;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.ApplicationContext;
@@ -354,6 +355,20 @@ class ArtemisAutoConfigurationTests {
 			context.getSourceApplicationContext().close();
 			assertThat(factory.createConnection()).isNull();
 		});
+	}
+
+	@Test
+	void cachingConnectionFactoryNotOnTheClasspathThenSimpleConnectionFactoryAutoConfigured() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader(CachingConnectionFactory.class))
+			.withPropertyValues("spring.artemis.pool.enabled=false", "spring.jms.cache.enabled=false")
+			.run((context) -> assertThat(context).hasSingleBean(ActiveMQConnectionFactory.class));
+	}
+
+	@Test
+	void cachingConnectionFactoryNotOnTheClasspathAndCacheEnabledThenSimpleConnectionFactoryNotConfigured() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader(CachingConnectionFactory.class))
+			.withPropertyValues("spring.artemis.pool.enabled=false", "spring.jms.cache.enabled=true")
+			.run((context) -> assertThat(context).doesNotHaveBean(ActiveMQConnectionFactory.class));
 	}
 
 	private ConnectionFactory getConnectionFactory(AssertableApplicationContext context) {


### PR DESCRIPTION
Currently, if `CachingConnectionFactory` is excluded no ConnectionFactory is
created.
