### PR TITLE
Test in `ExtractCommandTests` writes files to the project directory

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/test/java/org/springframework/boot/jarmode/layertools/ExtractCommandTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/test/java/org/springframework/boot/jarmode/layertools/ExtractCommandTests.java
@@ -167,6 +167,7 @@ class ExtractCommandTests {
 			}
 		});
 		given(this.context.getArchiveFile()).willReturn(this.jarFile);
+		given(this.context.getWorkingDir()).willReturn(this.extract);
 		assertThatIllegalStateException()
 			.isThrownBy(() -> this.command.run(Collections.emptyMap(), Collections.emptyList()))
 			.withMessageContaining("Entry 'e/../../e.jar' would be written");


### PR DESCRIPTION
This change fixes the `ExtractCommandTests#runWithJarFileThatWouldWriteEntriesOutsideDestinationFails` test to not write files to the project directory. This could cause issues with Gradle caching and up-to-date checks because some tasks depend on the project directory as an input (for example [Checkstyle](https://ge.solutions-team.gradle.com/c/nesra5apxdw7s/w3ds7hqzi2zpc/task-inputs?cacheability=cacheable&expanded=WyJ6NTZzZmNjamRybWZzLXNvdXJjZSIsIno1NnNmY2NqZHJtZnMtc291cmNlLTAtMCJd#change-z56sfccjdrmfs-source-0-0-0)). See below:

![image](https://github.com/spring-projects/spring-boot/assets/5797900/5966f6f7-6ead-46f1-9fbb-d7742a3e92fd)

To address this, I mocked the working directory to a temporary directory like all the other tests in this class.