### PR TITLE
Make spring.config.activate.on-cloud-platform=none match when the current cloud platform is null

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataProperties.java
@@ -32,6 +32,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Yanming Zhou
  */
 class ConfigDataProperties {
 
@@ -118,14 +119,14 @@ class ConfigDataProperties {
 			if (activationContext == null) {
 				return false;
 			}
-			boolean activate = true;
-			activate = activate && isActive(activationContext.getCloudPlatform());
+			boolean activate = isActive(activationContext.getCloudPlatform());
 			activate = activate && isActive(activationContext.getProfiles());
 			return activate;
 		}
 
 		private boolean isActive(CloudPlatform cloudPlatform) {
-			return this.onCloudPlatform == null || this.onCloudPlatform == cloudPlatform;
+			return this.onCloudPlatform == null || this.onCloudPlatform == CloudPlatform.NONE && cloudPlatform == null
+					|| this.onCloudPlatform == cloudPlatform;
 		}
 
 		private boolean isActive(Profiles profiles) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataPropertiesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataPropertiesTests.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Yanming Zhou
  */
 class ConfigDataPropertiesTests {
 
@@ -96,6 +97,13 @@ class ConfigDataPropertiesTests {
 				new Activate(CloudPlatform.KUBERNETES, null));
 		ConfigDataActivationContext context = new ConfigDataActivationContext(CloudPlatform.HEROKU, NULL_PROFILES);
 		assertThat(properties.isActive(context)).isFalse();
+	}
+
+	@Test
+	void isActiveWhenSpecificNoneCloudPlatformAgainstNullCloudPlatform() {
+		ConfigDataProperties properties = new ConfigDataProperties(NO_IMPORTS, new Activate(CloudPlatform.NONE, null));
+		ConfigDataActivationContext context = new ConfigDataActivationContext(NULL_CLOUD_PLATFORM, NULL_PROFILES);
+		assertThat(properties.isActive(context)).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
Fix GH-38506