### PR TITLE
Refactor AnsiPropertySource Static Initialization

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiPropertySource.java
@@ -16,8 +16,6 @@
 
 package org.springframework.boot.ansi;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -48,16 +46,13 @@ public class AnsiPropertySource extends PropertySource<AnsiElement> {
 	private static final Iterable<Mapping> MAPPINGS;
 
 	static {
-		List<Mapping> mappings = new ArrayList<>();
-		mappings.add(new EnumMapping<>("AnsiStyle.", AnsiStyle.class));
-		mappings.add(new EnumMapping<>("AnsiColor.", AnsiColor.class));
-		mappings.add(new Ansi8BitColorMapping("AnsiColor.", Ansi8BitColor::foreground));
-		mappings.add(new EnumMapping<>("AnsiBackground.", AnsiBackground.class));
-		mappings.add(new Ansi8BitColorMapping("AnsiBackground.", Ansi8BitColor::background));
-		mappings.add(new EnumMapping<>("Ansi.", AnsiStyle.class));
-		mappings.add(new EnumMapping<>("Ansi.", AnsiColor.class));
-		mappings.add(new EnumMapping<>("Ansi.BG_", AnsiBackground.class));
-		MAPPINGS = Collections.unmodifiableList(mappings);
+		MAPPINGS = List.of(new EnumMapping<>("AnsiStyle.", AnsiStyle.class),
+				new EnumMapping<>("AnsiColor.", AnsiColor.class),
+				new Ansi8BitColorMapping("AnsiColor.", Ansi8BitColor::foreground),
+				new EnumMapping<>("AnsiBackground.", AnsiBackground.class),
+				new Ansi8BitColorMapping("AnsiBackground.", Ansi8BitColor::background),
+				new EnumMapping<>("Ansi.", AnsiStyle.class), new EnumMapping<>("Ansi.", AnsiColor.class),
+				new EnumMapping<>("Ansi.BG_", AnsiBackground.class));
 	}
 
 	private final boolean encode;


### PR DESCRIPTION
### Overview
This pull request updates the static initialization block in the `AnsiPropertySource` class. The goal is to leverage modern Java features for cleaner and more readable code.

### Changes
- Replaced the verbose `ArrayList` and `Collections.unmodifiableList` initialization with the more concise `List.of()` method available from Java 9 onwards.
- This change reduces the code's verbosity, making it more readable and easier to maintain.
- The use of `List.of()` ensures that the list is inherently immutable, aligning with best practices for handling static final lists.

### Justification
- **Readability**: The original code used an `ArrayList` followed by wrapping it with `Collections.unmodifiableList`. While this approach is valid, it's more verbose and less readable. The new approach using `List.of()` is more straightforward and expressive.
- **Modern Practices**: Since the project targets Java 11/17, it's beneficial to utilize the newer and more efficient Java features. `List.of()` is a modern and concise way to initialize immutable lists, which is a common pattern in recent Java codebases.
- **Performance and Safety**: The immutable list created by `List.of()` is more performant and safer, as it prevents accidental modifications of the list, which is crucial for static final lists.

### Conclusion
By adopting this change, the `AnsiPropertySource` class becomes more aligned with modern Java practices, enhancing code readability and maintainability while ensuring immutability and safety of the static list.
