### PR TITLE
@Order does not work on (CommandLine|Application)Runner @Bean methods

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ApplicationRunner.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ApplicationRunner.java
@@ -30,7 +30,7 @@ import org.springframework.core.annotation.Order;
  * @see CommandLineRunner
  */
 @FunctionalInterface
-public interface ApplicationRunner {
+public non-sealed interface ApplicationRunner extends Runner {
 
 	/**
 	 * Callback used to run the bean.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/CommandLineRunner.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/CommandLineRunner.java
@@ -33,7 +33,7 @@ import org.springframework.core.annotation.Order;
  * @see ApplicationRunner
  */
 @FunctionalInterface
-public interface CommandLineRunner {
+public non-sealed interface CommandLineRunner extends Runner {
 
 	/**
 	 * Callback used to run the bean.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/Runner.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/Runner.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot;
+
+/**
+ * Marker interface for runners.
+ *
+ * @author Tadaya Tsuyukubo
+ * @see ApplicationRunner
+ * @see CommandLineRunner
+ */
+sealed interface Runner permits CommandLineRunner, ApplicationRunner {
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -165,6 +165,7 @@ import org.springframework.util.function.ThrowingSupplier;
  * @author Ethan Rubinson
  * @author Chris Bono
  * @author Moritz Halbritter
+ * @author Tadaya Tsuyukubo
  * @since 1.0.0
  * @see #run(Class, String[])
  * @see #run(Class[], String[])
@@ -755,18 +756,14 @@ public class SpringApplication {
 	}
 
 	private void callRunners(ApplicationContext context, ApplicationArguments args) {
-		List<Object> runners = new ArrayList<>();
-		runners.addAll(context.getBeansOfType(ApplicationRunner.class).values());
-		runners.addAll(context.getBeansOfType(CommandLineRunner.class).values());
-		AnnotationAwareOrderComparator.sort(runners);
-		for (Object runner : new LinkedHashSet<>(runners)) {
+		context.getBeanProvider(Runner.class).orderedStream().forEach((runner) -> {
 			if (runner instanceof ApplicationRunner applicationRunner) {
 				callRunner(applicationRunner, args);
 			}
 			if (runner instanceof CommandLineRunner commandLineRunner) {
 				callRunner(commandLineRunner, args);
 			}
-		}
+		});
 	}
 
 	private void callRunner(ApplicationRunner runner, ApplicationArguments args) {


### PR DESCRIPTION
Currently, when the order of an `CommandLineRunner` or `ApplicationRunner` bean is defined on the bean method it is not taken into account.

```java
@Bean
@Order(10)
CommandLineRunner runner() {
  return (args) -> ...;
}
```

This is because `SpringApplication` sorts them by actual beans and does not consider the bean definitions.
This behavior may be due to the fact that the ordering is determined collectively for both `CommandLineRunner` and `ApplicationRunner`.
In other words, when a `CommandLineRunner` has order=1 and an `ApplicationRunner` has order=2, the `CommandLineRunner` runs first, even though they are two different classes.

The `BeanFactory` does not provide an API to retrieve ordered beans for two distinct types of beans. This is why it is currently limited to sorting them based solely on bean instances and not on their bean definitions.

This PR introduces a sealed marker interface for `ApplicationRunner` and `CommandLineRunner`.
Then, using the interface to retrieve the beans in an ordered fashion, it takes into account the `@Order` on the bean definition(`@Bean` method in this case).
This allows for the use of `@Order` on `@Bean` methods for both `CommandLineRunner` and `ApplicationRunner`.
