### PR TITLE
Contrary to the documentation, setting spring.jms.listener.concurrency alone configures the maximum concurrency

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsProperties.java
@@ -198,8 +198,7 @@ public class JmsProperties {
 			if (this.concurrency == null) {
 				return (this.maxConcurrency != null) ? "1-" + this.maxConcurrency : null;
 			}
-			return ((this.maxConcurrency != null) ? this.concurrency + "-" + this.maxConcurrency
-					: String.valueOf(this.concurrency));
+			return this.concurrency + "-" + ((this.maxConcurrency != null) ? this.maxConcurrency : this.concurrency);
 		}
 
 		public Duration getReceiveTimeout() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsPropertiesTests.java
@@ -41,7 +41,7 @@ class JmsPropertiesTests {
 	void formatConcurrencyOnlyLowerBound() {
 		JmsProperties properties = new JmsProperties();
 		properties.getListener().setConcurrency(2);
-		assertThat(properties.getListener().formatConcurrency()).isEqualTo("2");
+		assertThat(properties.getListener().formatConcurrency()).isEqualTo("2-2");
 	}
 
 	@Test


### PR DESCRIPTION
Update JMS listener concurrency configuration to set the same minimum and maximum number of consumers when users specify only the minimum using `spring.jms.listener.concurrency` property.

Prior to this commit, when using `spring.jms.listener.concurrency` to set the minimum number of consumers without also specifying `spring.jms.listener.max-concurrency` would result in effective concurrency where the actual minimum number of consumers is always 1, while the maximum number of consumers is the value of `spring.jms.listener.concurrency`.

---

This fix results in a breaking change, however the current behavior is simply not aligned with the description of `spring.jms.listener.concurrency` property.

Also see the [javadoc of `DefaultMessageListenerContainer#setConcurrency`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/jms/listener/DefaultMessageListenerContainer.html#setConcurrency(java.lang.String)) which states:

> Specify concurrency limits via a "lower-upper" String, e.g. "5-10", **or a simple upper limit String, e.g. "10" (the lower limit will be 1 in this case)**.