### PR TITLE
Align javadoc of AbstractFilterRegistrationBean#setDispatcherTypes

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/AbstractFilterRegistrationBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/AbstractFilterRegistrationBean.java
@@ -169,9 +169,7 @@ public abstract class AbstractFilterRegistrationBean<T extends Filter> extends D
 	}
 
 	/**
-	 * Sets the dispatcher types that should be used with the registration. If not
-	 * specified the types will be deduced based on the value of
-	 * {@link #isAsyncSupported()}.
+	 * Sets the dispatcher types that should be used with the registration.
 	 * @param dispatcherTypes the dispatcher types
 	 */
 	public void setDispatcherTypes(EnumSet<DispatcherType> dispatcherTypes) {


### PR DESCRIPTION
The Javadoc of `AbstractFilterRegistrationBean#setDispatcherTypes` mistakenly claims that the dispatcher types will be deduced from `DynamicRegistrationBean.isAsyncSupported`. This is not true since [this commit](https://github.com/spring-projects/spring-boot/commit/f57dae639df1ea1adf890acfa619ccb7495c328b), and is misleading as by default `DynamicRegistrationBean.isAsyncSupported` is true, while the default dispatcher types for a filter that is not an instance of `OncePerRequestFilter` contains only `REQUEST`.