### PR TITLE
Deprecate OutputCaptureRule for removal

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/system/CapturedOutput.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/system/CapturedOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ package org.springframework.boot.test.system;
  * @since 2.2.0
  * @see OutputCaptureExtension
  */
+@SuppressWarnings("removal")
 public interface CapturedOutput extends CharSequence {
 
 	@Override

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/system/OutputCapture.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/system/OutputCapture.java
@@ -43,6 +43,7 @@ import org.springframework.util.ClassUtils;
  * @see OutputCaptureExtension
  * @see OutputCaptureRule
  */
+@SuppressWarnings("removal")
 class OutputCapture implements CapturedOutput {
 
 	private final Deque<SystemCapture> systemCaptures = new ArrayDeque<>();

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/system/OutputCaptureRule.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/system/OutputCaptureRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,10 @@ import static org.hamcrest.Matchers.allOf;
  * @author Phillip Webb
  * @author Andy Wilkinson
  * @since 2.2.0
+ * @deprecated since 3.2.0 for removal in 3.4.0 in favor of using JUnit 5 and
+ * {@link OutputCaptureExtension}
  */
+@Deprecated(since = "3.2.0", forRemoval = true)
 public class OutputCaptureRule implements TestRule, CapturedOutput {
 
 	private final OutputCapture delegate = new OutputCapture();

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/OutputCaptureRuleTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/system/OutputCaptureRuleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Roland Weisleder
  */
+@SuppressWarnings("removal")
+@Deprecated(since = "3.2.0", forRemoval = true)
 public class OutputCaptureRuleTests {
 
 	@Rule


### PR DESCRIPTION
Hi,

I know it's quite late in the 3.2.0 release process, but I wonder if we can deprecate `OutputCaptureRule` for removal still.

JUnit 5 has been released in 2017 if I remember correctly. It's also the recommended default for quite some time. I think it's time to deprecate JUnit 4 and related functionality.

Let me know what you think.
Cheers,
Christoph