### PR TITLE
Refactor RSocketPortInfoApplicationContextInitializer to extract "server.ports" to a constant

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/rsocket/context/RSocketPortInfoApplicationContextInitializer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/rsocket/context/RSocketPortInfoApplicationContextInitializer.java
@@ -54,6 +54,7 @@ public class RSocketPortInfoApplicationContextInitializer
 	private static class Listener implements ApplicationListener<RSocketServerInitializedEvent> {
 
 		private static final String PROPERTY_NAME = "local.rsocket.server.port";
+		private static final String SERVER_PORTS = "server.ports";
 
 		private final ConfigurableApplicationContext applicationContext;
 
@@ -79,9 +80,9 @@ public class RSocketPortInfoApplicationContextInitializer
 
 		private void setPortProperty(ConfigurableEnvironment environment, int port) {
 			MutablePropertySources sources = environment.getPropertySources();
-			PropertySource<?> source = sources.get("server.ports");
+			PropertySource<?> source = sources.get(SERVER_PORTS);
 			if (source == null) {
-				source = new MapPropertySource("server.ports", new HashMap<>());
+				source = new MapPropertySource(SERVER_PORTS, new HashMap<>());
 				sources.addFirst(source);
 			}
 			setPortProperty(port, source);


### PR DESCRIPTION
This commit refactors the RSocketPortInfoApplicationContextInitializer class to replace the hardcoding of "server.ports" with a constant named SERVER_PORTS. This improves code maintainability and readability.

- Introduced a constant for "server.ports"
- Updated all references to use the constant
