### PR TITLE
Fix shouldStopKeepAliveThreadIfContextIsClosed()

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
@@ -1425,8 +1425,9 @@ class SpringApplicationTests {
 		this.context.close();
 		Awaitility.await()
 			.atMost(Duration.ofSeconds(30))
-			.untilAsserted(() -> assertThat(getCurrentThreads())
-				.filteredOn((thread) -> thread.getName().equals("keep-alive")));
+			.untilAsserted(
+					() -> assertThat(getCurrentThreads()).filteredOn((thread) -> thread.getName().equals("keep-alive"))
+						.isEmpty());
 	}
 
 	private <S extends AvailabilityState> ArgumentMatcher<ApplicationEvent> isAvailabilityChangeEventWithState(


### PR DESCRIPTION
`.isEmpty()` seems to have been dropped accidentally in 9897576562b65f93c8ab4523ded7b1aa9785fd45.