### PR TITLE
Set default values for showSummary and showSummaryOutput

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -115,13 +115,8 @@ public class LiquibaseAutoConfiguration {
 			liquibase.setRollbackFile(properties.getRollbackFile());
 			liquibase.setTestRollbackOnUpdate(properties.isTestRollbackOnUpdate());
 			liquibase.setTag(properties.getTag());
-			if (properties.getShowSummary() != null) {
-				liquibase.setShowSummary(UpdateSummaryEnum.valueOf(properties.getShowSummary().name()));
-			}
-			if (properties.getShowSummaryOutput() != null) {
-				liquibase
-					.setShowSummaryOutput(UpdateSummaryOutputEnum.valueOf(properties.getShowSummaryOutput().name()));
-			}
+			liquibase.setShowSummary(UpdateSummaryEnum.valueOf(properties.getShowSummary().name()));
+			liquibase.setShowSummaryOutput(UpdateSummaryOutputEnum.valueOf(properties.getShowSummaryOutput().name()));
 			return liquibase;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseProperties.java
@@ -140,12 +140,12 @@ public class LiquibaseProperties {
 	/**
 	 * Whether to print a summary of the update operation.
 	 */
-	private ShowSummary showSummary;
+	private ShowSummary showSummary = ShowSummary.SUMMARY;
 
 	/**
 	 * Where to print a summary of the update operation.
 	 */
-	private ShowSummaryOutput showSummaryOutput;
+	private ShowSummaryOutput showSummaryOutput = ShowSummaryOutput.LOG;
 
 	public String getChangeLog() {
 		return this.changeLog;


### PR DESCRIPTION
This PR changes to set default values for `showSummary` and `showSummaryOutput` in `LiquibaseProperties` to align with its configuration metadata.

See gh-38522