### PR TITLE
IPv6 IP addresses cannot be used with RabbitMQ

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/PropertiesRabbitConnectionDetails.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/PropertiesRabbitConnectionDetails.java
@@ -53,8 +53,10 @@ class PropertiesRabbitConnectionDetails implements RabbitConnectionDetails {
 	public List<Address> getAddresses() {
 		List<Address> addresses = new ArrayList<>();
 		for (String address : this.properties.determineAddresses().split(",")) {
-			String[] components = address.split(":");
-			addresses.add(new Address(components[0], Integer.parseInt(components[1])));
+			int portSeparatorPosition = address.lastIndexOf(':');
+			String host = address.substring(0, portSeparatorPosition);
+			String port = address.substring(portSeparatorPosition + 1);
+			addresses.add(new Address(host, Integer.parseInt(port)));
 		}
 		return addresses;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/PropertiesRabbitConnectionDetails.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/PropertiesRabbitConnectionDetails.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012-2023 the original author or authors.
  *
- * Licen	sed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/PropertiesRabbitConnectionDetailsTest.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/PropertiesRabbitConnectionDetailsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.amqp;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.amqp.RabbitConnectionDetails.Address;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PropertiesRabbitConnectionDetailsTest {
+
+	@Test
+	void getAddresses() {
+		RabbitProperties properties = new RabbitProperties();
+		properties.setAddresses("localhost:1234,[::1]:32863");
+		PropertiesRabbitConnectionDetails propertiesRabbitConnectionDetails = new PropertiesRabbitConnectionDetails(properties);
+		List<Address> addresses = propertiesRabbitConnectionDetails.getAddresses();
+		assertThat(addresses.size()).isEqualTo(2);
+		assertThat(addresses.get(0).host()).isEqualTo("localhost");
+		assertThat(addresses.get(1).host()).isEqualTo("[::1]");
+		assertThat(addresses.get(0).port()).isEqualTo(1234);
+		assertThat(addresses.get(1).port()).isEqualTo(32863);
+	}
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
@@ -276,6 +276,13 @@ class RabbitPropertiesTests {
 	}
 
 	@Test
+	void determineAddressesUsesHostAndPortPropertiesWhenNoAddressesSetIpV6() {
+		this.properties.setHost("[::1]");
+		this.properties.setPort(32863);
+		assertThat(this.properties.determineAddresses()).isEqualTo("[::1]:32863");
+	}
+
+	@Test
 	void determineAddressesUsesHostAndPortPropertiesWhenNoAddressesSet() {
 		this.properties.setHost("rabbit.example.com");
 		this.properties.setPort(1234);


### PR DESCRIPTION
Failed to parse ipv6 addresses due to assumption of ipv4 addresses.

I think the regression was introduced in https://github.com/spring-projects/spring-boot/issues/34657