### PR TITLE
AbstractAotMojo should not add source or target if they are null

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractAotMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractAotMojo.java
@@ -53,6 +53,7 @@ import org.springframework.boot.maven.CommandLineBuilder.ClasspathBuilder;
  *
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author Omar YAYA
  * @since 3.0.0
  */
 public abstract class AbstractAotMojo extends AbstractDependencyFilterMojo {
@@ -152,10 +153,7 @@ public abstract class AbstractAotMojo extends AbstractDependencyFilterMojo {
 				options.add(releaseVersion);
 			}
 			else {
-				options.add("--source");
-				options.add(compilerConfiguration.getSourceMajorVersion());
-				options.add("--target");
-				options.add(compilerConfiguration.getTargetMajorVersion());
+				setSourceAndTargetVersions(compilerConfiguration, options);
 			}
 			options.addAll(new RunArguments(this.compilerArguments).getArgs());
 			Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromPaths(sourceFiles);
@@ -165,6 +163,19 @@ public abstract class AbstractAotMojo extends AbstractDependencyFilterMojo {
 			if (!result || errors.hasReportedErrors()) {
 				throw new IllegalStateException("Unable to compile generated source" + errors);
 			}
+		}
+	}
+	private static void setSourceAndTargetVersions(JavaCompilerPluginConfiguration compilerConfiguration,
+			List<String> options) {
+		String sourceMajorVersion = compilerConfiguration.getSourceMajorVersion();
+		if (sourceMajorVersion != null && !sourceMajorVersion.isEmpty()) {
+			options.add("--source");
+			options.add(sourceMajorVersion);
+		}
+		String targetMajorVersion = compilerConfiguration.getTargetMajorVersion();
+		if (targetMajorVersion != null && !targetMajorVersion.isEmpty()) {
+			options.add("--target");
+			options.add(targetMajorVersion);
 		}
 	}
 


### PR DESCRIPTION
### Description
Added null checks for source and target versions when compiling source files.

Issue Link: [ #36957: AbstractAotMojo should not add source or target if they are null ](https://github.com/spring-projects/spring-boot/issues/36957)

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
