### PR TITLE
Polish Javadoc for DockerImageNames.rabbit()

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/testcontainers/DockerImageNames.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/testcontainers/DockerImageNames.java
@@ -97,7 +97,8 @@ public final class DockerImageNames {
 
 	/**
 	 * Return a {@link DockerImageName} suitable for running RabbitMQ.
-	 * @return a docker image name for running redis
+	 * @return a docker image name for running RabbitMQ
+	 * @since 2.7.15
 	 */
 	public static DockerImageName rabbit() {
 		return DockerImageName.parse("rabbitmq").withTag(RABBIT_VERSION);


### PR DESCRIPTION
This PR polishes Javadoc for `DockerImageNames.rabbit()` a bit.

See gh-36610