### PR TITLE
Default value metadata for management.otlp.metrics.export.base-time-unit is missing

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -2055,6 +2055,10 @@
       }
     },
     {
+      "name": "management.otlp.metrics.export.base-time-unit",
+      "defaultValue": "milliseconds"
+    },
+    {
       "name": "management.otlp.tracing.compression",
       "defaultValue": "none"
     },


### PR DESCRIPTION
This PR adds metadata for `management.otlp.metrics.export.base-time-unit` property.

See gh-36393