### PR TITLE
Disable validate connection on borrow for Oracle UCP datasource

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceConfiguration.java
@@ -180,7 +180,6 @@ abstract class DataSourceConfiguration {
 				throws SQLException {
 			PoolDataSourceImpl dataSource = createDataSource(connectionDetails, PoolDataSourceImpl.class,
 					properties.getClassLoader());
-			dataSource.setValidateConnectionOnBorrow(true);
 			if (StringUtils.hasText(properties.getName())) {
 				dataSource.setConnectionPoolName(properties.getName());
 			}


### PR DESCRIPTION
Removed setValidateConnectionOnBorrow method call while creating UCP datasource. This value should be false by default and can be overridden through datasource properties.