### PR TITLE
Fix broken links in the documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/attributes.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/attributes.adoc
@@ -102,7 +102,7 @@
 :dynatrace-help: https://www.dynatrace.com/support/help
 :gradle-docs: https://docs.gradle.org/current/userguide
 :hibernate-docs: https://docs.jboss.org/hibernate/orm/{hibernate-version}/userguide/html_single/Hibernate_User_Guide.html
-:java-api: https://docs.oracle.com/javase/17/docs/api
+:java-api: https://docs.oracle.com/en/java/javase/17/docs/api
 :jooq-docs: https://www.jooq.org/doc/{jooq-version}/manual-single-page
 :junit5-docs: https://junit.org/junit5/docs/current/user-guide
 :kotlin-docs: https://kotlinlang.org/docs/reference/

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
@@ -1049,7 +1049,7 @@ Spring Boot has dedicated support for expressing durations.
 If you expose a `java.time.Duration` property, the following formats in application properties are available:
 
 * A regular `long` representation (using milliseconds as the default unit unless a `@DurationUnit` has been specified)
-* The standard ISO-8601 format {java-api}/java/time/Duration.html#parse-java.lang.CharSequence-[used by `java.time.Duration`]
+* The standard ISO-8601 format {java-api}/java.base/java/time/Duration.html#parse(java.lang.CharSequence)[used by `java.time.Duration`]
 * A more readable format where the value and the unit are coupled (`10s` means 10 seconds)
 
 Consider the following example:
@@ -1088,7 +1088,7 @@ In addition to durations, Spring Boot can also work with `java.time.Period` type
 The following formats can be used in application properties:
 
 * An regular `int` representation (using days as the default unit unless a `@PeriodUnit` has been specified)
-* The standard ISO-8601 format {java-api}/java/time/Period.html#parse-java.lang.CharSequence-[used by `java.time.Period`]
+* The standard ISO-8601 format {java-api}/java.base/java/time/Period.html#parse(java.lang.CharSequence)[used by `java.time.Period`]
 * A simpler format where the value and the unit pairs are coupled (`1y3d` means 1 year and 3 days)
 
 The following units are supported with the simple format:

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/logging.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/logging.adoc
@@ -1,7 +1,7 @@
 [[features.logging]]
 == Logging
 Spring Boot uses https://commons.apache.org/logging[Commons Logging] for all internal logging but leaves the underlying log implementation open.
-Default configurations are provided for {java-api}/java/util/logging/package-summary.html[Java Util Logging], https://logging.apache.org/log4j/2.x/[Log4j2], and https://logback.qos.ch/[Logback].
+Default configurations are provided for {java-api}/java.logging/java/util/logging/package-summary.html[Java Util Logging], https://logging.apache.org/log4j/2.x/[Log4j2], and https://logback.qos.ch/[Logback].
 In each case, loggers are pre-configured to use console output with optional file output also available.
 
 By default, if you use the "`Starters`", Logback is used for logging.


### PR DESCRIPTION
Fixes #37045 

Hi Spring Boot team,

This PR fixes 3 broken links to https://docs.oracle.com in the [Core Features section of the documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html).

In `attributes.adoc`, I found the attribute `java-api` that needed to be fixed:

**AS-IS**

```adoc
:java-api: https://docs.oracle.com/javase/17/docs/api
```

**TO-BE**

```adoc
:java-api: https://docs.oracle.com/en/java/javase/17/docs/api
```

Then I updated the following links that uses the `java-api` attribute:

- `{java-api}/java.base/java/time/Duration.html#parse(java.lang.CharSequence)`
- `{java-api}/java.base/java/time/Period.html#parse(java.lang.CharSequence)`
- `{java-api}/java.logging/java/util/logging/package-summary.html`