### PR TITLE
Update access log pattern documentation to align with changes in Tomcat 10

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/webserver.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/webserver.adoc
@@ -400,7 +400,7 @@ For instance, the following settings log access on Tomcat with a {tomcat-docs}/c
 	    basedir: "my-tomcat"
 	    accesslog:
 	      enabled: true
-	      pattern: "%t %a %r %s (%D ms)"
+	      pattern: "%t %a %r %s (%F ms)"
 ----
 
 NOTE: The default location for logs is a `logs` directory relative to the Tomcat base directory.
@@ -415,7 +415,7 @@ Access logging for Undertow can be configured in a similar fashion, as shown in 
 	  undertow:
 	    accesslog:
 	      enabled: true
-	      pattern: "%t %a %r %s (%D ms)"
+	      pattern: "%t %a %r %s (%F ms)"
 	    options:
 	      server:
 	        record-request-start-time: true


### PR DESCRIPTION
According to the Tomcat docs:
>%D - Time taken to process the request in microseconds
>%F - Time taken to commit the response, in milliseconds

Which means that in `(%D ms)` either the placeholder `(%F ms)` or the unit `(%D us)` should be changed.