### PR TITLE
Add default value metadata for management.metrics.export.signalfx.published-histogram-type

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -465,6 +465,10 @@
       }
     },
     {
+      "name": "management.metrics.export.signalfx.published-histogram-type",
+      "defaultValue": "default"
+    },
+    {
       "name": "management.metrics.export.simple.mode",
       "defaultValue": "cumulative"
     },


### PR DESCRIPTION
This PR adds default value metadata for `management.metrics.export.signalfx.published-histogram-type`.

See gh-36497