### PR TITLE
fix bootBuildImage task failing when native GraalVM compilation is slow and HTTP/S communication with Docker is used

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/DockerConfiguration.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/DockerConfiguration.java
@@ -69,10 +69,23 @@ public final class DockerConfiguration {
 				this.builderAuthentication, this.publishAuthentication, this.bindHostToBuilder);
 	}
 
+	public DockerConfiguration withHost(String address, boolean secure, String certificatePath, Integer socketTimeout) {
+		Assert.notNull(address, "Address must not be null");
+		return new DockerConfiguration(
+				DockerHostConfiguration.forAddress(address, secure, certificatePath).withSocketTimeout(socketTimeout),
+				this.builderAuthentication, this.publishAuthentication, this.bindHostToBuilder);
+	}
+
 	public DockerConfiguration withContext(String context) {
 		Assert.notNull(context, "Context must not be null");
 		return new DockerConfiguration(DockerHostConfiguration.forContext(context), this.builderAuthentication,
 				this.publishAuthentication, this.bindHostToBuilder);
+	}
+
+	public DockerConfiguration withContext(String context, Integer socketTimeout) {
+		Assert.notNull(context, "Context must not be null");
+		return new DockerConfiguration(DockerHostConfiguration.forContext(context).withSocketTimeout(socketTimeout),
+				this.builderAuthentication, this.publishAuthentication, this.bindHostToBuilder);
 	}
 
 	public DockerConfiguration withBindHostToBuilder(boolean bindHostToBuilder) {
@@ -123,11 +136,15 @@ public final class DockerConfiguration {
 
 		private final String certificatePath;
 
-		public DockerHostConfiguration(String address, String context, boolean secure, String certificatePath) {
+		private final Integer socketTimeout;
+
+		public DockerHostConfiguration(String address, String context, boolean secure, String certificatePath,
+				Integer socketTimeout) {
 			this.address = address;
 			this.context = context;
 			this.secure = secure;
 			this.certificatePath = certificatePath;
+			this.socketTimeout = socketTimeout;
 		}
 
 		public String getAddress() {
@@ -146,16 +163,25 @@ public final class DockerConfiguration {
 			return this.certificatePath;
 		}
 
+		public Integer getSocketTimeout() {
+			return this.socketTimeout;
+		}
+
 		public static DockerHostConfiguration forAddress(String address) {
-			return new DockerHostConfiguration(address, null, false, null);
+			return new DockerHostConfiguration(address, null, false, null, null);
 		}
 
 		public static DockerHostConfiguration forAddress(String address, boolean secure, String certificatePath) {
-			return new DockerHostConfiguration(address, null, secure, certificatePath);
+			return new DockerHostConfiguration(address, null, secure, certificatePath, null);
 		}
 
 		static DockerHostConfiguration forContext(String context) {
-			return new DockerHostConfiguration(null, context, false, null);
+			return new DockerHostConfiguration(null, context, false, null, null);
+		}
+
+		public DockerHostConfiguration withSocketTimeout(Integer socketTimeout) {
+			return new DockerHostConfiguration(this.address, this.context, this.secure, this.certificatePath,
+					socketTimeout);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/DockerHost.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/DockerHost.java
@@ -30,14 +30,17 @@ public class DockerHost {
 
 	private final String certificatePath;
 
+	private final Integer socketTimeout;
+
 	public DockerHost(String address) {
-		this(address, false, null);
+		this(address, false, null, null);
 	}
 
-	public DockerHost(String address, boolean secure, String certificatePath) {
+	public DockerHost(String address, boolean secure, String certificatePath, Integer socketTimeout) {
 		this.address = address;
 		this.secure = secure;
 		this.certificatePath = certificatePath;
+		this.socketTimeout = socketTimeout;
 	}
 
 	public String getAddress() {
@@ -50,6 +53,10 @@ public class DockerHost {
 
 	public String getCertificatePath() {
 		return this.certificatePath;
+	}
+
+	public Integer getSocketTimeout() {
+		return this.socketTimeout;
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/RemoteHttpClientTransportTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/RemoteHttpClientTransportTests.java
@@ -16,19 +16,28 @@
 
 package org.springframework.boot.buildpack.platform.docker.transport;
 
+import java.lang.reflect.Field;
+import java.security.NoSuchAlgorithmException;
 import java.util.function.Consumer;
 
 import javax.net.ssl.SSLContext;
 
+import org.apache.hc.core5.function.Resolver;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.io.SocketConfig;
+import org.assertj.core.util.TriFunction;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import org.springframework.boot.buildpack.platform.docker.configuration.DockerConfiguration.DockerHostConfiguration;
 import org.springframework.boot.buildpack.platform.docker.configuration.ResolvedDockerHost;
 import org.springframework.boot.buildpack.platform.docker.ssl.SslContextFactory;
+import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -94,6 +103,71 @@ class RemoteHttpClientTransportTests {
 			.from(DockerHostConfiguration.forAddress("tcp://192.168.1.2:2376", true, null));
 		assertThatIllegalArgumentException().isThrownBy(() -> RemoteHttpClientTransport.createIfPossible(dockerHost))
 			.withMessageContaining("Docker host TLS verification requires trust material");
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	void createIfPossibleWhenSocketTimeoutIsDefault(boolean secured) throws NoSuchAlgorithmException {
+
+		ResolvedDockerHost dockerHost = ResolvedDockerHost.from(DockerHostConfiguration
+			.forAddress("tcp://192.168.1.2:2376", secured, (secured) ? "/test-cert-path" : null));
+		RemoteHttpClientTransport transport;
+		if (secured) {
+			SslContextFactory sslContextFactory = mock(SslContextFactory.class);
+			given(sslContextFactory.forDirectory("/test-cert-path")).willReturn(SSLContext.getDefault());
+			transport = RemoteHttpClientTransport.createIfPossible(dockerHost, sslContextFactory);
+		}
+		else {
+			transport = RemoteHttpClientTransport.createIfPossible(dockerHost);
+		}
+
+		Resolver<?, ?> resolver = findTransportSocketConfigResolver(transport);
+		Object socketConfigObj = resolver.resolve(null);
+		assertThat(socketConfigObj).describedAs("Null socketConfig is for DEFAULT socketConfig during connection")
+			.isNull();
+
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	void createIfPossibleWhenSocketTimeoutIsConfigured(boolean secured) throws NoSuchAlgorithmException {
+
+		ResolvedDockerHost dockerHost = ResolvedDockerHost.from(DockerHostConfiguration
+			.forAddress("tcp://192.168.1.2:2376", secured, (secured) ? "/test-cert-path" : null)
+			.withSocketTimeout(123456));
+		RemoteHttpClientTransport transport;
+		if (secured) {
+			SslContextFactory sslContextFactory = mock(SslContextFactory.class);
+			given(sslContextFactory.forDirectory("/test-cert-path")).willReturn(SSLContext.getDefault());
+			transport = RemoteHttpClientTransport.createIfPossible(dockerHost, sslContextFactory);
+		}
+		else {
+			transport = RemoteHttpClientTransport.createIfPossible(dockerHost);
+		}
+
+		Resolver<?, ?> resolver = findTransportSocketConfigResolver(transport);
+		Object socketConfigObj = resolver.resolve(null);
+		assertThat(socketConfigObj).isInstanceOfSatisfying(SocketConfig.class,
+				(socketConfig) -> assertThat(socketConfig.getSoTimeout()).hasToString("123456 SECONDS"));
+	}
+
+	private static Resolver<?, ?> findTransportSocketConfigResolver(RemoteHttpClientTransport transport) {
+		TriFunction<Class<?>, String, Object, Object> getField = (aClass, fieldName, object) -> {
+			Field field = ReflectionUtils.findField(aClass, fieldName);
+			ReflectionUtils.makeAccessible(field);
+			return ReflectionUtils.getField(field, object);
+		};
+		Object clientObj = getField.apply(RemoteHttpClientTransport.class, "client", transport);
+		Object connManagerObj = getField.apply(clientObj.getClass(), "connManager", clientObj);
+		Object socketConfigResolverObj = getField.apply(connManagerObj.getClass(), "socketConfigResolver",
+				connManagerObj);
+
+		if (socketConfigResolverObj instanceof Resolver<?, ?>) {
+			return (Resolver<?, ?>) socketConfigResolverObj;
+		}
+		else {
+			return fail("Invalid %s type for ", Resolver.class, socketConfigResolverObj);
+		}
 	}
 
 	private Consumer<HttpHost> hostOf(String scheme, String hostName, int port) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging-oci-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/asciidoc/packaging-oci-image.adoc
@@ -51,6 +51,9 @@ The following table summarizes the available properties:
 | `host`
 | URL containing the host and port for the Docker daemon - for example `tcp://192.168.99.100:2376`
 
+| `socketTimeout`
+| When we use HTTP(S) connection to Docker daemon, we might want to specify socket-timeout property in milliseconds (default is 3 minutes, defined by Apache HTTP client).
+
 | `tlsVerify`
 | Enable secure HTTPS protocol when set to `true` (optional)
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/DockerSpec.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/DockerSpec.java
@@ -72,6 +72,10 @@ public abstract class DockerSpec {
 
 	@Input
 	@Optional
+	public abstract Property<Integer> getSocketTimeout();
+
+	@Input
+	@Optional
 	public abstract Property<Boolean> getBindHostToBuilder();
 
 	/**
@@ -134,11 +138,12 @@ public abstract class DockerSpec {
 			throw new GradleException(
 					"Invalid Docker configuration, either context or host can be provided but not both");
 		}
+		Integer socketTimeout = getSocketTimeout().getOrNull();
 		if (context != null) {
-			return dockerConfiguration.withContext(context);
+			return dockerConfiguration.withContext(context, socketTimeout);
 		}
 		if (host != null) {
-			return dockerConfiguration.withHost(host, getTlsVerify().get(), getCertPath().getOrNull());
+			return dockerConfiguration.withHost(host, getTlsVerify().get(), getCertPath().getOrNull(), socketTimeout);
 		}
 		return dockerConfiguration;
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging-oci-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/packaging-oci-image.adoc
@@ -66,6 +66,9 @@ The following table summarizes the available parameters:
 | `host`
 | URL containing the host and port for the Docker daemon - for example `tcp://192.168.99.100:2376`
 
+| `socketTimeout`
+| When we use HTTP(S) connection to Docker daemon, we might want to specify socket-timeout property in milliseconds (default is 3 minutes, defined by Apache HTTP client).
+
 | `tlsVerify`
 | Enable secure HTTPS protocol when set to `true` (optional)
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/Docker.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/Docker.java
@@ -29,6 +29,8 @@ public class Docker {
 
 	private String host;
 
+	private Integer socketTimeout;
+
 	private String context;
 
 	private boolean tlsVerify;
@@ -51,6 +53,14 @@ public class Docker {
 
 	void setHost(String host) {
 		this.host = host;
+	}
+
+	public Integer getSocketTimeout() {
+		return this.socketTimeout;
+	}
+
+	void setSocketTimeout(Integer socketTimeout) {
+		this.socketTimeout = socketTimeout;
 	}
 
 	/**
@@ -157,10 +167,10 @@ public class Docker {
 					"Invalid Docker configuration, either context or host can be provided but not both");
 		}
 		if (this.context != null) {
-			return dockerConfiguration.withContext(this.context);
+			return dockerConfiguration.withContext(this.context, this.socketTimeout);
 		}
 		if (this.host != null) {
-			return dockerConfiguration.withHost(this.host, this.tlsVerify, this.certPath);
+			return dockerConfiguration.withHost(this.host, this.tlsVerify, this.certPath, this.socketTimeout);
 		}
 		return dockerConfiguration;
 	}


### PR DESCRIPTION
Hi,

I find out following situation.

I have Gradle build with `gradle bootBuildImage` command. When I run it with Gitlab CICD and it's usage of DinD where environment variable `DOCKER_HOST=tcp://localhost:2375` is specified, build fails on `java.net.SocketTimeoutException: Read timed out` exception below.

After some investigation, I found out that it is because of HTTP communication with Docker daemon where Apache HTTP Client has default read-timeout set to `3 minutes`.

What I see in the log is:
```
    [creator]     [2/8] Performing analysis...  [*******]                        (233.2s @ 1.38GB)
    [creator]       15,829 (90.09%) of 17,571 types reachable
    [creator]       25,318 (67.44%) of 37,541 fields reachable
    [creator]       76,655 (61.95%) of 123,732 methods reachable
    [creator]        5,078 types,   338 fields, and 4,354 methods registered for reflection
    [creator]           64 types,    70 fields, and    55 methods registered for JNI access
    [creator]            4 native libraries: dl, pthread, rt, z
    [creator]     [3/8] Building universe...                                      (24.2s @ 2.88GB)
    [creator]     [4/8] Parsing methods...      [*****]                           (22.9s @ 3.06GB)
    [creator]     [5/8] Inlining methods...     [***]                             (14.8s @ 1.73GB)
...bam exception thrown here...
```
Step `[6/8]` is not finished withing default 3 minutes => no any data coming from `/log` Docker endpoint.

I was comparing configuration of HTTP client in docker-java and here and find out that there was regression as described here https://github.com/docker-java/docker-java/pull/1590#issuecomment-870581289 .

- Main fix is here `org.springframework.boot.buildpack.platform.docker.transport.RemoteHttpClientTransport#create`
- Setting 0 timeout => infinity to follow log stream correctly
- other changes are mainly to be able to reproduce timeout during test execution.

Also, I am not sure about test. It shows steps to reproduce without starting full blown build process and is highly dependent on environment. Main point here is that we need to "force" code to select `RemoteHttpClientTransport` and not `LocalHttpClientTransport` instance during execution of `org.springframework.boot.buildpack.platform.docker.transport.HttpTransport#create`.

Another think is why you do not use docker-java project, because it seems from source code that they have already solved most of the edge cases with Docker deamon communication.

Thx for your feedback

Ivos


<details><summary>Original exception</summary>
<pre>
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':bootBuildImage'.
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.lambda$executeIfValid$1(ExecuteActionsTaskExecuter.java:149)
	at org.gradle.internal.Try$Failure.ifSuccessfulOrElse(Try.java:282)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:147)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:135)
	at org.gradle.api.internal.tasks.execution.FinalizePropertiesTaskExecuter.execute(FinalizePropertiesTaskExecuter.java:46)
	at org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter.execute(ResolveTaskExecutionModeExecuter.java:51)
	at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)
	at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:74)
	at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:36)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)
	at org.gradle.execution.plan.LocalTaskNodeExecutor.execute(LocalTaskNodeExecutor.java:42)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:337)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:324)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:317)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:303)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:463)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:380)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:47)
Caused by: org.gradle.api.UncheckedIOException: java.net.SocketTimeoutException: Read timed out
	at org.gradle.internal.UncheckedException.throwAsUncheckedException(UncheckedException.java:62)
	at org.gradle.internal.UncheckedException.throwAsUncheckedException(UncheckedException.java:41)
	at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:128)
	at org.gradle.api.internal.project.taskfactory.StandardTaskAction.doExecute(StandardTaskAction.java:58)
	at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:51)
	at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:29)
	at org.gradle.api.internal.tasks.execution.TaskExecution$3.run(TaskExecution.java:248)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:29)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:26)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.run(DefaultBuildOperationRunner.java:47)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:68)
	at org.gradle.api.internal.tasks.execution.TaskExecution.executeAction(TaskExecution.java:233)
	at org.gradle.api.internal.tasks.execution.TaskExecution.executeActions(TaskExecution.java:216)
	at org.gradle.api.internal.tasks.execution.TaskExecution.executeWithPreviousOutputFiles(TaskExecution.java:199)
	at org.gradle.api.internal.tasks.execution.TaskExecution.execute(TaskExecution.java:166)
	at org.gradle.internal.execution.steps.ExecuteStep.executeInternal(ExecuteStep.java:105)
	at org.gradle.internal.execution.steps.ExecuteStep.access$000(ExecuteStep.java:44)
	at org.gradle.internal.execution.steps.ExecuteStep$1.call(ExecuteStep.java:59)
	at org.gradle.internal.execution.steps.ExecuteStep$1.call(ExecuteStep.java:56)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
	at org.gradle.internal.execution.steps.ExecuteStep.execute(ExecuteStep.java:56)
	at org.gradle.internal.execution.steps.ExecuteStep.execute(ExecuteStep.java:44)
	at org.gradle.internal.execution.steps.RemovePreviousOutputsStep.execute(RemovePreviousOutputsStep.java:67)
	at org.gradle.internal.execution.steps.RemovePreviousOutputsStep.execute(RemovePreviousOutputsStep.java:37)
	at org.gradle.internal.execution.steps.CancelExecutionStep.execute(CancelExecutionStep.java:41)
	at org.gradle.internal.execution.steps.TimeoutStep.executeWithoutTimeout(TimeoutStep.java:74)
	at org.gradle.internal.execution.steps.TimeoutStep.execute(TimeoutStep.java:55)
	at org.gradle.internal.execution.steps.CreateOutputsStep.execute(CreateOutputsStep.java:50)
	at org.gradle.internal.execution.steps.CreateOutputsStep.execute(CreateOutputsStep.java:28)
	at org.gradle.internal.execution.steps.CaptureStateAfterExecutionStep.executeDelegateBroadcastingChanges(CaptureStateAfterExecutionStep.java:100)
	at org.gradle.internal.execution.steps.CaptureStateAfterExecutionStep.execute(CaptureStateAfterExecutionStep.java:72)
	at org.gradle.internal.execution.steps.CaptureStateAfterExecutionStep.execute(CaptureStateAfterExecutionStep.java:50)
	at org.gradle.internal.execution.steps.ResolveInputChangesStep.execute(ResolveInputChangesStep.java:40)
	at org.gradle.internal.execution.steps.ResolveInputChangesStep.execute(ResolveInputChangesStep.java:29)
	at org.gradle.internal.execution.steps.BuildCacheStep.executeWithoutCache(BuildCacheStep.java:179)
	at org.gradle.internal.execution.steps.BuildCacheStep.lambda$execute$1(BuildCacheStep.java:70)
	at org.gradle.internal.Either$Right.fold(Either.java:175)
	at org.gradle.internal.execution.caching.CachingState.fold(CachingState.java:59)
	at org.gradle.internal.execution.steps.BuildCacheStep.execute(BuildCacheStep.java:68)
	at org.gradle.internal.execution.steps.BuildCacheStep.execute(BuildCacheStep.java:46)
	at org.gradle.internal.execution.steps.StoreExecutionStateStep.execute(StoreExecutionStateStep.java:36)
	at org.gradle.internal.execution.steps.StoreExecutionStateStep.execute(StoreExecutionStateStep.java:25)
	at org.gradle.internal.execution.steps.RecordOutputsStep.execute(RecordOutputsStep.java:36)
	at org.gradle.internal.execution.steps.RecordOutputsStep.execute(RecordOutputsStep.java:22)
	at org.gradle.internal.execution.steps.SkipUpToDateStep.executeBecause(SkipUpToDateStep.java:91)
	at org.gradle.internal.execution.steps.SkipUpToDateStep.lambda$execute$2(SkipUpToDateStep.java:55)
	at org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:55)
	at org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:37)
	at org.gradle.internal.execution.steps.ResolveChangesStep.execute(ResolveChangesStep.java:65)
	at org.gradle.internal.execution.steps.ResolveChangesStep.execute(ResolveChangesStep.java:36)
	at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:37)
	at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:27)
	at org.gradle.internal.execution.steps.ResolveCachingStateStep.execute(ResolveCachingStateStep.java:77)
	at org.gradle.internal.execution.steps.ResolveCachingStateStep.execute(ResolveCachingStateStep.java:38)
	at org.gradle.internal.execution.steps.ValidateStep.execute(ValidateStep.java:94)
	at org.gradle.internal.execution.steps.ValidateStep.execute(ValidateStep.java:49)
	at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.execute(CaptureStateBeforeExecutionStep.java:71)
	at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.execute(CaptureStateBeforeExecutionStep.java:45)
	at org.gradle.internal.execution.steps.SkipEmptyWorkStep.executeWithNonEmptySources(SkipEmptyWorkStep.java:177)
	at org.gradle.internal.execution.steps.SkipEmptyWorkStep.execute(SkipEmptyWorkStep.java:81)
	at org.gradle.internal.execution.steps.SkipEmptyWorkStep.execute(SkipEmptyWorkStep.java:53)
	at org.gradle.internal.execution.steps.RemoveUntrackedExecutionStateStep.execute(RemoveUntrackedExecutionStateStep.java:32)
	at org.gradle.internal.execution.steps.RemoveUntrackedExecutionStateStep.execute(RemoveUntrackedExecutionStateStep.java:21)
	at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsStartedStep.execute(MarkSnapshottingInputsStartedStep.java:38)
	at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.execute(LoadPreviousExecutionStateStep.java:36)
	at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.execute(LoadPreviousExecutionStateStep.java:23)
	at org.gradle.internal.execution.steps.CleanupStaleOutputsStep.execute(CleanupStaleOutputsStep.java:75)
	at org.gradle.internal.execution.steps.CleanupStaleOutputsStep.execute(CleanupStaleOutputsStep.java:41)
	at org.gradle.internal.execution.steps.AssignWorkspaceStep.lambda$execute$0(AssignWorkspaceStep.java:32)
	at org.gradle.api.internal.tasks.execution.TaskExecution$4.withWorkspace(TaskExecution.java:293)
	at org.gradle.internal.execution.steps.AssignWorkspaceStep.execute(AssignWorkspaceStep.java:30)
	at org.gradle.internal.execution.steps.AssignWorkspaceStep.execute(AssignWorkspaceStep.java:21)
	at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:37)
	at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:27)
	at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:47)
	at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:34)
	at org.gradle.internal.execution.impl.DefaultExecutionEngine$1.execute(DefaultExecutionEngine.java:64)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:146)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:135)
	at org.gradle.api.internal.tasks.execution.FinalizePropertiesTaskExecuter.execute(FinalizePropertiesTaskExecuter.java:46)
	at org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter.execute(ResolveTaskExecutionModeExecuter.java:51)
	at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)
	at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:74)
	at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:36)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)
	at org.gradle.execution.plan.LocalTaskNodeExecutor.execute(LocalTaskNodeExecutor.java:42)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:337)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:324)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:317)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:303)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:463)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:380)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:47)
Caused by: java.net.SocketTimeoutException: Read timed out
	at org.apache.hc.core5.http.impl.io.SessionInputBufferImpl.fillBuffer(SessionInputBufferImpl.java:149)
	at org.apache.hc.core5.http.impl.io.SessionInputBufferImpl.readLine(SessionInputBufferImpl.java:280)
	at org.apache.hc.core5.http.impl.io.ChunkedInputStream.getChunkSize(ChunkedInputStream.java:261)
	at org.apache.hc.core5.http.impl.io.ChunkedInputStream.nextChunk(ChunkedInputStream.java:222)
	at org.apache.hc.core5.http.impl.io.ChunkedInputStream.read(ChunkedInputStream.java:183)
	at org.apache.hc.core5.http.io.EofSensorInputStream.read(EofSensorInputStream.java:135)
	at org.springframework.boot.buildpack.platform.docker.LogUpdateEvent.read(LogUpdateEvent.java:110)
	at org.springframework.boot.buildpack.platform.docker.LogUpdateEvent.read(LogUpdateEvent.java:93)
	at org.springframework.boot.buildpack.platform.docker.LogUpdateEvent.readAll(LogUpdateEvent.java:78)
	at org.springframework.boot.buildpack.platform.docker.DockerApi$ContainerApi.logs(DockerApi.java:441)
	at org.springframework.boot.buildpack.platform.build.Lifecycle.run(Lifecycle.java:237)
	at org.springframework.boot.buildpack.platform.build.Lifecycle.execute(Lifecycle.java:162)
	at org.springframework.boot.buildpack.platform.build.Builder.executeLifecycle(Builder.java:160)
	at org.springframework.boot.buildpack.platform.build.Builder.build(Builder.java:116)
	at org.springframework.boot.gradle.tasks.bundling.BootBuildImage.buildImage(BootBuildImage.java:306)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:125)
	... 113 more
	Suppressed: java.net.SocketException: Socket closed
		at java.base/sun.nio.ch.NioSocketImpl.ensureOpenAndConnected(NioSocketImpl.java:165)
		at java.base/sun.nio.ch.NioSocketImpl.beginRead(NioSocketImpl.java:236)
		at java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:304)
		at java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:355)
		at java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:808)
		at java.base/java.net.Socket$SocketInputStream.read(Socket.java:966)
		at org.apache.hc.core5.http.impl.io.SessionInputBufferImpl.fillBuffer(SessionInputBufferImpl.java:149)
		at org.apache.hc.core5.http.impl.io.SessionInputBufferImpl.readLine(SessionInputBufferImpl.java:280)
		at org.apache.hc.core5.http.impl.io.ChunkedInputStream.getChunkSize(ChunkedInputStream.java:261)
		at org.apache.hc.core5.http.impl.io.ChunkedInputStream.nextChunk(ChunkedInputStream.java:222)
		at org.apache.hc.core5.http.impl.io.ChunkedInputStream.read(ChunkedInputStream.java:147)
		at org.apache.hc.core5.http.impl.io.ChunkedInputStream.close(ChunkedInputStream.java:314)
		at org.apache.hc.core5.io.Closer.close(Closer.java:48)
		at org.apache.hc.core5.http.impl.io.IncomingHttpEntity.close(IncomingHttpEntity.java:112)
		at org.apache.hc.core5.http.io.entity.HttpEntityWrapper.close(HttpEntityWrapper.java:120)
		at org.apache.hc.client5.http.impl.classic.ResponseEntityProxy.close(ResponseEntityProxy.java:180)
		at org.apache.hc.core5.io.Closer.close(Closer.java:48)
		at org.apache.hc.core5.http.message.BasicClassicHttpResponse.close(BasicClassicHttpResponse.java:93)
		at org.apache.hc.client5.http.impl.classic.CloseableHttpResponse.close(CloseableHttpResponse.java:200)
		at org.springframework.boot.buildpack.platform.docker.transport.HttpClientTransport$HttpClientResponse.close(HttpClientTransport.java:262)
		at org.springframework.boot.buildpack.platform.docker.DockerApi$ContainerApi.logs(DockerApi.java:440)
		at org.springframework.boot.buildpack.platform.build.Lifecycle.run(Lifecycle.java:237)
		at org.springframework.boot.buildpack.platform.build.Lifecycle.execute(Lifecycle.java:162)
		at org.springframework.boot.buildpack.platform.build.Builder.executeLifecycle(Builder.java:160)
		at org.springframework.boot.buildpack.platform.build.Builder.build(Builder.java:116)
		at org.springframework.boot.gradle.tasks.bundling.BootBuildImage.buildImage(BootBuildImage.java:306)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.base/java.lang.reflect.Method.invoke(Method.java:568)
		at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:125)
		at org.gradle.api.internal.project.taskfactory.StandardTaskAction.doExecute(StandardTaskAction.java:58)
		at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:51)
		at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:29)
		at org.gradle.api.internal.tasks.execution.TaskExecution$3.run(TaskExecution.java:248)
		at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:29)
		at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:26)
		at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
		at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
		at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
		at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
		at org.gradle.internal.operations.DefaultBuildOperationRunner.run(DefaultBuildOperationRunner.java:47)
		at org.gradle.internal.operations.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:68)
		at org.gradle.api.internal.tasks.execution.TaskExecution.executeAction(TaskExecution.java:233)
		at org.gradle.api.internal.tasks.execution.TaskExecution.executeActions(TaskExecution.java:216)
		at org.gradle.api.internal.tasks.execution.TaskExecution.executeWithPreviousOutputFiles(TaskExecution.java:199)
		at org.gradle.api.internal.tasks.execution.TaskExecution.execute(TaskExecution.java:166)
		at org.gradle.internal.execution.steps.ExecuteStep.executeInternal(ExecuteStep.java:105)
		at org.gradle.internal.execution.steps.ExecuteStep.access$000(ExecuteStep.java:44)
		at org.gradle.internal.execution.steps.ExecuteStep$1.call(ExecuteStep.java:59)
		at org.gradle.internal.execution.steps.ExecuteStep$1.call(ExecuteStep.java:56)
		at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
		at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
		at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
		at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
		at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
		at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
		at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
		at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
		at org.gradle.internal.execution.steps.ExecuteStep.execute(ExecuteStep.java:56)
		at org.gradle.internal.execution.steps.ExecuteStep.execute(ExecuteStep.java:44)
		at org.gradle.internal.execution.steps.RemovePreviousOutputsStep.execute(RemovePreviousOutputsStep.java:67)
		at org.gradle.internal.execution.steps.RemovePreviousOutputsStep.execute(RemovePreviousOutputsStep.java:37)
		at org.gradle.internal.execution.steps.CancelExecutionStep.execute(CancelExecutionStep.java:41)
		at org.gradle.internal.execution.steps.TimeoutStep.executeWithoutTimeout(TimeoutStep.java:74)
		at org.gradle.internal.execution.steps.TimeoutStep.execute(TimeoutStep.java:55)
		at org.gradle.internal.execution.steps.CreateOutputsStep.execute(CreateOutputsStep.java:50)
		at org.gradle.internal.execution.steps.CreateOutputsStep.execute(CreateOutputsStep.java:28)
		at org.gradle.internal.execution.steps.CaptureStateAfterExecutionStep.executeDelegateBroadcastingChanges(CaptureStateAfterExecutionStep.java:100)
		at org.gradle.internal.execution.steps.CaptureStateAfterExecutionStep.execute(CaptureStateAfterExecutionStep.java:72)
		at org.gradle.internal.execution.steps.CaptureStateAfterExecutionStep.execute(CaptureStateAfterExecutionStep.java:50)
		at org.gradle.internal.execution.steps.ResolveInputChangesStep.execute(ResolveInputChangesStep.java:40)
		at org.gradle.internal.execution.steps.ResolveInputChangesStep.execute(ResolveInputChangesStep.java:29)
		at org.gradle.internal.execution.steps.BuildCacheStep.executeWithoutCache(BuildCacheStep.java:179)
		at org.gradle.internal.execution.steps.BuildCacheStep.lambda$execute$1(BuildCacheStep.java:70)
		at org.gradle.internal.Either$Right.fold(Either.java:175)
		at org.gradle.internal.execution.caching.CachingState.fold(CachingState.java:59)
		at org.gradle.internal.execution.steps.BuildCacheStep.execute(BuildCacheStep.java:68)
		at org.gradle.internal.execution.steps.BuildCacheStep.execute(BuildCacheStep.java:46)
		at org.gradle.internal.execution.steps.StoreExecutionStateStep.execute(StoreExecutionStateStep.java:36)
		at org.gradle.internal.execution.steps.StoreExecutionStateStep.execute(StoreExecutionStateStep.java:25)
		at org.gradle.internal.execution.steps.RecordOutputsStep.execute(RecordOutputsStep.java:36)
		at org.gradle.internal.execution.steps.RecordOutputsStep.execute(RecordOutputsStep.java:22)
		at org.gradle.internal.execution.steps.SkipUpToDateStep.executeBecause(SkipUpToDateStep.java:91)
		at org.gradle.internal.execution.steps.SkipUpToDateStep.lambda$execute$2(SkipUpToDateStep.java:55)
		at java.base/java.util.Optional.orElseGet(Optional.java:364)
		at org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:55)
		at org.gradle.internal.execution.steps.SkipUpToDateStep.execute(SkipUpToDateStep.java:37)
		at org.gradle.internal.execution.steps.ResolveChangesStep.execute(ResolveChangesStep.java:65)
		at org.gradle.internal.execution.steps.ResolveChangesStep.execute(ResolveChangesStep.java:36)
		at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:37)
		at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep.execute(MarkSnapshottingInputsFinishedStep.java:27)
		at org.gradle.internal.execution.steps.ResolveCachingStateStep.execute(ResolveCachingStateStep.java:77)
		at org.gradle.internal.execution.steps.ResolveCachingStateStep.execute(ResolveCachingStateStep.java:38)
		at org.gradle.internal.execution.steps.ValidateStep.execute(ValidateStep.java:94)
		at org.gradle.internal.execution.steps.ValidateStep.execute(ValidateStep.java:49)
		at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.execute(CaptureStateBeforeExecutionStep.java:71)
		at org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep.execute(CaptureStateBeforeExecutionStep.java:45)
		at org.gradle.internal.execution.steps.SkipEmptyWorkStep.executeWithNonEmptySources(SkipEmptyWorkStep.java:177)
		at org.gradle.internal.execution.steps.SkipEmptyWorkStep.execute(SkipEmptyWorkStep.java:81)
		at org.gradle.internal.execution.steps.SkipEmptyWorkStep.execute(SkipEmptyWorkStep.java:53)
		at org.gradle.internal.execution.steps.RemoveUntrackedExecutionStateStep.execute(RemoveUntrackedExecutionStateStep.java:32)
		at org.gradle.internal.execution.steps.RemoveUntrackedExecutionStateStep.execute(RemoveUntrackedExecutionStateStep.java:21)
		at org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsStartedStep.execute(MarkSnapshottingInputsStartedStep.java:38)
		at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.execute(LoadPreviousExecutionStateStep.java:36)
		at org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep.execute(LoadPreviousExecutionStateStep.java:23)
		at org.gradle.internal.execution.steps.CleanupStaleOutputsStep.execute(CleanupStaleOutputsStep.java:75)
		at org.gradle.internal.execution.steps.CleanupStaleOutputsStep.execute(CleanupStaleOutputsStep.java:41)
		at org.gradle.internal.execution.steps.AssignWorkspaceStep.lambda$execute$0(AssignWorkspaceStep.java:32)
		at org.gradle.api.internal.tasks.execution.TaskExecution$4.withWorkspace(TaskExecution.java:293)
		at org.gradle.internal.execution.steps.AssignWorkspaceStep.execute(AssignWorkspaceStep.java:30)
		at org.gradle.internal.execution.steps.AssignWorkspaceStep.execute(AssignWorkspaceStep.java:21)
		at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:37)
		at org.gradle.internal.execution.steps.IdentityCacheStep.execute(IdentityCacheStep.java:27)
		at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:47)
		at org.gradle.internal.execution.steps.IdentifyStep.execute(IdentifyStep.java:34)
		at org.gradle.internal.execution.impl.DefaultExecutionEngine$1.execute(DefaultExecutionEngine.java:64)
		at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:146)
		at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:135)
		at org.gradle.api.internal.tasks.execution.FinalizePropertiesTaskExecuter.execute(FinalizePropertiesTaskExecuter.java:46)
		at org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter.execute(ResolveTaskExecutionModeExecuter.java:51)
		at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)
		at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:74)
		at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:36)
		at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)
		at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)
		at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)
		at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
		at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
		at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
		at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
		at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
		at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
		at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
		at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
		at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)
		at org.gradle.execution.plan.LocalTaskNodeExecutor.execute(LocalTaskNodeExecutor.java:42)
		at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:337)
		at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:324)
		at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:317)
		at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:303)
		at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:463)
		at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:380)
		at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
		at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:47)
		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
		at java.base/java.lang.Thread.run(Thread.java:833)
</pre>
</details> 