### PR TITLE
Remove obsolete prohibit for Couchbase Client library

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -210,10 +210,6 @@ bom {
 		}
 	}
 	library("Couchbase Client", "3.4.11") {
-		prohibit {
-			versionRange "[3.4.9]"
-			because "it contains unshaded io.opentelemetry classes that break our Otel integration"
-		}
 		group("com.couchbase.client") {
 			modules = [
 				"java-client"


### PR DESCRIPTION
This PR removes obsolete prohibit for Couchbase Client library.