### PR TITLE
Create RepositoryEventBeanValidationConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/rest/RepositoryEventBeanValidationConfiguration
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/rest/RepositoryEventBeanValidationConfiguration
@@ -1,0 +1,33 @@
+package org.springframework.boot.autoconfigure.data.rest;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.rest.core.event.ValidatingRepositoryEventListener;
+import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+/**
+ * Configurations for Bean Validation against Repository Events
+ *
+ * @author Yang Li
+ * @since 3.1.0
+ */
+@Configuration
+public class RepositoryEventBeanValidationConfiguration implements RepositoryRestConfigurer {
+
+	@Bean
+	@ConditionalOnClass(LocalValidatorFactoryBean.class)
+	@ConditionalOnMissingBean(LocalValidatorFactoryBean.class)
+	LocalValidatorFactoryBean localValidatorFactoryBean() {
+		return new LocalValidatorFactoryBean();
+	}
+
+	@Override
+	public void configureValidatingRepositoryEventListener(ValidatingRepositoryEventListener v) {
+		v.addValidator("beforeCreate", localValidatorFactoryBean());
+		v.addValidator("beforeSave", localValidatorFactoryBean());
+		v.addValidator("beforeLinkSave", localValidatorFactoryBean());
+	}
+}


### PR DESCRIPTION
create bean validation against Repository create and save operations.

Validating domain objects before invoking Repository operations (create and save) should be a default feature.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
