### PR TITLE
Remove duplicate code in NettyWebServerFactoryCustomizer

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/NettyWebServerFactoryCustomizer.java
@@ -65,7 +65,6 @@ public class NettyWebServerFactoryCustomizer
 			.to((maxKeepAliveRequests) -> customizeMaxKeepAliveRequests(factory, maxKeepAliveRequests));
 		if (this.serverProperties.getHttp2() != null && this.serverProperties.getHttp2().isEnabled()) {
 			map.from(this.serverProperties.getMaxHttpRequestHeaderSize())
-				.whenNonNull()
 				.to((size) -> customizeHttp2MaxHeaderSize(factory, size.toBytes()));
 		}
 		customizeRequestDecoder(factory, map);
@@ -87,23 +86,18 @@ public class NettyWebServerFactoryCustomizer
 	private void customizeRequestDecoder(NettyReactiveWebServerFactory factory, PropertyMapper propertyMapper) {
 		factory.addServerCustomizers((httpServer) -> httpServer.httpRequestDecoder((httpRequestDecoderSpec) -> {
 			propertyMapper.from(this.serverProperties.getMaxHttpRequestHeaderSize())
-				.whenNonNull()
 				.to((maxHttpRequestHeader) -> httpRequestDecoderSpec
 					.maxHeaderSize((int) maxHttpRequestHeader.toBytes()));
 			ServerProperties.Netty nettyProperties = this.serverProperties.getNetty();
 			propertyMapper.from(nettyProperties.getMaxInitialLineLength())
-				.whenNonNull()
 				.to((maxInitialLineLength) -> httpRequestDecoderSpec
 					.maxInitialLineLength((int) maxInitialLineLength.toBytes()));
 			propertyMapper.from(nettyProperties.getH2cMaxContentLength())
-				.whenNonNull()
 				.to((h2cMaxContentLength) -> httpRequestDecoderSpec
 					.h2cMaxContentLength((int) h2cMaxContentLength.toBytes()));
 			propertyMapper.from(nettyProperties.getInitialBufferSize())
-				.whenNonNull()
 				.to((initialBufferSize) -> httpRequestDecoderSpec.initialBufferSize((int) initialBufferSize.toBytes()));
 			propertyMapper.from(nettyProperties.isValidateHeaders())
-				.whenNonNull()
 				.to(httpRequestDecoderSpec::validateHeaders);
 			return httpRequestDecoderSpec;
 		}));


### PR DESCRIPTION
Since the PropertyMapper's `alwaysApplyingWhenNonNull()` has already been called, the subsequent `whenNonNull()` is unnecessary.