### PR TITLE
Remove tomcat-embed-el from spring-boot-starter-jetty

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-jetty/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-jetty/build.gradle
@@ -8,7 +8,6 @@ dependencies {
 	api("jakarta.servlet:jakarta.servlet-api")
 	api("jakarta.websocket:jakarta.websocket-api")
 	api("jakarta.websocket:jakarta.websocket-client-api")
-	api("org.apache.tomcat.embed:tomcat-embed-el")
 	api("org.eclipse.jetty.ee10:jetty-ee10-servlets")
 	api("org.eclipse.jetty.ee10:jetty-ee10-webapp")
 	api("org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jakarta-server")


### PR DESCRIPTION
I don't understand why the `org.apache.tomcat.embed:tomcat-embed-el` dependency is defined with the `api` scope in the `spring-boot-starter-jetty` module: it perfectly builds without it.
