### PR TITLE
Add ProcessInfoContributor

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/info/InfoContributorAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/info/InfoContributorAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.springframework.boot.actuate.info.GitInfoContributor;
 import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.actuate.info.JavaInfoContributor;
 import org.springframework.boot.actuate.info.OsInfoContributor;
+import org.springframework.boot.actuate.info.ProcessInfoContributor;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -90,6 +91,13 @@ public class InfoContributorAutoConfiguration {
 	@Order(DEFAULT_ORDER)
 	public OsInfoContributor osInfoContributor() {
 		return new OsInfoContributor();
+	}
+
+	@Bean
+	@ConditionalOnEnabledInfoContributor(value = "process", fallback = InfoContributorFallback.DISABLE)
+	@Order(DEFAULT_ORDER)
+	public ProcessInfoContributor processInfoContributor() {
+		return new ProcessInfoContributor();
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -310,6 +310,12 @@
       "defaultValue": false
     },
     {
+      "name": "management.info.process.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable process info.",
+      "defaultValue": false
+    },
+    {
       "name": "management.metrics.binders.files.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to enable files metrics.",

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/info/InfoContributorAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/info/InfoContributorAutoConfigurationTests.java
@@ -28,11 +28,13 @@ import org.springframework.boot.actuate.info.Info;
 import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.actuate.info.JavaInfoContributor;
 import org.springframework.boot.actuate.info.OsInfoContributor;
+import org.springframework.boot.actuate.info.ProcessInfoContributor;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.boot.info.GitProperties;
 import org.springframework.boot.info.JavaInfo;
 import org.springframework.boot.info.OsInfo;
+import org.springframework.boot.info.ProcessInfo;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -161,6 +163,16 @@ class InfoContributorAutoConfigurationTests {
 			Map<String, Object> content = invokeContributor(context.getBean(OsInfoContributor.class));
 			assertThat(content).containsKey("os");
 			assertThat(content.get("os")).isInstanceOf(OsInfo.class);
+		});
+	}
+
+	@Test
+	void processInfoContributor() {
+		this.contextRunner.withPropertyValues("management.info.process.enabled=true").run((context) -> {
+			assertThat(context).hasSingleBean(ProcessInfoContributor.class);
+			Map<String, Object> content = invokeContributor(context.getBean(ProcessInfoContributor.class));
+			assertThat(content).containsKey("process");
+			assertThat(content.get("process")).isInstanceOf(ProcessInfo.class);
 		});
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/ProcessInfoContributor.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/ProcessInfoContributor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.info;
+
+import org.springframework.aot.hint.BindingReflectionHintsRegistrar;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.boot.actuate.info.Info.Builder;
+import org.springframework.boot.actuate.info.ProcessInfoContributor.ProcessInfoContributorRuntimeHints;
+import org.springframework.boot.info.ProcessInfo;
+import org.springframework.context.annotation.ImportRuntimeHints;
+
+/**
+ * An {@link InfoContributor} that exposes {@link ProcessInfo}.
+ *
+ * @author Jonatan Ivanov
+ * @since 3.3.0
+ */
+@ImportRuntimeHints(ProcessInfoContributorRuntimeHints.class)
+public class ProcessInfoContributor implements InfoContributor {
+
+	private final ProcessInfo processInfo;
+
+	public ProcessInfoContributor() {
+		this.processInfo = new ProcessInfo();
+	}
+
+	@Override
+	public void contribute(Builder builder) {
+		builder.withDetail("process", this.processInfo);
+	}
+
+	static class ProcessInfoContributorRuntimeHints implements RuntimeHintsRegistrar {
+
+		private final BindingReflectionHintsRegistrar bindingRegistrar = new BindingReflectionHintsRegistrar();
+
+		@Override
+		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+			this.bindingRegistrar.registerReflectionHints(hints.reflection(), ProcessInfo.class);
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/info/ProcessInfoContributorTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/info/ProcessInfoContributorTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.info;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import org.springframework.boot.actuate.info.ProcessInfoContributor.ProcessInfoContributorRuntimeHints;
+import org.springframework.boot.info.ProcessInfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ProcessInfoContributor}.
+ *
+ * @author Jonatan Ivanov
+ */
+class ProcessInfoContributorTests {
+
+	@Test
+	void processInfoShouldBeAdded() {
+		ProcessInfoContributor processInfoContributor = new ProcessInfoContributor();
+		Info.Builder builder = new Info.Builder();
+		processInfoContributor.contribute(builder);
+		Info info = builder.build();
+		assertThat(info.get("process")).isInstanceOf(ProcessInfo.class);
+	}
+
+	@Test
+	void shouldRegisterHints() {
+		RuntimeHints runtimeHints = new RuntimeHints();
+		new ProcessInfoContributorRuntimeHints().registerHints(runtimeHints, getClass().getClassLoader());
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(ProcessInfo.class)
+			.withMemberCategories(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.DECLARED_FIELDS))
+			.accepts(runtimeHints);
+	}
+
+}

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/endpoints.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/endpoints.adoc
@@ -1087,12 +1087,17 @@ When appropriate, Spring auto-configures the following `InfoContributor` beans:
 | Exposes Operating System information.
 | None.
 
+| `process`
+| {spring-boot-actuator-module-code}/info/ProcessInfoContributor.java[`ProcessInfoContributor`]
+| Exposes process information.
+| None.
+
 |===
 
 Whether an individual contributor is enabled is controlled by its `management.info.<id>.enabled` property.
 Different contributors have different defaults for this property, depending on their prerequisites and the nature of the information that they expose.
 
-With no prerequisites to indicate that they should be enabled, the `env`, `java`, and `os` contributors are disabled by default.
+With no prerequisites to indicate that they should be enabled, the `env`, `java`, `os`, and `process` contributors are disabled by default.
 Each can be enabled by setting its `management.info.<id>.enabled` property to `true`.
 
 The `build` and `git` info contributors are enabled by default.
@@ -1187,6 +1192,12 @@ The `info` endpoint publishes information about your Java runtime environment, s
 [[actuator.endpoints.info.os-information]]
 ==== OS Information
 The `info` endpoint publishes information about your Operating System, see {spring-boot-module-api}/info/OsInfo.html[`OsInfo`] for more details.
+
+
+
+[[actuator.endpoints.info.process-information]]
+==== Process Information
+The `info` endpoint publishes information about your process, see {spring-boot-module-api}/info/ProcessInfo.html[`Process`] for more details.
 
 
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/ProcessInfo.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/ProcessInfo.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.info;
+
+/**
+ * Information about the process of the application.
+ *
+ * @author Jonatan Ivanov
+ * @since 3.3.0
+ */
+public class ProcessInfo {
+
+	private static final Runtime runtime = Runtime.getRuntime();
+
+	private final long pid;
+
+	private final long parentPid;
+
+	private final String owner;
+
+	public ProcessInfo() {
+		ProcessHandle process = ProcessHandle.current();
+		this.pid = process.pid();
+		this.parentPid = process.parent().map(ProcessHandle::pid).orElse(-1L);
+		this.owner = process.info().user().orElse(null);
+	}
+
+	/**
+	 * Number of processors available to the process. This value may change between
+	 * invocations especially in (containerized) environments where resource usage can be
+	 * isolated (for example using control groups).
+	 * @return result of {@link Runtime#availableProcessors()}
+	 * @see Runtime#availableProcessors()
+	 */
+	public int getCpus() {
+		return runtime.availableProcessors();
+	}
+
+	public long getPid() {
+		return this.pid;
+	}
+
+	public long getParentPid() {
+		return this.parentPid;
+	}
+
+	public String getOwner() {
+		return this.owner;
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/info/ProcessInfoTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/info/ProcessInfoTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.info;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ProcessInfo}.
+ *
+ * @author Jonatan Ivanov
+ */
+class ProcessInfoTests {
+
+	@Test
+	void processInfoIsAvailable() {
+		ProcessInfo processInfo = new ProcessInfo();
+		assertThat(processInfo.getCpus()).isEqualTo(Runtime.getRuntime().availableProcessors());
+		assertThat(processInfo.getOwner()).isEqualTo(ProcessHandle.current().info().user().orElse(null));
+		assertThat(processInfo.getPid()).isEqualTo(ProcessHandle.current().pid());
+		assertThat(processInfo.getParentPid())
+			.isEqualTo(ProcessHandle.current().parent().map(ProcessHandle::pid).orElse(null));
+	}
+
+}


### PR DESCRIPTION
This `InfoContributor` exposes information about the process of the application through actuator's info endpoint as part of the Enhanced Observability effort: https://github.com/spring-projects/spring-boot/issues/25476

When configured, it looks like this:
```json
"process": {
    "pid": 91379,
    "parentPid": 42323,
    "owner": "jonatan",
    "cpus": 16
}
```
The feature can be enabled by setting: `management.info.process.enabled=true`.

Next to the cpu I would also like to add memory (heap) information so that users can see what is the max heap size the jvm can use and what is the total heap size right now (can be interesting in a containerized environment just like the cpu count) but maybe in another PR since that can raise more questions/might need more feedback.

Also, there might be an issue with the current implementation. `ProcessInfo` assumes that `pid`, `parentPid` and `owner` will not change throughout the application lifecycle which is a fair assumption except if you do checkpoint and restore (crac).