### PR TITLE
Remove obsolete spring-boot-deployment-tests directory

### DIFF
--- a/spring-boot-tests/spring-boot-deployment-tests/src/intTest/resources/logback.xml
+++ b/spring-boot-tests/spring-boot-deployment-tests/src/intTest/resources/logback.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-	<include resource="org/springframework/boot/logging/logback/base.xml"/>
-</configuration>


### PR DESCRIPTION
Hi,

I just noticed a `spring-boot-deployment-tests` directory that should have been probably removed with #27499 when the deployment tests were moved to the system test pipeline.

Cheers,
Christoph 