### PR TITLE
Remove unecessary setCanBeResolved

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/SpringBootAotPlugin.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/SpringBootAotPlugin.java
@@ -169,7 +169,6 @@ public class SpringBootAotPlugin implements Plugin<Project> {
 			.getByName(inputSourceSet.getRuntimeClasspathConfigurationName());
 		return project.getConfigurations().create(taskName + "Classpath", (classpath) -> {
 			classpath.setCanBeConsumed(false);
-			classpath.setCanBeResolved(true);
 			classpath.setDescription("Classpath of the " + taskName + " task.");
 			removeDevelopmentOnly(base.getExtendsFrom(), developmentOnlyConfigurationNames)
 				.forEach(classpath::extendsFrom);


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

According to Gradle 8.4, the setCanBeResolved(true) method call is unecessary (and deprecated).
```
> Configure project :project
The resolvable usage is already allowed on configuration ':project:aotRuntimeClasspath'. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Remove the call to setCanBeResolved(true), it has no effect. Consult the upgrading guide for further information: https://docs.gradle.org/8.4/userguide/upgrading_version_8.html#redundant_configuration_usage_activation
```