### PR TITLE
Document supported SQL comment prefixes

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/data-initialization.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/data-initialization.adoc
@@ -62,6 +62,8 @@ While we do not recommend using multiple data source initialization technologies
 This will defer data source initialization until after any `EntityManagerFactory` beans have been created and initialized.
 `schema.sql` can then be used to make additions to any schema creation performed by Hibernate and `data.sql` can be used to populate it.
 
+NOTE: When including comments in your SQL file, it is advisable to use `--` for single-line comments and `/++*++` and `++*++/` for block comments. Be cautious when using other comment formats, as they may lead to the omission of certain SQL statements during parsing.
+
 If you are using a <<howto#howto.data-initialization.migration-tool,Higher-level Database Migration Tool>>, like Flyway or Liquibase, you should use them alone to create and initialize the schema.
 Using the basic `schema.sql` and `data.sql` scripts alongside Flyway or Liquibase is not recommended and support will be removed in a future release.
 


### PR DESCRIPTION
# Situation

I am attempting to initialize a database following the instructions in the [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/3.1.0/reference/html/howto.html#howto.data-initialization.using-basic-sql-scripts) under the "Initialize a Database Using Basic SQL Scripts" section.

When initializing the database with SQL files using `sql.init.mode=always`, you can specify the SQL file for initialization in the `/resources` directory (e.g., `/resources/schema.sql`).

Below is the content of the `/resources/schema.sql` file for initializing the schema:

```sql
# 1. remove table start
drop table if exists firstTable;
drop table if exists secondTable;
# 1. remove table end

# 2. create table start
create table firstTable
(
    id                   bigint auto_increment
        primary key,
    test_field           bigint               not null
);

create table secondTable
(
    id                   bigint auto_increment
        primary key,
    test_field           bigint               not null
);
# 2. create table end
```

In `schema.sql`, '#' is used for inline comments. However, since the `DEFAULT_COMMENT_PREFIX` is '--', some SQL statements were not parsed correctly, leading to issues as shown in the following image:

![Parsing Issue](https://github.com/spring-projects/spring-boot/assets/13290706/0e4baf15-6396-430e-a9f3-aea741fb9e4d)

As a result, the table creation for `firstTable`, as specified in `schema.sql`, was ignored:

![Table Creation Ignored](https://github.com/spring-projects/spring-boot/assets/13290706/d8623a5c-e1d3-44c2-a60b-2c9a6e3135e9)

To avoid any potential misunderstanding, I suggest adding a mention of this issue in the documentation.


# Changes

Added the following statement to [[howto.data-initialization.using-basic-sql-scripts]]

> NOTE: When including comments in your SQL file, it is advisable to use `--` for single-line comments and `/*` and `*/` for block comments. Be cautious when using other comment formats, as they may lead to the omission of certain SQL statements during parsing.