### PR TITLE
Use MappingJackson2MessageConverter(ObjectMapper) in WebSocketMessagingAutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/websocket/servlet/WebSocketMessagingAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/websocket/servlet/WebSocketMessagingAutoConfiguration.java
@@ -64,8 +64,7 @@ public class WebSocketMessagingAutoConfiguration {
 
 		@Override
 		public boolean configureMessageConverters(List<MessageConverter> messageConverters) {
-			MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
-			converter.setObjectMapper(this.objectMapper);
+			MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter(this.objectMapper);
 			DefaultContentTypeResolver resolver = new DefaultContentTypeResolver();
 			resolver.setDefaultMimeType(MimeTypeUtils.APPLICATION_JSON);
 			converter.setContentTypeResolver(resolver);


### PR DESCRIPTION
This PR changes to use the new `MappingJackson2MessageConverter(ObjectMapper)` constructor in `WebSocketMessagingAutoConfiguration.configureMessageConverters()`.

See https://github.com/spring-projects/spring-framework/pull/31234