### PR TITLE
Fix typos in method names

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoTests.java
@@ -100,7 +100,7 @@ class BuildInfoTests {
 	}
 
 	@Test
-	void nameCanBeExludedRemovedFromProperties() {
+	void nameCanBeExcludedRemovedFromProperties() {
 		BuildInfo task = createTask(createProject("test"));
 		task.getExcludes().add("name");
 		assertThat(buildInfoProperties(task)).doesNotContainKey("build.name");

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/Canonicalizer.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/Canonicalizer.java
@@ -41,7 +41,7 @@ final class Canonicalizer {
 
 	static String canonicalize(String path) {
 		path = removeEmbeddedSlashDotDotSlash(path);
-		path = removedEmbdeddedSlashDotSlash(path);
+		path = removeEmbeddedSlashDotSlash(path);
 		path = removeTrailingSlashDotDot(path);
 		path = removeTrailingSlashDot(path);
 		return path;
@@ -57,7 +57,7 @@ final class Canonicalizer {
 		return path;
 	}
 
-	private static String removedEmbdeddedSlashDotSlash(String path) {
+	private static String removeEmbeddedSlashDotSlash(String path) {
 		int index;
 		while ((index = path.indexOf("/./")) >= 0) {
 			String before = path.substring(0, index);

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/NestedJarFileTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/NestedJarFileTests.java
@@ -242,7 +242,7 @@ class NestedJarFileTests {
 	}
 
 	@Test
-	void sizeWhenClosedThowsException() throws Exception {
+	void sizeWhenClosedThrowsException() throws Exception {
 		try (NestedJarFile jar = new NestedJarFile(this.file)) {
 			jar.close();
 			assertThatIllegalStateException().isThrownBy(() -> jar.size()).withMessage("Zip file closed");
@@ -347,7 +347,7 @@ class NestedJarFileTests {
 	}
 
 	@Test
-	void streamStreamsEnties() throws IOException {
+	void streamStreamsEntries() throws IOException {
 		try (NestedJarFile jar = new NestedJarFile(this.file, "multi-release.jar")) {
 			assertThat(jar.stream().map((entry) -> entry.getName() + ":" + entry.getRealName())).containsExactly(
 					"META-INF/:META-INF/", "META-INF/MANIFEST.MF:META-INF/MANIFEST.MF",

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/SecurityInfoTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/SecurityInfoTests.java
@@ -55,7 +55,7 @@ class SecurityInfoTests {
 	}
 
 	@Test
-	void getWhenHasSignatureFileButNoSecuityMaterialReturnsNone() throws Exception {
+	void getWhenHasSignatureFileButNoSecurityMaterialReturnsNone() throws Exception {
 		File file = new File(this.temp, "test.jar");
 		TestJar.create(file, false, true);
 		try (ZipContent content = ZipContent.open(file.toPath())) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/launch/JarFileArchiveTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/launch/JarFileArchiveTests.java
@@ -80,7 +80,7 @@ class JarFileArchiveTests {
 	}
 
 	@Test
-	void getClassPathUrlsWhenNoPredicartesReturnsUrls() throws Exception {
+	void getClassPathUrlsWhenNoPredicatesReturnsUrls() throws Exception {
 		Set<URL> urls = this.archive.getClassPathUrls(Archive.ALL_ENTRIES);
 		URL[] expected = TestJar.expectedEntries()
 			.stream()

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/net/protocol/jar/CanonicalizerTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/net/protocol/jar/CanonicalizerTests.java
@@ -35,12 +35,12 @@ class CanonicalizerTests {
 	}
 
 	@Test
-	void canonicalizeWhenHasEmbdeddSlashDotDotSlash() {
+	void canonicalizeWhenHasEmbeddedSlashDotDotSlash() {
 		assertThat(Canonicalizer.canonicalize("/foo/../bar/bif/bam/../../baz")).isEqualTo("/bar/baz");
 	}
 
 	@Test
-	void canonicalizeWhenHasEmbdeddSlashDotSlash() {
+	void canonicalizeWhenHasEmbeddedSlashDotSlash() {
 		assertThat(Canonicalizer.canonicalize("/foo/./bar/bif/bam/././baz")).isEqualTo("/foo/bar/bif/bam/baz");
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/net/protocol/jar/JarUrlConnectionTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/net/protocol/jar/JarUrlConnectionTests.java
@@ -255,7 +255,7 @@ class JarUrlConnectionTests {
 	}
 
 	@Test
-	void getInputStreamWhenNoEntryAndOptimzedThrowsException() throws Exception {
+	void getInputStreamWhenNoEntryAndOptimizedThrowsException() throws Exception {
 		JarUrlConnection setupConnection = JarUrlConnection.open(JarUrl.create(this.file, "nested.jar"));
 		setupConnection.connect();
 		assertThat(JarUrlConnection.jarFiles.getCached(setupConnection.getJarFileURL())).isNotNull();
@@ -266,7 +266,7 @@ class JarUrlConnectionTests {
 	}
 
 	@Test
-	void getInputStreamWhenNoEntryAndNotOptimzedThrowsException() throws Exception {
+	void getInputStreamWhenNoEntryAndNotOptimizedThrowsException() throws Exception {
 		JarUrlConnection connection = JarUrlConnection.open(JarUrl.create(this.file, "nested.jar", "missing.dat"));
 		assertThatExceptionOfType(FileNotFoundException.class).isThrownBy(connection::getInputStream)
 			.withMessageContaining("JAR entry missing.dat not found in");
@@ -475,7 +475,7 @@ class JarUrlConnectionTests {
 	}
 
 	@Test
-	void openWhenNestedAndInCachedWithoutEntryAndOptimzationsEnabledReturnsNoFoundConnection() throws Exception {
+	void openWhenNestedAndInCachedWithoutEntryAndOptimizationsEnabledReturnsNoFoundConnection() throws Exception {
 		JarUrlConnection setupConnection = JarUrlConnection.open(JarUrl.create(this.file, "nested.jar"));
 		setupConnection.connect();
 		assertThat(JarUrlConnection.jarFiles.getCached(setupConnection.getJarFileURL())).isNotNull();

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/net/protocol/jar/UrlJarManifestTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/net/protocol/jar/UrlJarManifestTests.java
@@ -58,7 +58,7 @@ class UrlJarManifestTests {
 	}
 
 	@Test
-	void getEntrtyAttributesWhenSuppliedManifestIsNullReturnsNull() throws Exception {
+	void getEntryAttributesWhenSuppliedManifestIsNullReturnsNull() throws Exception {
 		UrlJarManifest urlJarManifest = new UrlJarManifest(() -> null);
 		assertThat(urlJarManifest.getEntryAttributes(new JarEntry("test"))).isNull();
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/net/protocol/nested/NestedLocationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/net/protocol/nested/NestedLocationTests.java
@@ -82,7 +82,7 @@ class NestedLocationTests {
 	}
 
 	@Test
-	void fromUrlWhenNoSeparatorThrowsExceptiuon() {
+	void fromUrlWhenNoSeparatorThrowsException() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> NestedLocation.fromUrl(new URL("nested:test.jar!nested.jar")))
 			.withMessageContaining("'path' must contain '/!'");
@@ -110,7 +110,7 @@ class NestedLocationTests {
 	}
 
 	@Test
-	void fromUriWhenNoSeparatorThrowsExceptiuon() {
+	void fromUriWhenNoSeparatorThrowsException() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> NestedLocation.fromUri(new URI("nested:test.jar!nested.jar")))
 			.withMessageContaining("'path' must contain '/!'");

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/nio/file/NestedByteChannelTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/nio/file/NestedByteChannelTests.java
@@ -65,7 +65,7 @@ class NestedByteChannelTests {
 	}
 
 	@AfterEach
-	void cleanuo() throws Exception {
+	void cleanup() throws Exception {
 		this.channel.close();
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/nio/file/NestedPathTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/nio/file/NestedPathTests.java
@@ -78,7 +78,7 @@ class NestedPathTests {
 	}
 
 	@Test
-	void isAbsoluteRerturnsTrue() {
+	void isAbsoluteReturnsTrue() {
 		assertThat(this.path.isAbsolute()).isTrue();
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/zip/DataBlockInputStreamTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/test/java/org/springframework/boot/loader/zip/DataBlockInputStreamTests.java
@@ -96,7 +96,7 @@ class DataBlockInputStreamTests {
 	}
 
 	@Test
-	void skipBackwardsPastBeginingSkipsBytes() throws Exception {
+	void skipBackwardsPastBeginningSkipsBytes() throws Exception {
 		assertThat(this.inputStream.skip(1)).isEqualTo(1);
 		assertThat(this.inputStream.skip(-100)).isEqualTo(-1);
 		assertThat(this.inputStream.read()).isEqualTo(0);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
@@ -220,7 +220,7 @@ class ConfigDataEnvironmentPostProcessorIntegrationTests {
 	}
 
 	@Test
-	void runWhenHasActiveProfilesFromMultipleAdditionaLocationsWithOneSwitchedOffLoadsExpectedProperties() {
+	void runWhenHasActiveProfilesFromMultipleAdditionalLocationsWithOneSwitchedOffLoadsExpectedProperties() {
 		ConfigurableApplicationContext context = this.application.run(
 				"--spring.config.additional-location=classpath:enabletwoprofiles.properties,classpath:enableprofile.properties");
 		ConfigurableEnvironment environment = context.getEnvironment();
@@ -230,7 +230,7 @@ class ConfigDataEnvironmentPostProcessorIntegrationTests {
 	}
 
 	@Test
-	void runWhenHaslocalFileLoadsWithLocalFileTakingPrecedenceOverClasspath() throws Exception {
+	void runWhenHasLocalFileLoadsWithLocalFileTakingPrecedenceOverClasspath() throws Exception {
 		File localFile = new File(new File("."), "application.properties");
 		assertThat(localFile).doesNotExist();
 		try {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/BindableRuntimeHintsRegistrarTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/BindableRuntimeHintsRegistrarTests.java
@@ -214,7 +214,7 @@ class BindableRuntimeHintsRegistrarTests {
 	}
 
 	@Test
-	void pregisterHintsWhenHasUnresolvedGeneric() {
+	void registerHintsWhenHasUnresolvedGeneric() {
 		RuntimeHints runtimeHints = registerHints(WithGeneric.class);
 		assertThat(runtimeHints.reflection().typeHints()).hasSize(2)
 			.anySatisfy(javaBeanBinding(WithGeneric.class, "getGeneric"))

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackConfigurationAotContributionTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackConfigurationAotContributionTests.java
@@ -185,7 +185,7 @@ class LogbackConfigurationAotContributionTests {
 	@Test
 	void componentTypesOfArraysAreRegisteredForReflection() {
 		ComponentModel component = new ComponentModel();
-		component.setClassName(ArrayParmeters.class.getName());
+		component.setClassName(ArrayParameters.class.getName());
 		TestGenerationContext generationContext = applyContribution(component);
 		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(InetSocketAddress.class))
 			.accepts(generationContext.getRuntimeHints());
@@ -287,7 +287,7 @@ class LogbackConfigurationAotContributionTests {
 
 	}
 
-	public static class ArrayParmeters {
+	public static class ArrayParameters {
 
 		public void addDestinations(InetSocketAddress... addresses) {
 


### PR DESCRIPTION
Hi,

long time no see. I just noticed a couple of method name typos - mostly in tests.

Cheers,
Christoph