### PR TITLE
 Update documentation to align with Mockito 5 using the inline mock maker by default

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/testing.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/testing.adoc
@@ -299,11 +299,6 @@ We recommend using a `@Bean` method to create and configure the mock in this sit
 Additionally, you can use `@SpyBean` to wrap any existing bean with a Mockito `spy`.
 See the {spring-boot-test-module-api}/mock/mockito/SpyBean.html[Javadoc] for full details.
 
-NOTE: CGLib proxies, such as those created for scoped beans, declare the proxied methods as `final`.
-This stops Mockito from functioning correctly as it cannot mock or spy on `final` methods in its default configuration.
-If you want to mock or spy on such a bean, configure Mockito to use its inline mock maker by adding `org.mockito:mockito-inline` to your application's test dependencies.
-This allows Mockito to mock and spy on `final` methods.
-
 NOTE: While Spring's test framework caches application contexts between tests and reuses a context for tests sharing the same configuration, the use of `@MockBean` or `@SpyBean` influences the cache key, which will most likely increase the number of contexts.
 
 TIP: If you are using `@SpyBean` to spy on a bean with `@Cacheable` methods that refer to parameters by name, your application must be compiled with `-parameters`.


### PR DESCRIPTION
With the upgrade to Mockito 5.3,  it dropped the mockito-inline module. Removed [this note](https://github.com/spring-projects/spring-boot/blob/9d42cff472c7d67972036d60ed2b1e64b41ee253/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/testing.adoc?plain=1#L302-L305) from the documentation.

Fixes https://github.com/spring-projects/spring-boot/issues/36769
