### PR TITLE
PropertiesMigrationListener wrongly reports property as deprecated

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-properties-migrator/src/test/java/org/springframework/boot/context/properties/migrator/PropertiesMigrationReporterTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-properties-migrator/src/test/java/org/springframework/boot/context/properties/migrator/PropertiesMigrationReporterTests.java
@@ -76,6 +76,14 @@ class PropertiesMigrationReporterTests {
 	}
 
 	@Test
+	void testDashReplacement() throws IOException {
+		this.environment.getPropertySources()
+			.addFirst(loadPropertySource("test", "config/config-warnings-dash-replacement.properties"));
+		String report = createWarningReport(loadRepository("metadata/sample-metadata.json"));
+		assertThat(report).isNull();
+	}
+
+	@Test
 	void warningReport() throws IOException {
 		this.environment.getPropertySources().addFirst(loadPropertySource("test", "config/config-warnings.properties"));
 		this.environment.getPropertySources().addFirst(loadPropertySource("ignore", "config/config-error.properties"));

--- a/spring-boot-project/spring-boot-tools/spring-boot-properties-migrator/src/test/resources/config/config-warnings-dash-replacement.properties
+++ b/spring-boot-project/spring-boot-tools/spring-boot-properties-migrator/src/test/resources/config/config-warnings-dash-replacement.properties
@@ -1,0 +1,2 @@
+
+test.key-store-password=value

--- a/spring-boot-project/spring-boot-tools/spring-boot-properties-migrator/src/test/resources/metadata/sample-metadata.json
+++ b/spring-boot-project/spring-boot-tools/spring-boot-properties-migrator/src/test/resources/metadata/sample-metadata.json
@@ -9,6 +9,17 @@
       "type": "java.util.Map<java.lang.String,java.lang.String>"
     },
     {
+      "name": "test.key-store-password",
+      "type": "java.lang.String"
+    },
+    {
+      "name": "test.keystore-password",
+      "type": "java.lang.String",
+      "deprecation": {
+        "replacement": "test.key-store-password"
+      }
+    },
+    {
       "name": "wrong.one",
       "deprecation": {
         "reason": "This is no longer supported.",

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/PropertyMappers.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/PropertyMappers.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.context.properties.source;
+
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+
+/**
+ * Adapter to find {@link ConfigurationPropertyName} in {@link PropertySource} then return
+ * {@link PropertySource} name.
+ *
+ * @author Wang Zhiyang
+ * @since 3.2
+ */
+public final class PropertyMappers {
+
+	private PropertyMappers() {
+
+	}
+
+	public static String map(PropertySource<?> source, ConfigurationPropertyName name) {
+		if (source == null || name == null) {
+			return null;
+		}
+		for (PropertyMapper mapper : getPropertyMappers(source)) {
+			try {
+				for (String candidate : mapper.map(name)) {
+					if (source.containsProperty(candidate)) {
+						return candidate;
+					}
+				}
+			}
+			catch (Exception ex) {
+			}
+		}
+		return null;
+	}
+
+	private static PropertyMapper[] getPropertyMappers(PropertySource<?> source) {
+		if (source instanceof SystemEnvironmentPropertySource && hasSystemEnvironmentName(source)) {
+			return new PropertyMapper[] { SystemEnvironmentPropertyMapper.INSTANCE, DefaultPropertyMapper.INSTANCE };
+		}
+		return new PropertyMapper[] { DefaultPropertyMapper.INSTANCE };
+	}
+
+	private static boolean hasSystemEnvironmentName(PropertySource<?> source) {
+		String name = source.getName();
+		return StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME.equals(name)
+				|| name.endsWith("-" + StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME);
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/PropertyMapperTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/source/PropertyMapperTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.context.properties.source;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link PropertyMappers}.
+ *
+ * @author Wang Zhiyang
+ */
+public class PropertyMapperTests {
+
+	@Test
+	void mapperSystemEnvironment() {
+		SystemEnvironmentPropertySource systemEnvironmentPropertySource = new SystemEnvironmentPropertySource(
+				StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
+				Collections.singletonMap("TEST_MAP_FOO_BAR", "baz"));
+		String candidate = PropertyMappers.map(systemEnvironmentPropertySource,
+				ConfigurationPropertyName.of("test.map.foo.bar"));
+		assertThat(candidate).isEqualTo("TEST_MAP_FOO_BAR");
+	}
+
+	@Test
+	void testMapPropertySource() {
+		Map<String, Object> source = Collections.singletonMap("custom.map-with-replacement.key", "1");
+		MapPropertySource mapPropertySource = new MapPropertySource("map", source);
+		String candidate = PropertyMappers.map(mapPropertySource,
+				ConfigurationPropertyName.of("custom.map-with-replacement.key"));
+		assertThat(candidate).isEqualTo("custom.map-with-replacement.key");
+	}
+
+}


### PR DESCRIPTION
because of the relaxed mapping support in SpringIterableConfigurationPropertySource, like "keystore" and "key-store" map to the same relaxed value.

- valid metadata-id by `PropertyMapper`
- add dash form unit test

Closes #35774 