### PR TITLE
Add virtual host support for Rabbit Stream

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -1207,6 +1207,12 @@ public class RabbitProperties {
 		private int port = DEFAULT_STREAM_PORT;
 
 		/**
+		 * Virtual host of a RabbitMQ instance with the Stream plugin enabled. When not
+		 * set, spring.rabbitmq.virtual-host is used.
+		 */
+		private String virtualHost;
+
+		/**
 		 * Login user to authenticate to the broker. When not set,
 		 * spring.rabbitmq.username is used.
 		 */
@@ -1237,6 +1243,14 @@ public class RabbitProperties {
 
 		public void setPort(int port) {
 			this.port = port;
+		}
+
+		public String getVirtualHost() {
+			return this.virtualHost;
+		}
+
+		public void setVirtualHost(String virtualHost) {
+			this.virtualHost = virtualHost;
 		}
 
 		public String getUsername() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitStreamConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitStreamConfiguration.java
@@ -102,6 +102,10 @@ class RabbitStreamConfiguration {
 		PropertyMapper map = PropertyMapper.get();
 		map.from(stream.getHost()).to(builder::host);
 		map.from(stream.getPort()).to(builder::port);
+		map.from(stream.getVirtualHost())
+			.as(withFallback(properties::getVirtualHost))
+			.whenNonNull()
+			.to(builder::virtualHost);
 		map.from(stream.getUsername()).as(withFallback(properties::getUsername)).whenNonNull().to(builder::username);
 		map.from(stream.getPassword()).as(withFallback(properties::getPassword)).whenNonNull().to(builder::password);
 		return builder;

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitStreamConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitStreamConfigurationTests.java
@@ -144,6 +144,24 @@ class RabbitStreamConfigurationTests {
 	}
 
 	@Test
+	void whenStreamVirtualHostIsSetThenEnvironmentUsesCustomVirtualHost() {
+		EnvironmentBuilder builder = mock(EnvironmentBuilder.class);
+		RabbitProperties properties = new RabbitProperties();
+		properties.getStream().setVirtualHost("stream-virtual-host");
+		RabbitStreamConfiguration.configure(builder, properties);
+		then(builder).should().virtualHost("stream-virtual-host");
+	}
+
+	@Test
+	void whenStreamVirtualHostIsNotSetButDefaultVirtualHostIsSetThenEnvironmentUsesDefaultVirtualHost() {
+		EnvironmentBuilder builder = mock(EnvironmentBuilder.class);
+		RabbitProperties properties = new RabbitProperties();
+		properties.setVirtualHost("default-virtual-host");
+		RabbitStreamConfiguration.configure(builder, properties);
+		then(builder).should().virtualHost("default-virtual-host");
+	}
+
+	@Test
 	void whenStreamCredentialsAreNotSetThenEnvironmentUsesRabbitCredentials() {
 		EnvironmentBuilder builder = mock(EnvironmentBuilder.class);
 		RabbitProperties properties = new RabbitProperties();


### PR DESCRIPTION
Fixes #37123

I assume the documentation at https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-docs/src/docs/asciidoc/application-properties.adoc?plain=1#L32 is generated automatically.