### PR TITLE
Fix link to Elasticsearch health indicator

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/endpoints.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/endpoints.adoc
@@ -598,7 +598,7 @@ with the `key` listed in the following table:
 | Checks for low disk space.
 
 | `elasticsearch`
-| {spring-boot-actuator-module-code}/elasticsearch/ElasticsearchRestHealthIndicator.java[`ElasticsearchRestHealthIndicator`]
+| {spring-boot-actuator-module-code}/elasticsearch/ElasticsearchRestClientHealthIndicator.java[`ElasticsearchRestClientHealthIndicator`]
 | Checks that an Elasticsearch cluster is up.
 
 | `hazelcast`


### PR DESCRIPTION
Hi,

I just noticed a broken doc link to the Elasticsearch health indicator.

Cheers,
Christoph