### PR TITLE
RepackageMojo doesn't support 1 digit numerical values for project.build.outputTimestamp

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/MavenBuildOutputTimestamp.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/MavenBuildOutputTimestamp.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.maven;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+public final class MavenBuildOutputTimestamp {
+
+	private MavenBuildOutputTimestamp() {
+		// Utility class
+	}
+
+	// This implementation was copied from the maven-archiver
+	// https://github.com/apache/maven-archiver/blob/cc2f6a219f6563f450b0c00e8ccd651520b67406/src/main/java/org/apache/maven/archiver/MavenArchiver.java#L768
+
+	private static final Instant DATE_MIN = Instant.parse("1980-01-01T00:00:02Z");
+
+	private static final Instant DATE_MAX = Instant.parse("2099-12-31T23:59:59Z");
+
+	/**
+	 * Parse output timestamp configured for Reproducible Builds' archive entries.
+	 *
+	 * <p>
+	 * Either as {@link java.time.format.DateTimeFormatter#ISO_OFFSET_DATE_TIME} or as a
+	 * number representing seconds since the epoch (like <a href=
+	 * "https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>).
+	 * @param outputTimestamp the value of {@code ${project.build.outputTimestamp}}
+	 * (maybe {@code null})
+	 * @return the parsed timestamp as an {@code Optional<Instant>}, {@code empty} if
+	 * input is {@code null} or input contains only 1 character (not a number)
+	 * @throws IllegalArgumentException if the outputTimestamp is neither ISO 8601 nor an
+	 * integer, or it's not within the valid range 1980-01-01T00:00:02Z to
+	 * 2099-12-31T23:59:59Z
+	 */
+	public static Optional<Instant> parseBuildOutputTimestamp(String outputTimestamp) {
+		// Fail-fast on nulls
+		if (outputTimestamp == null) {
+			return Optional.empty();
+		}
+
+		// Number representing seconds since the epoch
+		if (isNumeric(outputTimestamp)) {
+			return Optional.of(Instant.ofEpochSecond(Long.parseLong(outputTimestamp)));
+		}
+
+		// no timestamp configured (1 character configuration is useful to override a full
+		// value during pom
+		// inheritance)
+		if (outputTimestamp.length() < 2) {
+			return Optional.empty();
+		}
+
+		try {
+			// Parse the date in UTC such as '2011-12-03T10:15:30Z' or with an offset
+			// '2019-10-05T20:37:42+06:00'.
+			final Instant date = OffsetDateTime.parse(outputTimestamp)
+				.withOffsetSameInstant(ZoneOffset.UTC)
+				.truncatedTo(ChronoUnit.SECONDS)
+				.toInstant();
+
+			if (date.isBefore(DATE_MIN) || date.isAfter(DATE_MAX)) {
+				throw new IllegalArgumentException(
+						"'" + date + "' is not within the valid range " + DATE_MIN + " to " + DATE_MAX);
+			}
+			return Optional.of(date);
+		}
+		catch (DateTimeParseException pe) {
+			throw new IllegalArgumentException("Invalid project.build.outputTimestamp value '" + outputTimestamp + "'",
+					pe);
+		}
+	}
+
+	private static boolean isNumeric(String str) {
+
+		if (str.isEmpty()) {
+			return false;
+		}
+
+		for (char c : str.toCharArray()) {
+			if (!Character.isDigit(c)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
@@ -222,9 +222,12 @@ public class RepackageMojo extends AbstractPackagerMojo {
 	}
 
 	private FileTime parseOutputTimestamp() {
-		// Maven ignores a single-character timestamp as it is "useful to override a full
-		// value during pom inheritance"
-		if (this.outputTimestamp == null || this.outputTimestamp.length() < 2) {
+		// Maven ignores a single-character non-digit timestamp as it is
+		// "useful to override a full value during pom inheritance"
+		if (this.outputTimestamp == null || this.outputTimestamp.isEmpty()) {
+			return null;
+		}
+		if (this.outputTimestamp.length() == 1 && !Character.isDigit(this.outputTimestamp.charAt(0))) {
 			return null;
 		}
 		return FileTime.from(getOutputTimestampEpochSeconds(), TimeUnit.SECONDS);

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
@@ -19,7 +19,6 @@ package org.springframework.boot.maven;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.attribute.FileTime;
-import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -222,24 +221,9 @@ public class RepackageMojo extends AbstractPackagerMojo {
 	}
 
 	private FileTime parseOutputTimestamp() {
-		// Maven ignores a single-character non-digit timestamp as it is
-		// "useful to override a full value during pom inheritance"
-		if (this.outputTimestamp == null || this.outputTimestamp.isEmpty()) {
-			return null;
-		}
-		if (this.outputTimestamp.length() == 1 && !Character.isDigit(this.outputTimestamp.charAt(0))) {
-			return null;
-		}
-		return FileTime.from(getOutputTimestampEpochSeconds(), TimeUnit.SECONDS);
-	}
-
-	private long getOutputTimestampEpochSeconds() {
-		try {
-			return Long.parseLong(this.outputTimestamp);
-		}
-		catch (NumberFormatException ex) {
-			return OffsetDateTime.parse(this.outputTimestamp).toInstant().getEpochSecond();
-		}
+		return MavenBuildOutputTimestamp.parseBuildOutputTimestamp(this.outputTimestamp)
+			.map(instant -> FileTime.from(instant.getEpochSecond(), TimeUnit.SECONDS))
+			.orElse(null);
 	}
 
 	private Repackager getRepackager(File source) {


### PR DESCRIPTION
For a build to be reproducible the `project.build.outputTimestamp` needs to be set to a valid value for the `spring-boot-maven-plugin`.

This can be either a number (indicating the epoch seconds) or an ISO 8601 timestamp.

These example values all work as expected (plugin version 3.1.3):
- '2023-09-17T12:34:56Z' --> Valid timestamp
- '1694946896' --> Valid timestamp
- 'a' --> Valid (= null, no timestamp)
- '' --> Valid (= null, no timestamp)
- 'aa' --> Invalid (parse error, build fails)

This merge request fixes the edge case of having a single character numerical timestamp which has been implemented differently from what Maven does.

Maven accepts a '0' as a valid timestamp.
See for example https://github.com/apache/maven-archiver/blob/master/src/main/java/org/apache/maven/archiver/MavenArchiver.java#L762

The Spring Boot maven plugin currently sees the '0' as a null instead (i.e. no timestamp set instead of epoch=0).