### PR TITLE
Rename JMS listener minimum concurrency property

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsProperties.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.jms;
 import java.time.Duration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 /**
  * Configuration properties for JMS.
@@ -148,7 +149,7 @@ public class JmsProperties {
 		/**
 		 * Minimum number of concurrent consumers.
 		 */
-		private Integer concurrency;
+		private Integer minConcurrency;
 
 		/**
 		 * Maximum number of concurrent consumers.
@@ -178,12 +179,23 @@ public class JmsProperties {
 			this.acknowledgeMode = acknowledgeMode;
 		}
 
+		@DeprecatedConfigurationProperty(replacement = "spring.jms.listener.min-concurrency", since = "3.2.0")
+		@Deprecated(since = "3.2.0", forRemoval = true)
 		public Integer getConcurrency() {
-			return this.concurrency;
+			return this.minConcurrency;
 		}
 
+		@Deprecated(since = "3.2.0", forRemoval = true)
 		public void setConcurrency(Integer concurrency) {
-			this.concurrency = concurrency;
+			this.minConcurrency = concurrency;
+		}
+
+		public Integer getMinConcurrency() {
+			return this.minConcurrency;
+		}
+
+		public void setMinConcurrency(Integer minConcurrency) {
+			this.minConcurrency = minConcurrency;
 		}
 
 		public Integer getMaxConcurrency() {
@@ -195,11 +207,11 @@ public class JmsProperties {
 		}
 
 		public String formatConcurrency() {
-			if (this.concurrency == null) {
+			if (this.minConcurrency == null) {
 				return (this.maxConcurrency != null) ? "1-" + this.maxConcurrency : null;
 			}
-			return ((this.maxConcurrency != null) ? this.concurrency + "-" + this.maxConcurrency
-					: String.valueOf(this.concurrency));
+			return ((this.maxConcurrency != null) ? this.minConcurrency + "-" + this.maxConcurrency
+					: String.valueOf(this.minConcurrency));
 		}
 
 		public Duration getReceiveTimeout() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
@@ -143,7 +143,7 @@ class JmsAutoConfigurationTests {
 	void testJmsListenerContainerFactoryWithCustomSettings() {
 		this.contextRunner.withUserConfiguration(EnableJmsConfiguration.class)
 			.withPropertyValues("spring.jms.listener.autoStartup=false", "spring.jms.listener.acknowledgeMode=client",
-					"spring.jms.listener.concurrency=2", "spring.jms.listener.receiveTimeout=2s",
+					"spring.jms.listener.minConcurrency=2", "spring.jms.listener.receiveTimeout=2s",
 					"spring.jms.listener.maxConcurrency=10")
 			.run(this::testJmsListenerContainerFactoryWithCustomSettings);
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsPropertiesTests.java
@@ -40,7 +40,7 @@ class JmsPropertiesTests {
 	@Test
 	void formatConcurrencyOnlyLowerBound() {
 		JmsProperties properties = new JmsProperties();
-		properties.getListener().setConcurrency(2);
+		properties.getListener().setMinConcurrency(2);
 		assertThat(properties.getListener().formatConcurrency()).isEqualTo("2");
 	}
 
@@ -54,7 +54,7 @@ class JmsPropertiesTests {
 	@Test
 	void formatConcurrencyBothBounds() {
 		JmsProperties properties = new JmsProperties();
-		properties.getListener().setConcurrency(2);
+		properties.getListener().setMinConcurrency(2);
 		properties.getListener().setMaxConcurrency(10);
 		assertThat(properties.getListener().formatConcurrency()).isEqualTo("2-10");
 	}


### PR DESCRIPTION
This commit renames `spring.jms.listener.concurrency` property to `spring.jms.listener.min-concurrency` in order to better align it with `spring.jms.listener.max-concurrency`.

Closes gh-37448

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
