### PR TITLE
Add Spring Pulsar container property customizers

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfiguration.java
@@ -149,11 +149,12 @@ public class PulsarAutoConfiguration {
 	@ConditionalOnMissingBean(name = "pulsarListenerContainerFactory")
 	ConcurrentPulsarListenerContainerFactory<Object> pulsarListenerContainerFactory(
 			PulsarConsumerFactory<Object> pulsarConsumerFactory, SchemaResolver schemaResolver,
-			TopicResolver topicResolver) {
+			TopicResolver topicResolver, ObjectProvider<PulsarContainerPropertiesCustomizer> customizersProvider) {
 		PulsarContainerProperties containerProperties = new PulsarContainerProperties();
 		containerProperties.setSchemaResolver(schemaResolver);
 		containerProperties.setTopicResolver(topicResolver);
 		this.propertiesMapper.customizeContainerProperties(containerProperties);
+		customizersProvider.orderedStream().forEach((customizer) -> customizer.customize(containerProperties));
 		return new ConcurrentPulsarListenerContainerFactory<>(pulsarConsumerFactory, containerProperties);
 	}
 
@@ -178,10 +179,12 @@ public class PulsarAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(name = "pulsarReaderContainerFactory")
 	DefaultPulsarReaderContainerFactory<?> pulsarReaderContainerFactory(PulsarReaderFactory<?> pulsarReaderFactory,
-			SchemaResolver schemaResolver) {
+			SchemaResolver schemaResolver,
+			ObjectProvider<PulsarReaderContainerPropertiesCustomizer> customizersProvider) {
 		PulsarReaderContainerProperties readerContainerProperties = new PulsarReaderContainerProperties();
 		readerContainerProperties.setSchemaResolver(schemaResolver);
 		this.propertiesMapper.customizeReaderContainerProperties(readerContainerProperties);
+		customizersProvider.orderedStream().forEach((customizer) -> customizer.customize(readerContainerProperties));
 		return new DefaultPulsarReaderContainerFactory<>(pulsarReaderFactory, readerContainerProperties);
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarContainerPropertiesCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarContainerPropertiesCustomizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.pulsar;
+
+import org.springframework.pulsar.listener.PulsarContainerProperties;
+
+/**
+ * The interface to customize a {@link PulsarContainerProperties}.
+ *
+ * @author Chris Bono
+ * @since 3.2.0
+ */
+@FunctionalInterface
+public interface PulsarContainerPropertiesCustomizer {
+
+	/**
+	 * Customizes a {@link PulsarContainerProperties}.
+	 * @param containerProperties the container properties to customize
+	 */
+	void customize(PulsarContainerProperties containerProperties);
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarReaderContainerPropertiesCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarReaderContainerPropertiesCustomizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.pulsar;
+
+import org.springframework.pulsar.reader.PulsarReaderContainerProperties;
+
+/**
+ * The interface to customize a {@link PulsarReaderContainerProperties}.
+ *
+ * @author Chris Bono
+ * @since 3.2.0
+ */
+@FunctionalInterface
+public interface PulsarReaderContainerPropertiesCustomizer {
+
+	/**
+	 * Customizes a {@link PulsarReaderContainerProperties}.
+	 * @param containerProperties the container properties to customize
+	 */
+	void customize(PulsarReaderContainerProperties containerProperties);
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/ReactivePulsarContainerPropertiesCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/ReactivePulsarContainerPropertiesCustomizer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.pulsar;
+
+import org.springframework.pulsar.reactive.listener.ReactivePulsarContainerProperties;
+
+/**
+ * The interface to customize a {@link ReactivePulsarContainerProperties}.
+ *
+ * @param <T> the message payload type
+ * @author Chris Bono
+ * @since 3.2.0
+ */
+@FunctionalInterface
+public interface ReactivePulsarContainerPropertiesCustomizer<T> {
+
+	/**
+	 * Customizes a {@link ReactivePulsarContainerProperties}.
+	 * @param containerProperties the container properties to customize
+	 */
+	void customize(ReactivePulsarContainerProperties<T> containerProperties);
+
+}

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/messaging/pulsar.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/messaging/pulsar.adoc
@@ -140,7 +140,8 @@ If you need more control over the consumer factory configuration, consider regis
 These customizers are applied to all consumers created by the factory, and therefore all `@PulsarListener` instances.
 You can also customize a single listener by setting the `consumerCustomizer` attribute of the `@PulsarListener` annotation.
 
-
+The properties of the underlying listener container can also be customized by registering one or more `PulsarContainerPropertiesCustomizer` beans.
+These customizers are applied to all created listener containers.
 
 [[messaging.pulsar.receiving-reactive]]
 === Receiving a Message Reactively
@@ -156,7 +157,8 @@ If you need more control over the consumer factory configuration, consider regis
 These customizers are applied to all consumers created by the factory, and therefore all `@ReactivePulsarListener` instances.
 You can also customize a single listener by setting the `consumerCustomizer` attribute of the `@ReactivePulsarListener` annotation.
 
-
+The properties of the underlying listener container can also be customized by registering one or more `ReactivePulsarContainerPropertiesCustomizer` beans.
+These customizers are applied to all created listener containers.
 
 [[messaging.pulsar.reading]]
 === Reading a Message
@@ -175,6 +177,8 @@ If you need more control over the reader factory configuration, consider registe
 These customizers are applied to all readers created by the factory, and therefore all `@PulsarReader` instances.
 You can also customize a single listener by setting the `readerCustomizer` attribute of the `@PulsarReader` annotation.
 
+The properties of the underlying reader container can also be customized by registering one or more `PulsarReaderContainerPropertiesCustomizer` beans.
+These customizers are applied to all created reader containers.
 
 
 [[messaging.pulsar.reading-reactive]]


### PR DESCRIPTION
This commit adds the ability for users to register property customizers for the auto-configured Spring Pulsar listener containers.

The motivation is to ultimately give users the ability to set the `AsyncTaskExecutors` on the underlying listener containers to support Java virtual threads capability.

See #36347

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
