### PR TITLE
Build against Oracle JDBC driver variant ojdbc11

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-autoconfigure/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	optional("com.h2database:h2")
 	optional("com.nimbusds:oauth2-oidc-sdk")
 	optional("com.oracle.database.jdbc:ojdbc11")
-	optional("com.oracle.database.jdbc:ucp")
+	optional("com.oracle.database.jdbc:ucp11")
 	optional("com.querydsl:querydsl-core")
 	optional("com.samskivert:jmustache")
 	optional("io.lettuce:lettuce-core")

--- a/spring-boot-project/spring-boot-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-autoconfigure/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	optional("com.hazelcast:hazelcast-spring")
 	optional("com.h2database:h2")
 	optional("com.nimbusds:oauth2-oidc-sdk")
-	optional("com.oracle.database.jdbc:ojdbc8")
+	optional("com.oracle.database.jdbc:ojdbc11")
 	optional("com.oracle.database.jdbc:ucp")
 	optional("com.querydsl:querydsl-core")
 	optional("com.samskivert:jmustache")

--- a/spring-boot-project/spring-boot/build.gradle
+++ b/spring-boot-project/spring-boot/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	optional("com.google.code.gson:gson")
 	optional("com.mchange:c3p0")
 	optional("com.oracle.database.jdbc:ucp")
-	optional("com.oracle.database.jdbc:ojdbc8")
+	optional("com.oracle.database.jdbc:ojdbc11")
 	optional("com.samskivert:jmustache")
 	optional("com.squareup.okhttp3:okhttp")
 	optional("com.zaxxer:HikariCP")

--- a/spring-boot-project/spring-boot/build.gradle
+++ b/spring-boot-project/spring-boot/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 	optional("com.h2database:h2")
 	optional("com.google.code.gson:gson")
 	optional("com.mchange:c3p0")
-	optional("com.oracle.database.jdbc:ucp")
+	optional("com.oracle.database.jdbc:ucp11")
 	optional("com.oracle.database.jdbc:ojdbc11")
 	optional("com.samskivert:jmustache")
 	optional("com.squareup.okhttp3:okhttp")


### PR DESCRIPTION
Oracle provides multiple variants of their jdbc driver and connection pool, each targeting a different JDK baseline.

From https://www.oracle.com/database/technologies/maven-central-guide.html#DIY

ojdbc8: Supports JDBC 4.2 spec and for use with JDK8 and JDK11
ojdbc11: Supports JDBC 4.3 spec and for use with JDK11 and JDK17
ucp11: The Java Universal Connection Pool for Oracle Database compiled with JDK11

This PR updates spring-boot to build against the 11 variants.

Also, start.spring.io still provides the **ojdbc8** dependency.

```
<dependency>
      <groupId>com.oracle.database.jdbc</groupId>
      <artifactId>ojdbc8</artifactId>
      <scope>runtime</scope>
</dependency>

```