### PR TITLE
Tomcat Version updated to 10.1.13 due to CVE-2023-41080

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 kotlinVersion=1.9.10
 nativeBuildToolsVersion=0.9.24
 springFrameworkVersion=6.1.0-M4
-tomcatVersion=10.1.12
+tomcatVersion=10.1.13
 
 kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
Hi,
I know this is against the TOS.
Due to I don't know when the next Spring boot minor release is. Here is the fix for CVE-2023-41080.
Which is in fact only a version change.

regards
Max