### PR TITLE
Rename local variable in BatchAutoConfiguration

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
@@ -78,9 +78,9 @@ public class BatchAutoConfiguration {
 	public JobLauncherApplicationRunner jobLauncherApplicationRunner(JobLauncher jobLauncher, JobExplorer jobExplorer,
 			JobRepository jobRepository, BatchProperties properties) {
 		JobLauncherApplicationRunner runner = new JobLauncherApplicationRunner(jobLauncher, jobExplorer, jobRepository);
-		String jobNames = properties.getJob().getName();
-		if (StringUtils.hasText(jobNames)) {
-			runner.setJobName(jobNames);
+		String jobName = properties.getJob().getName();
+		if (StringUtils.hasText(jobName)) {
+			runner.setJobName(jobName);
 		}
 		return runner;
 	}


### PR DESCRIPTION
Due to [gh-25373](https://github.com/spring-projects/spring-boot/issues/25373), BatchProperties receives jobName instead of jobNames.