### PR TITLE
Annotating default R2DBC transaction manager with @Primary annotation.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcTransactionManagerAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcTransactionManagerAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.Ordered;
 import org.springframework.r2dbc.connection.R2dbcTransactionManager;
 import org.springframework.transaction.ReactiveTransactionManager;
@@ -43,6 +44,7 @@ import org.springframework.transaction.ReactiveTransactionManager;
 public class R2dbcTransactionManagerAutoConfiguration {
 
 	@Bean
+	@Primary
 	@ConditionalOnMissingBean(ReactiveTransactionManager.class)
 	public R2dbcTransactionManager connectionFactoryTransactionManager(ConnectionFactory connectionFactory) {
 		return new R2dbcTransactionManager(connectionFactory);


### PR DESCRIPTION
####  Describing Your Changes

Incase a vendor chooses to extend `R2dbcTransactionManager` and provide an autoconfiguration for the same, It conflicts with the already provided autoconfiguration resulting in `context.getBean()` throws exception as  multiple beans are available.

For a scenario where a vendor wants their users to use the standard transaction manager for standard use cases and use the custom one for the vendor specific use cases, we should be able to access both beans. This change will mark the standard transaction manager as primary one and it will be given preference when auto-wiring a dependency for standard use cases. And for the specific usecases they can use the custom transaction manager using `@Transactional` annotation. For ex:

```
@Transactional(transactionManager = "customTransactionManager")
```

