### PR TITLE
Use "spring.application.name" as fallback of "spring.kafka.consumer.group-id"

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
@@ -276,7 +276,7 @@ public class KafkaProperties {
 
 		/**
 		 * Unique string that identifies the consumer group to which this consumer
-		 * belongs.
+		 * belongs, default to "spring.application.name" if present.
 		 */
 		private String groupId;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfigurationTests.java
@@ -107,6 +107,7 @@ import static org.mockito.Mockito.never;
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Yanming Zhou
  */
 class KafkaAutoConfigurationTests {
 
@@ -166,6 +167,25 @@ class KafkaAutoConfigurationTests {
 				assertThat(configs).containsEntry("baz", "qux");
 				assertThat(configs).containsEntry("foo.bar.baz", "qux.fiz.buz");
 				assertThat(configs).containsEntry("fiz.buz", "fix.fox");
+			});
+	}
+
+	@Test
+	void consumerPropertiesWithApplicationNameAndWithoutGroupId() {
+		this.contextRunner.withPropertyValues("spring.application.name=foo").run((context) -> {
+			DefaultKafkaConsumerFactory<?, ?> consumerFactory = context.getBean(DefaultKafkaConsumerFactory.class);
+			Map<String, Object> configs = consumerFactory.getConfigurationProperties();
+			assertThat(configs).containsEntry(ConsumerConfig.GROUP_ID_CONFIG, "foo");
+		});
+	}
+
+	@Test
+	void consumerPropertiesWithBothApplicationNameAndGroupId() {
+		this.contextRunner.withPropertyValues("spring.kafka.consumer.group-id=bar", "spring.application.name=foo")
+			.run((context) -> {
+				DefaultKafkaConsumerFactory<?, ?> consumerFactory = context.getBean(DefaultKafkaConsumerFactory.class);
+				Map<String, Object> configs = consumerFactory.getConfigurationProperties();
+				assertThat(configs).containsEntry(ConsumerConfig.GROUP_ID_CONFIG, "bar");
 			});
 	}
 


### PR DESCRIPTION
Keep it consistent with `spring.kafka.streams.application-id`.

https://github.com/spring-projects/spring-boot/blob/4c4fdb35e9b7e4d83405355e75b26b2c20b5d380/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaStreamsAnnotationDrivenConfiguration.java#L63-L76