### PR TITLE
Add support for multiple flyway instances

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
@@ -16,28 +16,14 @@
 
 package org.springframework.boot.autoconfigure.flyway;
 
-import java.sql.DatabaseMetaData;
-import java.time.Duration;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 import javax.sql.DataSource;
 
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
-import org.flywaydb.core.api.callback.Callback;
-import org.flywaydb.core.api.configuration.FluentConfiguration;
-import org.flywaydb.core.api.migration.JavaMigration;
-import org.flywaydb.core.extensibility.ConfigurationExtension;
-import org.flywaydb.core.internal.database.postgresql.PostgreSQLConfigurationExtension;
-import org.flywaydb.database.oracle.OracleConfigurationExtension;
-import org.flywaydb.database.sqlserver.SQLServerConfigurationExtension;
 
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
@@ -51,37 +37,22 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration.FlywayAutoConfigurationRuntimeHints;
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration.FlywayDataSourceCondition;
-import org.springframework.boot.autoconfigure.flyway.FlywayProperties.Oracle;
-import org.springframework.boot.autoconfigure.flyway.FlywayProperties.Postgresql;
-import org.springframework.boot.autoconfigure.flyway.FlywayProperties.Sqlserver;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.JdbcConnectionDetails;
 import org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.context.properties.PropertyMapper;
-import org.springframework.boot.jdbc.DataSourceBuilder;
-import org.springframework.boot.jdbc.DatabaseDriver;
 import org.springframework.boot.sql.init.dependency.DatabaseInitializationDependencyConfigurer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportRuntimeHints;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 import org.springframework.jdbc.support.JdbcUtils;
