### PR TITLE
Add a configuration property for configuring sessionTransacted flag on auto-configured JMS listener container

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/DefaultJmsListenerContainerFactoryConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/DefaultJmsListenerContainerFactoryConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.util.Assert;
  *
  * @author Stephane Nicoll
  * @author Eddú Meléndez
+ * @author Vedran Pavic
  * @since 1.3.3
  */
 public final class DefaultJmsListenerContainerFactoryConfigurer {
@@ -101,11 +102,15 @@ public final class DefaultJmsListenerContainerFactoryConfigurer {
 		Assert.notNull(connectionFactory, "ConnectionFactory must not be null");
 		factory.setConnectionFactory(connectionFactory);
 		factory.setPubSubDomain(this.jmsProperties.isPubSubDomain());
+		JmsProperties.Listener listener = this.jmsProperties.getListener();
 		if (this.transactionManager != null) {
 			factory.setTransactionManager(this.transactionManager);
 		}
-		else {
+		else if (listener.getSessionTransacted() == null) {
 			factory.setSessionTransacted(true);
+		}
+		if (listener.getSessionTransacted() != null) {
+			factory.setSessionTransacted(listener.getSessionTransacted());
 		}
 		if (this.destinationResolver != null) {
 			factory.setDestinationResolver(this.destinationResolver);
@@ -116,7 +121,6 @@ public final class DefaultJmsListenerContainerFactoryConfigurer {
 		if (this.exceptionListener != null) {
 			factory.setExceptionListener(this.exceptionListener);
 		}
-		JmsProperties.Listener listener = this.jmsProperties.getListener();
 		factory.setAutoStartup(listener.isAutoStartup());
 		if (listener.getAcknowledgeMode() != null) {
 			factory.setSessionAcknowledgeMode(listener.getAcknowledgeMode().getMode());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsProperties.java
@@ -27,6 +27,7 @@ import org.springframework.boot.context.properties.DeprecatedConfigurationProper
  * @author Greg Turnquist
  * @author Phillip Webb
  * @author Stephane Nicoll
+ * @author Vedran Pavic
  * @since 1.0.0
  */
 @ConfigurationProperties(prefix = "spring.jms")
@@ -147,6 +148,11 @@ public class JmsProperties {
 		private AcknowledgeMode acknowledgeMode;
 
 		/**
+		 * Whether the container should use transacted JMS sessions.
+		 */
+		private Boolean sessionTransacted;
+
+		/**
 		 * Minimum number of concurrent consumers. When max-concurrency is not specified
 		 * the minimum will also be used as the maximum.
 		 */
@@ -178,6 +184,14 @@ public class JmsProperties {
 
 		public void setAcknowledgeMode(AcknowledgeMode acknowledgeMode) {
 			this.acknowledgeMode = acknowledgeMode;
+		}
+
+		public Boolean getSessionTransacted() {
+			return this.sessionTransacted;
+		}
+
+		public void setSessionTransacted(Boolean sessionTransacted) {
+			this.sessionTransacted = sessionTransacted;
 		}
 
 		@DeprecatedConfigurationProperty(replacement = "spring.jms.listener.min-concurrency", since = "3.2.0")

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
@@ -57,6 +57,7 @@ import static org.mockito.Mockito.mock;
  * @author Stephane Nicoll
  * @author Aurélien Leboulanger
  * @author Eddú Meléndez
+ * @author Vedran Pavic
  */
 class JmsAutoConfigurationTests {
 
@@ -143,8 +144,8 @@ class JmsAutoConfigurationTests {
 	void testJmsListenerContainerFactoryWithCustomSettings() {
 		this.contextRunner.withUserConfiguration(EnableJmsConfiguration.class)
 			.withPropertyValues("spring.jms.listener.autoStartup=false", "spring.jms.listener.acknowledgeMode=client",
-					"spring.jms.listener.minConcurrency=2", "spring.jms.listener.receiveTimeout=2s",
-					"spring.jms.listener.maxConcurrency=10")
+					"spring.jms.listener.sessionTransacted=false", "spring.jms.listener.minConcurrency=2",
+					"spring.jms.listener.receiveTimeout=2s", "spring.jms.listener.maxConcurrency=10")
 			.run(this::testJmsListenerContainerFactoryWithCustomSettings);
 	}
 
@@ -152,6 +153,7 @@ class JmsAutoConfigurationTests {
 		DefaultMessageListenerContainer container = getContainer(loaded, "jmsListenerContainerFactory");
 		assertThat(container.isAutoStartup()).isFalse();
 		assertThat(container.getSessionAcknowledgeMode()).isEqualTo(Session.CLIENT_ACKNOWLEDGE);
+		assertThat(container.isSessionTransacted()).isFalse();
 		assertThat(container.getConcurrentConsumers()).isEqualTo(2);
 		assertThat(container.getMaxConcurrentConsumers()).isEqualTo(10);
 		assertThat(container).hasFieldOrPropertyWithValue("receiveTimeout", 2000L);
@@ -180,6 +182,18 @@ class JmsAutoConfigurationTests {
 	}
 
 	@Test
+	void testDefaultContainerFactoryWithJtaTransactionManagerAndSessionTransactedEnabled() {
+		this.contextRunner.withUserConfiguration(TestConfiguration7.class, EnableJmsConfiguration.class)
+			.withPropertyValues("spring.jms.listener.sessionTransacted=true")
+			.run((context) -> {
+				DefaultMessageListenerContainer container = getContainer(context, "jmsListenerContainerFactory");
+				assertThat(container.isSessionTransacted()).isTrue();
+				assertThat(container).hasFieldOrPropertyWithValue("transactionManager",
+						context.getBean(JtaTransactionManager.class));
+			});
+	}
+
+	@Test
 	void testDefaultContainerFactoryNonJtaTransactionManager() {
 		this.contextRunner.withUserConfiguration(TestConfiguration8.class, EnableJmsConfiguration.class)
 			.run((context) -> {
@@ -196,6 +210,17 @@ class JmsAutoConfigurationTests {
 			assertThat(container.isSessionTransacted()).isTrue();
 			assertThat(container).hasFieldOrPropertyWithValue("transactionManager", null);
 		});
+	}
+
+	@Test
+	void testDefaultContainerFactoryNoTransactionManagerAndSessionTransactedDisabled() {
+		this.contextRunner.withUserConfiguration(EnableJmsConfiguration.class)
+			.withPropertyValues("spring.jms.listener.sessionTransacted=false")
+			.run((context) -> {
+				DefaultMessageListenerContainer container = getContainer(context, "jmsListenerContainerFactory");
+				assertThat(container.isSessionTransacted()).isFalse();
+				assertThat(container).hasFieldOrPropertyWithValue("transactionManager", null);
+			});
 	}
 
 	@Test


### PR DESCRIPTION
This commit introduces `spring.jms.listener.session-transacted` property in order to enable explicit configuration of `sessionTransacted` on the `DefaultMessageListenerContainer`.

Prior to this commit, `sessionTransacted` would be configured implicitly based on presence of `JtaTransactionManager`.

---

The background for this change is that some JMS providers (SQS in my case) do not support transactions (see [related code](https://github.com/awslabs/amazon-sqs-java-messaging-lib/blob/4cb91355cb92d9361a2179233c9db89383b1299e/src/main/java/com/amazon/sqs/javamessaging/SQSSession.java#L721-L727)). With such a provider, the default behavior of auto-configuration to set `sessionTransacted` to `true` when `JtaTransactionManager` is not present results in a non-working setup that requires something along these lines:

```java
@Bean
DefaultJmsListenerContainerFactory jmsListenerContainerFactory(ConnectionFactory connectionFactory,
        DefaultJmsListenerContainerFactoryConfigurer configurer) {
    DefaultJmsListenerContainerFactory jmsListenerContainerFactory = new DefaultJmsListenerContainerFactory();
    configurer.configure(jmsListenerContainerFactory, connectionFactory);
    jmsListenerContainerFactory.setSessionTransacted(false);
    return jmsListenerContainerFactory;
}
```

Note that this PR does not change the existing logic - if `spring.jms.listener.session-transacted` is not set, `sessionTransacted` will still be set based on presence of `JtaTransactionManager`.