### PR TITLE
Use project.getLayout().getBuildDirectory() instead of project.getBuildDir()

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ApplicationPluginAction.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ApplicationPluginAction.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.gradle.plugin;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
@@ -89,7 +88,7 @@ final class ApplicationPluginAction implements PluginApplicationAction {
 			}
 		});
 		createStartScripts.getConventionMapping()
-			.map("outputDir", () -> new File(project.getBuildDir(), "bootScripts"));
+			.map("outputDir", () -> project.getLayout().getBuildDirectory().dir("bootScripts").get().getAsFile());
 		createStartScripts.getConventionMapping().map("applicationName", javaApplication::getApplicationName);
 		createStartScripts.getConventionMapping().map("defaultJvmOpts", javaApplication::getApplicationDefaultJvmArgs);
 	}


### PR DESCRIPTION
`Project.getBuildDir()` is deprecated since Gradle 8.3, It will cause `Task :spring-boot-project:spring-boot-tools:spring-boot-gradle-plugin:compileJava FAILED`

See https://github.com/gradle/gradle/issues/20210
