### PR TITLE
Add auto-configuration for CountedAspect and TimedAspect

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAspectsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAspectsAutoConfiguration.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics;
+
+import io.micrometer.core.aop.CountedAspect;
+import io.micrometer.core.aop.MeterTagAnnotationHandler;
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.aspectj.weaver.Advice;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for Micrometer-based metrics
+ * aspects.
+ *
+ * @author Jonatan Ivanov
+ * @since 3.2.0
+ */
+@AutoConfiguration(after = { MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class })
+@ConditionalOnClass({ MeterRegistry.class, Advice.class })
+@ConditionalOnBean(MeterRegistry.class)
+public class MetricsAspectsAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	CountedAspect countedAspect(MeterRegistry registry) {
+		return new CountedAspect(registry);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	TimedAspect timedAspect(MeterRegistry registry,
+			ObjectProvider<MeterTagAnnotationHandler> meterTagAnnotationHandler) {
+		TimedAspect timedAspect = new TimedAspect(registry);
+		meterTagAnnotationHandler.ifAvailable(timedAspect::setMeterTagAnnotationHandler);
+		return timedAspect;
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -43,6 +43,7 @@ org.springframework.boot.actuate.autoconfigure.metrics.JvmMetricsAutoConfigurati
 org.springframework.boot.actuate.autoconfigure.metrics.KafkaMetricsAutoConfiguration
 org.springframework.boot.actuate.autoconfigure.metrics.Log4J2MetricsAutoConfiguration
 org.springframework.boot.actuate.autoconfigure.metrics.LogbackMetricsAutoConfiguration
+org.springframework.boot.actuate.autoconfigure.metrics.MetricsAspectsAutoConfiguration
 org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration
 org.springframework.boot.actuate.autoconfigure.metrics.MetricsEndpointAutoConfiguration
 org.springframework.boot.actuate.autoconfigure.metrics.SystemMetricsAutoConfiguration

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAspectsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAspectsAutoConfigurationTests.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.metrics;
+
+import io.micrometer.core.aop.CountedAspect;
+import io.micrometer.core.aop.MeterTagAnnotationHandler;
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.aspectj.weaver.Advice;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.test.MetricsRun;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MetricsAspectsAutoConfiguration}.
+ *
+ * @author Jonatan Ivanov
+ */
+class MetricsAspectsAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().with(MetricsRun.simple())
+		.withConfiguration(AutoConfigurations.of(MetricsAspectsAutoConfiguration.class));
+
+	@Test
+	void shouldConfigureAspects() {
+		this.contextRunner.run((context) -> {
+			assertThat(context).hasSingleBean(CountedAspect.class);
+			assertThat(context).hasSingleBean(TimedAspect.class);
+		});
+	}
+
+	@Test
+	void shouldConfigureMeterTagAnnotationHandler() {
+		this.contextRunner.withUserConfiguration(MeterTagAnnotationHandlerConfiguration.class).run((context) -> {
+			assertThat(context).hasSingleBean(CountedAspect.class);
+			assertThat(ReflectionTestUtils.getField(context.getBean(TimedAspect.class), "meterTagAnnotationHandler"))
+				.isSameAs(context.getBean(MeterTagAnnotationHandler.class));
+		});
+	}
+
+	@Test
+	void shouldNotConfigureAspectsIfMicrometerIsMissing() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader(MeterRegistry.class)).run((context) -> {
+			assertThat(context).doesNotHaveBean(CountedAspect.class);
+			assertThat(context).doesNotHaveBean(TimedAspect.class);
+		});
+	}
+
+	@Test
+	void shouldNotConfigureAspectsIfAspectjIsMissing() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader(Advice.class)).run((context) -> {
+			assertThat(context).doesNotHaveBean(CountedAspect.class);
+			assertThat(context).doesNotHaveBean(TimedAspect.class);
+		});
+	}
+
+	@Test
+	void shouldNotConfigureAspectsIfMeterRegistryBeanIsMissing() {
+		new ApplicationContextRunner().run((context) -> {
+			assertThat(context).doesNotHaveBean(MeterRegistry.class);
+			assertThat(context).doesNotHaveBean(CountedAspect.class);
+			assertThat(context).doesNotHaveBean(TimedAspect.class);
+		});
+	}
+
+	@Test
+	void shouldBackOffIfAspectBeansExist() {
+		this.contextRunner.withUserConfiguration(CustomAspectsConfiguration.class).run((context) -> {
+			assertThat(context).hasSingleBean(CountedAspect.class).hasBean("customCountedAspect");
+			assertThat(context).hasSingleBean(TimedAspect.class).hasBean("customTimedAspect");
+		});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomAspectsConfiguration {
+
+		@Bean
+		CountedAspect customCountedAspect(MeterRegistry registry) {
+			return new CountedAspect(registry);
+		}
+
+		@Bean
+		TimedAspect customTimedAspect(MeterRegistry registry) {
+			return new TimedAspect(registry);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class MeterTagAnnotationHandlerConfiguration {
+
+		@Bean
+		MeterTagAnnotationHandler meterTagAnnotationHandler() {
+			return new MeterTagAnnotationHandler(null, null);
+		}
+
+	}
+
+}


### PR DESCRIPTION
Similarly to https://github.com/spring-projects/spring-boot/pull/35191, this PR adds support for auto-configuring `CountedAspect` and `TimedAspect`, which enables the usage of `@Counted` and `@Timed`.