### PR TITLE
Update Dynatrace documentation links

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/metrics.adoc
@@ -168,9 +168,9 @@ You can also change the interval at which metrics are sent to Datadog:
 [[actuator.metrics.export.dynatrace]]
 ==== Dynatrace
 Dynatrace offers two metrics ingest APIs, both of which are implemented for {micrometer-registry-docs}/dynatrace[Micrometer].
-You can find the Dynatrace documentation on Micrometer metrics ingest {dynatrace-help}/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/micrometer[here].
-Configuration properties in the `v1` namespace apply only when exporting to the {dynatrace-help}/dynatrace-api/environment-api/metric-v1/[Timeseries v1 API].
-Configuration properties in the `v2` namespace apply only when exporting to the {dynatrace-help}/dynatrace-api/environment-api/metric-v2/post-ingest-metrics/[Metrics v2 API].
+You can find the Dynatrace documentation on Micrometer metrics ingest {dynatrace-docs}/micrometer-metrics-ingest[here].
+Configuration properties in the `v1` namespace apply only when exporting to the {dynatrace-docs}/api-metrics[Timeseries v1 API].
+Configuration properties in the `v2` namespace apply only when exporting to the {dynatrace-docs}/api-metrics-v2-post-datapoints[Metrics v2 API].
 Note that this integration can export only to either the `v1` or `v2` version of the API at a time, with `v2` being preferred.
 If the `device-id` (required for v1 but not used in v2) is set in the `v1` namespace, metrics are exported to the `v1` endpoint.
 Otherwise, `v2` is assumed.
@@ -187,7 +187,7 @@ You can use the v2 API in two ways.
 ====== Auto-configuration
 Dynatrace auto-configuration is available for hosts that are monitored by the OneAgent or by the Dynatrace Operator for Kubernetes.
 
-**Local OneAgent:** If a OneAgent is running on the host, metrics are automatically exported to the {dynatrace-help}/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/local-api/[local OneAgent ingest endpoint].
+**Local OneAgent:** If a OneAgent is running on the host, metrics are automatically exported to the {dynatrace-docs}/local-api[local OneAgent ingest endpoint].
 The ingest endpoint forwards the metrics to the Dynatrace backend.
 
 **Dynatrace Kubernetes Operator:** When running in Kubernetes with the Dynatrace Operator installed, the registry will automatically pick up your endpoint URI and API token from the operator instead.
@@ -198,8 +198,8 @@ This is the default behavior and requires no special setup beyond a dependency o
 
 [[actuator.metrics.export.dynatrace.v2-api.manual-config]]
 ====== Manual configuration
-If no auto-configuration is available, the endpoint of the {dynatrace-help}/dynatrace-api/environment-api/metric-v2/post-ingest-metrics/[Metrics v2 API] and an API token are required.
-The {dynatrace-help}/dynatrace-api/basics/dynatrace-api-authentication/[API token] must have the "`Ingest metrics`" (`metrics.ingest`) permission set.
+If no auto-configuration is available, the endpoint of the {dynatrace-docs}/api-metrics-v2-post-datapoints[Metrics v2 API] and an API token are required.
+The {dynatrace-docs}/api-authentication[API token] must have the "`Ingest metrics`" (`metrics.ingest`) permission set.
 We recommend limiting the scope of the token to this one permission.
 You must ensure that the endpoint URI contains the path (for example, `/api/v2/metrics/ingest`):
 
@@ -220,7 +220,7 @@ The example below configures metrics export using the `example` environment id:
 	        api-token: "YOUR_TOKEN"
 ----
 
-When using the Dynatrace v2 API, the following optional features are available (more details can be found in the {dynatrace-help}/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/micrometer#dt-configuration-properties[Dynatrace documentation]):
+When using the Dynatrace v2 API, the following optional features are available (more details can be found in the {dynatrace-docs}/micrometer-metrics-ingest#dt-configuration-properties[Dynatrace documentation]):
 
 * Metric key prefix: Sets a prefix that is prepended to all exported metric keys.
 * Enrich with Dynatrace metadata: If a OneAgent or Dynatrace operator is running, enrich metrics with additional metadata (for example, about the host, process, or pod).
@@ -254,7 +254,7 @@ In this scenario, the automatically configured endpoint is used:
 
 [[actuator.metrics.export.dynatrace.v1-api]]
 ===== v1 API (Legacy)
-The Dynatrace v1 API metrics registry pushes metrics to the configured URI periodically by using the {dynatrace-help}/dynatrace-api/environment-api/metric-v1/[Timeseries v1 API].
+The Dynatrace v1 API metrics registry pushes metrics to the configured URI periodically by using the {dynatrace-docs}/api-metrics[Timeseries v1 API].
 For backwards-compatibility with existing setups, when `device-id` is set (required for v1, but not used in v2), metrics are exported to the Timeseries v1 endpoint.
 To export metrics to {micrometer-registry-docs}/dynatrace[Dynatrace], your API token, device ID, and URI must be provided:
 
@@ -289,7 +289,7 @@ The following example sets the export interval to 30 seconds:
 	        step: "30s"
 ----
 
-You can find more information on how to set up the Dynatrace exporter for Micrometer in the {micrometer-registry-docs}/dynatrace[Micrometer documentation] and the {dynatrace-help}/how-to-use-dynatrace/metrics/metric-ingestion/ingestion-methods/micrometer[Dynatrace documentation].
+You can find more information on how to set up the Dynatrace exporter for Micrometer in the {micrometer-registry-docs}/dynatrace[Micrometer documentation] and the {dynatrace-docs}/micrometer-metrics-ingest[Dynatrace documentation].
 
 
 

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/attributes.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/attributes.adoc
@@ -98,7 +98,7 @@
 :spring-webservices-docs: https://docs.spring.io/spring-ws/docs/{spring-webservices-version}/reference/html/
 :ant-docs: https://ant.apache.org/manual
 :dependency-management-plugin-code: https://github.com/spring-gradle-plugins/dependency-management-plugin
-:dynatrace-help: https://www.dynatrace.com/support/help
+:dynatrace-docs: https://docs.dynatrace.com/docs/shortlink
 :gradle-docs: https://docs.gradle.org/current/userguide
 :hibernate-docs: https://docs.jboss.org/hibernate/orm/{hibernate-version}/userguide/html_single/Hibernate_User_Guide.html
 :java-api: https://docs.oracle.com/en/java/javase/17/docs/api


### PR DESCRIPTION
At Dynatrace, the documentation URLs now have an overhauled format, including new shortlinks. This PR swaps out the "old" links with the new style of shortlink in the documentation.

I based this PR on 2.7.x, since the docs for that are still up (and 2.7 is still in commercial support IIUC). Will these changes be merged forward? Or should I just create a PR based on 3.1.x instead, since that is the officially supported version?