### PR TITLE
Add properties for configuring Jackson's EnumFeature and JsonNodeFeature

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
@@ -213,6 +213,8 @@ public class JacksonAutoConfiguration {
 				configureFeatures(builder, this.jacksonProperties.getMapper());
 				configureFeatures(builder, this.jacksonProperties.getParser());
 				configureFeatures(builder, this.jacksonProperties.getGenerator());
+				configureFeatures(builder, this.jacksonProperties.getEnumDatatype());
+				configureFeatures(builder, this.jacksonProperties.getJsonNodeDatatype());
 				configureDateFormat(builder);
 				configurePropertyNamingStrategy(builder);
 				configureModules(builder);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.cfg.EnumFeature;
+import com.fasterxml.jackson.databind.cfg.JsonNodeFeature;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -38,6 +40,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Andy Wilkinson
  * @author Marcel Overdijk
  * @author Johannes Edmeier
+ * @author Eddú Meléndez
  * @since 1.2.0
  */
 @ConfigurationProperties(prefix = "spring.jackson")
@@ -85,6 +88,16 @@ public class JacksonProperties {
 	 * Jackson on/off features for generators.
 	 */
 	private final Map<JsonGenerator.Feature, Boolean> generator = new EnumMap<>(JsonGenerator.Feature.class);
+
+	/**
+	 * Jackson on/off features for enum types.
+	 */
+	private final Map<EnumFeature, Boolean> enumDatatype = new EnumMap<>(EnumFeature.class);
+
+	/**
+	 * Jackson on/off features for JsonNode types.
+	 */
+	private final Map<JsonNodeFeature, Boolean> jsonNodeDatatype = new EnumMap<>(JsonNodeFeature.class);
 
 	/**
 	 * Controls the inclusion of properties during serialization. Configured with one of
@@ -152,6 +165,14 @@ public class JacksonProperties {
 
 	public Map<JsonGenerator.Feature, Boolean> getGenerator() {
 		return this.generator;
+	}
+
+	public Map<EnumFeature, Boolean> getEnumDatatype() {
+		return this.enumDatatype;
+	}
+
+	public Map<JsonNodeFeature, Boolean> getJsonNodeDatatype() {
+		return this.jsonNodeDatatype;
 	}
 
 	public JsonInclude.Include getDefaultPropertyInclusion() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfigurationTests.java
@@ -45,6 +45,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
 import com.fasterxml.jackson.databind.cfg.ConstructorDetector.SingleArgConstructor;
+import com.fasterxml.jackson.databind.cfg.EnumFeature;
+import com.fasterxml.jackson.databind.cfg.JsonNodeFeature;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
@@ -88,6 +90,7 @@ import static org.mockito.Mockito.mock;
  * @author Johannes Edmeier
  * @author Grzegorz Poznachowski
  * @author Ralf Ueberfuhr
+ * @author Eddú Meléndez
  */
 class JacksonAutoConfigurationTests {
 
@@ -286,6 +289,24 @@ class JacksonAutoConfigurationTests {
 			assertThat(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES.enabledByDefault()).isTrue();
 			assertThat(mapper.getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES))
 				.isFalse();
+		});
+	}
+
+	@Test
+	void enableEnumFeature() {
+		this.contextRunner.withPropertyValues("spring.jackson.enum-data-type.write_enums_to_lowercase:true").run((context) -> {
+			ObjectMapper mapper = context.getBean(ObjectMapper.class);
+			assertThat(EnumFeature.WRITE_ENUMS_TO_LOWERCASE.enabledByDefault()).isFalse();
+			assertThat(mapper.getSerializationConfig().isEnabled(EnumFeature.WRITE_ENUMS_TO_LOWERCASE)).isTrue();
+		});
+	}
+
+	@Test
+	void disableJsonNodeFeature() {
+		this.contextRunner.withPropertyValues("spring.jackson.json-node-data-type.write_null_properties:false").run((context) -> {
+			ObjectMapper mapper = context.getBean(ObjectMapper.class);
+			assertThat(JsonNodeFeature.WRITE_NULL_PROPERTIES.enabledByDefault()).isTrue();
+			assertThat(mapper.getDeserializationConfig().isEnabled(JsonNodeFeature.WRITE_NULL_PROPERTIES)).isFalse();
 		});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfigurationTests.java
@@ -294,20 +294,23 @@ class JacksonAutoConfigurationTests {
 
 	@Test
 	void enableEnumFeature() {
-		this.contextRunner.withPropertyValues("spring.jackson.enum-data-type.write_enums_to_lowercase:true").run((context) -> {
-			ObjectMapper mapper = context.getBean(ObjectMapper.class);
-			assertThat(EnumFeature.WRITE_ENUMS_TO_LOWERCASE.enabledByDefault()).isFalse();
-			assertThat(mapper.getSerializationConfig().isEnabled(EnumFeature.WRITE_ENUMS_TO_LOWERCASE)).isTrue();
-		});
+		this.contextRunner.withPropertyValues("spring.jackson.enum-data-type.write_enums_to_lowercase:true")
+			.run((context) -> {
+				ObjectMapper mapper = context.getBean(ObjectMapper.class);
+				assertThat(EnumFeature.WRITE_ENUMS_TO_LOWERCASE.enabledByDefault()).isFalse();
+				assertThat(mapper.getSerializationConfig().isEnabled(EnumFeature.WRITE_ENUMS_TO_LOWERCASE)).isTrue();
+			});
 	}
 
 	@Test
 	void disableJsonNodeFeature() {
-		this.contextRunner.withPropertyValues("spring.jackson.json-node-data-type.write_null_properties:false").run((context) -> {
-			ObjectMapper mapper = context.getBean(ObjectMapper.class);
-			assertThat(JsonNodeFeature.WRITE_NULL_PROPERTIES.enabledByDefault()).isTrue();
-			assertThat(mapper.getDeserializationConfig().isEnabled(JsonNodeFeature.WRITE_NULL_PROPERTIES)).isFalse();
-		});
+		this.contextRunner.withPropertyValues("spring.jackson.json-node-data-type.write_null_properties:false")
+			.run((context) -> {
+				ObjectMapper mapper = context.getBean(ObjectMapper.class);
+				assertThat(JsonNodeFeature.WRITE_NULL_PROPERTIES.enabledByDefault()).isTrue();
+				assertThat(mapper.getDeserializationConfig().isEnabled(JsonNodeFeature.WRITE_NULL_PROPERTIES))
+					.isFalse();
+			});
 	}
 
 	@Test


### PR DESCRIPTION
Both, `EnumFeature` and `JsonNodeFeature` implement `DataTypeFeature`,
which was recently added in spring-framework. This commits introduces
support to allow the configuration via properties.

See spring-projects/spring-framework#31380
