### PR TITLE
Managed types for Neo4j are not used in Neo4j Data auto configuration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jDataAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.boot.autoconfigure.transaction.TransactionManagerCust
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.neo4j.aot.Neo4jManagedTypes;
 import org.springframework.data.neo4j.core.DatabaseSelectionProvider;
 import org.springframework.data.neo4j.core.Neo4jClient;
 import org.springframework.data.neo4j.core.Neo4jOperations;
@@ -71,12 +72,18 @@ public class Neo4jDataAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public Neo4jMappingContext neo4jMappingContext(ApplicationContext applicationContext,
-			Neo4jConversions neo4jConversions) throws ClassNotFoundException {
+	Neo4jManagedTypes neo4jManagedTypes(ApplicationContext applicationContext) throws ClassNotFoundException {
 		Set<Class<?>> initialEntityClasses = new EntityScanner(applicationContext).scan(Node.class,
 				RelationshipProperties.class);
+		return Neo4jManagedTypes.fromIterable(initialEntityClasses);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public Neo4jMappingContext neo4jMappingContext(Neo4jManagedTypes managedTypes, Neo4jConversions neo4jConversions) {
+
 		Neo4jMappingContext context = new Neo4jMappingContext(neo4jConversions);
-		context.setInitialEntitySet(initialEntityClasses);
+		context.setManagedTypes(managedTypes);
 		return context;
 	}
 


### PR DESCRIPTION
This fixes #37573.

I tested the fix locally in native image mode and added a test that reliable fails without using `Neo4jManagedTypes` proper. 
I don't know whether you run the integration tests in native mode, or put them somewhere else. If the latter is the case, please point me where I can move this or feel free to move it around yourself.

I suggest back porting this to 3.1 and 3.0 (I think 3.0 already managed SDN 7, including the dedicated managed types).

Thanks a lot!