### PR TITLE
Use 'MySql', 'MariaDb' instead 'Mysql', 'Mariadb'

### DIFF
--- a/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/mariadb/MariaDbEnvironmentTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/mariadb/MariaDbEnvironmentTests.java
@@ -30,25 +30,26 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Jinseong Hwang
  */
 class MariaDbEnvironmentTests {
 
 	@Test
-	void createWhenHasMariadbRandomRootPasswordThrowsException() {
+	void createWhenHasMariaDbRandomRootPasswordThrowsException() {
 		assertThatIllegalStateException()
 			.isThrownBy(() -> new MariaDbEnvironment(Map.of("MARIADB_RANDOM_ROOT_PASSWORD", "true")))
 			.withMessage("MARIADB_RANDOM_ROOT_PASSWORD is not supported");
 	}
 
 	@Test
-	void createWhenHasMysqlRandomRootPasswordThrowsException() {
+	void createWhenHasMySqlRandomRootPasswordThrowsException() {
 		assertThatIllegalStateException()
 			.isThrownBy(() -> new MariaDbEnvironment(Map.of("MYSQL_RANDOM_ROOT_PASSWORD", "true")))
 			.withMessage("MYSQL_RANDOM_ROOT_PASSWORD is not supported");
 	}
 
 	@Test
-	void createWhenHasMariadbRootPasswordHashThrowsException() {
+	void createWhenHasMariaDbRootPasswordHashThrowsException() {
 		assertThatIllegalStateException()
 			.isThrownBy(() -> new MariaDbEnvironment(Map.of("MARIADB_ROOT_PASSWORD_HASH", "0FF")))
 			.withMessage("MARIADB_ROOT_PASSWORD_HASH is not supported");
@@ -67,7 +68,7 @@ class MariaDbEnvironmentTests {
 	}
 
 	@Test
-	void getUsernameWhenHasMariadbUser() {
+	void getUsernameWhenHasMariaDbUser() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_USER", "myself", "MARIADB_PASSWORD", "secret", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getUsername()).isEqualTo("myself");
@@ -81,84 +82,84 @@ class MariaDbEnvironmentTests {
 	}
 
 	@Test
-	void getUsernameWhenHasMariadbUserAndMySqlUser() {
+	void getUsernameWhenHasMariaDbUserAndMySqlUser() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(Map.of("MARIADB_USER", "myself", "MYSQL_USER", "me",
 				"MARIADB_PASSWORD", "secret", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getUsername()).isEqualTo("myself");
 	}
 
 	@Test
-	void getUsernameWhenHasNoMariadbUserOrMySqlUser() {
+	void getUsernameWhenHasNoMariaDbUserOrMySqlUser() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_PASSWORD", "secret", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getUsername()).isEqualTo("root");
 	}
 
 	@Test
-	void getPasswordWhenHasMariadbPassword() {
+	void getPasswordWhenHasMariaDbPassword() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_PASSWORD", "secret", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEqualTo("secret");
 	}
 
 	@Test
-	void getPasswordWhenHasMysqlPassword() {
+	void getPasswordWhenHasMySqlPassword() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MYSQL_PASSWORD", "secret", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEqualTo("secret");
 	}
 
 	@Test
-	void getPasswordWhenHasMysqlRootPassword() {
+	void getPasswordWhenHasMySqlRootPassword() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MYSQL_ROOT_PASSWORD", "secret", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEqualTo("secret");
 	}
 
 	@Test
-	void getPasswordWhenHasMariadbPasswordAndMysqlPassword() {
+	void getPasswordWhenHasMariaDbPasswordAndMySqlPassword() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_PASSWORD", "secret", "MYSQL_PASSWORD", "donttell", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEqualTo("secret");
 	}
 
 	@Test
-	void getPasswordWhenHasMariadbPasswordAndMysqlRootPassword() {
+	void getPasswordWhenHasMariaDbPasswordAndMySqlRootPassword() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_PASSWORD", "secret", "MYSQL_ROOT_PASSWORD", "donttell", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEqualTo("secret");
 	}
 
 	@Test
-	void getPasswordWhenHasNoPasswordAndMariadbAllowEmptyPassword() {
+	void getPasswordWhenHasNoPasswordAndMariaDbAllowEmptyPassword() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_ALLOW_EMPTY_PASSWORD", "true", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEmpty();
 	}
 
 	@Test
-	void getPasswordWhenHasNoPasswordAndMysqlAllowEmptyPassword() {
+	void getPasswordWhenHasNoPasswordAndMySqlAllowEmptyPassword() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MYSQL_ALLOW_EMPTY_PASSWORD", "true", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEmpty();
 	}
 
 	@Test
-	void getDatabaseWhenHasMariadbDatabase() {
+	void getDatabaseWhenHasMariaDbDatabase() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_ALLOW_EMPTY_PASSWORD", "true", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getDatabase()).isEqualTo("db");
 	}
 
 	@Test
-	void getDatabaseWhenHasMysqlDatabase() {
+	void getDatabaseWhenHasMySqlDatabase() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_ALLOW_EMPTY_PASSWORD", "true", "MYSQL_DATABASE", "db"));
 		assertThat(environment.getDatabase()).isEqualTo("db");
 	}
 
 	@Test
-	void getDatabaseWhenHasMariadbAndMysqlDatabase() {
+	void getDatabaseWhenHasMariaDbAndMySqlDatabase() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_ALLOW_EMPTY_PASSWORD", "true", "MARIADB_DATABASE", "db", "MYSQL_DATABASE", "otherdb"));
 		assertThat(environment.getDatabase()).isEqualTo("db");

--- a/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/mariadb/MariaDbEnvironmentTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/mariadb/MariaDbEnvironmentTests.java
@@ -35,21 +35,21 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 class MariaDbEnvironmentTests {
 
 	@Test
-	void createWhenHasMariaDbRandomRootPasswordThrowsException() {
+	void createWhenHasMariadbRandomRootPasswordThrowsException() {
 		assertThatIllegalStateException()
 			.isThrownBy(() -> new MariaDbEnvironment(Map.of("MARIADB_RANDOM_ROOT_PASSWORD", "true")))
 			.withMessage("MARIADB_RANDOM_ROOT_PASSWORD is not supported");
 	}
 
 	@Test
-	void createWhenHasMySqlRandomRootPasswordThrowsException() {
+	void createWhenHasMysqlRandomRootPasswordThrowsException() {
 		assertThatIllegalStateException()
 			.isThrownBy(() -> new MariaDbEnvironment(Map.of("MYSQL_RANDOM_ROOT_PASSWORD", "true")))
 			.withMessage("MYSQL_RANDOM_ROOT_PASSWORD is not supported");
 	}
 
 	@Test
-	void createWhenHasMariaDbRootPasswordHashThrowsException() {
+	void createWhenHasMariadbRootPasswordHashThrowsException() {
 		assertThatIllegalStateException()
 			.isThrownBy(() -> new MariaDbEnvironment(Map.of("MARIADB_ROOT_PASSWORD_HASH", "0FF")))
 			.withMessage("MARIADB_ROOT_PASSWORD_HASH is not supported");
@@ -68,98 +68,98 @@ class MariaDbEnvironmentTests {
 	}
 
 	@Test
-	void getUsernameWhenHasMariaDbUser() {
+	void getUsernameWhenHasMariadbUser() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_USER", "myself", "MARIADB_PASSWORD", "secret", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getUsername()).isEqualTo("myself");
 	}
 
 	@Test
-	void getUsernameWhenHasMySqlUser() {
+	void getUsernameWhenHasMysqlUser() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MYSQL_USER", "myself", "MARIADB_PASSWORD", "secret", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getUsername()).isEqualTo("myself");
 	}
 
 	@Test
-	void getUsernameWhenHasMariaDbUserAndMySqlUser() {
+	void getUsernameWhenHasMariadbUserAndMysqlUser() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(Map.of("MARIADB_USER", "myself", "MYSQL_USER", "me",
 				"MARIADB_PASSWORD", "secret", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getUsername()).isEqualTo("myself");
 	}
 
 	@Test
-	void getUsernameWhenHasNoMariaDbUserOrMySqlUser() {
+	void getUsernameWhenHasNoMariadbUserOrMysqlUser() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_PASSWORD", "secret", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getUsername()).isEqualTo("root");
 	}
 
 	@Test
-	void getPasswordWhenHasMariaDbPassword() {
+	void getPasswordWhenHasMariadbPassword() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_PASSWORD", "secret", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEqualTo("secret");
 	}
 
 	@Test
-	void getPasswordWhenHasMySqlPassword() {
+	void getPasswordWhenHasMysqlPassword() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MYSQL_PASSWORD", "secret", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEqualTo("secret");
 	}
 
 	@Test
-	void getPasswordWhenHasMySqlRootPassword() {
+	void getPasswordWhenHasMysqlRootPassword() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MYSQL_ROOT_PASSWORD", "secret", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEqualTo("secret");
 	}
 
 	@Test
-	void getPasswordWhenHasMariaDbPasswordAndMySqlPassword() {
+	void getPasswordWhenHasMariadbPasswordAndMysqlPassword() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_PASSWORD", "secret", "MYSQL_PASSWORD", "donttell", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEqualTo("secret");
 	}
 
 	@Test
-	void getPasswordWhenHasMariaDbPasswordAndMySqlRootPassword() {
+	void getPasswordWhenHasMariadbPasswordAndMysqlRootPassword() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_PASSWORD", "secret", "MYSQL_ROOT_PASSWORD", "donttell", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEqualTo("secret");
 	}
 
 	@Test
-	void getPasswordWhenHasNoPasswordAndMariaDbAllowEmptyPassword() {
+	void getPasswordWhenHasNoPasswordAndMariadbAllowEmptyPassword() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_ALLOW_EMPTY_PASSWORD", "true", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEmpty();
 	}
 
 	@Test
-	void getPasswordWhenHasNoPasswordAndMySqlAllowEmptyPassword() {
+	void getPasswordWhenHasNoPasswordAndMysqlAllowEmptyPassword() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MYSQL_ALLOW_EMPTY_PASSWORD", "true", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEmpty();
 	}
 
 	@Test
-	void getDatabaseWhenHasMariaDbDatabase() {
+	void getDatabaseWhenHasMariadbDatabase() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_ALLOW_EMPTY_PASSWORD", "true", "MARIADB_DATABASE", "db"));
 		assertThat(environment.getDatabase()).isEqualTo("db");
 	}
 
 	@Test
-	void getDatabaseWhenHasMySqlDatabase() {
+	void getDatabaseWhenHasMysqlDatabase() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_ALLOW_EMPTY_PASSWORD", "true", "MYSQL_DATABASE", "db"));
 		assertThat(environment.getDatabase()).isEqualTo("db");
 	}
 
 	@Test
-	void getDatabaseWhenHasMariaDbAndMySqlDatabase() {
+	void getDatabaseWhenHasMariadbAndMysqlDatabase() {
 		MariaDbEnvironment environment = new MariaDbEnvironment(
 				Map.of("MARIADB_ALLOW_EMPTY_PASSWORD", "true", "MARIADB_DATABASE", "db", "MYSQL_DATABASE", "otherdb"));
 		assertThat(environment.getDatabase()).isEqualTo("db");

--- a/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/mysql/MySqlEnvironmentTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/mysql/MySqlEnvironmentTests.java
@@ -30,11 +30,12 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Jinseong Hwang
  */
 class MySqlEnvironmentTests {
 
 	@Test
-	void createWhenHasMysqlRandomRootPasswordThrowsException() {
+	void createWhenHasMySqlRandomRootPasswordThrowsException() {
 		assertThatIllegalStateException()
 			.isThrownBy(() -> new MySqlEnvironment(Map.of("MYSQL_RANDOM_ROOT_PASSWORD", "true")))
 			.withMessage("MYSQL_RANDOM_ROOT_PASSWORD is not supported");
@@ -66,27 +67,27 @@ class MySqlEnvironmentTests {
 	}
 
 	@Test
-	void getPasswordWhenHasMysqlPassword() {
+	void getPasswordWhenHasMySqlPassword() {
 		MySqlEnvironment environment = new MySqlEnvironment(Map.of("MYSQL_PASSWORD", "secret", "MYSQL_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEqualTo("secret");
 	}
 
 	@Test
-	void getPasswordWhenHasMysqlRootPassword() {
+	void getPasswordWhenHasMySqlRootPassword() {
 		MySqlEnvironment environment = new MySqlEnvironment(
 				Map.of("MYSQL_ROOT_PASSWORD", "secret", "MYSQL_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEqualTo("secret");
 	}
 
 	@Test
-	void getPasswordWhenHasNoPasswordAndMysqlAllowEmptyPassword() {
+	void getPasswordWhenHasNoPasswordAndMySqlAllowEmptyPassword() {
 		MySqlEnvironment environment = new MySqlEnvironment(
 				Map.of("MYSQL_ALLOW_EMPTY_PASSWORD", "true", "MYSQL_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEmpty();
 	}
 
 	@Test
-	void getDatabaseWhenHasMysqlDatabase() {
+	void getDatabaseWhenHasMySqlDatabase() {
 		MySqlEnvironment environment = new MySqlEnvironment(
 				Map.of("MYSQL_ALLOW_EMPTY_PASSWORD", "true", "MYSQL_DATABASE", "db"));
 		assertThat(environment.getDatabase()).isEqualTo("db");

--- a/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/mysql/MySqlEnvironmentTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/mysql/MySqlEnvironmentTests.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 class MySqlEnvironmentTests {
 
 	@Test
-	void createWhenHasMySqlRandomRootPasswordThrowsException() {
+	void createWhenHasMysqlRandomRootPasswordThrowsException() {
 		assertThatIllegalStateException()
 			.isThrownBy(() -> new MySqlEnvironment(Map.of("MYSQL_RANDOM_ROOT_PASSWORD", "true")))
 			.withMessage("MYSQL_RANDOM_ROOT_PASSWORD is not supported");
@@ -54,40 +54,40 @@ class MySqlEnvironmentTests {
 	}
 
 	@Test
-	void getUsernameWhenHasMySqlUser() {
+	void getUsernameWhenHasMysqlUser() {
 		MySqlEnvironment environment = new MySqlEnvironment(
 				Map.of("MYSQL_USER", "myself", "MYSQL_PASSWORD", "secret", "MYSQL_DATABASE", "db"));
 		assertThat(environment.getUsername()).isEqualTo("myself");
 	}
 
 	@Test
-	void getUsernameWhenHasNoMySqlUser() {
+	void getUsernameWhenHasNoMysqlUser() {
 		MySqlEnvironment environment = new MySqlEnvironment(Map.of("MYSQL_PASSWORD", "secret", "MYSQL_DATABASE", "db"));
 		assertThat(environment.getUsername()).isEqualTo("root");
 	}
 
 	@Test
-	void getPasswordWhenHasMySqlPassword() {
+	void getPasswordWhenHasMysqlPassword() {
 		MySqlEnvironment environment = new MySqlEnvironment(Map.of("MYSQL_PASSWORD", "secret", "MYSQL_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEqualTo("secret");
 	}
 
 	@Test
-	void getPasswordWhenHasMySqlRootPassword() {
+	void getPasswordWhenHasMysqlRootPassword() {
 		MySqlEnvironment environment = new MySqlEnvironment(
 				Map.of("MYSQL_ROOT_PASSWORD", "secret", "MYSQL_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEqualTo("secret");
 	}
 
 	@Test
-	void getPasswordWhenHasNoPasswordAndMySqlAllowEmptyPassword() {
+	void getPasswordWhenHasNoPasswordAndMysqlAllowEmptyPassword() {
 		MySqlEnvironment environment = new MySqlEnvironment(
 				Map.of("MYSQL_ALLOW_EMPTY_PASSWORD", "true", "MYSQL_DATABASE", "db"));
 		assertThat(environment.getPassword()).isEmpty();
 	}
 
 	@Test
-	void getDatabaseWhenHasMySqlDatabase() {
+	void getDatabaseWhenHasMysqlDatabase() {
 		MySqlEnvironment environment = new MySqlEnvironment(
 				Map.of("MYSQL_ALLOW_EMPTY_PASSWORD", "true", "MYSQL_DATABASE", "db"));
 		assertThat(environment.getDatabase()).isEqualTo("db");

--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/testcontainers/DockerImageNames.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/testcontainers/DockerImageNames.java
@@ -119,7 +119,7 @@ public final class DockerImageNames {
 
 	/**
 	 * Return a {@link DockerImageName} suitable for running MariaDB.
-	 * @return a docker image name for running Mariadb
+	 * @return a docker image name for running MariaDB
 	 */
 	public static DockerImageName mariadb() {
 		return DockerImageName.parse("mariadb").withTag(MARIADB_VERSION);


### PR DESCRIPTION
While reading the code of Spring Boot, I noticed inconsistency in capitalization. 

Here are some instances:

- In most classes and methods, 'MySql' is written as such, but in test methods, it's written as 'Mysql'.
- In most classes and methods, 'MariaDb' is written as such, but in test methods, it's written as 'Mariadb'.

I hope it leads to more consistent and readable code.
Thanks.