### PR TITLE
Unwrap a validator instance of specified type contained in SpringValidatorAdapter

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/ValidatorAdapter.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/ValidatorAdapter.java
@@ -157,9 +157,6 @@ public class ValidatorAdapter implements SmartValidator, ApplicationContextAware
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T unwrap(Class<T> type) {
-		if (this.target == null) {
-			return null;
-		}
 		if (type.isAssignableFrom(this.target.getClass())) {
 			if (this.target instanceof SpringValidatorAdapter adapter) {
 				return adapter.unwrap(type);
@@ -167,7 +164,7 @@ public class ValidatorAdapter implements SmartValidator, ApplicationContextAware
 			return (T) this.target;
 		}
 
-		throw new ValidationException("Cannot unwrap to " + type);
+		throw new IllegalArgumentException("Cannot unwrap " + this.target + " to " + type.getName());
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/ValidatorAdapter.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/validation/ValidatorAdapter.java
@@ -39,6 +39,7 @@ import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
  *
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Zisis Pavloudis
  * @since 2.0.0
  */
 public class ValidatorAdapter implements SmartValidator, ApplicationContextAware, InitializingBean, DisposableBean {
@@ -151,6 +152,22 @@ public class ValidatorAdapter implements SmartValidator, ApplicationContextAware
 			return new ValidatorAdapter(new SpringValidatorAdapter(jakartaValidator), existingBean);
 		}
 		return validator;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T unwrap(Class<T> type) {
+		if (this.target == null) {
+			return null;
+		}
+		if (type.isAssignableFrom(this.target.getClass())) {
+			if (this.target instanceof SpringValidatorAdapter adapter) {
+				return adapter.unwrap(type);
+			}
+			return (T) this.target;
+		}
+
+		throw new ValidationException("Cannot unwrap to " + type);
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/validation/ValidatorAdapterTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/validation/ValidatorAdapterTests.java
@@ -18,7 +18,10 @@ package org.springframework.boot.autoconfigure.validation;
 
 import java.util.HashMap;
 
+import jakarta.validation.Validator;
 import jakarta.validation.constraints.Min;
+import org.hibernate.validator.HibernateValidator;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -89,6 +92,15 @@ class ValidatorAdapterTests {
 			.withClassLoader(new FilteredClassLoader(FilteredClassLoader.ClassPathResourceFilter.of(hibernateValidator),
 					FilteredClassLoader.PackageFilter.of("org.hibernate.validator")))
 			.run((context) -> ValidatorAdapter.get(context, null));
+	}
+
+	@Test
+	void unwrapValidatorInstanceOfJakartaTypeAndExceptionThrownWhenTypeNotSupported() {
+		this.contextRunner.withUserConfiguration(LocalValidatorFactoryBeanConfig.class).run((context) -> {
+			ValidatorAdapter wrapper = context.getBean(ValidatorAdapter.class);
+			assertThat(wrapper.unwrap(Validator.class)).isInstanceOf(Validator.class);
+			Assertions.assertThrows(IllegalArgumentException.class, () -> wrapper.unwrap(HibernateValidator.class));
+		});
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
Hi Spring boot team!

This PR attempts to close gh-37081 by implementing the unwrap method in `boot/autoconfigure/validation/ValidatorAdapter` provided by Spring's `SmartValidator` interface which was added in consequence to Spring's [gh-31082](https://github.com/spring-projects/spring-framework/issues/31082).

It has been tested against the sample project provided in [gh-31082](https://github.com/spring-projects/spring-framework/issues/31082) and returns a Bad Request as long as the `@Validated` annotation is removed from class-level.

```
2023-08-28T19:55:01.610+03:00  INFO 14176 --- [           main] com.example.demo.DemoApplication         : Started DemoApplication in 3.059 seconds (process running for 3.702)
2023-08-28T19:55:10.613+03:00 DEBUG 14176 --- [ctor-http-nio-3] o.s.w.s.adapter.HttpWebHandlerAdapter    : [01873b0d-1] HTTP GET "/class/-1"
2023-08-28T19:55:10.642+03:00 DEBUG 14176 --- [ctor-http-nio-3] s.w.r.r.m.a.RequestMappingHandlerMapping : [01873b0d-1] Mapped to com.example.demo.ClassLevelController#getEntity(Long)
2023-08-28T19:55:10.849+03:00 DEBUG 14176 --- [ctor-http-nio-3] org.springframework.web.HttpLogging      : [01873b0d-1] Resolved [HandlerMethodValidationException: 400 BAD_REQUEST "Validation failure"] for HTTP GET /class/-1
2023-08-28T19:55:10.892+03:00 DEBUG 14176 --- [ctor-http-nio-3] org.springframework.web.HttpLogging      : [01873b0d-1] Encoding [{timestamp=Mon Aug 28 19:55:10 EEST 2023, path=/class/-1, status=400, error=Bad Request, requestId=0 (truncated)...]
2023-08-28T19:55:10.938+03:00 DEBUG 14176 --- [ctor-http-nio-3] o.s.w.s.adapter.HttpWebHandlerAdapter    : [01873b0d-1] Completed 400 BAD_REQUEST
2023-08-28T19:55:28.995+03:00 DEBUG 14176 --- [ctor-http-nio-3] o.s.w.s.adapter.HttpWebHandlerAdapter    : [01873b0d-2] HTTP GET "/method/-1"
2023-08-28T19:55:28.996+03:00 DEBUG 14176 --- [ctor-http-nio-3] s.w.r.r.m.a.RequestMappingHandlerMapping : [01873b0d-2] Mapped to com.example.demo.MethodLevelController#getEntity(Long)
2023-08-28T19:55:29.003+03:00 DEBUG 14176 --- [ctor-http-nio-3] org.springframework.web.HttpLogging      : [01873b0d-2] Resolved [HandlerMethodValidationException: 400 BAD_REQUEST "Validation failure"] for HTTP GET /method/-1
2023-08-28T19:55:29.004+03:00 DEBUG 14176 --- [ctor-http-nio-3] org.springframework.web.HttpLogging      : [01873b0d-2] Encoding [{timestamp=Mon Aug 28 19:55:29 EEST 2023, path=/method/-1, status=400, error=Bad Request, requestId= (truncated)...]
2023-08-28T19:55:29.005+03:00 DEBUG 14176 --- [ctor-http-nio-3] o.s.w.s.adapter.HttpWebHandlerAdapter    : [01873b0d-2] Completed 400 BAD_REQUEST
```

However it appears that `boot.autoconfigure.validation.ValidationAutoConfigurationTests#methodValidationPostProcessorValidatorDependencyDoesNotTriggerEarlyInitialization` fails when building against latest Spring 6.1.0-SNAPSHOT logging multiple warnings of 
```
Bean 'org.springframework.boot.autoconfigure.validation.ValidationAutoConfigurationTests$CustomValidatorConfiguration$SomeServiceConfiguration' of type [org.springframework.boot.autoconfigure.validation.ValidationAutoConfigurationTests$CustomValidatorConfiguration$SomeServiceConfiguration] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). Is this bean getting eagerly injected into a currently created BeanPostProcessor [methodValidationPostProcessor]
```

I've taken the liberty in submitting this PR as the above test also fails when not having my changes incorporated, I am not sure whether this is deemed an issue in Spring or in Spring boot but I think it shows some resemblence to Spring's [gh-24553](https://github.com/spring-projects/spring-framework/issues/24553).