### PR TITLE
Remove link to LiveReload website due to timeout

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/using/devtools.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/using/devtools.adoc
@@ -269,7 +269,7 @@ If you find such a problem, you need to request a fix with the original authors.
 [[using.devtools.livereload]]
 === LiveReload
 The `spring-boot-devtools` module includes an embedded LiveReload server that can be used to trigger a browser refresh when a resource is changed.
-LiveReload browser extensions are freely available for Chrome, Firefox and Safari from http://livereload.com/extensions/[livereload.com].
+LiveReload browser extensions are freely available for Chrome, Firefox and Safari. You can find these extensions by searching 'LiveReload' in the marketplace or store of your chosen browser.
 
 If you do not want to start the LiveReload server when your application runs, you can set the configprop:spring.devtools.livereload.enabled[] property to `false`.
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

I noticed that the link to [livereload.com](http://livereload.com/extensions/) in section 6.8.4 of the docs, times out. On further investigation, the LiveReload website seems to be down completely. This pull request removes the link and suggests that the user locates the extensions by searching in their chosen browser's marketplace.
