### PR TITLE
Add new properties and align dependency exclusions for Liquibase 4.22.0

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -108,7 +108,6 @@ dependencies {
 	optional("org.hibernate.validator:hibernate-validator")
 	optional("org.influxdb:influxdb-java")
 	optional("org.liquibase:liquibase-core") {
-		exclude group: "javax.activation", module: "javax.activation-api"
 		exclude group: "javax.xml.bind", module: "jaxb-api"
 	}
 	optional("org.mongodb:mongodb-driver-reactivestreams")

--- a/spring-boot-project/spring-boot-actuator/build.gradle
+++ b/spring-boot-project/spring-boot-actuator/build.gradle
@@ -50,7 +50,6 @@ dependencies {
 	optional("org.hibernate.validator:hibernate-validator")
 	optional("org.influxdb:influxdb-java")
 	optional("org.liquibase:liquibase-core") {
-		exclude group: "javax.activation", module: "javax.activation-api"
 		exclude(group: "javax.xml.bind", module: "jaxb-api")
 	}
 	optional("org.mongodb:mongodb-driver-reactivestreams")

--- a/spring-boot-project/spring-boot-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-autoconfigure/build.gradle
@@ -122,7 +122,6 @@ dependencies {
 		exclude group: "javax.xml.bind", module: "jaxb-api"
 	}
 	optional("org.liquibase:liquibase-core") {
-		exclude group: "javax.activation", module: "javax.activation-api"
 		exclude group: "javax.xml.bind", module: "jaxb-api"
 	}
 	optional("org.messaginghub:pooled-jms") {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -113,6 +113,8 @@ public class LiquibaseAutoConfiguration {
 			liquibase.setRollbackFile(properties.getRollbackFile());
 			liquibase.setTestRollbackOnUpdate(properties.isTestRollbackOnUpdate());
 			liquibase.setTag(properties.getTag());
+			liquibase.setShowSummary(properties.getShowSummary());
+			liquibase.setShowSummaryOutput(properties.getShowSummaryOutput());
 			return liquibase;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
@@ -19,6 +19,8 @@ package org.springframework.boot.autoconfigure.liquibase;
 import java.io.File;
 import java.util.Map;
 
+import liquibase.UpdateSummaryEnum;
+import liquibase.UpdateSummaryOutputEnum;
 import liquibase.integration.spring.SpringLiquibase;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -134,6 +136,18 @@ public class LiquibaseProperties {
 	 * with that tag.
 	 */
 	private String tag;
+
+	/**
+	 * Whether to print a summary of the update operation. Values can be 'off', 'summary'
+	 * (default), 'verbose'
+	 */
+	private UpdateSummaryEnum showSummary;
+
+	/**
+	 * Where to print a summary of the update operation. Values can be 'log' (default),
+	 * 'console', or 'all'.
+	 */
+	private UpdateSummaryOutputEnum showSummaryOutput;
 
 	public String getChangeLog() {
 		return this.changeLog;
@@ -286,6 +300,22 @@ public class LiquibaseProperties {
 
 	public void setTag(String tag) {
 		this.tag = tag;
+	}
+
+	public UpdateSummaryEnum getShowSummary() {
+		return this.showSummary;
+	}
+
+	public void setShowSummary(UpdateSummaryEnum showSummary) {
+		this.showSummary = showSummary;
+	}
+
+	public UpdateSummaryOutputEnum getShowSummaryOutput() {
+		return this.showSummaryOutput;
+	}
+
+	public void setShowSummaryOutput(UpdateSummaryOutputEnum showSummaryOutput) {
+		this.showSummaryOutput = showSummaryOutput;
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
@@ -29,6 +29,8 @@ import java.util.function.Consumer;
 import javax.sql.DataSource;
 
 import com.zaxxer.hikari.HikariDataSource;
+import liquibase.UpdateSummaryEnum;
+import liquibase.UpdateSummaryOutputEnum;
 import liquibase.integration.spring.SpringLiquibase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -117,6 +119,9 @@ class LiquibaseAutoConfigurationTests {
 				assertThat(liquibase.getDefaultSchema()).isNull();
 				assertThat(liquibase.isDropFirst()).isFalse();
 				assertThat(liquibase.isClearCheckSums()).isFalse();
+				UpdateSummaryOutputEnum showSummaryOutput = (UpdateSummaryOutputEnum) ReflectionTestUtils
+					.getField(liquibase, "showSummaryOutput");
+				assertThat(showSummaryOutput).isEqualTo(UpdateSummaryOutputEnum.LOG);
 			}));
 	}
 
@@ -381,6 +386,28 @@ class LiquibaseAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
 			.withPropertyValues("spring.liquibase.label-filter:test, production")
 			.run(assertLiquibase((liquibase) -> assertThat(liquibase.getLabelFilter()).isEqualTo("test, production")));
+	}
+
+	@Test
+	void overrideShowSummary() {
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+			.withPropertyValues("spring.liquibase.show-summary=off")
+			.run(assertLiquibase((liquibase) -> {
+				UpdateSummaryEnum showSummary = (UpdateSummaryEnum) ReflectionTestUtils.getField(liquibase,
+						"showSummary");
+				assertThat(showSummary).isEqualTo(UpdateSummaryEnum.OFF);
+			}));
+	}
+
+	@Test
+	void overrideShowSummaryOutput() {
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+			.withPropertyValues("spring.liquibase.show-summary-output=all")
+			.run(assertLiquibase((liquibase) -> {
+				UpdateSummaryOutputEnum showSummaryOutput = (UpdateSummaryOutputEnum) ReflectionTestUtils
+					.getField(liquibase, "showSummaryOutput");
+				assertThat(showSummaryOutput).isEqualTo(UpdateSummaryOutputEnum.ALL);
+			}));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/build.gradle
+++ b/spring-boot-project/spring-boot/build.gradle
@@ -71,7 +71,6 @@ dependencies {
 		exclude(group: "javax.xml.bind", module: "jaxb-api")
 	}
 	optional("org.liquibase:liquibase-core") {
-		exclude group: "javax.activation", module: "javax.activation-api"
 		exclude(group: "javax.xml.bind", module: "jaxb-api")
 	}
 	optional("org.postgresql:postgresql")

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-r2dbc-liquibase/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-r2dbc-liquibase/build.gradle
@@ -9,7 +9,6 @@ dependencies {
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-data-r2dbc"))
 
 	runtimeOnly("org.liquibase:liquibase-core") {
-		exclude group: "javax.activation", module: "javax.activation-api"
 		exclude group: "javax.xml.bind", module: "jaxb-api"
 	}
 	runtimeOnly("org.postgresql:postgresql")

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-liquibase/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-liquibase/build.gradle
@@ -11,7 +11,6 @@ dependencies {
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-web"))
 	implementation("jakarta.xml.bind:jakarta.xml.bind-api")
 	implementation("org.liquibase:liquibase-core") {
-		exclude group: "javax.activation", module: "javax.activation-api"
 		exclude group: "javax.xml.bind", module: "jaxb-api"
 	}
 


### PR DESCRIPTION
Hi, there are a couple of changes in liquibase 4.24.0 that are relevant to Spring Boot: 
- https://github.com/liquibase/liquibase/issues/4487 There isn't a dependency on `javax.activation-api` anymore, so I removed the corresponding exclusions.
- Some new properties were added in `SpringLiquibase`, so I added them to the autoconfiguration too https://github.com/liquibase/liquibase/pull/4574 https://github.com/liquibase/liquibase/pull/4395

Bye!