### PR TITLE
Exclude unwanted transitive dependencies from Apache Pulsar

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1148,17 +1148,30 @@ bom {
 				"pulsar-client-1x",
 				"pulsar-client-2x-shaded",
 				"pulsar-client-admin-api",
-				"pulsar-client-admin-original",
-				"pulsar-client-admin",
-				"pulsar-client-all",
+				"pulsar-client-admin-original" {
+					exclude group: 'com.sun.activation', module: 'javax.activation'
+				},
+				"pulsar-client-admin" {
+					exclude group: 'com.sun.activation', module: 'javax.activation'
+					exclude group: 'javax.validation', module: 'validation-api'
+				},
+				"pulsar-client-all" {
+					exclude group: 'com.sun.activation', module: 'javax.activation'
+					exclude group: 'javax.validation', module: 'validation-api'
+				},
 				"pulsar-client-api",
 				"pulsar-client-auth-athenz",
 				"pulsar-client-auth-sasl",
 				"pulsar-client-messagecrypto-bc",
-				"pulsar-client-original",
+				"pulsar-client-original" {
+					exclude group: 'com.sun.activation', module: 'javax.activation'
+				},
 				"pulsar-client-tools-api",
 				"pulsar-client-tools",
-				"pulsar-client",
+				"pulsar-client" {
+					exclude group: 'com.sun.activation', module: 'javax.activation'
+					exclude group: 'javax.validation', module: 'validation-api'
+				},
 				"pulsar-common",
 				"pulsar-config-validation",
 				"pulsar-functions-api",
@@ -1221,11 +1234,22 @@ bom {
 	library("Pulsar Reactive", "0.4.0") {
 		group("org.apache.pulsar") {
 			modules = [
-				"pulsar-client-reactive-adapter",
+				"pulsar-client-reactive-adapter" {
+					// it includes a pulsar-client with unwanted transitive deps
+					exclude group: "org.apache.pulsar", module: "pulsar-client"
+				},
 				"pulsar-client-reactive-api",
 				"pulsar-client-reactive-jackson",
-				"pulsar-client-reactive-producer-cache-caffeine-shaded",
-				"pulsar-client-reactive-producer-cache-caffeine"
+				"pulsar-client-reactive-producer-cache-caffeine-shaded" {
+					// it includes a pulsar-client-reactive-adapter that includes a
+					// pulsar-client with unwanted transitive deps
+					exclude group: "org.apache.pulsar", module: "pulsar-client-reactive-adapter"
+				},
+				"pulsar-client-reactive-producer-cache-caffeine" {
+					// it includes a pulsar-client-reactive-adapter that includes a
+					// pulsar-client with unwanted transitive deps
+					exclude group: "org.apache.pulsar", module: "pulsar-client-reactive-adapter"
+				}
 			]
 		}
 	}


### PR DESCRIPTION
Several of the Apache Pulsar libs are bringing along transitive dependencies (`com.sun.activation:javax.activation` and `javax.validation:validation-api`). This commit adds exclusions to the Spring Boot BOM for these problematic transitive dependencies.

**NOTE:** Currently these exclusions are handled in the Spring for Apache Pulsar framework for a couple of the Pulsar libs
- https://github.com/spring-projects/spring-pulsar/blob/5ff3d99b99673c67c59528ae02c02c2eae4cd837/spring-pulsar/spring-pulsar.gradle#L9-L12
- https://github.com/spring-projects/spring-pulsar/blob/5ff3d99b99673c67c59528ae02c02c2eae4cd837/spring-pulsar-reactive/spring-pulsar-reactive.gradle#L9-L16
However, this list is not exhaustive and it is possible for users to include other Pulsar libs which will not have the unwanted visitors excluded. Adding the exclusions here guarantees the unwanted visitors will never arrive. 

This commit adds exclusions for these problematic transitive dependencies here in the Spring Boot BOM.



