### PR TITLE
Allow configure finalName per repackage execution

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
@@ -69,7 +69,7 @@ public class RepackageMojo extends AbstractPackagerMojo {
 	 * Name of the generated archive.
 	 * @since 1.0.0
 	 */
-	@Parameter(defaultValue = "${project.build.finalName}", readonly = true)
+	@Parameter(defaultValue = "${project.build.finalName}")
 	private String finalName;
 
 	/**


### PR DESCRIPTION
Of course we can override the `finalName` in `configuration`. Change the parameter property so that we don't suffer warnings:

```
[WARNING] Plugin validation issues were detected in 1 plugin(s)
[WARNING] 
[WARNING]  * org.springframework.boot:spring-boot-maven-plugin:3.1.4
[WARNING]   Declared at location(s):
[WARNING]    * io.korandoru.hawkeye:hawkeye-cli:3.5.3-SNAPSHOT (hawkeye-cli/pom.xml) @ line 45
[WARNING]   Used in module(s):
[WARNING]    * io.korandoru.hawkeye:hawkeye-cli:3.5.3-SNAPSHOT (hawkeye-cli/pom.xml)
[WARNING]   Mojo issue(s):
[WARNING]    * Mojo spring-boot:repackage (org.springframework.boot.maven.RepackageMojo)
[WARNING]      - Parameter 'finalName' is read-only, must not be used in configuration
[WARNING] 
```

Below is my config:


```xml
            <plugin>
                <groupId>org.springframework.boot</groupId>
                <artifactId>spring-boot-maven-plugin</artifactId>
                <version>${spring-boot-maven-plugin.version}</version>
                <executions>
                    <execution>
                        <id>repackage</id>
                        <goals>
                            <goal>repackage</goal>
                        </goals>
                        <configuration>
                            <finalName>hawkeye</finalName>
                        </configuration>
                    </execution>
                </executions>
                <configuration>
                    <mainClass>io.korandoru.hawkeye.command.HawkEyeCommandMain</mainClass>
                    <embeddedLaunchScript>src/embeddedLaunchScript.sh</embeddedLaunchScript>
                    <executable>true</executable>
                </configuration>
            </plugin>
```