### PR TITLE
Default value of spring.jmx.registration-policy is not documented

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1580,6 +1580,10 @@
       "defaultValue": "auto"
     },
     {
+      "name": "spring.jmx.registration-policy",
+      "defaultValue": "fail-on-existing"
+    },
+    {
       "name": "spring.jpa.hibernate.use-new-id-generator-mappings",
       "type": "java.lang.Boolean",
       "description": "Whether to use Hibernate's newer IdentifierGenerator for AUTO, TABLE and SEQUENCE. This is actually a shortcut for the \"hibernate.id.new_generator_mappings\" property. When not specified will default to \"true\".",
@@ -2994,10 +2998,6 @@
           "name": "any"
         }
       ]
-    },
-    {
-      "name": "spring.jmx.registration-policy",
-      "defaultValue": "fail-on-existing"
     },
     {
       "name": "spring.jmx.server",


### PR DESCRIPTION
Moves default value declaration of `spring.jmx.registration-policy` from `hints`  to `properties`
Closes #37596 