### PR TITLE
Fix Observation Filter docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
@@ -768,7 +768,7 @@ TIP: In some cases, exceptions handled in web controllers are not recorded as re
 Applications can opt in and record exceptions by <<web#web.servlet.spring-mvc.error-handling, setting handled exceptions as request attributes>>.
 
 By default, all requests are handled.
-To customize the filter, provide a `@Bean` that implements `FilterRegistrationBean<WebMvcMetricsFilter>`.
+To customize the filter, provide a `@Bean` that implements `FilterRegistrationBean<ServerHttpObservationFilter>`.
 
 
 


### PR DESCRIPTION
`WebMvcMetricsFilter` no longer exists since 3.0 and should be replaced with `ServerHttpObservationFilter`. Documentation still references the old class name