-import org.springframework.jdbc.support.MetaDataAccessException;
-import org.springframework.util.Assert;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
-import org.springframework.util.StringUtils;
-import org.springframework.util.function.SingletonSupplier;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Flyway database migrations.
@@ -124,14 +95,8 @@ public class FlywayAutoConfiguration {
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(JdbcUtils.class)
 	@ConditionalOnMissingBean(Flyway.class)
-	@EnableConfigurationProperties(FlywayProperties.class)
 	public static class FlywayConfiguration {
 
-		private final FlywayProperties properties;
-
-		FlywayConfiguration(FlywayProperties properties) {
-			this.properties = properties;
-		}
 
 		@Bean
 		ResourceProviderCustomizer resourceProviderCustomizer() {
@@ -139,272 +104,18 @@ public class FlywayAutoConfiguration {
 		}
 
 		@Bean
-		@ConditionalOnMissingBean(FlywayConnectionDetails.class)
-		PropertiesFlywayConnectionDetails flywayConnectionDetails() {
-			return new PropertiesFlywayConnectionDetails(this.properties);
+		FlywayFactory flywayFactory(ResourceLoader resourceLoader, ObjectProvider<DataSource> dataSource, ResourceProviderCustomizer resourceProviderCustomizer) {
+			return new FlywayFactory(resourceLoader, dataSource, resourceProviderCustomizer);
 		}
 
-		@Bean
-		@ConditionalOnClass(name = "org.flywaydb.database.sqlserver.SQLServerConfigurationExtension")
-		SqlServerFlywayConfigurationCustomizer sqlServerFlywayConfigurationCustomizer() {
-			return new SqlServerFlywayConfigurationCustomizer(this.properties);
-		}
-
-		@Bean
-		@ConditionalOnClass(name = "org.flywaydb.database.oracle.OracleConfigurationExtension")
-		OracleFlywayConfigurationCustomizer oracleFlywayConfigurationCustomizer() {
-			return new OracleFlywayConfigurationCustomizer(this.properties);
-		}
-
-		@Bean
-		@ConditionalOnClass(name = "org.flywaydb.core.internal.database.postgresql.PostgreSQLConfigurationExtension")
-		PostgresqlFlywayConfigurationCustomizer postgresqlFlywayConfigurationCustomizer() {
-			return new PostgresqlFlywayConfigurationCustomizer(this.properties);
-		}
-
-		@Bean
-		Flyway flyway(FlywayConnectionDetails connectionDetails, ResourceLoader resourceLoader,
-				ObjectProvider<DataSource> dataSource, @FlywayDataSource ObjectProvider<DataSource> flywayDataSource,
-				ObjectProvider<FlywayConfigurationCustomizer> fluentConfigurationCustomizers,
-				ObjectProvider<JavaMigration> javaMigrations, ObjectProvider<Callback> callbacks,
-				ResourceProviderCustomizer resourceProviderCustomizer) {
-			FluentConfiguration configuration = new FluentConfiguration(resourceLoader.getClassLoader());
-			configureDataSource(configuration, flywayDataSource.getIfAvailable(), dataSource.getIfUnique(),
-					connectionDetails);
-			configureProperties(configuration, this.properties);
-			configureCallbacks(configuration, callbacks.orderedStream().toList());
-			configureJavaMigrations(configuration, javaMigrations.orderedStream().toList());
-			fluentConfigurationCustomizers.orderedStream().forEach((customizer) -> customizer.customize(configuration));
-			resourceProviderCustomizer.customize(configuration);
-			return configuration.load();
-		}
-
-		private void configureDataSource(FluentConfiguration configuration, DataSource flywayDataSource,
-				DataSource dataSource, FlywayConnectionDetails connectionDetails) {
-			DataSource migrationDataSource = getMigrationDataSource(flywayDataSource, dataSource, connectionDetails);
-			configuration.dataSource(migrationDataSource);
-		}
-
-		private DataSource getMigrationDataSource(DataSource flywayDataSource, DataSource dataSource,
-				FlywayConnectionDetails connectionDetails) {
-			if (flywayDataSource != null) {
-				return flywayDataSource;
-			}
-			String url = connectionDetails.getJdbcUrl();
-			if (url != null) {
-				DataSourceBuilder<?> builder = DataSourceBuilder.create().type(SimpleDriverDataSource.class);
-				builder.url(url);
-				applyConnectionDetails(connectionDetails, builder);
-				return builder.build();
-			}
-			String user = connectionDetails.getUsername();
-			if (user != null && dataSource != null) {
-				DataSourceBuilder<?> builder = DataSourceBuilder.derivedFrom(dataSource)
-					.type(SimpleDriverDataSource.class);
-				applyConnectionDetails(connectionDetails, builder);
-				return builder.build();
-			}
-			Assert.state(dataSource != null, "Flyway migration DataSource missing");
-			return dataSource;
-		}
-
-		private void applyConnectionDetails(FlywayConnectionDetails connectionDetails, DataSourceBuilder<?> builder) {
-			builder.username(connectionDetails.getUsername());
-			builder.password(connectionDetails.getPassword());
-			String driverClassName = connectionDetails.getDriverClassName();
-			if (StringUtils.hasText(driverClassName)) {
-				builder.driverClassName(driverClassName);
-			}
-		}
-
-		/**
-		 * Configure the given {@code configuration} using the given {@code properties}.
-		 * <p>
-		 * To maximize forwards- and backwards-compatibility method references are not
-		 * used.
-		 * @param configuration the configuration
-		 * @param properties the properties
-		 */
-		private void configureProperties(FluentConfiguration configuration, FlywayProperties properties) {
-			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
-			String[] locations = new LocationResolver(configuration.getDataSource())
-				.resolveLocations(properties.getLocations())
-				.toArray(new String[0]);
-			configuration.locations(locations);
-			map.from(properties.isFailOnMissingLocations())
-				.to((failOnMissingLocations) -> configuration.failOnMissingLocations(failOnMissingLocations));
-			map.from(properties.getEncoding()).to((encoding) -> configuration.encoding(encoding));
-			map.from(properties.getConnectRetries())
-				.to((connectRetries) -> configuration.connectRetries(connectRetries));
-			map.from(properties.getConnectRetriesInterval())
-				.as(Duration::getSeconds)
-				.as(Long::intValue)
-				.to((connectRetriesInterval) -> configuration.connectRetriesInterval(connectRetriesInterval));
-			map.from(properties.getLockRetryCount())
-				.to((lockRetryCount) -> configuration.lockRetryCount(lockRetryCount));
-			map.from(properties.getDefaultSchema()).to((schema) -> configuration.defaultSchema(schema));
-			map.from(properties.getSchemas())
-				.as(StringUtils::toStringArray)
-				.to((schemas) -> configuration.schemas(schemas));
-			map.from(properties.isCreateSchemas()).to((createSchemas) -> configuration.createSchemas(createSchemas));
-			map.from(properties.getTable()).to((table) -> configuration.table(table));
-			map.from(properties.getTablespace()).to((tablespace) -> configuration.tablespace(tablespace));
-			map.from(properties.getBaselineDescription())
-				.to((baselineDescription) -> configuration.baselineDescription(baselineDescription));
-			map.from(properties.getBaselineVersion())
-				.to((baselineVersion) -> configuration.baselineVersion(baselineVersion));
-			map.from(properties.getInstalledBy()).to((installedBy) -> configuration.installedBy(installedBy));
-			map.from(properties.getPlaceholders()).to((placeholders) -> configuration.placeholders(placeholders));
-			map.from(properties.getPlaceholderPrefix())
-				.to((placeholderPrefix) -> configuration.placeholderPrefix(placeholderPrefix));
-			map.from(properties.getPlaceholderSuffix())
-				.to((placeholderSuffix) -> configuration.placeholderSuffix(placeholderSuffix));
-			map.from(properties.getPlaceholderSeparator())
-				.to((placeHolderSeparator) -> configuration.placeholderSeparator(placeHolderSeparator));
-			map.from(properties.isPlaceholderReplacement())
-				.to((placeholderReplacement) -> configuration.placeholderReplacement(placeholderReplacement));
-			map.from(properties.getSqlMigrationPrefix())
-				.to((sqlMigrationPrefix) -> configuration.sqlMigrationPrefix(sqlMigrationPrefix));
-			map.from(properties.getSqlMigrationSuffixes())
-				.as(StringUtils::toStringArray)
-				.to((sqlMigrationSuffixes) -> configuration.sqlMigrationSuffixes(sqlMigrationSuffixes));
-			map.from(properties.getSqlMigrationSeparator())
-				.to((sqlMigrationSeparator) -> configuration.sqlMigrationSeparator(sqlMigrationSeparator));
-			map.from(properties.getRepeatableSqlMigrationPrefix())
-				.to((repeatableSqlMigrationPrefix) -> configuration
-					.repeatableSqlMigrationPrefix(repeatableSqlMigrationPrefix));
-			map.from(properties.getTarget()).to((target) -> configuration.target(target));
-			map.from(properties.isBaselineOnMigrate())
-				.to((baselineOnMigrate) -> configuration.baselineOnMigrate(baselineOnMigrate));
-			map.from(properties.isCleanDisabled()).to((cleanDisabled) -> configuration.cleanDisabled(cleanDisabled));
-			map.from(properties.isCleanOnValidationError())
-				.to((cleanOnValidationError) -> configuration.cleanOnValidationError(cleanOnValidationError));
-			map.from(properties.isGroup()).to((group) -> configuration.group(group));
-			map.from(properties.isMixed()).to((mixed) -> configuration.mixed(mixed));
-			map.from(properties.isOutOfOrder()).to((outOfOrder) -> configuration.outOfOrder(outOfOrder));
-			map.from(properties.isSkipDefaultCallbacks())
-				.to((skipDefaultCallbacks) -> configuration.skipDefaultCallbacks(skipDefaultCallbacks));
-			map.from(properties.isSkipDefaultResolvers())
-				.to((skipDefaultResolvers) -> configuration.skipDefaultResolvers(skipDefaultResolvers));
-			map.from(properties.isValidateMigrationNaming())
-				.to((validateMigrationNaming) -> configuration.validateMigrationNaming(validateMigrationNaming));
-			map.from(properties.isValidateOnMigrate())
-				.to((validateOnMigrate) -> configuration.validateOnMigrate(validateOnMigrate));
-			map.from(properties.getInitSqls())
-				.whenNot(CollectionUtils::isEmpty)
-				.as((initSqls) -> StringUtils.collectionToDelimitedString(initSqls, "\n"))
-				.to((initSql) -> configuration.initSql(initSql));
-			map.from(properties.getScriptPlaceholderPrefix())
-				.to((prefix) -> configuration.scriptPlaceholderPrefix(prefix));
-			map.from(properties.getScriptPlaceholderSuffix())
-				.to((suffix) -> configuration.scriptPlaceholderSuffix(suffix));
-			configureExecuteInTransaction(configuration, properties, map);
-			map.from(properties::getLoggers).to((loggers) -> configuration.loggers(loggers));
-			// Flyway Teams properties
-			map.from(properties.getBatch()).to((batch) -> configuration.batch(batch));
-			map.from(properties.getDryRunOutput()).to((dryRunOutput) -> configuration.dryRunOutput(dryRunOutput));
-			map.from(properties.getErrorOverrides())
-				.to((errorOverrides) -> configuration.errorOverrides(errorOverrides));
-			map.from(properties.getLicenseKey()).to((licenseKey) -> configuration.licenseKey(licenseKey));
-			map.from(properties.getStream()).to((stream) -> configuration.stream(stream));
-			map.from(properties.getUndoSqlMigrationPrefix())
-				.to((undoSqlMigrationPrefix) -> configuration.undoSqlMigrationPrefix(undoSqlMigrationPrefix));
-			map.from(properties.getCherryPick()).to((cherryPick) -> configuration.cherryPick(cherryPick));
-			map.from(properties.getJdbcProperties())
-				.whenNot(Map::isEmpty)
-				.to((jdbcProperties) -> configuration.jdbcProperties(jdbcProperties));
-			map.from(properties.getKerberosConfigFile())
-				.to((configFile) -> configuration.kerberosConfigFile(configFile));
-			map.from(properties.getOutputQueryResults())
-				.to((outputQueryResults) -> configuration.outputQueryResults(outputQueryResults));
-			map.from(properties.getSkipExecutingMigrations())
-				.to((skipExecutingMigrations) -> configuration.skipExecutingMigrations(skipExecutingMigrations));
-			map.from(properties.getIgnoreMigrationPatterns())
-				.whenNot(List::isEmpty)
-				.to((ignoreMigrationPatterns) -> configuration
-					.ignoreMigrationPatterns(ignoreMigrationPatterns.toArray(new String[0])));
-			map.from(properties.getDetectEncoding())
-				.to((detectEncoding) -> configuration.detectEncoding(detectEncoding));
-		}
-
-		private void configureExecuteInTransaction(FluentConfiguration configuration, FlywayProperties properties,
-				PropertyMapper map) {
-			try {
-				map.from(properties.isExecuteInTransaction()).to(configuration::executeInTransaction);
-			}
-			catch (NoSuchMethodError ex) {
-				// Flyway < 9.14
-			}
-		}
-
-		private void configureCallbacks(FluentConfiguration configuration, List<Callback> callbacks) {
-			if (!callbacks.isEmpty()) {
-				configuration.callbacks(callbacks.toArray(new Callback[0]));
-			}
-		}
-
-		private void configureJavaMigrations(FluentConfiguration flyway, List<JavaMigration> migrations) {
-			if (!migrations.isEmpty()) {
-				flyway.javaMigrations(migrations.toArray(new JavaMigration[0]));
-			}
-		}
-
-		@Bean
-		@ConditionalOnMissingBean
-		public FlywayMigrationInitializer flywayInitializer(Flyway flyway,
-				ObjectProvider<FlywayMigrationStrategy> migrationStrategy) {
-			return new FlywayMigrationInitializer(flyway, migrationStrategy.getIfAvailable());
+		@Configuration(proxyBeanMethods = false)
+		@Import(FlywayInstancesRegistrar.class)
+		static class FlywayInstancesConfiguration {
 		}
 
 	}
 
-	private static class LocationResolver {
 
-		private static final String VENDOR_PLACEHOLDER = "{vendor}";
-
-		private final DataSource dataSource;
-
-		LocationResolver(DataSource dataSource) {
-			this.dataSource = dataSource;
-		}
-
-		List<String> resolveLocations(List<String> locations) {
-			if (usesVendorLocation(locations)) {
-				DatabaseDriver databaseDriver = getDatabaseDriver();
-				return replaceVendorLocations(locations, databaseDriver);
-			}
-			return locations;
-		}
-
-		private List<String> replaceVendorLocations(List<String> locations, DatabaseDriver databaseDriver) {
-			if (databaseDriver == DatabaseDriver.UNKNOWN) {
-				return locations;
-			}
-			String vendor = databaseDriver.getId();
-			return locations.stream().map((location) -> location.replace(VENDOR_PLACEHOLDER, vendor)).toList();
-		}
-
-		private DatabaseDriver getDatabaseDriver() {
-			try {
-				String url = JdbcUtils.extractDatabaseMetaData(this.dataSource, DatabaseMetaData::getURL);
-				return DatabaseDriver.fromJdbcUrl(url);
-			}
-			catch (MetaDataAccessException ex) {
-				throw new IllegalStateException(ex);
-			}
-
-		}
-
-		private boolean usesVendorLocation(Collection<String> locations) {
-			for (String location : locations) {
-				if (location.contains(VENDOR_PLACEHOLDER)) {
-					return true;
-				}
-			}
-			return false;
-		}
-
-	}
 
 	/**
 	 * Convert a String or Number to a {@link MigrationVersion}.
@@ -494,100 +205,6 @@ public class FlywayAutoConfiguration {
 		@Override
 		public String getDriverClassName() {
 			return this.properties.getDriverClassName();
-		}
-
-	}
-
-	@Order(Ordered.HIGHEST_PRECEDENCE)
-	static final class OracleFlywayConfigurationCustomizer implements FlywayConfigurationCustomizer {
-
-		private final FlywayProperties properties;
-
-		OracleFlywayConfigurationCustomizer(FlywayProperties properties) {
-			this.properties = properties;
-		}
-
-		@Override
-		public void customize(FluentConfiguration configuration) {
-			Extension<OracleConfigurationExtension> extension = new Extension<>(configuration,
-					OracleConfigurationExtension.class, "Oracle");
-			Oracle properties = this.properties.getOracle();
-			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
-			map.from(properties::getSqlplus).to(extension.via((ext, sqlplus) -> ext.setSqlplus(sqlplus)));
-			map.from(properties::getSqlplusWarn)
-				.to(extension.via((ext, sqlplusWarn) -> ext.setSqlplusWarn(sqlplusWarn)));
-			map.from(properties::getWalletLocation)
-				.to(extension.via((ext, walletLocation) -> ext.setWalletLocation(walletLocation)));
-			map.from(properties::getKerberosCacheFile)
-				.to(extension.via((ext, kerberosCacheFile) -> ext.setKerberosCacheFile(kerberosCacheFile)));
-		}
-
-	}
-
-	@Order(Ordered.HIGHEST_PRECEDENCE)
-	static final class PostgresqlFlywayConfigurationCustomizer implements FlywayConfigurationCustomizer {
-
-		private final FlywayProperties properties;
-
-		PostgresqlFlywayConfigurationCustomizer(FlywayProperties properties) {
-			this.properties = properties;
-		}
-
-		@Override
-		public void customize(FluentConfiguration configuration) {
-			Extension<PostgreSQLConfigurationExtension> extension = new Extension<>(configuration,
-					PostgreSQLConfigurationExtension.class, "PostgreSQL");
-			Postgresql properties = this.properties.getPostgresql();
-			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
-			map.from(properties::getTransactionalLock)
-				.to(extension.via((ext, transactionalLock) -> ext.setTransactionalLock(transactionalLock)));
-		}
-
-	}
-
-	@Order(Ordered.HIGHEST_PRECEDENCE)
-	static final class SqlServerFlywayConfigurationCustomizer implements FlywayConfigurationCustomizer {
-
-		private final FlywayProperties properties;
-
-		SqlServerFlywayConfigurationCustomizer(FlywayProperties properties) {
-			this.properties = properties;
-		}
-
-		@Override
-		public void customize(FluentConfiguration configuration) {
-			Extension<SQLServerConfigurationExtension> extension = new Extension<>(configuration,
-					SQLServerConfigurationExtension.class, "SQL Server");
-			Sqlserver properties = this.properties.getSqlserver();
-			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
-			map.from(properties::getKerberosLoginFile).to(extension.via(this::setKerberosLoginFile));
-		}
-
-		private void setKerberosLoginFile(SQLServerConfigurationExtension configuration, String file) {
-			configuration.getKerberos().getLogin().setFile(file);
-		}
-
-	}
-
-	/**
-	 * Helper class used to map properties to a {@link ConfigurationExtension}.
-	 *
-	 * @param <E> the extension type
-	 */
-	static class Extension<E extends ConfigurationExtension> {
-
-		private SingletonSupplier<E> extension;
-
-		Extension(FluentConfiguration configuration, Class<E> type, String name) {
-			this.extension = SingletonSupplier.of(() -> {
-				E extension = configuration.getPluginRegister().getPlugin(type);
-				Assert.notNull(extension, () -> "Flyway %s extension missing".formatted(name));
-				return extension;
-			});
-		}
-
-		<T> Consumer<T> via(BiConsumer<E, T> action) {
-			return (value) -> action.accept(this.extension.get(), value);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayFactory.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayFactory.java
@@ -1,0 +1,421 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.flyway;
+
+import java.sql.DatabaseMetaData;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import javax.sql.DataSource;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.callback.Callback;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.flywaydb.core.api.migration.JavaMigration;
+import org.flywaydb.core.extensibility.ConfigurationExtension;
+import org.flywaydb.core.internal.database.postgresql.PostgreSQLConfigurationExtension;
+import org.flywaydb.database.oracle.OracleConfigurationExtension;
+import org.flywaydb.database.sqlserver.SQLServerConfigurationExtension;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration.PropertiesFlywayConnectionDetails;
+import org.springframework.boot.autoconfigure.flyway.FlywayProperties.Oracle;
+import org.springframework.boot.autoconfigure.flyway.FlywayProperties.Postgresql;
+import org.springframework.boot.autoconfigure.flyway.FlywayProperties.Sqlserver;
+import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.jdbc.DatabaseDriver;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+import org.springframework.jdbc.support.JdbcUtils;
+import org.springframework.jdbc.support.MetaDataAccessException;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.util.function.SingletonSupplier;
+
+class FlywayFactory {
+
+	private final ResourceLoader resourceLoader;
+
+	private final ObjectProvider<DataSource> dataSource;
+
+	private final ResourceProviderCustomizer resourceProviderCustomizer;
+
+	FlywayFactory(ResourceLoader resourceLoader, ObjectProvider<DataSource> dataSource, ResourceProviderCustomizer resourceProviderCustomizer) {
+		this.resourceLoader = resourceLoader;
+		this.dataSource = dataSource;
+		this.resourceProviderCustomizer = resourceProviderCustomizer;
+	}
+
+	Flyway createFlyway(FlywayProperties properties,
+			ObjectProvider<FlywayConnectionDetails> connectionDetails,
+			ObjectProvider<DataSource> flywayDataSource,
+			ObjectProvider<FlywayConfigurationCustomizer> flywayConfigurationCustomizers,
+			ObjectProvider<Callback> callbacks,
+			ObjectProvider<JavaMigration> javaMigrations) {
+		FluentConfiguration configuration = new FluentConfiguration(this.resourceLoader.getClassLoader());
+		configureDataSource(configuration, flywayDataSource.getIfAvailable(), this.dataSource.getIfUnique(),
+				connectionDetails.getIfAvailable(() -> new PropertiesFlywayConnectionDetails(properties)));
+		configureProperties(configuration, properties);
+		configureCallbacks(configuration, callbacks.orderedStream().toList());
+		configureJavaMigrations(configuration, javaMigrations.orderedStream().toList());
+		createDatabaseCustomizers(properties).forEach((customizer) -> customizer.customize(configuration));
+		flywayConfigurationCustomizers.orderedStream().forEach((customizer) -> customizer.customize(configuration));
+		this.resourceProviderCustomizer.customize(configuration);
+		return configuration.load();
+	}
+
+	private void configureDataSource(FluentConfiguration configuration, DataSource flywayDataSource,
+			DataSource dataSource, FlywayConnectionDetails connectionDetails) {
+		DataSource migrationDataSource = getMigrationDataSource(flywayDataSource, dataSource, connectionDetails);
+		configuration.dataSource(migrationDataSource);
+	}
+
+	private DataSource getMigrationDataSource(DataSource flywayDataSource, DataSource dataSource,
+			FlywayConnectionDetails connectionDetails) {
+		if (flywayDataSource != null) {
+			return flywayDataSource;
+		}
+		String url = connectionDetails.getJdbcUrl();
+		if (url != null) {
+			DataSourceBuilder<?> builder = DataSourceBuilder.create().type(SimpleDriverDataSource.class);
+			builder.url(url);
+			applyConnectionDetails(connectionDetails, builder);
+			return builder.build();
+		}
+		String user = connectionDetails.getUsername();
+		if (user != null && dataSource != null) {
+			DataSourceBuilder<?> builder = DataSourceBuilder.derivedFrom(dataSource)
+					.type(SimpleDriverDataSource.class);
+			applyConnectionDetails(connectionDetails, builder);
+			return builder.build();
+		}
+		Assert.state(dataSource != null, "Flyway migration DataSource missing");
+		return dataSource;
+	}
+
+	private void applyConnectionDetails(FlywayConnectionDetails connectionDetails, DataSourceBuilder<?> builder) {
+		builder.username(connectionDetails.getUsername());
+		builder.password(connectionDetails.getPassword());
+		String driverClassName = connectionDetails.getDriverClassName();
+		if (StringUtils.hasText(driverClassName)) {
+			builder.driverClassName(driverClassName);
+		}
+	}
+
+	/**
+	 * Configure the given {@code configuration} using the given {@code properties}.
+	 * <p>
+	 * To maximize forwards- and backwards-compatibility method references are not
+	 * used.
+	 * @param configuration the configuration
+	 * @param properties the properties
+	 */
+	private void configureProperties(FluentConfiguration configuration, FlywayProperties properties) {
+		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
+		String[] locations = new LocationResolver(configuration.getDataSource())
+				.resolveLocations(properties.getLocations())
+				.toArray(new String[0]);
+		configuration.locations(locations);
+		map.from(properties.isFailOnMissingLocations())
+				.to((failOnMissingLocations) -> configuration.failOnMissingLocations(failOnMissingLocations));
+		map.from(properties.getEncoding()).to((encoding) -> configuration.encoding(encoding));
+		map.from(properties.getConnectRetries())
+				.to((connectRetries) -> configuration.connectRetries(connectRetries));
+		map.from(properties.getConnectRetriesInterval())
+				.as(Duration::getSeconds)
+				.as(Long::intValue)
+				.to((connectRetriesInterval) -> configuration.connectRetriesInterval(connectRetriesInterval));
+		map.from(properties.getLockRetryCount())
+				.to((lockRetryCount) -> configuration.lockRetryCount(lockRetryCount));
+		map.from(properties.getDefaultSchema()).to((schema) -> configuration.defaultSchema(schema));
+		map.from(properties.getSchemas())
+				.as(StringUtils::toStringArray)
+				.to((schemas) -> configuration.schemas(schemas));
+		map.from(properties.isCreateSchemas()).to((createSchemas) -> configuration.createSchemas(createSchemas));
+		map.from(properties.getTable()).to((table) -> configuration.table(table));
+		map.from(properties.getTablespace()).to((tablespace) -> configuration.tablespace(tablespace));
+		map.from(properties.getBaselineDescription())
+				.to((baselineDescription) -> configuration.baselineDescription(baselineDescription));
+		map.from(properties.getBaselineVersion())
+				.to((baselineVersion) -> configuration.baselineVersion(baselineVersion));
+		map.from(properties.getInstalledBy()).to((installedBy) -> configuration.installedBy(installedBy));
+		map.from(properties.getPlaceholders()).to((placeholders) -> configuration.placeholders(placeholders));
+		map.from(properties.getPlaceholderPrefix())
+				.to((placeholderPrefix) -> configuration.placeholderPrefix(placeholderPrefix));
+		map.from(properties.getPlaceholderSuffix())
+				.to((placeholderSuffix) -> configuration.placeholderSuffix(placeholderSuffix));
+		map.from(properties.getPlaceholderSeparator())
+				.to((placeHolderSeparator) -> configuration.placeholderSeparator(placeHolderSeparator));
+		map.from(properties.isPlaceholderReplacement())
+				.to((placeholderReplacement) -> configuration.placeholderReplacement(placeholderReplacement));
+		map.from(properties.getSqlMigrationPrefix())
+				.to((sqlMigrationPrefix) -> configuration.sqlMigrationPrefix(sqlMigrationPrefix));
+		map.from(properties.getSqlMigrationSuffixes())
+				.as(StringUtils::toStringArray)
+				.to((sqlMigrationSuffixes) -> configuration.sqlMigrationSuffixes(sqlMigrationSuffixes));
+		map.from(properties.getSqlMigrationSeparator())
+				.to((sqlMigrationSeparator) -> configuration.sqlMigrationSeparator(sqlMigrationSeparator));
+		map.from(properties.getRepeatableSqlMigrationPrefix())
+				.to((repeatableSqlMigrationPrefix) -> configuration
+						.repeatableSqlMigrationPrefix(repeatableSqlMigrationPrefix));
+		map.from(properties.getTarget()).to((target) -> configuration.target(target));
+		map.from(properties.isBaselineOnMigrate())
+				.to((baselineOnMigrate) -> configuration.baselineOnMigrate(baselineOnMigrate));
+		map.from(properties.isCleanDisabled()).to((cleanDisabled) -> configuration.cleanDisabled(cleanDisabled));
+		map.from(properties.isCleanOnValidationError())
+				.to((cleanOnValidationError) -> configuration.cleanOnValidationError(cleanOnValidationError));
+		map.from(properties.isGroup()).to((group) -> configuration.group(group));
+		map.from(properties.isMixed()).to((mixed) -> configuration.mixed(mixed));
+		map.from(properties.isOutOfOrder()).to((outOfOrder) -> configuration.outOfOrder(outOfOrder));
+		map.from(properties.isSkipDefaultCallbacks())
+				.to((skipDefaultCallbacks) -> configuration.skipDefaultCallbacks(skipDefaultCallbacks));
+		map.from(properties.isSkipDefaultResolvers())
+				.to((skipDefaultResolvers) -> configuration.skipDefaultResolvers(skipDefaultResolvers));
+		map.from(properties.isValidateMigrationNaming())
+				.to((validateMigrationNaming) -> configuration.validateMigrationNaming(validateMigrationNaming));
+		map.from(properties.isValidateOnMigrate())
+				.to((validateOnMigrate) -> configuration.validateOnMigrate(validateOnMigrate));
+		map.from(properties.getInitSqls())
+				.whenNot(CollectionUtils::isEmpty)
+				.as((initSqls) -> StringUtils.collectionToDelimitedString(initSqls, "\n"))
+				.to((initSql) -> configuration.initSql(initSql));
+		map.from(properties.getScriptPlaceholderPrefix())
+				.to((prefix) -> configuration.scriptPlaceholderPrefix(prefix));
+		map.from(properties.getScriptPlaceholderSuffix())
+				.to((suffix) -> configuration.scriptPlaceholderSuffix(suffix));
+		configureExecuteInTransaction(configuration, properties, map);
+		map.from(properties::getLoggers).to((loggers) -> configuration.loggers(loggers));
+		// Flyway Teams properties
+		map.from(properties.getBatch()).to((batch) -> configuration.batch(batch));
+		map.from(properties.getDryRunOutput()).to((dryRunOutput) -> configuration.dryRunOutput(dryRunOutput));
+		map.from(properties.getErrorOverrides())
+				.to((errorOverrides) -> configuration.errorOverrides(errorOverrides));
+		map.from(properties.getLicenseKey()).to((licenseKey) -> configuration.licenseKey(licenseKey));
+		map.from(properties.getStream()).to((stream) -> configuration.stream(stream));
+		map.from(properties.getUndoSqlMigrationPrefix())
+				.to((undoSqlMigrationPrefix) -> configuration.undoSqlMigrationPrefix(undoSqlMigrationPrefix));
+		map.from(properties.getCherryPick()).to((cherryPick) -> configuration.cherryPick(cherryPick));
+		map.from(properties.getJdbcProperties())
+				.whenNot(Map::isEmpty)
+				.to((jdbcProperties) -> configuration.jdbcProperties(jdbcProperties));
+		map.from(properties.getKerberosConfigFile())
+				.to((configFile) -> configuration.kerberosConfigFile(configFile));
+		map.from(properties.getOutputQueryResults())
+				.to((outputQueryResults) -> configuration.outputQueryResults(outputQueryResults));
+		map.from(properties.getSkipExecutingMigrations())
+				.to((skipExecutingMigrations) -> configuration.skipExecutingMigrations(skipExecutingMigrations));
+		map.from(properties.getIgnoreMigrationPatterns())
+				.whenNot(List::isEmpty)
+				.to((ignoreMigrationPatterns) -> configuration
+						.ignoreMigrationPatterns(ignoreMigrationPatterns.toArray(new String[0])));
+		map.from(properties.getDetectEncoding())
+				.to((detectEncoding) -> configuration.detectEncoding(detectEncoding));
+	}
+
+	private void configureExecuteInTransaction(FluentConfiguration configuration, FlywayProperties properties,
+			PropertyMapper map) {
+		try {
+			map.from(properties.isExecuteInTransaction()).to(configuration::executeInTransaction);
+		}
+		catch (NoSuchMethodError ex) {
+			// Flyway < 9.14
+		}
+	}
+
+	private void configureCallbacks(FluentConfiguration configuration, List<Callback> callbacks) {
+		if (!callbacks.isEmpty()) {
+			configuration.callbacks(callbacks.toArray(new Callback[0]));
+		}
+	}
+
+	private void configureJavaMigrations(FluentConfiguration flyway, List<JavaMigration> migrations) {
+		if (!migrations.isEmpty()) {
+			flyway.javaMigrations(migrations.toArray(new JavaMigration[0]));
+		}
+	}
+
+	private static class LocationResolver {
+
+		private static final String VENDOR_PLACEHOLDER = "{vendor}";
+
+		private final DataSource dataSource;
+
+		LocationResolver(DataSource dataSource) {
+			this.dataSource = dataSource;
+		}
+
+		List<String> resolveLocations(List<String> locations) {
+			if (usesVendorLocation(locations)) {
+				DatabaseDriver databaseDriver = getDatabaseDriver();
+				return replaceVendorLocations(locations, databaseDriver);
+			}
+			return locations;
+		}
+
+		private List<String> replaceVendorLocations(List<String> locations, DatabaseDriver databaseDriver) {
+			if (databaseDriver == DatabaseDriver.UNKNOWN) {
+				return locations;
+			}
+			String vendor = databaseDriver.getId();
+			return locations.stream().map((location) -> location.replace(VENDOR_PLACEHOLDER, vendor)).toList();
+		}
+
+		private DatabaseDriver getDatabaseDriver() {
+			try {
+				String url = JdbcUtils.extractDatabaseMetaData(this.dataSource, DatabaseMetaData::getURL);
+				return DatabaseDriver.fromJdbcUrl(url);
+			}
+			catch (MetaDataAccessException ex) {
+				throw new IllegalStateException(ex);
+			}
+
+		}
+
+		private boolean usesVendorLocation(Collection<String> locations) {
+			for (String location : locations) {
+				if (location.contains(VENDOR_PLACEHOLDER)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+	}
+
+	private List<FlywayConfigurationCustomizer> createDatabaseCustomizers(FlywayProperties properties) {
+		List<FlywayConfigurationCustomizer> customizers = new ArrayList<>();
+		if (isClassLoadable("org.flywaydb.database.sqlserver.SQLServerConfigurationExtension")) {
+			customizers.add(new SqlServerFlywayConfigurationCustomizer(properties));
+		}
+		if (isClassLoadable("org.flywaydb.database.oracle.OracleConfigurationExtension")) {
+			customizers.add(new OracleFlywayConfigurationCustomizer(properties));
+		}
+		if (isClassLoadable("org.flywaydb.core.internal.database.postgresql.PostgreSQLConfigurationExtension")) {
+			customizers.add(new PostgresqlFlywayConfigurationCustomizer(properties));
+		}
+		return customizers;
+	}
+
+	private boolean isClassLoadable(String className) {
+		try {
+			Class.forName(className, false, getClass().getClassLoader());
+			return true;
+		}
+		catch (Throwable ex) {
+			return false;
+		}
+	}
+
+	static final class OracleFlywayConfigurationCustomizer implements FlywayConfigurationCustomizer {
+
+		private final FlywayProperties properties;
+
+		OracleFlywayConfigurationCustomizer(FlywayProperties properties) {
+			this.properties = properties;
+		}
+
+		@Override
+		public void customize(FluentConfiguration configuration) {
+			Extension<OracleConfigurationExtension> extension = new Extension<>(configuration,
+					OracleConfigurationExtension.class, "Oracle");
+			Oracle properties = this.properties.getOracle();
+			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
+			map.from(properties::getSqlplus).to(extension.via((ext, sqlplus) -> ext.setSqlplus(sqlplus)));
+			map.from(properties::getSqlplusWarn)
+					.to(extension.via((ext, sqlplusWarn) -> ext.setSqlplusWarn(sqlplusWarn)));
+			map.from(properties::getWalletLocation)
+					.to(extension.via((ext, walletLocation) -> ext.setWalletLocation(walletLocation)));
+			map.from(properties::getKerberosCacheFile)
+					.to(extension.via((ext, kerberosCacheFile) -> ext.setKerberosCacheFile(kerberosCacheFile)));
+		}
+
+	}
+
+	static final class PostgresqlFlywayConfigurationCustomizer implements FlywayConfigurationCustomizer {
+
+		private final FlywayProperties properties;
+
+		PostgresqlFlywayConfigurationCustomizer(FlywayProperties properties) {
+			this.properties = properties;
+		}
+
+		@Override
+		public void customize(FluentConfiguration configuration) {
+			Extension<PostgreSQLConfigurationExtension> extension = new Extension<>(configuration,
+					PostgreSQLConfigurationExtension.class, "PostgreSQL");
+			Postgresql properties = this.properties.getPostgresql();
+			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
+			map.from(properties::getTransactionalLock)
+					.to(extension.via((ext, transactionalLock) -> ext.setTransactionalLock(transactionalLock)));
+		}
+
+	}
+
+	static final class SqlServerFlywayConfigurationCustomizer implements FlywayConfigurationCustomizer {
+
+		private final FlywayProperties properties;
+
+		SqlServerFlywayConfigurationCustomizer(FlywayProperties properties) {
+			this.properties = properties;
+		}
+
+		@Override
+		public void customize(FluentConfiguration configuration) {
+			Extension<SQLServerConfigurationExtension> extension = new Extension<>(configuration,
+					SQLServerConfigurationExtension.class, "SQL Server");
+			Sqlserver properties = this.properties.getSqlserver();
+			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
+			map.from(properties::getKerberosLoginFile).to(extension.via(this::setKerberosLoginFile));
+		}
+
+		private void setKerberosLoginFile(SQLServerConfigurationExtension configuration, String file) {
+			configuration.getKerberos().getLogin().setFile(file);
+		}
+
+	}
+
+	/**
+	 * Helper class used to map properties to a {@link ConfigurationExtension}.
+	 *
+	 * @param <E> the extension type
+	 */
+	static class Extension<E extends ConfigurationExtension> {
+
+		private SingletonSupplier<E> extension;
+
+		Extension(FluentConfiguration configuration, Class<E> type, String name) {
+			this.extension = SingletonSupplier.of(() -> {
+				E extension = configuration.getPluginRegister().getPlugin(type);
+				Assert.notNull(extension, () -> "Flyway %s extension missing".formatted(name));
+				return extension;
+			});
+		}
+
+		<T> Consumer<T> via(BiConsumer<E, T> action) {
+			return (value) -> action.accept(this.extension.get(), value);
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayInstance.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayInstance.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.flyway;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE,ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface FlywayInstance {
+
+	String value() default "";
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayInstancesProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayInstancesProperties.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.flyway;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.flyway")
+public class FlywayInstancesProperties extends FlywayProperties {
+
+	private Map<String, FlywayProperties> instances = new HashMap<>();
+
+	public Map<String, FlywayProperties> getInstances() {
+		return this.instances;
+	}
+
+	public void setInstances(Map<String, FlywayProperties> instances) {
+		this.instances = instances;
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayInstancesRegistrar.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayInstancesRegistrar.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.flyway;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import javax.sql.DataSource;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.callback.Callback;
+import org.flywaydb.core.api.migration.JavaMigration;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.util.Assert;
+
+class FlywayInstancesRegistrar implements ImportBeanDefinitionRegistrar {
+	private final ListableBeanFactory listableBeanFactory;
+	private final Binder binder;
+
+	public FlywayInstancesRegistrar(BeanFactory beanFactory, Environment environment) {
+		this.listableBeanFactory = (ListableBeanFactory) beanFactory;
+		this.binder = Binder.get(environment);
+	}
+
+	@Override
+	public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+		FlywayInstancesProperties instancesProperties = new FlywayInstancesProperties();
+		this.binder.bind("spring.flyway", Bindable.ofInstance(instancesProperties));
+
+		if (instancesProperties.getInstances().isEmpty()) {
+			registry.registerBeanDefinition("flyway",
+					BeanDefinitionBuilder.genericBeanDefinition(Flyway.class, createFlywaySupplier(null, instancesProperties)).getBeanDefinition());
+
+			if (this.listableBeanFactory.getBeanNamesForType(FlywayMigrationInitializer.class).length == 0) {
+				registry.registerBeanDefinition("flywayMigrationInitializer",
+						BeanDefinitionBuilder.genericBeanDefinition(FlywayMigrationInitializer.class,
+								createFlywayMigrationInitializerSupplier(null, "flyway")).getBeanDefinition());
+			}
+		} else {
+			for (String flywayInstanceName : instancesProperties.getInstances().keySet()) {
+				FlywayProperties properties = bindFlywayInstanceProperties(flywayInstanceName);
+
+				if (properties.isEnabled()) {
+					String flywayBeanName = "flyway-" + flywayInstanceName;
+
+					registry.registerBeanDefinition(flywayBeanName,
+							BeanDefinitionBuilder.genericBeanDefinition(Flyway.class, createFlywaySupplier(flywayInstanceName, properties)).getBeanDefinition());
+
+					registry.registerBeanDefinition("flywayMigrationInitializer-" + flywayInstanceName,
+							BeanDefinitionBuilder.genericBeanDefinition(FlywayMigrationInitializer.class,
+									createFlywayMigrationInitializerSupplier(flywayInstanceName, flywayBeanName)).getBeanDefinition());
+				}
+			}
+		}
+	}
+
+	private FlywayProperties bindFlywayInstanceProperties(String flywayInstanceName) {
+		FlywayProperties properties = new FlywayProperties();
+		this.binder.bind("spring.flyway", Bindable.ofInstance(properties));
+		this.binder.bind("spring.flyway.instances." + flywayInstanceName, Bindable.ofInstance(properties));
+		return properties;
+	}
+
+	private Supplier<Flyway> createFlywaySupplier(String flywayInstanceName, FlywayProperties properties) {
+		return () -> {
+			ObjectProvider<FlywayConnectionDetails> connectionDetails = findBeans(flywayInstanceName, FlywayConnectionDetails.class, null, true, true);
+			ObjectProvider<DataSource> flywayDataSource = findBeans(flywayInstanceName, DataSource.class, FlywayDataSource.class, true, true);
+			ObjectProvider<FlywayConfigurationCustomizer> flywayConfigurationCustomizers = findBeans(flywayInstanceName, FlywayConfigurationCustomizer.class, null, false, true);
+			ObjectProvider<Callback> callbacks = findBeans(flywayInstanceName, Callback.class, null, false, true);
+			ObjectProvider<JavaMigration> javaMigrations = findBeans(flywayInstanceName, JavaMigration.class, null, true, false);
+
+			FlywayFactory flywayFactory = this.listableBeanFactory.getBean(FlywayFactory.class);
+			return flywayFactory.createFlyway(properties, connectionDetails, flywayDataSource, flywayConfigurationCustomizers, callbacks, javaMigrations);
+		};
+	}
+
+	private Supplier<FlywayMigrationInitializer> createFlywayMigrationInitializerSupplier(String flywayInstanceName, String flywayBeanName) {
+		return () -> {
+			ObjectProvider<FlywayMigrationStrategy> flywayMigrationStrategy = findBeans(flywayInstanceName, FlywayMigrationStrategy.class, null, true, true);
+			return new FlywayMigrationInitializer(this.listableBeanFactory.getBean(flywayBeanName, Flyway.class), flywayMigrationStrategy.getIfAvailable());
+		};
+	}
+
+	private <T> ObjectProvider<T> findBeans(String flywayInstanceName, Class<T> type, Class<? extends Annotation> additionalAnnotation, boolean preferInstanceBeans, boolean allowGeneralBeans) {
+		if (flywayInstanceName == null) {
+			return this.listableBeanFactory.getBeanProvider(type);
+		}
+
+		Map<String, T> generalBeans = new HashMap<>();
+		Map<String, T> instanceBeans = new HashMap<>();
+
+		for (Map.Entry<String, T> beanWithName : this.listableBeanFactory.getBeansOfType(type).entrySet()) {
+			if (additionalAnnotation != null && this.listableBeanFactory.findAnnotationOnBean(beanWithName.getKey(), additionalAnnotation) == null) {
+				continue;
+			}
+
+			FlywayInstance flywayInstanceSpecific = this.listableBeanFactory.findAnnotationOnBean(beanWithName.getKey(), FlywayInstance.class);
+			if (flywayInstanceSpecific == null) {
+				Assert.isTrue(allowGeneralBeans, "Undefined instance binding for bean " + beanWithName.getKey() + " of type " +  type.getName());
+
+				generalBeans.put(beanWithName.getKey(), beanWithName.getValue());
+			} else if (flywayInstanceSpecific.value().equals(flywayInstanceName)) {
+				instanceBeans.put(beanWithName.getKey(), beanWithName.getValue());
+			}
+		}
+
+		Stream<Map<String, T>> stream;
+		if (preferInstanceBeans && !instanceBeans.isEmpty()) {
+			stream = Stream.of(instanceBeans);
+		} else {
+			stream = Stream.of(generalBeans, instanceBeans);
+		}
+
+		StaticListableBeanFactory staticListableBeanFactory = new StaticListableBeanFactory();
+		stream.flatMap(map -> map.entrySet().stream()).forEach(beanWithName -> staticListableBeanFactory.addBean(beanWithName.getKey(), beanWithName.getValue()));
+		return staticListableBeanFactory.getBeanProvider(type);
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayProperties.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 import org.springframework.boot.convert.DurationUnit;
 
@@ -40,7 +39,6 @@ import org.springframework.boot.convert.DurationUnit;
  * @author Chris Bono
  * @since 1.1.0
  */
-@ConfigurationProperties(prefix = "spring.flyway")
 public class FlywayProperties {
 
 	/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayFactoryTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayFactoryTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.flyway;
+
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.flyway.FlywayFactory.OracleFlywayConfigurationCustomizer;
+import org.springframework.boot.autoconfigure.flyway.FlywayFactory.PostgresqlFlywayConfigurationCustomizer;
+import org.springframework.boot.autoconfigure.flyway.FlywayFactory.SqlServerFlywayConfigurationCustomizer;
+
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+public class FlywayFactoryTests {
+
+	@Test
+	void oracleExtensionIsNotLoadedByDefault() {
+		FluentConfiguration configuration = mock(FluentConfiguration.class);
+		new OracleFlywayConfigurationCustomizer(new FlywayProperties()).customize(configuration);
+		then(configuration).shouldHaveNoInteractions();
+	}
+
+	@Test
+	void sqlServerExtensionIsNotLoadedByDefault() {
+		FluentConfiguration configuration = mock(FluentConfiguration.class);
+		new SqlServerFlywayConfigurationCustomizer(new FlywayProperties()).customize(configuration);
+		then(configuration).shouldHaveNoInteractions();
+	}
+
+	@Test
+	void postgresqlExtensionIsNotLoadedByDefault() {
+		FluentConfiguration configuration = mock(FluentConfiguration.class);
+		new PostgresqlFlywayConfigurationCustomizer(new FlywayProperties()).customize(configuration);
+		then(configuration).shouldHaveNoInteractions();
+	}
+
+}


### PR DESCRIPTION
Hi,

after my comment in another discussion to [provide support for auto-configuring multiple beans](https://github.com/spring-projects/spring-boot/issues/15732#issuecomment-1774167022) I would like to contribute my solution for flyway. This is an integrated version from an internal adaption which we use in my company. The implementation is fully compatible with the current default behaviour.

To use the new behaviour you have to define properties like `spring.flyway.instances.{name}.*`. The {name} is a custom definition for the flyway instance. Every property tree overrides than the global properties which are placed in `spring.flyway.*`. In general these are default-schema and location, but all other work too. Every instance can be disabled separately. Auto completion for properties works in the IDE too.

In order to bind configuration beans to a flyway instance a new annotation `@FlywayInstance({name})` exists, which binds a bean to the specific instance by the {name} defined in the properties. When no explicit binding exists, the bean will be the default for all instances. For `FlywayConnectionDetails`, `FlywayDataSource` and `FlywayMigrationStrategy` a specific bean will be preferred. For `FlywayConfigurationCustomizer` und `Callback` the default and the instance specific beans are joined by order. Only `JavaMigration` expects an explicit binding, to avoid configuration errors. A predefined `FlywayMigrationInitializer` will only be used in the default mode. In multi instance mode every flyway bean gets its own `FlywayMigrationInitializer`.

Most tests work and I added tests for the new feature. I can add documentation based on feedback. 

Greetings,
Ben