### PR TITLE
Re-add @ConditionalOnEnabledTracing on BraveAutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfiguration.java
@@ -79,6 +79,7 @@ import org.springframework.core.env.Environment;
 @AutoConfiguration(before = MicrometerTracingAutoConfiguration.class)
 @ConditionalOnClass({ Tracer.class, BraveTracer.class })
 @EnableConfigurationProperties(TracingProperties.class)
+@ConditionalOnEnabledTracing
 public class BraveAutoConfiguration {
 
 	private static final BraveBaggageManager BRAVE_BAGGAGE_MANAGER = new BraveBaggageManager();


### PR DESCRIPTION
`@ConditionalOnEnabledTracing` used to be on the `BraveAutoConfiguration`. See this revision: https://github.com/spring-projects/spring-boot/blob/411586347c8fae00373028bac51dfd16e69661c5/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/BraveAutoConfiguration.java

It's unclear to me from the git history why it was removed, and I think it's incorrect.
This is causing an issue with (testing) upgrading to 3.2 currently.