### PR TITLE
Add JVM Checkpoint Restore documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/deployment/efficient.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/deployment/efficient.adoc
@@ -65,3 +65,16 @@ It implies the following restrictions:
 - Properties that change if a bean is created are not supported (for example, `@ConditionalOnProperty` and `.enable` properties).
 
 To learn more about ahead-of-time processing, please see the <<native-image#native-image.introducing-graalvm-native-images.understanding-aot-processing,Understanding Spring Ahead-of-Time Processing section>>.
+
+[[deployment.efficient.crac]]
+=== Checkpoint and Restore With the JVM
+
+https://wiki.openjdk.org/display/crac/Main[CRaC] is an OpenJDK project that defines a new Java API to allow you to checkpoint and restore an application on the HotSpot JVM. It is based on https://github.com/checkpoint-restore/criu[CRIU], a project that implements checkpoint/restore functionality on Linux.
+
+The principle is the following: you start your application almost as usual but with a CRaC enabled version of the JDK like https://www.azul.com/downloads/?package=jdk-crac#zulu[the one provided by Azul]. Then at some point, potentially after some workloads that will make your JVM hot by executing all common code paths, you trigger a checkpoint using an API call, a `jcmd` command, an HTTP endpoint, or another mechanism.
+
+A memory representation of the running JVM, including its warmness, is then serialized to disk, allowing a very fast restoration at a later point, potentially on another machine with a similar operating system and CPU architecture. The restored process retains all the capabilities of the HotSpot JVM, including further JIT optimizations at runtime.
+
+Based on the foundations provided by Spring Framework, Spring Boot provides support for checkpointing and restoring your application, and manages out-of-the-box the lifecycle of resources such as socket, files and thread pools https://github.com/spring-projects/spring-checkpoint-restore-smoke-tests/blob/main/STATUS.adoc[on a limited scope]. Additional lifecycle management is expected for other dependencies and potentially for the application code dealing with such resources.
+
+You can find more details about the 2 modes supported ("on demand checkpoint/restore of a running application" and "automatic checkpoint/restore at startup"), how to enable Project CRaC support and some guidelines in {spring-framework-docs}/integration/checkpoint-restore.html[the Spring Framework JVM Checkpoint Restore support documentation].


### PR DESCRIPTION
My proposal is to put CRaC documentation in the efficient deployment section, since we are providing an initial support and given the conciseness of the documentation, a dedicated top level section looks like not the best outcome from my point of view.

I have not added a link to the very useful https://github.com/sdeleuze/spring-boot-crac-demo repository since that's a personal one, and I was not sure it was ok for you. But if you are, I think it would add quite a lot of added value to include it (feel free to update my PR accordingly).

I did not add additional warnings on Spring Boot side related to being careful on not leaking sensitive data since Spring Framework documentation is already pretty clear about it, but if you want add a warning on Spring Boot side, that's on option.