### PR TITLE
Add Javadoc since for AbstractAotMojo.getSession()

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractAotMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractAotMojo.java
@@ -96,6 +96,11 @@ public abstract class AbstractAotMojo extends AbstractDependencyFilterMojo {
 	@Parameter(property = "spring-boot.aot.compilerArguments")
 	private String compilerArguments;
 
+	/**
+	 * Return Maven execution session.
+	 * @return session
+	 * @since 3.0.10
+	 */
 	protected final MavenSession getSession() {
 		return this.session;
 	}


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `AbstractAotMojo.getSession()`.

See gh-36724