### PR TITLE
Refer to ActiveMQ as ActiveMQ "Classic"

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/messaging/jms.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/messaging/jms.adoc
@@ -8,13 +8,13 @@ Spring Boot also auto-configures the necessary infrastructure to send and receiv
 
 
 [[messaging.jms.activemq]]
-=== ActiveMQ Support
-When https://activemq.apache.org/[ActiveMQ] is available on the classpath, Spring Boot can configure a `ConnectionFactory`.
+=== ActiveMQ "Classic" Support
+When https://activemq.apache.org/components/classic[ActiveMQ "Classic"] is available on the classpath, Spring Boot can configure a `ConnectionFactory`.
 
-NOTE: If you use `spring-boot-starter-activemq`, the necessary dependencies to connect to an ActiveMQ instance are provided, as is the Spring infrastructure to integrate with JMS.
+NOTE: If you use `spring-boot-starter-activemq`, the necessary dependencies to connect to an ActiveMQ "Classic" instance are provided, as is the Spring infrastructure to integrate with JMS.
 
-ActiveMQ configuration is controlled by external configuration properties in `+spring.activemq.*+`.
-By default, ActiveMQ is auto-configured to use the https://activemq.apache.org/tcp-transport-reference[TCP transport], connecting by default to `tcp://localhost:61616`. The following example shows how to change the default broker URL:
+ActiveMQ "Classic" configuration is controlled by external configuration properties in `+spring.activemq.*+`.
+By default, ActiveMQ "Classic" is auto-configured to use the https://activemq.apache.org/tcp-transport-reference[TCP transport], connecting by default to `tcp://localhost:61616`. The following example shows how to change the default broker URL:
 
 [source,yaml,indent=0,configprops,configblocks]
 ----
@@ -49,7 +49,7 @@ If you'd rather use native pooling, you can do so by adding a dependency to `org
 TIP: See {spring-boot-autoconfigure-module-code}/jms/activemq/ActiveMQProperties.java[`ActiveMQProperties`] for more of the supported options.
 You can also register an arbitrary number of beans that implement `ActiveMQConnectionFactoryCustomizer` for more advanced customizations.
 
-By default, ActiveMQ creates a destination if it does not yet exist so that destinations are resolved against their provided names.
+By default, ActiveMQ "Classic" creates a destination if it does not yet exist so that destinations are resolved against their provided names.
 
 
 
@@ -102,7 +102,7 @@ If you'd rather use native pooling, you can do so by adding a dependency on `org
 
 See {spring-boot-autoconfigure-module-code}/jms/artemis/ArtemisProperties.java[`ArtemisProperties`] for more supported options.
 
-No JNDI lookup is involved, and destinations are resolved against their names, using either the `name` attribute in the Artemis configuration or the names provided through configuration.
+No JNDI lookup is involved, and destinations are resolved against their names, using either the `name` attribute in the ActiveMQ Artemis configuration or the names provided through configuration.
 
 
 


### PR DESCRIPTION
The Apache ActiveMQ project has adopted the label "Classic" for the 5.x broker in order to more easily compare and contrast it with the broker code-named Artemis.

The Spring docs should do the same to clarify ActiveMQ broker usage and configuration.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
