### PR TITLE
When using Jetty, filters, listeners, and servlets are not initialized with the same thread context classloader

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyEmbeddedWebAppContext.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyEmbeddedWebAppContext.java
@@ -49,7 +49,14 @@ class JettyEmbeddedWebAppContext extends WebAppContext {
 		}
 
 		void deferredInitialize() throws Exception {
-			super.initialize();
+			ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+			try {
+				Thread.currentThread().setContextClassLoader(getServletContext().getClassLoader());
+				super.initialize();
+			}
+			finally {
+				Thread.currentThread().setContextClassLoader(contextClassLoader);
+			}
 		}
 
 	}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/gh37638/DummyFilter.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/gh37638/DummyFilter.java
@@ -21,8 +21,6 @@ import java.io.IOException;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
-import jakarta.servlet.ServletContextEvent;
-import jakarta.servlet.ServletContextListener;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
@@ -30,7 +28,8 @@ import jakarta.servlet.ServletResponse;
 import org.springframework.stereotype.Component;
 
 /**
- * Simple Servlet Filter that catches the current context classloader during its initialization.
+ * Simple Servlet Filter that catches the current context classloader during its
+ * initialization.
  */
 @Component
 public class DummyFilter implements Filter {
@@ -43,7 +42,9 @@ public class DummyFilter implements Filter {
 	}
 
 	@Override
-	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
 
 	}
+
 }

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/gh37638/DummyFilter.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/gh37638/DummyFilter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.jetty.gh37638;
+
+import java.io.IOException;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Simple Servlet Filter that catches the current context classloader during its initialization.
+ */
+@Component
+public class DummyFilter implements Filter {
+
+	ClassLoader classLoader;
+
+	@Override
+	public void init(FilterConfig filterConfig) {
+		this.classLoader = Thread.currentThread().getContextClassLoader();
+	}
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+	}
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/gh37638/DummyListener.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/gh37638/DummyListener.java
@@ -22,7 +22,8 @@ import jakarta.servlet.ServletContextListener;
 import org.springframework.stereotype.Component;
 
 /**
- * Simple Servlet Listener that catches the current context classloader during its initialization.
+ * Simple Servlet Listener that catches the current context classloader during its
+ * initialization.
  */
 @Component
 public class DummyListener implements ServletContextListener {
@@ -33,4 +34,5 @@ public class DummyListener implements ServletContextListener {
 	public void contextInitialized(ServletContextEvent sce) {
 		this.classLoader = Thread.currentThread().getContextClassLoader();
 	}
+
 }

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/gh37638/DummyListener.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/gh37638/DummyListener.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.jetty.gh37638;
+
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Simple Servlet Listener that catches the current context classloader during its initialization.
+ */
+@Component
+public class DummyListener implements ServletContextListener {
+
+	ClassLoader classLoader;
+
+	@Override
+	public void contextInitialized(ServletContextEvent sce) {
+		this.classLoader = Thread.currentThread().getContextClassLoader();
+	}
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/gh37638/DummyServlet.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/gh37638/DummyServlet.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.jetty.gh37638;
+
+import java.io.IOException;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Simple Servlet that catches the current context classloader during its initialization.
+ */
+@Component
+public class DummyServlet implements Servlet {
+
+	ClassLoader classLoader;
+
+	@Override
+	public void init(ServletConfig servletConfig) {
+		this.classLoader = Thread.currentThread().getContextClassLoader();
+	}
+
+	@Override
+	public ServletConfig getServletConfig() {
+		return null;
+	}
+
+	@Override
+	public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
+
+	}
+
+	@Override
+	public String getServletInfo() {
+		return null;
+	}
+
+	@Override
+	public void destroy() {
+
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/gh37638/DummyServlet.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/gh37638/DummyServlet.java
@@ -18,9 +18,6 @@ package smoketest.jetty.gh37638;
 
 import java.io.IOException;
 
-import jakarta.servlet.Filter;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.FilterConfig;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/test/java/smoketest/jetty/gh37638/ClassloaderTest.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/test/java/smoketest/jetty/gh37638/ClassloaderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.jetty.gh37638;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class ClassloaderTest {
+
+	@Autowired
+	private DummyFilter dummyFilter;
+
+	@Autowired
+	private DummyListener dummyListener;
+
+	@Autowired
+	private DummyServlet dummyServlet;
+
+	@Test
+	void sameContextLoaders() {
+		assertThat(this.dummyFilter.classLoader).isNotNull();
+		assertThat(this.dummyListener.classLoader).isNotNull();
+		assertThat(this.dummyServlet.classLoader).isNotNull();
+
+		assertThat(this.dummyFilter.classLoader).isSameAs(this.dummyListener.classLoader);
+		assertThat(this.dummyListener.classLoader).isSameAs(this.dummyServlet.classLoader);
+		assertThat(this.dummyServlet.classLoader).isSameAs(this.dummyFilter.classLoader);
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/test/java/smoketest/jetty/gh37638/ClassloaderTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jetty/src/test/java/smoketest/jetty/gh37638/ClassloaderTests.java
@@ -25,7 +25,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-class ClassloaderTest {
+class ClassloaderTests {
 
 	@Autowired
 	private DummyFilter dummyFilter;


### PR DESCRIPTION
Web applications currently see different context classloaders depending on the lifecycle.

Most of the time the `Thread.currentThread().getContextClassLoader()` is an `org.eclipse.jetty.ee10.webapp.WebAppClassLoader`. For example during `jakarta.servlet.ServletContextListener#contextInitialized`.

During `jakarta.servlet.Servlet#init` however, the current context classloader is of type `jdk.internal.loader.ClassLoaders.AppClassLoader`.

Seeing different classloaders for different lifecycle calls in the same servlet context breaks Mojarra and MyFaces.

This PR fixes this, by explicitly setting the context classloader for the deferred servlet initialization.