### PR TITLE
Add Javadoc since for AbstractRabbitListenerContainerFactoryConfigurer.setTaskExecutor()

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/AbstractRabbitListenerContainerFactoryConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/AbstractRabbitListenerContainerFactoryConfigurer.java
@@ -87,6 +87,7 @@ public abstract class AbstractRabbitListenerContainerFactoryConfigurer<T extends
 	/**
 	 * Set the task executor to use.
 	 * @param taskExecutor the task executor
+	 * @since 3.2.0
 	 */
 	public void setTaskExecutor(Executor taskExecutor) {
 		this.taskExecutor = taskExecutor;


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `AbstractRabbitListenerContainerFactoryConfigurer.setTaskExecutor()`.

See gh-36387