### PR TITLE
Merge all previous parameters in case of a batch job restart

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
@@ -28,7 +28,9 @@ import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.batch.core.launch.support.SimpleJobOperator;
+import org.springframework.batch.core.repository.ExecutionContextSerializer;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.dao.DefaultExecutionContextSerializer;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -120,13 +122,18 @@ public class BatchAutoConfiguration {
 
 		private final List<BatchConversionServiceCustomizer> batchConversionServiceCustomizers;
 
+		private final ExecutionContextSerializer executionContextSerializer;
+
 		SpringBootBatchConfiguration(DataSource dataSource, @BatchDataSource ObjectProvider<DataSource> batchDataSource,
 				PlatformTransactionManager transactionManager, BatchProperties properties,
-				ObjectProvider<BatchConversionServiceCustomizer> batchConversionServiceCustomizers) {
+				ObjectProvider<BatchConversionServiceCustomizer> batchConversionServiceCustomizers,
+				ObjectProvider<ExecutionContextSerializer> executionContextSerializer) {
 			this.dataSource = batchDataSource.getIfAvailable(() -> dataSource);
 			this.transactionManager = transactionManager;
 			this.properties = properties;
 			this.batchConversionServiceCustomizers = batchConversionServiceCustomizers.orderedStream().toList();
+			this.executionContextSerializer = executionContextSerializer
+				.getIfAvailable(DefaultExecutionContextSerializer::new);
 		}
 
 		@Override
@@ -158,6 +165,11 @@ public class BatchAutoConfiguration {
 				customizer.customize(conversionService);
 			}
 			return conversionService;
+		}
+
+		@Override
+		protected ExecutionContextSerializer getExecutionContextSerializer() {
+			return this.executionContextSerializer;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
@@ -20,14 +20,10 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
-import org.springframework.batch.core.configuration.ListableJobLocator;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.support.DefaultBatchConfiguration;
-import org.springframework.batch.core.converter.JobParametersConverter;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.batch.core.launch.JobOperator;
-import org.springframework.batch.core.launch.support.SimpleJobOperator;
 import org.springframework.batch.core.repository.ExecutionContextSerializer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.dao.DefaultExecutionContextSerializer;
@@ -95,20 +91,6 @@ public class BatchAutoConfiguration {
 	@ConditionalOnMissingBean(ExitCodeGenerator.class)
 	public JobExecutionExitCodeGenerator jobExecutionExitCodeGenerator() {
 		return new JobExecutionExitCodeGenerator();
-	}
-
-	@Bean
-	@ConditionalOnMissingBean(JobOperator.class)
-	public SimpleJobOperator jobOperator(ObjectProvider<JobParametersConverter> jobParametersConverter,
-			JobExplorer jobExplorer, JobLauncher jobLauncher, ListableJobLocator jobRegistry,
-			JobRepository jobRepository) {
-		SimpleJobOperator factory = new SimpleJobOperator();
-		factory.setJobExplorer(jobExplorer);
-		factory.setJobLauncher(jobLauncher);
-		factory.setJobRegistry(jobRegistry);
-		factory.setJobRepository(jobRepository);
-		jobParametersConverter.ifAvailable(factory::setJobParametersConverter);
-		return factory;
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunner.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunner.java
@@ -19,7 +19,6 @@ package org.springframework.boot.autoconfigure.batch;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -230,8 +229,7 @@ public class JobLauncherApplicationRunner
 	private JobParameters getNextJobParametersForExisting(Job job, JobParameters jobParameters) {
 		JobExecution lastExecution = this.jobRepository.getLastJobExecution(job.getName(), jobParameters);
 		if (isStoppedOrFailed(lastExecution) && job.isRestartable()) {
-			JobParameters previousIdentifyingParameters = getGetIdentifying(lastExecution.getJobParameters());
-			return merge(previousIdentifyingParameters, jobParameters);
+			return merge(lastExecution.getJobParameters(), jobParameters);
 		}
 		return jobParameters;
 	}
@@ -239,16 +237,6 @@ public class JobLauncherApplicationRunner
 	private boolean isStoppedOrFailed(JobExecution execution) {
 		BatchStatus status = (execution != null) ? execution.getStatus() : null;
 		return (status == BatchStatus.STOPPED || status == BatchStatus.FAILED);
-	}
-
-	private JobParameters getGetIdentifying(JobParameters parameters) {
-		HashMap<String, JobParameter<?>> nonIdentifying = new LinkedHashMap<>(parameters.getParameters().size());
-		parameters.getParameters().forEach((key, value) -> {
-			if (value.isIdentifying()) {
-				nonIdentifying.put(key, value);
-			}
-		});
-		return new JobParameters(nonIdentifying);
 	}
 
 	private JobParameters merge(JobParameters parameters, JobParameters additionals) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunner.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunner.java
@@ -229,7 +229,9 @@ public class JobLauncherApplicationRunner
 	private JobParameters getNextJobParametersForExisting(Job job, JobParameters jobParameters) {
 		JobExecution lastExecution = this.jobRepository.getLastJobExecution(job.getName(), jobParameters);
 		if (isStoppedOrFailed(lastExecution) && job.isRestartable()) {
-			return merge(lastExecution.getJobParameters(), jobParameters);
+			JobParameters previousIdentifyingParameters = new JobParameters(
+					lastExecution.getJobParameters().getIdentifyingParameters());
+			return merge(previousIdentifyingParameters, jobParameters);
 		}
 		return jobParameters;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfigurationTests.java
@@ -42,6 +42,7 @@ import org.springframework.batch.core.configuration.support.DefaultBatchConfigur
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.job.AbstractJob;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.batch.core.repository.ExecutionContextSerializer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.dao.DefaultExecutionContextSerializer;
@@ -113,8 +114,11 @@ class BatchAutoConfigurationTests {
 		this.contextRunner.withInitializer(ConditionEvaluationReportLoggingListener.forLogLevel(LogLevel.INFO))
 			.withUserConfiguration(TestConfiguration.class, EmbeddedDataSourceConfiguration.class)
 			.run((context) -> {
+				assertThat(context).hasSingleBean(JobRepository.class);
 				assertThat(context).hasSingleBean(JobLauncher.class);
 				assertThat(context).hasSingleBean(JobExplorer.class);
+				assertThat(context).hasSingleBean(JobRegistry.class);
+				assertThat(context).hasSingleBean(JobOperator.class);
 				assertThat(context.getBean(BatchProperties.class).getJdbc().getInitializeSchema())
 					.isEqualTo(DatabaseInitializationMode.EMBEDDED);
 				assertThat(new JdbcTemplate(context.getBean(DataSource.class))

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunnerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/JobLauncherApplicationRunnerTests.java
@@ -24,6 +24,7 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionException;
 import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.JobParameters;
@@ -168,6 +169,48 @@ class JobLauncherApplicationRunnerTests {
 			jobLauncherContext.runner.execute(job,
 					new JobParametersBuilder(jobParameters).addLong("run.id", 1L).toJobParameters());
 			assertThat(jobLauncherContext.jobInstances()).hasSize(1);
+		});
+	}
+
+	@Test
+	void retryFailedExecutionWithNonIdentifyingParameters_previousParamsAreMerged() {
+		this.contextRunner.run((context) -> {
+			PlatformTransactionManager transactionManager = context.getBean(PlatformTransactionManager.class);
+			JobLauncherApplicationRunnerContext jobLauncherContext = new JobLauncherApplicationRunnerContext(context);
+			Job job = jobLauncherContext.jobBuilder()
+				.start(jobLauncherContext.stepBuilder().tasklet(throwingTasklet(), transactionManager).build())
+				.incrementer(new RunIdIncrementer())
+				.build();
+			JobParameters jobParameters = new JobParametersBuilder().addLong("id", 1L, false)
+				.addLong("foo", 2L, false)
+				.toJobParameters();
+			jobLauncherContext.runner.execute(job, jobParameters);
+			assertThat(jobLauncherContext.jobInstances()).hasSize(1);
+
+			// try to re-run a failed execution with non identifying parameters
+			// identifying parameter 'run.id' is used to find the failed execution.
+			// non-identifying parameter 'id' is copied form the previous execution.
+			// non-identifying parameter 'foo' is replaced with a new value.
+			jobLauncherContext.runner.execute(job,
+					new JobParametersBuilder().addLong("run.id", 1L).addLong("foo", 3L, false).toJobParameters());
+
+			assertThat(jobLauncherContext.jobInstances()).hasSize(1);
+
+			JobExecution initialExecution = jobLauncherContext.jobExplorer.getJobExecution(1L);
+			assertThat(initialExecution).isNotNull();
+			JobParameters initialParams = initialExecution.getJobParameters();
+			assertThat(initialParams.getParameters()).hasSize(3);
+			assertThat(initialParams.getLong("id")).isEqualTo(1L);
+			assertThat(initialParams.getLong("foo")).isEqualTo(2L);
+			assertThat(initialParams.getLong("run.id")).isEqualTo(1L);
+
+			JobExecution retryExecution = jobLauncherContext.jobExplorer.getJobExecution(2L);
+			assertThat(retryExecution).isNotNull();
+			JobParameters retryParams = retryExecution.getJobParameters();
+			assertThat(retryParams.getParameters()).hasSize(3);
+			assertThat(retryParams.getLong("id")).isEqualTo(1L);
+			assertThat(retryParams.getLong("foo")).isEqualTo(3L);
+			assertThat(retryParams.getLong("run.id")).isEqualTo(1L);
 		});
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/batch.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/batch.adoc
@@ -53,7 +53,11 @@ Consider the following command:
 
 This provides only one argument to the batch job: `someParameter=someValue`.
 
+=== Restarting a stopped or failed Job
 
+In order to restart a failed `Job`, all parameters (identifying and non-identifying) have to be re-specified on the command line. Non-identifying parameters are *not* copied from the previous execution. This allows them to be modified or removed.
+
+NOTE: When using a custom `JobParametersIncrementer`: Be prepared to gather all parameters managed by the incrementer in order to restart a failed execution.
 
 [[howto.batch.storing-job-repository]]
 === Storing the Job Repository


### PR DESCRIPTION
### Merge all previous parameters in case of a batch job restart

When looking to replace a custom job launcher with `JobLauncherApplicationRunner` I noticed that upon job restart, it will not copy non-identifying parameters from the previous (failed) execution to the retry execution. 

This PR uses the identifying parameter from the command line to find the failed job execution.  All other parameters of the failed invocation are merged with the command-line.

This seems to be in sync with `org.springframework.batch.core.launch.support.SimpleJobOperator#restart`. Restart works using the failed instance-id and will copy all params of the failed execution - but lacks the possibility to override non-identifying params.

Scenario: Batch Job Definition uses a `JobParametersIncrementer` implementation.

**initial / regular invocation**

`# java -jar batch-app.jar`

The incrementer will generate three job parameters:

```
export_number,java.lang.Long,2,Y
time.start,java.time.LocalDateTime,1970-01-01T00:00:00,N
time.end,java.time.LocalDateTime,2023-11-06T07:44:42.138356,N

```

If the job execution fails, in order to restart the job, one would have to pass all three parameter on the command line

**current restart invocation**

```
# java -jar batch-app.jar \
export_number,java.lang.Long,2,true \
time.start,java.time.LocalDateTime,1970-01-01T00:00:00,false \
time.end,java.time.LocalDateTime,2023-11-06T07:44:42.138356,false

```

My PR would allow to restart the job using only the identifying parameter, while the non-identifying params would be copied from the failed invocation.

**simplified restart invocation**

```
# java -jar batch-app.jar export_number,java.lang.Long,2,true
```

The current restart invocation would still work, cli parameters would  have precedence over the old non-identifying prameters. Identifying parameters must be identical anyway.