### PR TITLE
Auto-configure a JwtAuthenticationConverter

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/OAuth2ResourceServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/OAuth2ResourceServerProperties.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
 import org.springframework.core.io.Resource;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
 
@@ -35,6 +36,7 @@ import org.springframework.util.StreamUtils;
  * @author Madhura Bhave
  * @author Artsiom Yudovin
  * @author Mushtaq Ahmed
+ * @author Yan Kardziyaka
  * @since 2.1.0
  */
 @ConfigurationProperties(prefix = "spring.security.oauth2.resourceserver")
@@ -80,6 +82,28 @@ public class OAuth2ResourceServerProperties {
 		 */
 		private List<String> audiences = new ArrayList<>();
 
+		/**
+		 * Prefix to use for {@link GrantedAuthority authorities} mapped from JWT.
+		 */
+		private String authorityPrefix;
+
+		/**
+		 * Regex to use for splitting the value of the authorities claim into
+		 * {@link GrantedAuthority authorities}.
+		 */
+		private String authoritiesClaimDelimiter;
+
+		/**
+		 * Name of token claim to use for mapping {@link GrantedAuthority authorities}
+		 * from JWT.
+		 */
+		private String authoritiesClaimName;
+
+		/**
+		 * JWT principal claim name.
+		 */
+		private String principalClaimName;
+
 		public String getJwkSetUri() {
 			return this.jwkSetUri;
 		}
@@ -118,6 +142,38 @@ public class OAuth2ResourceServerProperties {
 
 		public void setAudiences(List<String> audiences) {
 			this.audiences = audiences;
+		}
+
+		public String getAuthorityPrefix() {
+			return this.authorityPrefix;
+		}
+
+		public void setAuthorityPrefix(String authorityPrefix) {
+			this.authorityPrefix = authorityPrefix;
+		}
+
+		public String getAuthoritiesClaimDelimiter() {
+			return this.authoritiesClaimDelimiter;
+		}
+
+		public void setAuthoritiesClaimDelimiter(String authoritiesClaimDelimiter) {
+			this.authoritiesClaimDelimiter = authoritiesClaimDelimiter;
+		}
+
+		public String getAuthoritiesClaimName() {
+			return this.authoritiesClaimName;
+		}
+
+		public void setAuthoritiesClaimName(String authoritiesClaimName) {
+			this.authoritiesClaimName = authoritiesClaimName;
+		}
+
+		public String getPrincipalClaimName() {
+			return this.principalClaimName;
+		}
+
+		public void setPrincipalClaimName(String principalClaimName) {
+			this.principalClaimName = principalClaimName;
 		}
 
 		public String readPublicKey() throws IOException {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerConfiguration.java
@@ -34,6 +34,7 @@ class ReactiveOAuth2ResourceServerConfiguration {
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass({ BearerTokenAuthenticationToken.class, ReactiveJwtDecoder.class })
 	@Import({ ReactiveOAuth2ResourceServerJwkConfiguration.JwtConfiguration.class,
+			ReactiveOAuth2ResourceServerJwkConfiguration.JwtConverterConfiguration.class,
 			ReactiveOAuth2ResourceServerJwkConfiguration.WebSecurityConfiguration.class })
 	static class JwtConfiguration {
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerJwkConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerJwkConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.IssuerUriCondition;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.KeyValueCondition;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -49,6 +50,9 @@ import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder.JwkSetUriReactiveJwtDecoderBuilder;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.SupplierReactiveJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtGrantedAuthoritiesConverterAdapter;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.WebFilterChainProxy;
 import org.springframework.util.CollectionUtils;
@@ -64,6 +68,7 @@ import org.springframework.util.CollectionUtils;
  * @author Anastasiia Losieva
  * @author Mushtaq Ahmed
  * @author Roman Golovin
+ * @author Yan Kardziyaka
  */
 @Configuration(proxyBeanMethods = false)
 class ReactiveOAuth2ResourceServerJwkConfiguration {
@@ -159,6 +164,34 @@ class ReactiveOAuth2ResourceServerJwkConfiguration {
 						getValidators(JwtValidators.createDefaultWithIssuer(this.properties.getIssuerUri())));
 				return jwtDecoder;
 			});
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnMissingBean(ReactiveJwtAuthenticationConverter.class)
+	static class JwtConverterConfiguration {
+
+		private final OAuth2ResourceServerProperties.Jwt properties;
+
+		JwtConverterConfiguration(OAuth2ResourceServerProperties properties) {
+			this.properties = properties.getJwt();
+		}
+
+		@Bean
+		ReactiveJwtAuthenticationConverter reactiveJwtAuthenticationConverter() {
+			JwtGrantedAuthoritiesConverter grantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
+			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
+			map.from(this.properties.getAuthorityPrefix()).to(grantedAuthoritiesConverter::setAuthorityPrefix);
+			map.from(this.properties.getAuthoritiesClaimDelimiter())
+				.to(grantedAuthoritiesConverter::setAuthoritiesClaimDelimiter);
+			map.from(this.properties.getAuthoritiesClaimName())
+				.to(grantedAuthoritiesConverter::setAuthoritiesClaimName);
+			ReactiveJwtAuthenticationConverter jwtAuthenticationConverter = new ReactiveJwtAuthenticationConverter();
+			map.from(this.properties.getPrincipalClaimName()).to(jwtAuthenticationConverter::setPrincipalClaimName);
+			jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(
+					new ReactiveJwtGrantedAuthoritiesConverterAdapter(grantedAuthoritiesConverter));
+			return jwtAuthenticationConverter;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.boot.autoconfigure.security.ConditionalOnDefaultWebSe
 import org.springframework.boot.autoconfigure.security.oauth2.resource.IssuerUriCondition;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.KeyValueCondition;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -48,6 +49,8 @@ import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder.JwkSetUriJwtDecoderBuilder;
 import org.springframework.security.oauth2.jwt.SupplierJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.util.CollectionUtils;
 
@@ -63,6 +66,7 @@ import static org.springframework.security.config.Customizer.withDefaults;
  * @author HaiTao Zhang
  * @author Mushtaq Ahmed
  * @author Roman Golovin
+ * @author Yan Kardziyaka
  */
 @Configuration(proxyBeanMethods = false)
 class OAuth2ResourceServerJwtConfiguration {
@@ -169,6 +173,33 @@ class OAuth2ResourceServerJwtConfiguration {
 			http.authorizeHttpRequests((requests) -> requests.anyRequest().authenticated());
 			http.oauth2ResourceServer((resourceServer) -> resourceServer.jwt(withDefaults()));
 			return http.build();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnMissingBean(JwtAuthenticationConverter.class)
+	static class JwtConverterConfiguration {
+
+		private final OAuth2ResourceServerProperties.Jwt properties;
+
+		JwtConverterConfiguration(OAuth2ResourceServerProperties properties) {
+			this.properties = properties.getJwt();
+		}
+
+		@Bean
+		JwtAuthenticationConverter getJwtAuthenticationConverter() {
+			JwtGrantedAuthoritiesConverter grantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
+			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
+			map.from(this.properties.getAuthorityPrefix()).to(grantedAuthoritiesConverter::setAuthorityPrefix);
+			map.from(this.properties.getAuthoritiesClaimDelimiter())
+				.to(grantedAuthoritiesConverter::setAuthoritiesClaimDelimiter);
+			map.from(this.properties.getAuthoritiesClaimName())
+				.to(grantedAuthoritiesConverter::setAuthoritiesClaimName);
+			JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
+			map.from(this.properties.getPrincipalClaimName()).to(jwtAuthenticationConverter::setPrincipalClaimName);
+			jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(grantedAuthoritiesConverter);
+			return jwtAuthenticationConverter;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/Oauth2ResourceServerConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/Oauth2ResourceServerConfiguration.java
@@ -32,7 +32,8 @@ class Oauth2ResourceServerConfiguration {
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(JwtDecoder.class)
 	@Import({ OAuth2ResourceServerJwtConfiguration.JwtDecoderConfiguration.class,
-			OAuth2ResourceServerJwtConfiguration.OAuth2SecurityFilterChainConfiguration.class })
+			OAuth2ResourceServerJwtConfiguration.OAuth2SecurityFilterChainConfiguration.class,
+			OAuth2ResourceServerJwtConfiguration.JwtConverterConfiguration.class })
 	static class JwtConfiguration {
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/JwtConverterCustomizationsArgumentsProvider.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/JwtConverterCustomizationsArgumentsProvider.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.security.oauth2.resource;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * {@link ArgumentsProvider Arguments provider} supplying different Spring Boot properties
+ * to customize JWT converter behavior, JWT token for conversion, expected principal name
+ * and expected authorities.
+ *
+ * @author Yan Kardziyaka
+ */
+public final class JwtConverterCustomizationsArgumentsProvider implements ArgumentsProvider {
+
+	@Override
+	public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
+		String customPrefix = "CUSTOM_AUTHORITY_PREFIX_";
+		String customDelimiter = "[~,#:]";
+		String customAuthoritiesClaim = "custom_authorities";
+		String customPrincipalClaim = "custom_principal";
+
+		String jwkSetUriProperty = "spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://jwk-set-uri.com";
+		String authorityPrefixProperty = "spring.security.oauth2.resourceserver.jwt.authority-prefix=" + customPrefix;
+		String authoritiesDelimiterProperty = "spring.security.oauth2.resourceserver.jwt.authorities-claim-delimiter="
+				+ customDelimiter;
+		String authoritiesClaimProperty = "spring.security.oauth2.resourceserver.jwt.authorities-claim-name="
+				+ customAuthoritiesClaim;
+		String principalClaimProperty = "spring.security.oauth2.resourceserver.jwt.principal-claim-name="
+				+ customPrincipalClaim;
+
+		String[] noJwtConverterProps = { jwkSetUriProperty };
+		String[] customPrefixProps = { jwkSetUriProperty, authorityPrefixProperty };
+		String[] customDelimiterProps = { jwkSetUriProperty, authoritiesDelimiterProperty };
+		String[] customAuthoritiesClaimProps = { jwkSetUriProperty, authoritiesClaimProperty };
+		String[] customPrincipalClaimProps = { jwkSetUriProperty, principalClaimProperty };
+		String[] allJwtConverterProps = { jwkSetUriProperty, authorityPrefixProperty, authoritiesDelimiterProperty,
+				authoritiesClaimProperty, principalClaimProperty };
+
+		String[] jwtScopes = { "custom_scope0", "custom_scope1" };
+		String subjectValue = UUID.randomUUID().toString();
+		String customPrincipalValue = UUID.randomUUID().toString();
+
+		Jwt.Builder jwtBuilder = Jwt.withTokenValue("token")
+			.header("alg", "none")
+			.expiresAt(Instant.MAX)
+			.issuedAt(Instant.MIN)
+			.issuer("https://issuer.example.org")
+			.jti("jti")
+			.notBefore(Instant.MIN)
+			.subject(subjectValue)
+			.claim(customPrincipalClaim, customPrincipalValue);
+
+		Jwt noAuthoritiesCustomizationsJwt = jwtBuilder.claim("scp", jwtScopes[0] + " " + jwtScopes[1]).build();
+		Jwt customAuthoritiesDelimiterJwt = jwtBuilder.claim("scp", jwtScopes[0] + "~" + jwtScopes[1]).build();
+		Jwt customAuthoritiesClaimJwt = jwtBuilder.claim("scp", null)
+			.claim(customAuthoritiesClaim, jwtScopes[0] + " " + jwtScopes[1])
+			.build();
+		Jwt customAuthoritiesClaimAndDelimiterJwt = jwtBuilder.claim("scp", null)
+			.claim(customAuthoritiesClaim, jwtScopes[0] + "~" + jwtScopes[1])
+			.build();
+
+		String[] customPrefixAuthorities = { customPrefix + jwtScopes[0], customPrefix + jwtScopes[1] };
+		String[] defaultPrefixAuthorities = { "SCOPE_" + jwtScopes[0], "SCOPE_" + jwtScopes[1] };
+
+		return Stream.of(
+				Arguments.of(Named.named("No JWT converter customizations", noJwtConverterProps),
+						noAuthoritiesCustomizationsJwt, subjectValue, defaultPrefixAuthorities),
+				Arguments.of(Named.named("Custom prefix for GrantedAuthority", customPrefixProps),
+						noAuthoritiesCustomizationsJwt, subjectValue, customPrefixAuthorities),
+				Arguments.of(Named.named("Custom delimiter for JWT scopes", customDelimiterProps),
+						customAuthoritiesDelimiterJwt, subjectValue, defaultPrefixAuthorities),
+				Arguments.of(Named.named("Custom JWT authority claim name", customAuthoritiesClaimProps),
+						customAuthoritiesClaimJwt, subjectValue, defaultPrefixAuthorities),
+				Arguments.of(Named.named("Custom JWT principal claim name", customPrincipalClaimProps),
+						noAuthoritiesCustomizationsJwt, customPrincipalValue, defaultPrefixAuthorities),
+				Arguments.of(Named.named("All JWT converter customizations", allJwtConverterProps),
+						customAuthoritiesClaimAndDelimiterJwt, customPrincipalValue, customPrefixAuthorities));
+	}
+
+}


### PR DESCRIPTION

Adds support for auto-configuring `JwtAuthenticationConverter` (and `ReactiveJwtAuthenticationConverter`) with following properties:
- `spring.security.oauth2.resourceserver.jwt.authority-prefix`
- `spring.security.oauth2.resourceserver.jwt.authorities-claim-delimiter`
- `spring.security.oauth2.resourceserver.jwt.authorities-claim-name`
- `spring.security.oauth2.resourceserver.jwt.principal-claim-name`

Closes gh-33689

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
