### PR TITLE
Remove obsolete prohibit for Undertow library

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1982,10 +1982,6 @@ bom {
 		}
 	}
 	library("Undertow", "2.2.28.Final") {
-		prohibit {
-			versionRange "[2.2.27.Final]"
-			because "it is not compatibile with Java 8 (https://issues.redhat.com/browse/UNDERTOW-2324)"
-		}
 		group("io.undertow") {
 			modules = [
 				"undertow-core",


### PR DESCRIPTION
This PR removes obsolete prohibit for Undertow library.