### PR TITLE
Provide a configuration property for RabbitMQ's max inbound message body size

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitConnectionFactoryBeanConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitConnectionFactoryBeanConfigurer.java
@@ -133,6 +133,9 @@ public class RabbitConnectionFactoryBeanConfigurer {
 			.to(factory::setChannelRpcTimeout);
 		map.from(this.credentialsProvider).whenNonNull().to(factory::setCredentialsProvider);
 		map.from(this.credentialsRefreshService).whenNonNull().to(factory::setCredentialsRefreshService);
+		map.from(this.rabbitProperties.getMaxInboundMessageBodySize())
+			.whenNonNull()
+			.to(mimbs -> factory.setMaxInboundMessageBodySize(Math.toIntExact(mimbs.toBytes())));
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitConnectionFactoryBeanConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitConnectionFactoryBeanConfigurer.java
@@ -135,7 +135,7 @@ public class RabbitConnectionFactoryBeanConfigurer {
 		map.from(this.credentialsRefreshService).whenNonNull().to(factory::setCredentialsRefreshService);
 		map.from(this.rabbitProperties.getMaxInboundMessageBodySize())
 			.whenNonNull()
-			.to(mimbs -> factory.setMaxInboundMessageBodySize(Math.toIntExact(mimbs.toBytes())));
+			.to((mimbs) -> factory.setMaxInboundMessageBodySize(Math.toIntExact(mimbs.toBytes())));
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -31,6 +31,7 @@ import org.springframework.boot.context.properties.source.InvalidConfigurationPr
 import org.springframework.boot.convert.DurationUnit;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.util.unit.DataSize;
 
 /**
  * Configuration properties for Rabbit.
@@ -129,6 +130,11 @@ public class RabbitProperties {
 	 * Continuation timeout for RPC calls in channels. Set it to zero to wait forever.
 	 */
 	private Duration channelRpcTimeout = Duration.ofMinutes(10);
+
+	/**
+	 * Maximum body size of inbound (received) messages in bytes.
+	 */
+	private DataSize maxInboundMessageBodySize;
 
 	/**
 	 * Cache configuration.
@@ -358,6 +364,14 @@ public class RabbitProperties {
 
 	public void setChannelRpcTimeout(Duration channelRpcTimeout) {
 		this.channelRpcTimeout = channelRpcTimeout;
+	}
+
+	public DataSize getMaxInboundMessageBodySize() {
+		return this.maxInboundMessageBodySize;
+	}
+
+	public void setMaxInboundMessageBodySize(DataSize maxInboundMessageBodySize) {
+		this.maxInboundMessageBodySize = maxInboundMessageBodySize;
 	}
 
 	public Cache getCache() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitAutoConfigurationTests.java
@@ -150,6 +150,9 @@ class RabbitAutoConfigurationTests {
 			com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory = getTargetConnectionFactory(context);
 			assertThat(rabbitConnectionFactory.getUsername()).isEqualTo(properties.getUsername());
 			assertThat(rabbitConnectionFactory.getPassword()).isEqualTo(properties.getPassword());
+			com.rabbitmq.client.ConnectionFactory defaultCf = new com.rabbitmq.client.ConnectionFactory();
+			assertThat(rabbitConnectionFactory).hasFieldOrPropertyWithValue("maxInboundMessageBodySize",
+					ReflectionTestUtils.getField(defaultCf, "maxInboundMessageBodySize"));
 		});
 	}
 
@@ -160,7 +163,8 @@ class RabbitAutoConfigurationTests {
 			.withPropertyValues("spring.rabbitmq.host:remote-server", "spring.rabbitmq.port:9000",
 					"spring.rabbitmq.address-shuffle-mode=random", "spring.rabbitmq.username:alice",
 					"spring.rabbitmq.password:secret", "spring.rabbitmq.virtual_host:/vhost",
-					"spring.rabbitmq.connection-timeout:123", "spring.rabbitmq.channel-rpc-timeout:140")
+					"spring.rabbitmq.connection-timeout:123", "spring.rabbitmq.channel-rpc-timeout:140",
+					"spring.rabbitmq.max-inbound-message-body-size:128MB")
 			.run((context) -> {
 				CachingConnectionFactory connectionFactory = context.getBean(CachingConnectionFactory.class);
 				assertThat(connectionFactory.getHost()).isEqualTo("remote-server");
@@ -172,6 +176,7 @@ class RabbitAutoConfigurationTests {
 				assertThat(rcf.getConnectionTimeout()).isEqualTo(123);
 				assertThat(rcf.getChannelRpcTimeout()).isEqualTo(140);
 				assertThat((List<Address>) ReflectionTestUtils.getField(connectionFactory, "addresses")).hasSize(1);
+				assertThat(rcf).hasFieldOrPropertyWithValue("maxInboundMessageBodySize", 1024 * 1024 * 128);
 			});
 	}
 


### PR DESCRIPTION
See https://stackoverflow.com/questions/77185001/spring-cloud-stream-with-rabbitmq-binder-throws-java-lang-illegalstateexception/77187720#77187720