### PR TITLE
Update Pulsar Reactive client 0.4.0

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1218,7 +1218,7 @@ bom {
 			]
 		}
 	}
-	library("Pulsar Reactive", "0.3.0") {
+	library("Pulsar Reactive", "0.4.0") {
 		group("org.apache.pulsar") {
 			modules = [
 				"pulsar-client-reactive-adapter",

--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-pulsar-reactive/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-pulsar-reactive/build.gradle
@@ -11,9 +11,6 @@ dependencies {
 
 checkRuntimeClasspathForConflicts {
 	ignore { name -> name.startsWith("org/bouncycastle/") ||
-				name.matches("^org\\/apache\\/pulsar\\/.*\\/package-info.class\$") ||
-				name.equals("findbugsExclude.xml") ||
-				name.startsWith("org/springframework/pulsar/shade/com/github/benmanes/caffeine/") ||
-				name.startsWith("org/springframework/pulsar/shade/com/google/errorprone/") ||
-				name.startsWith("org/springframework/pulsar/shade/org/checkerframework/") }
+			name.matches("^org\\/apache\\/pulsar\\/.*\\/package-info.class\$") ||
+			name.equals("findbugsExclude.xml") }
 }


### PR DESCRIPTION
This commit updates the Reactive client used by Spring Pulsar to version 0.4.0. 

The updated client also fixes an issue where the non-reactive and reactive shaded producer cache had the same relocation prefix. 
This allows the removal of the shaded relocation prefixes from the `checkRuntimeClasspathForConflicts` ignore closure.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
