### PR TITLE
Polish "IO.Validation" Documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/io/validation.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/io/validation.adoc
@@ -1,6 +1,6 @@
 [[io.validation]]
 == Validation
-The method validation feature supported by Bean Validation 1.1 is automatically enabled as long as a JSR-303 implementation (such as Hibernate validator) is on the classpath.
+The method validation feature supported by https://beanvalidation.org/[Bean Validation Api] is automatically enabled as long as a JSR-303 implementation (such as https://hibernate.org/validator/[Hibernate validator]) is on the classpath.
 This lets bean methods be annotated with `jakarta.validation` constraints on their parameters and/or on their return value.
 Target classes with such annotated methods need to be annotated with the `@Validated` annotation at the type level for their methods to be searched for inline constraint annotations.
 
@@ -9,8 +9,20 @@ For instance, the following service triggers the validation of the first argumen
 include::code:MyBean[]
 
 The application's `MessageSource` is used when resolving `+{parameters}+` in constraint messages.
-This allows you to use <<features.adoc#features.internationalization,your application's `messages.properties` files>> for Bean Validation messages.
+This allows you to use your application's <<features.adoc#features.internationalization,`messages.properties`>> files for Bean Validation messages.
 Once the parameters have been resolved, message interpolation is completed using Bean Validation's default interpolator.
 
+[[io.validation.groups]]
+=== Validation Groups
+JSR-303's Validation Groups can be provided to the Validator in two ways.
+
+* Statically by including the Class references in a `@Validated` Annotation on the Parameter
+* Programmatically by direct usage of a `SmartValidator`
+
+NOTE: Out of the box Group integrations like Hibernate's https://docs.jboss.org/hibernate/stable/validator/reference/en-US/html_single/#_groupsequenceprovider[`@GroupSequenceProvider`]
+usually work without additional configuration.
+
+[[io.validation.configuration]]
+=== ValidatorFactory Customization
 To customize the `Configuration` used to build the `ValidatorFactory`, define a `ValidationConfigurationCustomizer` bean.
 When multiple customizer beans are defined, they are called in order based on their `@Order` annotation or `Ordered` implementation.


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR polishes the Validation Section of the IO docs to include additional information regarding the handling of JSR-303's "Groups" within the context of Spring.
Also includes links to the Hibernate Validator Implementation of JSR-303, as it is currently the default provided by `spring-boot-starter-validation`, and is directly linked within the [Spring Framework](https://docs.spring.io/spring-framework/reference/core/validation/beanvalidation.html) Core Validation Documentation.

Debated if this inclusion belonged in the Spring Framework Docs, or the Spring Boot Docs. Decided to put it here as Spring Framework's Documentation felt more about under the hood interactions, where this was more notes and interactions.