### PR TITLE
Add property for maximum number of reactive sessions

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -329,6 +329,11 @@ public class ServerProperties {
 			@DurationUnit(ChronoUnit.SECONDS)
 			private Duration timeout = Duration.ofMinutes(30);
 
+			/**
+			 * The maximum number of sessions that can be stored.
+			 */
+			private int maxSessions = 10_000;
+
 			@NestedConfigurationProperty
 			private final Cookie cookie = new Cookie();
 
@@ -338,6 +343,14 @@ public class ServerProperties {
 
 			public void setTimeout(Duration timeout) {
 				this.timeout = timeout;
+			}
+
+			public int getMaxSessions() {
+				return this.maxSessions;
+			}
+
+			public void setMaxSessions(int maxSessions) {
+				this.maxSessions = maxSessions;
 			}
 
 			public Cookie getCookie() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfiguration.java
@@ -332,7 +332,10 @@ public class WebFluxAutoConfiguration {
 		public WebSessionManager webSessionManager(ObjectProvider<WebSessionIdResolver> webSessionIdResolver) {
 			DefaultWebSessionManager webSessionManager = new DefaultWebSessionManager();
 			Duration timeout = this.serverProperties.getReactive().getSession().getTimeout();
-			webSessionManager.setSessionStore(new MaxIdleTimeInMemoryWebSessionStore(timeout));
+			int maxSessions = this.serverProperties.getReactive().getSession().getMaxSessions();
+			MaxIdleTimeInMemoryWebSessionStore sessionStore = new MaxIdleTimeInMemoryWebSessionStore(timeout);
+			sessionStore.setMaxSessions(maxSessions);
+			webSessionManager.setSessionStore(sessionStore);
 			webSessionIdResolver.ifAvailable(webSessionManager::setSessionIdResolver);
 			return webSessionManager;
 		}


### PR DESCRIPTION
By default, the maxinum number of sessions is [10,000](https://github.com/spring-projects/spring-framework/blob/302cdeeee67f9291be45147ffc5b543bfcb32d77/spring-web/src/main/java/org/springframework/web/server/session/InMemoryWebSessionStore.java#L51) while using Reactive server. Our users always receive errors that reach the maxinum session limit. See [here](https://github.com/spring-projects/spring-framework/blob/302cdeeee67f9291be45147ffc5b543bfcb32d77/spring-web/src/main/java/org/springframework/web/server/session/InMemoryWebSessionStore.java#L281) for source code.

This PR allows users to freely configure the maxinum number of sessions by setting property `server.reactive.session.max-sessions`.
