### PR TITLE
Correct the description of spring.artemis.broker-url

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisProperties.java
@@ -44,7 +44,7 @@ public class ArtemisProperties {
 	private ArtemisMode mode;
 
 	/**
-	 * Artemis broker port.
+	 * Artemis broker url.
 	 */
 	private String brokerUrl;
 


### PR DESCRIPTION
Fix description of brokerUrl property refer to url instead of port.