### PR TITLE
Cleanup kotlin sources

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/data/sql/h2webconsole/springsecurity/DevProfileSecurityConfiguration.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/data/sql/h2webconsole/springsecurity/DevProfileSecurityConfiguration.kt
@@ -40,7 +40,7 @@ class DevProfileSecurityConfiguration {
 
 	// tag::customizer[]
 	private fun <T> yourCustomAuthorization(): Customizer<T> {
-		return Customizer.withDefaults<T>()
+		return Customizer.withDefaults()
 	}
 	// end::customizer[]
 

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/externalconfig/typesafeconfigurationproperties/validate/nested/MyProperties.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/externalconfig/typesafeconfigurationproperties/validate/nested/MyProperties.kt
@@ -29,7 +29,7 @@ class MyProperties {
 
 	var remoteAddress: @NotNull InetAddress? = null
 
-	val security: @Valid Security? = Security()
+	val security: @Valid Security = Security()
 
 	class Security {
 		var username: @NotEmpty String? = null

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testcontainers/atdevelopmenttime/devtools/MyContainersConfiguration.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testcontainers/atdevelopmenttime/devtools/MyContainersConfiguration.kt
@@ -17,7 +17,7 @@ package org.springframework.boot.docs.features.testcontainers.atdevelopmenttime.
 
 import org.springframework.boot.devtools.restart.RestartScope
 import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
 import org.springframework.context.annotation.Bean
 import org.testcontainers.containers.MongoDBContainer
 

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testcontainers/atdevelopmenttime/dynamicproperties/MyContainersConfiguration.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testcontainers/atdevelopmenttime/dynamicproperties/MyContainersConfiguration.kt
@@ -17,7 +17,7 @@
 package org.springframework.boot.docs.features.testcontainers.atdevelopmenttime.dynamicproperties
 
 import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Bean
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.testcontainers.containers.MongoDBContainer
 
@@ -27,8 +27,8 @@ class MyContainersConfiguration {
 	@Bean
 	fun monogDbContainer(properties: DynamicPropertyRegistry): MongoDBContainer {
 		var container = MongoDBContainer("mongo:5.0")
-		properties.add("spring.data.mongodb.host", container::getHost);
-		properties.add("spring.data.mongodb.port", container::getFirstMappedPort);
+		properties.add("spring.data.mongodb.host", container::getHost)
+		properties.add("spring.data.mongodb.port", container::getFirstMappedPort)
 		return container
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testcontainers/atdevelopmenttime/importingcontainerdeclarations/MyContainersConfiguration.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testcontainers/atdevelopmenttime/importingcontainerdeclarations/MyContainersConfiguration.kt
@@ -21,6 +21,4 @@ import org.springframework.boot.testcontainers.context.ImportTestcontainers
 
 @TestConfiguration(proxyBeanMethods = false)
 @ImportTestcontainers(MyContainers::class)
-class MyContainersConfiguration {
-
-}
+class MyContainersConfiguration

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/autoconfiguredrestclient/MyRestClientServiceTests.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/autoconfiguredrestclient/MyRestClientServiceTests.kt
@@ -31,7 +31,7 @@ class MyRestClientServiceTests(
 	@Autowired val server: MockRestServiceServer) {
 
 	@Test
-	fun getVehicleDetailsWhenResultIsSuccessShouldReturnDetails(): Unit {
+	fun getVehicleDetailsWhenResultIsSuccessShouldReturnDetails() {
 		server.expect(MockRestRequestMatchers.requestTo("https://example.com/greet/details"))
 			.andRespond(MockRestResponseCreators.withSuccess("hello", MediaType.TEXT_PLAIN))
 		val greeting = service.callRestService()

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/autoconfiguredrestclient/MyRestTemplateServiceTests.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/autoconfiguredrestclient/MyRestTemplateServiceTests.kt
@@ -31,7 +31,7 @@ class MyRestTemplateServiceTests(
 	@Autowired val server: MockRestServiceServer) {
 
 	@Test
-	fun getVehicleDetailsWhenResultIsSuccessShouldReturnDetails(): Unit {
+	fun getVehicleDetailsWhenResultIsSuccessShouldReturnDetails() {
 		server.expect(MockRestRequestMatchers.requestTo("/greet/details"))
 			.andRespond(MockRestResponseCreators.withSuccess("hello", MediaType.TEXT_PLAIN))
 		val greeting = service.callRestService()

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/userconfigurationandslicing/MyMongoConfiguration.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/userconfigurationandslicing/MyMongoConfiguration.kt
@@ -17,7 +17,7 @@
 package org.springframework.boot.docs.features.testing.springbootapplications.userconfigurationandslicing
 
 import org.springframework.context.annotation.Configuration
-import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.config.EnableMongoAuditing
 
 @Configuration(proxyBeanMethods = false)
 @EnableMongoAuditing

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/usingmain/always/MyApplicationTests.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/usingmain/always/MyApplicationTests.kt
@@ -19,7 +19,6 @@ package org.springframework.boot.docs.features.testing.springbootapplications.us
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.UseMainMethod
-import org.springframework.context.annotation.Import
 
 @SpringBootTest(useMainMethod = UseMainMethod.ALWAYS)
 class MyApplicationTests {

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/usingmain/custom/MyApplication.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/usingmain/custom/MyApplication.kt
@@ -26,6 +26,6 @@ class MyApplication
 fun main(args: Array<String>) {
 	runApplication<MyApplication>(*args) {
 		setBannerMode(Banner.Mode.OFF)
-		setAdditionalProfiles("myprofile");
+		setAdditionalProfiles("myprofile")
 	}
 }

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/testcontainers/serviceconnections/MyRedisConfiguration.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/testcontainers/serviceconnections/MyRedisConfiguration.kt
@@ -18,7 +18,7 @@ package org.springframework.boot.docs.features.testing.testcontainers.servicecon
 
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection
-import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Bean
 import org.testcontainers.containers.GenericContainer
 
 @TestConfiguration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/messaging/pulsar/sending/MyBean.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/messaging/pulsar/sending/MyBean.kt
@@ -17,7 +17,6 @@
 package org.springframework.boot.docs.messaging.pulsar.sending
 
 import org.apache.pulsar.client.api.PulsarClientException
-import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.pulsar.core.PulsarTemplate
 import org.springframework.stereotype.Component
 

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/web/graphql/runtimewiring/GreetingController.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/web/graphql/runtimewiring/GreetingController.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.docs.web.graphql.runtimewiring;
+package org.springframework.boot.docs.web.graphql.runtimewiring
 
 import org.springframework.graphql.data.method.annotation.Argument
 import org.springframework.graphql.data.method.annotation.QueryMapping

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/web/security/springwebflux/MyWebFluxSecurityConfiguration.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/web/security/springwebflux/MyWebFluxSecurityConfiguration.kt
@@ -19,7 +19,6 @@ package org.springframework.boot.docs.web.security.springwebflux
 import org.springframework.boot.autoconfigure.security.reactive.PathRequest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.security.config.Customizer
 import org.springframework.security.config.Customizer.withDefaults
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.web.server.SecurityWebFilterChain

--- a/spring-boot-project/spring-boot-test/src/test/kotlin/org/springframework/boot/test/context/KotlinApplicationWithMainThrowingException.kt
+++ b/spring-boot-project/spring-boot-test/src/test/kotlin/org/springframework/boot/test/context/KotlinApplicationWithMainThrowingException.kt
@@ -4,8 +4,7 @@ import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.runApplication
 
 @SpringBootConfiguration(proxyBeanMethods = false)
-open class KotlinApplicationWithMainThrowingException {
-}
+open class KotlinApplicationWithMainThrowingException
 
 fun main(args: Array<String>) {
 	runApplication<KotlinApplicationWithMainThrowingException>(*args)

--- a/spring-boot-project/spring-boot-test/src/test/kotlin/org/springframework/boot/test/context/SpringBootContextLoaderKotlinTests.kt
+++ b/spring-boot-project/spring-boot-test/src/test/kotlin/org/springframework/boot/test/context/SpringBootContextLoaderKotlinTests.kt
@@ -18,9 +18,7 @@ package org.springframework.boot.test.context
 
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.jupiter.api.Test
-import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.test.context.SpringBootTest.UseMainMethod
-import org.springframework.context.annotation.Configuration
 import org.springframework.test.context.TestContext
 import org.springframework.test.context.TestContextManager
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/running/application-plugin-main-class-name.gradle.kts
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/running/application-plugin-main-class-name.gradle.kts
@@ -1,5 +1,3 @@
-import org.springframework.boot.gradle.tasks.run.BootRun
-
 plugins {
 	java
 	application

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/running/spring-boot-dsl-main-class-name.gradle.kts
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/gradle/running/spring-boot-dsl-main-class-name.gradle.kts
@@ -1,5 +1,3 @@
-import org.springframework.boot.gradle.tasks.run.BootRun
-
 plugins {
 	java
 	application

--- a/spring-boot-project/spring-boot/src/main/kotlin/org/springframework/boot/SpringApplicationExtensions.kt
+++ b/spring-boot-project/spring-boot/src/main/kotlin/org/springframework/boot/SpringApplicationExtensions.kt
@@ -21,7 +21,6 @@ import org.springframework.util.Assert
 import org.springframework.util.ClassUtils
 import org.springframework.util.ReflectionUtils
 import kotlin.reflect.KClass
-import kotlin.reflect.KType
 
 /**
  * Top-level function acting as a Kotlin shortcut allowing to write

--- a/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/context/properties/KotlinConfigurationPropertiesTests.kt
+++ b/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/context/properties/KotlinConfigurationPropertiesTests.kt
@@ -38,7 +38,7 @@ class KotlinConfigurationPropertiesTests {
 
 	@AfterEach
 	fun cleanUp() {
-		this.context.close();
+		this.context.close()
 	}
 
 	@Test //gh-18652
@@ -48,22 +48,22 @@ class KotlinConfigurationPropertiesTests {
 				RootBeanDefinition(BingProperties::class.java))
 		beanFactory.registerSingleton("foo", BingProperties(""))
 		this.context.register(EnableConfigProperties::class.java)
-		this.context.refresh();
+		this.context.refresh()
 	}
 
 	@Test
 	fun `type with constructor bound lateinit property can be bound`() {
 		this.context.register(EnableLateInitProperties::class.java)
-		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context, "lateinit.inner.value=alpha");
-		this.context.refresh();
+		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context, "lateinit.inner.value=alpha")
+		this.context.refresh()
 		assertThat(this.context.getBean(LateInitProperties::class.java).inner.value).isEqualTo("alpha")
 	}
 
 	@Test
 	fun `type with constructor bound lateinit property with default can be bound`() {
 		this.context.register(EnableLateInitPropertiesWithDefault::class.java)
-		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context, "lateinit-with-default.inner.bravo=two");
-		this.context.refresh();
+		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context, "lateinit-with-default.inner.bravo=two")
+		this.context.refresh()
 		val properties = this.context.getBean(LateInitPropertiesWithDefault::class.java)
 		assertThat(properties.inner.alpha).isEqualTo("apple")
 		assertThat(properties.inner.bravo).isEqualTo("two")
@@ -72,20 +72,16 @@ class KotlinConfigurationPropertiesTests {
 	@Test
 	fun `mutable data class properties can be imported`() {
 		this.context.register(MutableDataClassPropertiesImporter::class.java)
-		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context, "mutable.prop=alpha");
-		this.context.refresh();
+		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context, "mutable.prop=alpha")
+		this.context.refresh()
 		assertThat(this.context.getBean(MutableDataClassProperties::class.java).prop).isEqualTo("alpha")
 	}
 
 	@ConfigurationProperties(prefix = "foo")
-	class BingProperties(@Suppress("UNUSED_PARAMETER") bar: String) {
-
-	}
+	class BingProperties(@Suppress("UNUSED_PARAMETER") bar: String)
 
 	@EnableConfigurationProperties
-	class EnableConfigProperties {
-
-	}
+	class EnableConfigProperties
 
 	@ConfigurationProperties("lateinit")
 	class LateInitProperties {
@@ -97,9 +93,7 @@ class KotlinConfigurationPropertiesTests {
 	data class Inner(val value: String)
 
 	@EnableConfigurationProperties(LateInitPropertiesWithDefault::class)
-	class EnableLateInitPropertiesWithDefault {
-
-	}
+	class EnableLateInitPropertiesWithDefault
 
 	@ConfigurationProperties("lateinit-with-default")
 	class LateInitPropertiesWithDefault {
@@ -111,15 +105,12 @@ class KotlinConfigurationPropertiesTests {
 	data class InnerWithDefault(val alpha: String = "apple", val bravo: String = "banana")
 
 	@EnableConfigurationProperties(LateInitProperties::class)
-	class EnableLateInitProperties {
-
-	}
+	class EnableLateInitProperties
 
 	@EnableConfigurationProperties
 	@Configuration(proxyBeanMethods = false)
 	@Import(MutableDataClassProperties::class)
-	class MutableDataClassPropertiesImporter {
-	}
+	class MutableDataClassPropertiesImporter
 
 	@ConfigurationProperties(prefix = "mutable")
 	data class MutableDataClassProperties(

--- a/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/context/properties/bind/KotlinBindableRuntimeHintsRegistrarTests.kt
+++ b/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/context/properties/bind/KotlinBindableRuntimeHintsRegistrarTests.kt
@@ -20,7 +20,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.aot.hint.MemberCategory
 import org.springframework.aot.hint.RuntimeHints
-import org.springframework.aot.hint.predicate.RuntimeHintsPredicates
 
 
 /**

--- a/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/context/properties/bind/KotlinDefaultBindConstructorProviderTests.kt
+++ b/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/context/properties/bind/KotlinDefaultBindConstructorProviderTests.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.context.properties.bind;
+package org.springframework.boot.context.properties.bind
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
@@ -46,7 +46,7 @@ class KotlinDefaultBindConstructorProviderTests {
 	@Test
 	fun `type with primary and secondary annotated constructor should use secondary constructor for binding`() {
 		val bindConstructor = this.constructorProvider.getBindConstructor(ConstructorBindingOnSecondaryWithPrimaryConstructor::class.java, false)
-		assertThat(bindConstructor).isNotNull();
+		assertThat(bindConstructor).isNotNull()
 	}
 
 	@Test
@@ -116,12 +116,12 @@ class KotlinDefaultBindConstructorProviderTests {
 	@Test
 	fun `data class with default values should use constructor binding`() {
 		val bindConstructor = this.constructorProvider.getBindConstructor(ConstructorBindingDataClassWithDefaultValues::class.java, false)
-		assertThat(bindConstructor).isNotNull();
+		assertThat(bindConstructor).isNotNull()
 	}
 
 	class FooProperties
 
-	class PrimaryWithAutowiredSecondaryProperties constructor(val name: String?, val counter: Int = 42) {
+	class PrimaryWithAutowiredSecondaryProperties(val name: String?, val counter: Int = 42) {
 
 		@Autowired
 		constructor(@Suppress("UNUSED_PARAMETER") foo: String) : this(foo, 21)
@@ -133,9 +133,7 @@ class KotlinDefaultBindConstructorProviderTests {
 		constructor(@Suppress("UNUSED_PARAMETER") foo: String)
 	}
 
-	class AutowiredPrimaryProperties @Autowired constructor(val name: String?, val counter: Int = 42) {
-
-	}
+	class AutowiredPrimaryProperties @Autowired constructor(val name: String?, val counter: Int = 42)
 
 	class ConstructorBindingOnSecondaryAndAutowiredPrimaryProperties @Autowired constructor(val name: String?, val counter: Int = 42) {
 
@@ -149,7 +147,7 @@ class KotlinDefaultBindConstructorProviderTests {
 		constructor(@Suppress("UNUSED_PARAMETER") foo: String) : this(foo, 21)
 	}
 
-	class ConstructorBindingOnSecondaryWithPrimaryConstructor constructor(val name: String?, val counter: Int = 42) {
+	class ConstructorBindingOnSecondaryWithPrimaryConstructor(val name: String?, val counter: Int = 42) {
 
 		@ConstructorBinding
 		constructor(@Suppress("UNUSED_PARAMETER") foo: String) : this(foo, 21)


### PR DESCRIPTION
1. remove unused imports
2. remove redundant semicolon
3. remove empty class body
4. remove redundant 'constructor' keyword
5. remove redundant 'Unit' return type
6. use non-null type if possible
