### PR TITLE
Report friendly error for starting application with AOT mode but not AOT-processed

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -168,6 +168,7 @@ import org.springframework.util.function.ThrowingSupplier;
  * @author Chris Bono
  * @author Moritz Halbritter
  * @author Tadaya Tsuyukubo
+ * @author Yanming Zhou
  * @since 1.0.0
  * @see #run(Class, String[])
  * @see #run(Class[], String[])
@@ -436,6 +437,12 @@ public class SpringApplication {
 					initializers.stream().filter(AotApplicationContextInitializer.class::isInstance).toList());
 			if (aotInitializers.isEmpty()) {
 				String initializerClassName = this.mainApplicationClass.getName() + "__ApplicationContextInitializer";
+				if (!ClassUtils.isPresent(initializerClassName, getClassLoader())) {
+					throw new IllegalArgumentException(
+							"You are starting application with AOT mode but not AOT-processed,"
+									+ " please build your application with AOT first."
+									+ " Or remove system property 'spring.aot.enabled=true' to run as regular mode.");
+				}
 				aotInitializers.add(AotApplicationContextInitializer.forInitializerClasses(initializerClassName));
 			}
 			initializers.removeAll(aotInitializers);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
@@ -163,6 +163,7 @@ import static org.mockito.Mockito.spy;
  * @author Sebastien Deleuze
  * @author Moritz Halbritter
  * @author Tadaya Tsuyukubo
+ * @author Yanming Zhou
  */
 @ExtendWith(OutputCaptureExtension.class)
 class SpringApplicationTests {
@@ -1369,6 +1370,21 @@ class SpringApplicationTests {
 		try {
 			ApplicationContext context = application.run();
 			assertThat(context.getBean("test")).isEqualTo("test");
+		}
+		finally {
+			System.clearProperty(AotDetector.AOT_ENABLED);
+		}
+	}
+
+	@Test
+	void shouldReportFriendlyErrorIfAotInitializerNotFound() {
+		SpringApplication application = new SpringApplication(TestSpringApplication.class);
+		application.setWebApplicationType(WebApplicationType.NONE);
+		application.setMainApplicationClass(TestSpringApplication.class);
+		System.setProperty(AotDetector.AOT_ENABLED, "true");
+		try {
+			assertThatIllegalArgumentException().isThrownBy(application::run)
+				.withMessageContaining(AotDetector.AOT_ENABLED);
 		}
 		finally {
 			System.clearProperty(AotDetector.AOT_ENABLED);


### PR DESCRIPTION
 Error is reported as:
```
java.lang.IllegalArgumentException: You are starting application with AOT mode but not AOT-processed, please build your application with AOT first. Or remove system property 'spring.aot.enabled=true' to run as regular mode.
	at org.springframework.boot.SpringApplication.addAotGeneratedInitializerIfNecessary(SpringApplication.java:441) ~[main/:?]
	at org.springframework.boot.SpringApplication.prepareContext(SpringApplication.java:396) ~[main/:?]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:322) ~[main/:?]
```
instead of:
```
java.lang.IllegalArgumentException: Could not find class [org.springframework.boot.SpringApplicationTests$TestSpringApplication__ApplicationContextInitializer]
	at org.springframework.util.ClassUtils.resolveClassName(ClassUtils.java:355) ~[spring-core-6.1.0-RC2.jar:6.1.0-RC2]
	at org.springframework.context.aot.AotApplicationContextInitializer.instantiateInitializer(AotApplicationContextInitializer.java:80) ~[spring-context-6.1.0-RC2.jar:6.1.0-RC2]
	at org.springframework.context.aot.AotApplicationContextInitializer.initialize(AotApplicationContextInitializer.java:71) ~[spring-context-6.1.0-RC2.jar:6.1.0-RC2]
	at org.springframework.context.aot.AotApplicationContextInitializer.lambda$forInitializerClasses$0(AotApplicationContextInitializer.java:61) ~[spring-context-6.1.0-RC2.jar:6.1.0-RC2]
	at org.springframework.boot.SpringApplication.applyInitializers(SpringApplication.java:623) ~[main/:?]
	at org.springframework.boot.SpringApplication.prepareContext(SpringApplication.java:397) ~[main/:?]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:322) ~[main/:?]
	... 
Caused by: java.lang.ClassNotFoundException: org.springframework.boot.SpringApplicationTests$TestSpringApplication__ApplicationContextInitializer
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641) ~[?:?]
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188) ~[?:?]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525) ~[?:?]
	at java.base/java.lang.Class.forName0(Native Method) ~[?:?]
	at java.base/java.lang.Class.forName(Class.java:467) ~[?:?]
	at org.springframework.util.ClassUtils.forName(ClassUtils.java:304) ~[spring-core-6.1.0-RC2.jar:6.1.0-RC2]
	at org.springframework.util.ClassUtils.resolveClassName(ClassUtils.java:345) ~[spring-core-6.1.0-RC2.jar:6.1.0-RC2]
	... 
```