### PR TITLE
Fix resolveAllWithDataSourceWhenValueDoesNotContainPlaceholderShouldNotInteractWithDataSource()

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/init/PlatformPlaceholderDatabaseDriverResolverTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/init/PlatformPlaceholderDatabaseDriverResolverTests.java
@@ -72,7 +72,7 @@ class PlatformPlaceholderDatabaseDriverResolverTests {
 	@Test
 	void resolveAllWithDataSourceWhenValueDoesNotContainPlaceholderShouldNotInteractWithDataSource() {
 		DataSource dataSource = mock(DataSource.class);
-		new PlatformPlaceholderDatabaseDriverResolver().resolveAll(mock(DataSource.class), "schema.sql");
+		new PlatformPlaceholderDatabaseDriverResolver().resolveAll(dataSource, "schema.sql");
 		then(dataSource).shouldHaveNoInteractions();
 	}
 


### PR DESCRIPTION
This PR fixes `resolveAllWithDataSourceWhenValueDoesNotContainPlaceholderShouldNotInteractWithDataSource()`.