### PR TITLE
System SSL certificates are not used by the Apache HTTP Client in a RestTemplate built with RestTemplateBuilder

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/ClientHttpRequestFactories.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/ClientHttpRequestFactories.java
@@ -31,7 +31,6 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
-import okhttp3.OkHttpClient;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
@@ -42,7 +41,6 @@ import org.apache.hc.core5.http.io.SocketConfig;
 import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
-
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.boot.ssl.SslBundle;
 import org.springframework.boot.ssl.SslOptions;
@@ -56,6 +54,9 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
+
+import okhttp3.OkHttpClient;
+
 
 /**
  * Utility class that can be used to create {@link ClientHttpRequestFactory} instances
@@ -212,7 +213,7 @@ public final class ClientHttpRequestFactories {
 						options.getEnabledProtocols(), options.getCiphers(), new DefaultHostnameVerifier());
 				connectionManagerBuilder.setSSLSocketFactory(socketFactory);
 			}
-			PoolingHttpClientConnectionManager connectionManager = connectionManagerBuilder.build();
+			PoolingHttpClientConnectionManager connectionManager = connectionManagerBuilder.useSystemProperties().build();
 			return HttpClientBuilder.create().useSystemProperties().setConnectionManager(connectionManager).build();
 		}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/ClientHttpRequestFactories.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/ClientHttpRequestFactories.java
@@ -31,6 +31,7 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import okhttp3.OkHttpclient;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
@@ -41,6 +42,7 @@ import org.apache.hc.core5.http.io.SocketConfig;
 import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.boot.ssl.SslBundle;
 import org.springframework.boot.ssl.SslOptions;
@@ -54,8 +56,6 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
-
-import okhttp3.OkHttpClient;
 
 
 /**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/ClientHttpRequestFactories.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/ClientHttpRequestFactories.java
@@ -212,7 +212,8 @@ public final class ClientHttpRequestFactories {
 						options.getEnabledProtocols(), options.getCiphers(), new DefaultHostnameVerifier());
 				connectionManagerBuilder.setSSLSocketFactory(socketFactory);
 			}
-			PoolingHttpClientConnectionManager connectionManager = connectionManagerBuilder.useSystemProperties().build();
+			PoolingHttpClientConnectionManager connectionManager = connectionManagerBuilder.useSystemProperties()
+				.build();
 			return HttpClientBuilder.create().useSystemProperties().setConnectionManager(connectionManager).build();
 		}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/ClientHttpRequestFactories.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/ClientHttpRequestFactories.java
@@ -31,7 +31,7 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
-import okhttp3.OkHttpclient;
+import okhttp3.OkHttpClient;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
@@ -56,7 +56,6 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
-
 
 /**
  * Utility class that can be used to create {@link ClientHttpRequestFactory} instances


### PR DESCRIPTION
With this change, the SSL certificates that are provided by the system are picked up by default when using the `RestTemplateBuilder`.

This aligns with the implementation of `new RestTemplate()` which is already doing this, and can be considered a follow-up to a [previous (partial) fix](https://github.com/spring-projects/spring-boot/commit/c22cbb0e2dfbc71ba19d83084af962f207c152fb) from 5 months ago relating to [this issue](https://github.com/spring-projects/spring-boot/issues/35815).

(For context, `RestTemplate` is using `SimpleClientHttpRequestFactory` by default, which appears to be picking up the SSL certificates from the environment)

In our Cloud Foundry environment, where the SSL certificates are provided by the system through [a build-pack](https://github.com/cloudfoundry/java-buildpack-security-provider/blob/8117fa264727de9688db6539158d445918f3a472/src/main/java/org/cloudfoundry/security/CloudFoundryContainerKeyManagerFactory.java#L72C34-L72C54), we encountered a problem with SSL certificates. The SSL certificates from the system work fine with `new RestTemplate()`, but not with `new RestTemplateBuilder.build()`. This seems unintentional, especially considering a previous (partial) fix that added some functionality (through `useSystemProperties()`) but missed the SSL properties.

As I am quite new to the Java & Spring Boot ecosystem I am not entirely sure how to best test this, but the issue we are facing seems to be a spring-boot issue to me, which can hopefully be fixed with my PR.