### PR TITLE
Add ConnectionDetails and ServiceConnection support to Pulsar

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-autoconfigure/build.gradle
@@ -277,4 +277,5 @@ tasks.named("checkSpringConfigurationMetadata").configure {
 
 test {
 	jvmArgs += "--add-opens=java.base/java.net=ALL-UNNAMED"
+	jvmArgs += "--add-opens=java.base/sun.net=ALL-UNNAMED"
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PropertiesPulsarConnectionDetails.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PropertiesPulsarConnectionDetails.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.pulsar;
+
+/**
+ * Adapts {@link PulsarProperties} to {@link PulsarConnectionDetails}.
+ *
+ * @author Chris Bono
+ */
+class PropertiesPulsarConnectionDetails implements PulsarConnectionDetails {
+
+	private final PulsarProperties pulsarProperties;
+
+	PropertiesPulsarConnectionDetails(PulsarProperties pulsarProperties) {
+		this.pulsarProperties = pulsarProperties;
+	}
+
+	@Override
+	public String getPulsarBrokerUrl() {
+		return this.pulsarProperties.getClient().getServiceUrl();
+	}
+
+	@Override
+	public String getPulsarAdminUrl() {
+		return this.pulsarProperties.getAdmin().getServiceUrl();
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarConnectionDetails.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarConnectionDetails.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.pulsar;
+
+import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
+
+/**
+ * Details required to establish a connection to a Pulsar service.
+ *
+ * @author Chris Bono
+ * @since 3.2.0
+ */
+public interface PulsarConnectionDetails extends ConnectionDetails {
+
+	/**
+	 * Returns the Pulsar service URL for the broker.
+	 * @return the Pulsar service URL for the broker
+	 */
+	String getPulsarBrokerUrl();
+
+	/**
+	 * Returns the Pulsar web URL for the admin endpoint.
+	 * @return the Pulsar web URL for the admin endpoint
+	 */
+	String getPulsarAdminUrl();
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
@@ -53,6 +53,7 @@ final class PulsarPropertiesMapper {
 		PulsarProperties.Client properties = this.properties.getClient();
 		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		map.from(properties::getServiceUrl).to(clientBuilder::serviceUrl);
+
 		map.from(properties::getConnectionTimeout).to(timeoutProperty(clientBuilder::connectionTimeout));
 		map.from(properties::getOperationTimeout).to(timeoutProperty(clientBuilder::operationTimeout));
 		map.from(properties::getLookupTimeout).to(timeoutProperty(clientBuilder::lookupTimeout));

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PropertiesPulsarConnectionDetailsTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PropertiesPulsarConnectionDetailsTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.pulsar;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link PropertiesPulsarConnectionDetails}.
+ *
+ * @author Chris Bono
+ */
+class PropertiesPulsarConnectionDetailsTests {
+
+	@Test
+	void pulsarBrokerUrlIsObtainedFromPulsarProperties() {
+		var pulsarProps = new PulsarProperties();
+		pulsarProps.getClient().setServiceUrl("foo");
+		var connectionDetails = new PropertiesPulsarConnectionDetails(pulsarProps);
+		assertThat(connectionDetails.getPulsarBrokerUrl()).isEqualTo("foo");
+	}
+
+	@Test
+	void pulsarAdminUrlIsObtainedFromPulsarProperties() {
+		var pulsarProps = new PulsarProperties();
+		pulsarProps.getAdmin().setServiceUrl("foo");
+		var connectionDetails = new PropertiesPulsarConnectionDetails(pulsarProps);
+		assertThat(connectionDetails.getPulsarAdminUrl()).isEqualTo("foo");
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfigurationTests.java
@@ -114,6 +114,7 @@ class PulsarAutoConfigurationTests {
 	@Test
 	void autoConfiguresBeans() {
 		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(PulsarConfiguration.class)
+			.hasSingleBean(PulsarConnectionDetails.class)
 			.hasSingleBean(DefaultPulsarClientFactory.class)
 			.hasSingleBean(PulsarClient.class)
 			.hasSingleBean(PulsarAdministration.class)

--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/pulsar/PulsarDockerComposeConnectionDetailsFactory.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/pulsar/PulsarDockerComposeConnectionDetailsFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docker.compose.service.connection.pulsar;
+
+import org.springframework.boot.autoconfigure.pulsar.PulsarConnectionDetails;
+import org.springframework.boot.docker.compose.core.RunningService;
+import org.springframework.boot.docker.compose.service.connection.DockerComposeConnectionDetailsFactory;
+import org.springframework.boot.docker.compose.service.connection.DockerComposeConnectionSource;
+
+/**
+ * {@link DockerComposeConnectionDetailsFactory} to create {@link PulsarConnectionDetails}
+ * for a {@code pulsar} service.
+ *
+ * @author Chris Bono
+ */
+class PulsarDockerComposeConnectionDetailsFactory
+		extends DockerComposeConnectionDetailsFactory<PulsarConnectionDetails> {
+
+	private static final int PULSAR_BROKER_PORT = 6650;
+
+	private static final int PULSAR_ADMIN_PORT = 8080;
+
+	PulsarDockerComposeConnectionDetailsFactory() {
+		super("apachepulsar/pulsar");
+	}
+
+	@Override
+	protected PulsarConnectionDetails getDockerComposeConnectionDetails(DockerComposeConnectionSource source) {
+		return new PulsarDockerComposeConnectionDetails(source.getRunningService());
+	}
+
+	/**
+	 * {@link PulsarConnectionDetails} backed by a {@code pulsar} {@link RunningService}.
+	 */
+	static class PulsarDockerComposeConnectionDetails extends DockerComposeConnectionDetails
+			implements PulsarConnectionDetails {
+
+		private final String brokerUrl;
+
+		private final String adminUrl;
+
+		PulsarDockerComposeConnectionDetails(RunningService service) {
+			super(service);
+			this.brokerUrl = "pulsar://%s:%s".formatted(service.host(), service.ports().get(PULSAR_BROKER_PORT));
+			this.adminUrl = "http://%s:%s".formatted(service.host(), service.ports().get(PULSAR_ADMIN_PORT));
+		}
+
+		@Override
+		public String getPulsarBrokerUrl() {
+			return this.brokerUrl;
+		}
+
+		@Override
+		public String getPulsarAdminUrl() {
+			return this.adminUrl;
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/pulsar/package-info.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/pulsar/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for docker compose Pulsar service connections.
+ */
+package org.springframework.boot.docker.compose.service.connection.pulsar;

--- a/spring-boot-project/spring-boot-docker-compose/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/resources/META-INF/spring.factories
@@ -19,9 +19,9 @@ org.springframework.boot.docker.compose.service.connection.oracle.OracleJdbcDock
 org.springframework.boot.docker.compose.service.connection.oracle.OracleR2dbcDockerComposeConnectionDetailsFactory,\
 org.springframework.boot.docker.compose.service.connection.postgres.PostgresJdbcDockerComposeConnectionDetailsFactory,\
 org.springframework.boot.docker.compose.service.connection.postgres.PostgresR2dbcDockerComposeConnectionDetailsFactory,\
+org.springframework.boot.docker.compose.service.connection.pulsar.PulsarDockerComposeConnectionDetailsFactory,\
 org.springframework.boot.docker.compose.service.connection.rabbit.RabbitDockerComposeConnectionDetailsFactory,\
 org.springframework.boot.docker.compose.service.connection.redis.RedisDockerComposeConnectionDetailsFactory,\
 org.springframework.boot.docker.compose.service.connection.sqlserver.SqlServerJdbcDockerComposeConnectionDetailsFactory,\
 org.springframework.boot.docker.compose.service.connection.sqlserver.SqlServerR2dbcDockerComposeConnectionDetailsFactory,\
 org.springframework.boot.docker.compose.service.connection.zipkin.ZipkinDockerComposeConnectionDetailsFactory
-

--- a/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/pulsar/PulsarDockerComposeConnectionDetailsFactoryIntegrationTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/pulsar/PulsarDockerComposeConnectionDetailsFactoryIntegrationTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docker.compose.service.connection.pulsar;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.pulsar.PulsarConnectionDetails;
+import org.springframework.boot.docker.compose.service.connection.test.AbstractDockerComposeIntegrationTests;
+import org.springframework.boot.testsupport.testcontainers.DockerImageNames;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link PulsarDockerComposeConnectionDetailsFactory}.
+ *
+ * @author Chris Bono
+ */
+class PulsarDockerComposeConnectionDetailsFactoryIntegrationTests extends AbstractDockerComposeIntegrationTests {
+
+	PulsarDockerComposeConnectionDetailsFactoryIntegrationTests() {
+		super("pulsar-compose.yaml", DockerImageNames.pulsar());
+	}
+
+	@Test
+	void runCreatesConnectionDetails() {
+		PulsarConnectionDetails connectionDetails = run(PulsarConnectionDetails.class);
+		assertThat(connectionDetails).isNotNull();
+		assertThat(connectionDetails.getPulsarBrokerUrl()).matches("^pulsar:\\/\\/\\S+:\\d+");
+		assertThat(connectionDetails.getPulsarAdminUrl()).matches("^http:\\/\\/\\S+:\\d+");
+	}
+
+}

--- a/spring-boot-project/spring-boot-docker-compose/src/test/resources/org/springframework/boot/docker/compose/service/connection/pulsar/pulsar-compose.yaml
+++ b/spring-boot-project/spring-boot-docker-compose/src/test/resources/org/springframework/boot/docker/compose/service/connection/pulsar/pulsar-compose.yaml
@@ -1,0 +1,9 @@
+services:
+  pulsar:
+    image: '{imageName}'
+    ports:
+      - '8080'
+      - '6650'
+    command: bin/pulsar standalone
+    healthcheck:
+      test: curl http://127.0.0.1:8080/admin/v2/namespaces/public/default

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/docker-compose.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/docker-compose.adoc
@@ -76,6 +76,9 @@ The following service connections are currently supported:
 | `MongoConnectionDetails`
 | Containers named "mongo"
 
+| `PulsarConnectionDetails`
+| Containers named "apachepulsar/pulsar"
+
 | `R2dbcConnectionDetails`
 | Containers named "gvenzl/oracle-xe", "mariadb", "mssql/server", "mysql", or "postgres"
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/testing.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/testing.adoc
@@ -992,6 +992,9 @@ The following service connection factories are provided in the `spring-boot-test
 | `Neo4jConnectionDetails`
 | Containers of type `Neo4jContainer`
 
+| `PulsarConnectionDetails`
+| Containers of type `PulsarContainer`
+
 | `R2dbcConnectionDetails`
 | Containers of type `MariaDBContainer`, `MSSQLServerContainer`, `MySQLContainer`, `OracleContainer`, or `PostgreSQLContainer`
 

--- a/spring-boot-project/spring-boot-testcontainers/build.gradle
+++ b/spring-boot-project/spring-boot-testcontainers/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	optional("org.testcontainers:neo4j")
 	optional("org.testcontainers:oracle-xe")
 	optional("org.testcontainers:postgresql")
+	optional("org.testcontainers:pulsar")
 	optional("org.testcontainers:rabbitmq")
 	optional("org.testcontainers:redpanda")
 	optional("org.testcontainers:r2dbc")
@@ -50,8 +51,13 @@ dependencies {
 	testImplementation("org.springframework:spring-r2dbc")
 	testImplementation("org.springframework.amqp:spring-rabbit")
 	testImplementation("org.springframework.kafka:spring-kafka")
+	testImplementation("org.springframework.pulsar:spring-pulsar")
 	testImplementation("org.testcontainers:junit-jupiter")
 
 	testRuntimeOnly("com.oracle.database.r2dbc:oracle-r2dbc")
 }
 
+test {
+	jvmArgs += "--add-opens=java.base/java.net=ALL-UNNAMED"
+	jvmArgs += "--add-opens=java.base/sun.net=ALL-UNNAMED"
+}

--- a/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/pulsar/PulsarContainerConnectionDetailsFactory.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/pulsar/PulsarContainerConnectionDetailsFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.testcontainers.service.connection.pulsar;
+
+import org.testcontainers.containers.PulsarContainer;
+
+import org.springframework.boot.autoconfigure.pulsar.PulsarConnectionDetails;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionDetailsFactory;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionSource;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+
+/**
+ * {@link ContainerConnectionDetailsFactory} to create {@link PulsarConnectionDetails}
+ * from a {@link ServiceConnection @ServiceConnection}-annotated {@link PulsarContainer}.
+ *
+ * @author Chris Bono
+ */
+class PulsarContainerConnectionDetailsFactory
+		extends ContainerConnectionDetailsFactory<PulsarContainer, PulsarConnectionDetails> {
+
+	@Override
+	protected PulsarConnectionDetails getContainerConnectionDetails(ContainerConnectionSource<PulsarContainer> source) {
+		return new PulsarContainerConnectionDetails(source);
+	}
+
+	/**
+	 * {@link PulsarConnectionDetails} backed by a {@link ContainerConnectionSource}.
+	 */
+	private static final class PulsarContainerConnectionDetails extends ContainerConnectionDetails<PulsarContainer>
+			implements PulsarConnectionDetails {
+
+		private PulsarContainerConnectionDetails(ContainerConnectionSource<PulsarContainer> source) {
+			super(source);
+		}
+
+		@Override
+		public String getPulsarBrokerUrl() {
+			return getContainer().getPulsarBrokerUrl();
+		}
+
+		@Override
+		public String getPulsarAdminUrl() {
+			return getContainer().getHttpServiceUrl();
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/pulsar/package-info.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/pulsar/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for testcontainers Pulsar service connections.
+ */
+package org.springframework.boot.testcontainers.service.connection.pulsar;

--- a/spring-boot-project/spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
@@ -19,6 +19,7 @@ org.springframework.boot.testcontainers.service.connection.kafka.KafkaContainerC
 org.springframework.boot.testcontainers.service.connection.liquibase.LiquibaseContainerConnectionDetailsFactory,\
 org.springframework.boot.testcontainers.service.connection.mongo.MongoContainerConnectionDetailsFactory,\
 org.springframework.boot.testcontainers.service.connection.neo4j.Neo4jContainerConnectionDetailsFactory,\
+org.springframework.boot.testcontainers.service.connection.pulsar.PulsarContainerConnectionDetailsFactory,\
 org.springframework.boot.testcontainers.service.connection.r2dbc.MariaDbR2dbcContainerConnectionDetailsFactory,\
 org.springframework.boot.testcontainers.service.connection.r2dbc.MySqlR2dbcContainerConnectionDetailsFactory,\
 org.springframework.boot.testcontainers.service.connection.r2dbc.OracleR2dbcContainerConnectionDetailsFactory,\

--- a/spring-boot-project/spring-boot-testcontainers/src/test/java/org/springframework/boot/testcontainers/service/connection/pulsar/PulsarContainerConnectionDetailsFactoryIntegrationTests.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/test/java/org/springframework/boot/testcontainers/service/connection/pulsar/PulsarContainerConnectionDetailsFactoryIntegrationTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.testcontainers.service.connection.pulsar;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PulsarContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.pulsar.PulsarAutoConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.testsupport.testcontainers.DockerImageNames;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.pulsar.annotation.PulsarListener;
+import org.springframework.pulsar.core.PulsarTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link PulsarContainerConnectionDetailsFactory}.
+ *
+ * @author Chris Bono
+ */
+@SpringJUnitConfig
+@Testcontainers(disabledWithoutDocker = true)
+@TestPropertySource(properties = { "spring.pulsar.consumer.subscription.initial-position=earliest" })
+class PulsarContainerConnectionDetailsFactoryIntegrationTests {
+
+	@Container
+	@ServiceConnection
+	@SuppressWarnings("unused")
+	static final PulsarContainer PULSAR = new PulsarContainer(DockerImageNames.pulsar())
+		.withStartupTimeout(Duration.ofMinutes(3));
+
+	@Autowired
+	private PulsarTemplate<String> pulsarTemplate;
+
+	@Autowired
+	private TestListener listener;
+
+	@Test
+	void connectionCanBeMadeToPulsarContainer() throws PulsarClientException {
+		this.pulsarTemplate.send("test-topic", "test-data");
+		Awaitility.waitAtMost(Duration.ofSeconds(30))
+			.untilAsserted(() -> assertThat(this.listener.messages).containsExactly("test-data"));
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportAutoConfiguration(PulsarAutoConfiguration.class)
+	static class TestConfiguration {
+
+		@Bean
+		TestListener testListener() {
+			return new TestListener();
+		}
+
+	}
+
+	static class TestListener {
+
+		private final List<String> messages = new ArrayList<>();
+
+		@PulsarListener(topics = "test-topic")
+		void processMessage(String message) {
+			this.messages.add(message);
+		}
+
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-pulsar/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-pulsar/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-pulsar-reactive"))
 	testImplementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-test"))
 	testImplementation(project(":spring-boot-project:spring-boot-tools:spring-boot-test-support"))
+	testImplementation(project(":spring-boot-project:spring-boot-testcontainers"))
 	testImplementation("org.awaitility:awaitility")
 	testImplementation("org.testcontainers:junit-jupiter")
 	testImplementation("org.testcontainers:pulsar")

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-pulsar/src/test/java/smoketest/pulsar/SamplePulsarApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-pulsar/src/test/java/smoketest/pulsar/SamplePulsarApplicationTests.java
@@ -32,10 +32,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.boot.testsupport.testcontainers.DockerImageNames;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,14 +43,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SamplePulsarApplicationTests {
 
 	@Container
+	@ServiceConnection
+	@SuppressWarnings("unused")
 	static final PulsarContainer container = new PulsarContainer(DockerImageNames.pulsar()).withStartupAttempts(2)
 		.withStartupTimeout(Duration.ofMinutes(3));
-
-	@DynamicPropertySource
-	static void pulsarProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.pulsar.client.service-url", container::getPulsarBrokerUrl);
-		registry.add("spring.pulsar.admin.service-url", container::getHttpServiceUrl);
-	}
 
 	abstract class PulsarApplication {
 


### PR DESCRIPTION
1. Add connection details to Pulsar auto-configuration.
2. Add service connection details impl to Pulsar for testcontainers support
3. Update Pulsar smoke tests to use `@ServiceConnection`
4. Add docker compose connection details impl (Docker Compose support)

cc: @eddumelendez @philwebb 