### PR TITLE
Cleanup java sources

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureCheck.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureCheck.java
@@ -89,7 +89,7 @@ public abstract class ArchitectureCheck extends DefaultTask {
 		if (!violations.isEmpty()) {
 			StringBuilder report = new StringBuilder();
 			for (EvaluationResult violation : violations) {
-				report.append(violation.getFailureReport().toString());
+				report.append(violation.getFailureReport());
 				report.append(String.format("%n"));
 			}
 			Files.writeString(outputFile.toPath(), report.toString(), StandardOpenOption.CREATE,

--- a/buildSrc/src/main/java/org/springframework/boot/build/autoconfigure/AutoConfigurationPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/autoconfigure/AutoConfigurationPlugin.java
@@ -154,7 +154,7 @@ public class AutoConfigurationPlugin implements Plugin<Project> {
 		});
 	}
 
-	private static record AutoConfigurationImports(Path importsFile, List<String> imports) {
+	private record AutoConfigurationImports(Path importsFile, List<String> imports) {
 
 	}
 

--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/BomPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/BomPlugin.java
@@ -221,7 +221,7 @@ public class BomPlugin implements Plugin<Project> {
 						.collect(Collectors.toSet());
 					Node target = dependency;
 					for (String classifier : classifiers) {
-						if (classifier.length() > 0) {
+						if (!classifier.isEmpty()) {
 							if (target == null) {
 								target = new Node(null, "dependency");
 								target.appendNode("groupId", groupId);

--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/bomr/MavenMetadataVersionResolver.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/bomr/MavenMetadataVersionResolver.java
@@ -69,7 +69,7 @@ final class MavenMetadataVersionResolver implements VersionResolver {
 		if ("/".equals(uri.getPath())) {
 			return uri;
 		}
-		return URI.create(uri.toString() + "/");
+		return URI.create(uri + "/");
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointAutoConfigurationTests.java
@@ -125,7 +125,7 @@ class WebEndpointAutoConfigurationTests {
 		@Override
 		public String getRootPath(EndpointId endpointId) {
 			if (endpointId.toString().endsWith("one")) {
-				return "1/" + endpointId.toString();
+				return "1/" + endpointId;
 			}
 			return null;
 		}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/EndpointDiscoverer.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/EndpointDiscoverer.java
@@ -234,9 +234,8 @@ public abstract class EndpointDiscoverer<E extends ExposableEndpoint<O>, O exten
 			String extensionBeanNames = extensions.stream()
 				.map(ExtensionBean::getBeanName)
 				.collect(Collectors.joining(", "));
-			throw new IllegalStateException("Unable to map duplicate endpoint operations: " + duplicates.toString()
-					+ " to " + endpointBean.getBeanName()
-					+ (extensions.isEmpty() ? "" : " (" + extensionBeanNames + ")"));
+			throw new IllegalStateException("Unable to map duplicate endpoint operations: " + duplicates + " to "
+					+ endpointBean.getBeanName() + (extensions.isEmpty() ? "" : " (" + extensionBeanNames + ")"));
 		}
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthEndpointSupport.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthEndpointSupport.java
@@ -127,7 +127,7 @@ abstract class HealthEndpointSupport<C, T> {
 	private String getName(String[] path, int pathOffset) {
 		StringBuilder name = new StringBuilder();
 		while (pathOffset < path.length) {
-			name.append((name.length() != 0) ? "/" : "");
+			name.append((!name.isEmpty()) ? "/" : "");
 			name.append(path[pathOffset]);
 			pathOffset++;
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnBeanCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnBeanCondition.java
@@ -332,7 +332,7 @@ class OnBeanCondition extends FilteringSpringBootCondition implements Configurat
 
 	private void appendMessageForNoMatches(StringBuilder reason, Collection<String> unmatched, String description) {
 		if (!unmatched.isEmpty()) {
-			if (reason.length() > 0) {
+			if (!reason.isEmpty()) {
 				reason.append(" and ");
 			}
 			reason.append("did not find any beans ");
@@ -347,7 +347,7 @@ class OnBeanCondition extends FilteringSpringBootCondition implements Configurat
 		appendMessageForMatches(reason, matchResult.getMatchedAnnotations(), "annotated with");
 		appendMessageForMatches(reason, matchResult.getMatchedTypes(), "of type");
 		if (!matchResult.getMatchedNames().isEmpty()) {
-			if (reason.length() > 0) {
+			if (!reason.isEmpty()) {
 				reason.append(" and ");
 			}
 			reason.append("found beans named ");
@@ -360,7 +360,7 @@ class OnBeanCondition extends FilteringSpringBootCondition implements Configurat
 			String description) {
 		if (!matches.isEmpty()) {
 			matches.forEach((key, value) -> {
-				if (reason.length() > 0) {
+				if (!reason.isEmpty()) {
 					reason.append(" and ");
 				}
 				reason.append("found beans ");

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/env/DevToolsHomePropertiesPostProcessor.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/env/DevToolsHomePropertiesPostProcessor.java
@@ -144,7 +144,7 @@ public class DevToolsHomePropertiesPostProcessor implements EnvironmentPostProce
 	}
 
 	@SafeVarargs
-	private final File getHomeDirectory(Supplier<String>... pathSuppliers) {
+	private File getHomeDirectory(Supplier<String>... pathSuppliers) {
 		for (Supplier<String> pathSupplier : pathSuppliers) {
 			String path = pathSupplier.get();
 			if (StringUtils.hasText(path)) {

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/AssertProviderApplicationContextInvocationHandler.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/AssertProviderApplicationContextInvocationHandler.java
@@ -153,7 +153,7 @@ class AssertProviderApplicationContextInvocationHandler implements InvocationHan
 
 	private ApplicationContext getStartedApplicationContext() {
 		if (this.startupFailure != null) {
-			throw new IllegalStateException(toString() + " failed to start", this.startupFailure);
+			throw new IllegalStateException(this + " failed to start", this.startupFailure);
 		}
 		return this.applicationContext;
 	}

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/TestRestTemplate.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/TestRestTemplate.java
@@ -956,7 +956,7 @@ public class TestRestTemplate {
 	private URI applyRootUriIfNecessary(URI uri) {
 		UriTemplateHandler uriTemplateHandler = this.restTemplate.getUriTemplateHandler();
 		if ((uriTemplateHandler instanceof RootUriTemplateHandler rootHandler) && uri.toString().startsWith("/")) {
-			return URI.create(rootHandler.getRootUri() + uri.toString());
+			return URI.create(rootHandler.getRootUri() + uri);
 		}
 		return uri;
 	}

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/json/AbstractJsonMarshalTesterTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/json/AbstractJsonMarshalTesterTests.java
@@ -169,7 +169,7 @@ abstract class AbstractJsonMarshalTesterTests {
 		assertThat(tester.parse(MAP_JSON)).asMap().containsEntry("a", OBJECT);
 	}
 
-	protected static final ExampleObject createExampleObject(String name, int age) {
+	protected static ExampleObject createExampleObject(String name, int age) {
 		ExampleObject exampleObject = new ExampleObject();
 		exampleObject.setName(name);
 		exampleObject.setAge(age);

--- a/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/ServiceConnectionContextCustomizer.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/ServiceConnectionContextCustomizer.java
@@ -91,8 +91,7 @@ class ServiceConnectionContextCustomizer implements ContextCustomizer {
 	 * Relevant details from {@link ContainerConnectionSource} used as a
 	 * MergedContextConfiguration cache key.
 	 */
-	private static record CacheKey(String connectionName, Set<Class<?>> connectionDetailsTypes,
-			Container<?> container) {
+	private record CacheKey(String connectionName, Set<Class<?>> connectionDetailsTypes, Container<?> container) {
 
 		CacheKey(ContainerConnectionSource<?> source) {
 			this(source.getConnectionName(), source.getConnectionDetailsTypes(), source.getContainerSupplier().get());

--- a/spring-boot-project/spring-boot-testcontainers/src/test/java/org/springframework/boot/testcontainers/ImportTestcontainersTests.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/test/java/org/springframework/boot/testcontainers/ImportTestcontainersTests.java
@@ -162,7 +162,7 @@ class ImportTestcontainersTests {
 	}
 
 	@Retention(RetentionPolicy.RUNTIME)
-	static @interface ContainerAnnotation {
+	@interface ContainerAnnotation {
 
 	}
 

--- a/spring-boot-project/spring-boot-testcontainers/src/test/java/org/springframework/boot/testcontainers/properties/TestcontainersPropertySourceAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/test/java/org/springframework/boot/testcontainers/properties/TestcontainersPropertySourceAutoConfigurationTests.java
@@ -68,7 +68,7 @@ class TestcontainersPropertySourceAutoConfigurationTests {
 	}
 
 	@ConfigurationProperties("container")
-	static record ContainerProperties(int port) {
+	record ContainerProperties(int port) {
 	}
 
 	static class TestBean {

--- a/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/AutoConfigureAnnotationProcessor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-autoconfigure-processor/src/main/java/org/springframework/boot/autoconfigureprocessor/AutoConfigureAnnotationProcessor.java
@@ -345,7 +345,7 @@ public class AutoConfigureAnnotationProcessor extends AbstractProcessor {
 			}
 			StringBuilder result = new StringBuilder();
 			for (Object item : list) {
-				result.append((result.length() != 0) ? "," : "");
+				result.append((!result.isEmpty()) ? "," : "");
 				result.append(item);
 			}
 			return result.toString();

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/json-shade/java/org/springframework/boot/configurationprocessor/json/JSONStringer.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/json-shade/java/org/springframework/boot/configurationprocessor/json/JSONStringer.java
@@ -173,7 +173,7 @@ public class JSONStringer {
 	 * @throws JSONException if processing of json failed
 	 */
 	JSONStringer open(Scope empty, String openBracket) throws JSONException {
-		if (this.stack.isEmpty() && this.out.length() > 0) {
+		if (this.stack.isEmpty() && !this.out.isEmpty()) {
 			throw new JSONException("Nesting problem: multiple top-level roots");
 		}
 		beforeValue();
@@ -423,7 +423,7 @@ public class JSONStringer {
 	 */
 	@Override
 	public String toString() {
-		return this.out.length() == 0 ? null : this.out.toString();
+		return this.out.isEmpty() ? null : this.out.toString();
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/ItemMetadata.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/ItemMetadata.java
@@ -65,7 +65,7 @@ public final class ItemMetadata implements Comparable<ItemMetadata> {
 			fullName.append(prefix);
 		}
 		if (name != null) {
-			if (fullName.length() > 0) {
+			if (!fullName.isEmpty()) {
 				fullName.append('.');
 			}
 			fullName.append(ConfigurationMetadata.toDashedCase(name));

--- a/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/test/java/org/springframework/boot/jarmode/layertools/TestPrintStream.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-jarmode-layertools/src/test/java/org/springframework/boot/jarmode/layertools/TestPrintStream.java
@@ -37,7 +37,7 @@ import org.springframework.util.FileCopyUtils;
  */
 class TestPrintStream extends PrintStream implements AssertProvider<PrintStreamAssert> {
 
-	private final Class<? extends Object> testClass;
+	private final Class<?> testClass;
 
 	TestPrintStream(Object testInstance) {
 		super(new ByteArrayOutputStream());

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractAotMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractAotMojo.java
@@ -227,7 +227,7 @@ public abstract class AbstractAotMojo extends AbstractDependencyFilterMojo {
 		}
 
 		boolean hasReportedErrors() {
-			return this.message.length() > 0;
+			return !this.message.isEmpty();
 		}
 
 		@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractRunMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractRunMojo.java
@@ -342,7 +342,7 @@ public abstract class AbstractRunMojo extends AbstractDependencyFilterMojo {
 		try {
 			StringBuilder classpath = new StringBuilder();
 			for (URL ele : getClassPathUrls()) {
-				if (classpath.length() > 0) {
+				if (!classpath.isEmpty()) {
 					classpath.append(File.pathSeparator);
 				}
 				classpath.append(new File(ele.toURI()));

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/CommandLineBuilder.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/CommandLineBuilder.java
@@ -98,7 +98,7 @@ final class CommandLineBuilder {
 		static String build(List<URL> classpathElements) {
 			StringBuilder classpath = new StringBuilder();
 			for (URL element : classpathElements) {
-				if (classpath.length() > 0) {
+				if (!classpath.isEmpty()) {
 					classpath.append(File.pathSeparator);
 				}
 				classpath.append(toFile(element));

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
@@ -118,7 +118,7 @@ class StartupInfoLogger {
 		}
 		append(context, "started by ", () -> System.getProperty("user.name"));
 		append(context, "in ", () -> System.getProperty("user.dir"));
-		if (context.length() > 0) {
+		if (!context.isEmpty()) {
 			message.append(" (");
 			message.append(context);
 			message.append(")");
@@ -140,7 +140,7 @@ class StartupInfoLogger {
 			value = defaultValue;
 		}
 		if (StringUtils.hasLength(value)) {
-			message.append((message.length() > 0) ? " " : "");
+			message.append((!message.isEmpty()) ? " " : "");
 			message.append(prefix);
 			message.append(value);
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/DataObjectPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/DataObjectPropertyName.java
@@ -52,7 +52,7 @@ public abstract class DataObjectPropertyName {
 				}
 				else {
 					ch = (ch != '_') ? ch : '-';
-					if (Character.isUpperCase(ch) && result.length() > 0 && result.charAt(result.length() - 1) != '-') {
+					if (Character.isUpperCase(ch) && !result.isEmpty() && result.charAt(result.length() - 1) != '-') {
 						result.append('-');
 					}
 					result.append(Character.toLowerCase(ch));

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
@@ -211,7 +211,7 @@ class MapBinder extends AggregateBinder<Map<Object, Object>> {
 		private String getKeyName(ConfigurationPropertyName name) {
 			StringBuilder result = new StringBuilder();
 			for (int i = this.root.getNumberOfElements(); i < name.getNumberOfElements(); i++) {
-				if (result.length() != 0) {
+				if (!result.isEmpty()) {
 					result.append('.');
 				}
 				result.append(name.getElement(i, Form.ORIGINAL));

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -543,7 +543,7 @@ public final class ConfigurationPropertyName implements Comparable<Configuration
 		StringBuilder result = new StringBuilder(elements * 8);
 		for (int i = 0; i < elements; i++) {
 			boolean indexed = isIndexed(i);
-			if (result.length() > 0 && !indexed) {
+			if (!result.isEmpty() && !indexed) {
 				result.append('.');
 			}
 			if (indexed) {
@@ -615,7 +615,7 @@ public final class ConfigurationPropertyName implements Comparable<Configuration
 			Assert.isTrue(returnNullIfInvalid, "Name must not be null");
 			return null;
 		}
-		if (name.length() == 0) {
+		if (name.isEmpty()) {
 			return Elements.EMPTY;
 		}
 		if (name.charAt(0) == '.' || name.charAt(name.length() - 1) == '.') {
@@ -674,7 +674,7 @@ public final class ConfigurationPropertyName implements Comparable<Configuration
 	static ConfigurationPropertyName adapt(CharSequence name, char separator,
 			Function<CharSequence, CharSequence> elementValueProcessor) {
 		Assert.notNull(name, "Name must not be null");
-		if (name.length() == 0) {
+		if (name.isEmpty()) {
 			return EMPTY;
 		}
 		Elements elements = new ElementsParser(name, separator).parse(elementValueProcessor);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SystemEnvironmentPropertyMapper.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SystemEnvironmentPropertyMapper.java
@@ -57,7 +57,7 @@ final class SystemEnvironmentPropertyMapper implements PropertyMapper {
 	private String convertName(ConfigurationPropertyName name, int numberOfElements) {
 		StringBuilder result = new StringBuilder();
 		for (int i = 0; i < numberOfElements; i++) {
-			if (result.length() > 0) {
+			if (!result.isEmpty()) {
 				result.append('_');
 			}
 			result.append(name.getElement(i, Form.UNIFORM).toUpperCase(Locale.ENGLISH));
@@ -68,7 +68,7 @@ final class SystemEnvironmentPropertyMapper implements PropertyMapper {
 	private String convertLegacyName(ConfigurationPropertyName name) {
 		StringBuilder result = new StringBuilder();
 		for (int i = 0; i < name.getNumberOfElements(); i++) {
-			if (result.length() > 0) {
+			if (!result.isEmpty()) {
 				result.append('_');
 			}
 			result.append(convertLegacyNameElement(name.getElement(i, Form.ORIGINAL)));

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
@@ -158,7 +158,7 @@ public class BasicJsonParser extends AbstractJsonParser {
 			}
 			index++;
 		}
-		if (build.length() > 0) {
+		if (!build.isEmpty()) {
 			list.add(build.toString().trim());
 		}
 		return list;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/ColorConverter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/ColorConverter.java
@@ -130,7 +130,7 @@ public final class ColorConverter extends LogEventPatternConverter {
 		for (PatternFormatter formatter : this.formatters) {
 			formatter.format(event, buf);
 		}
-		if (buf.length() > 0) {
+		if (!buf.isEmpty()) {
 			AnsiElement element = this.styling;
 			if (element == null) {
 				// Assume highlighting

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -260,14 +260,14 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 		List<Throwable> suppressedExceptions = new ArrayList<>();
 		for (Status status : loggerContext.getStatusManager().getCopyOfStatusList()) {
 			if (status.getLevel() == Status.ERROR) {
-				errors.append((errors.length() > 0) ? String.format("%n") : "");
-				errors.append(status.toString());
+				errors.append((!errors.isEmpty()) ? String.format("%n") : "");
+				errors.append(status);
 				if (status.getThrowable() != null) {
 					suppressedExceptions.add(status.getThrowable());
 				}
 			}
 		}
-		if (errors.length() == 0) {
+		if (errors.isEmpty()) {
 			if (!StatusUtil.contextHasStatusListener(loggerContext)) {
 				StatusPrinter.printInCaseOfErrorsOrWarnings(loggerContext);
 			}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/r2dbc/ConnectionFactoryBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/r2dbc/ConnectionFactoryBuilder.java
@@ -245,7 +245,7 @@ public final class ConnectionFactoryBuilder {
 
 		private ConnectionFactoryOptions delegateFactoryOptions(ConnectionFactoryOptions options) {
 			String protocol = toString(options.getRequiredValue(ConnectionFactoryOptions.PROTOCOL));
-			if (protocol.trim().length() == 0) {
+			if (protocol.trim().isEmpty()) {
 				throw new IllegalArgumentException(String.format("Protocol %s is not valid.", protocol));
 			}
 			String[] protocols = protocol.split(COLON, 2);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/ApplicationPid.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/ApplicationPid.java
@@ -104,7 +104,7 @@ public class ApplicationPid {
 
 	private void assertCanOverwrite(File file) throws IOException {
 		if (!file.canWrite() || !canWritePosixFile(file)) {
-			throw new FileNotFoundException(file.toString() + " (permission denied)");
+			throw new FileNotFoundException(file + " (permission denied)");
 		}
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
@@ -877,7 +877,7 @@ class ConfigDataEnvironmentPostProcessorIntegrationTests {
 				map.put("spring", "boot");
 			}
 			String suffix = (!resource.isProfileSpecific()) ? "" : ":ps";
-			map.put(resource.toString() + suffix, "true");
+			map.put(resource + suffix, "true");
 			MapPropertySource propertySource = new MapPropertySource("loaded" + suffix, map);
 			return new ConfigData(Collections.singleton(propertySource));
 		}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
@@ -3091,7 +3091,7 @@ class ConfigurationPropertiesTests {
 
 	}
 
-	static record NestedRecord(String name) {
+	record NestedRecord(String name) {
 	}
 
 	@EnableConfigurationProperties

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/DefaultBindConstructorProviderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/DefaultBindConstructorProviderTests.java
@@ -207,7 +207,7 @@ class DefaultBindConstructorProviderTests {
 
 	}
 
-	static record OneConstructorOnRecord(String name, int age) {
+	record OneConstructorOnRecord(String name, int age) {
 
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/StaticResourceJarsTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/StaticResourceJarsTests.java
@@ -81,7 +81,7 @@ class StaticResourceJarsTests {
 	void ignoreWildcardUrls() throws Exception {
 		File jarFile = createResourcesJar("test-resources.jar");
 		URL folderUrl = jarFile.getParentFile().toURI().toURL();
-		URL wildcardUrl = new URL(folderUrl.toString() + "*.jar");
+		URL wildcardUrl = new URL(folderUrl + "*.jar");
 		List<URL> staticResourceJarUrls = new StaticResourceJars().getUrlsFrom(wildcardUrl);
 		assertThat(staticResourceJarUrls).isEmpty();
 	}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/main/java/smoketest/websocket/jetty/snake/Snake.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/main/java/smoketest/websocket/jetty/snake/Snake.java
@@ -141,7 +141,7 @@ public class Snake {
 				sb.append(',');
 				sb.append(String.format("{x: %d, y: %d}", Integer.valueOf(location.x), Integer.valueOf(location.y)));
 			}
-			return String.format("{'id':%d,'body':[%s]}", Integer.valueOf(this.id), sb.toString());
+			return String.format("{'id':%d,'body':[%s]}", Integer.valueOf(this.id), sb);
 		}
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/main/java/smoketest/websocket/jetty/snake/SnakeTimer.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/main/java/smoketest/websocket/jetty/snake/SnakeTimer.java
@@ -77,7 +77,7 @@ public final class SnakeTimer {
 				sb.append(',');
 			}
 		}
-		broadcast(String.format("{'type': 'update', 'data' : [%s]}", sb.toString()));
+		broadcast(String.format("{'type': 'update', 'data' : [%s]}", sb));
 	}
 
 	public static void broadcast(String message) {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/main/java/smoketest/websocket/jetty/snake/SnakeWebSocketHandler.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-jetty/src/main/java/smoketest/websocket/jetty/snake/SnakeWebSocketHandler.java
@@ -74,7 +74,7 @@ public class SnakeWebSocketHandler extends TextWebSocketHandler {
 				sb.append(',');
 			}
 		}
-		SnakeTimer.broadcast(String.format("{'type': 'join','data':[%s]}", sb.toString()));
+		SnakeTimer.broadcast(String.format("{'type': 'join','data':[%s]}", sb));
 	}
 
 	@Override

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/main/java/smoketest/websocket/tomcat/snake/Snake.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/main/java/smoketest/websocket/tomcat/snake/Snake.java
@@ -141,7 +141,7 @@ public class Snake {
 				sb.append(',');
 				sb.append(String.format("{x: %d, y: %d}", Integer.valueOf(location.x), Integer.valueOf(location.y)));
 			}
-			return String.format("{'id':%d,'body':[%s]}", Integer.valueOf(this.id), sb.toString());
+			return String.format("{'id':%d,'body':[%s]}", Integer.valueOf(this.id), sb);
 		}
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/main/java/smoketest/websocket/tomcat/snake/SnakeTimer.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/main/java/smoketest/websocket/tomcat/snake/SnakeTimer.java
@@ -77,7 +77,7 @@ public final class SnakeTimer {
 				sb.append(',');
 			}
 		}
-		broadcast(String.format("{'type': 'update', 'data' : [%s]}", sb.toString()));
+		broadcast(String.format("{'type': 'update', 'data' : [%s]}", sb));
 	}
 
 	public static void broadcast(String message) {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/main/java/smoketest/websocket/tomcat/snake/SnakeWebSocketHandler.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-tomcat/src/main/java/smoketest/websocket/tomcat/snake/SnakeWebSocketHandler.java
@@ -74,7 +74,7 @@ public class SnakeWebSocketHandler extends TextWebSocketHandler {
 				sb.append(',');
 			}
 		}
-		SnakeTimer.broadcast(String.format("{'type': 'join','data':[%s]}", sb.toString()));
+		SnakeTimer.broadcast(String.format("{'type': 'join','data':[%s]}", sb));
 	}
 
 	@Override

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/main/java/smoketest/websocket/undertow/snake/Snake.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/main/java/smoketest/websocket/undertow/snake/Snake.java
@@ -141,7 +141,7 @@ public class Snake {
 				sb.append(',');
 				sb.append(String.format("{x: %d, y: %d}", Integer.valueOf(location.x), Integer.valueOf(location.y)));
 			}
-			return String.format("{'id':%d,'body':[%s]}", Integer.valueOf(this.id), sb.toString());
+			return String.format("{'id':%d,'body':[%s]}", Integer.valueOf(this.id), sb);
 		}
 	}
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/main/java/smoketest/websocket/undertow/snake/SnakeTimer.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/main/java/smoketest/websocket/undertow/snake/SnakeTimer.java
@@ -77,7 +77,7 @@ public final class SnakeTimer {
 				sb.append(',');
 			}
 		}
-		broadcast(String.format("{'type': 'update', 'data' : [%s]}", sb.toString()));
+		broadcast(String.format("{'type': 'update', 'data' : [%s]}", sb));
 	}
 
 	public static void broadcast(String message) {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/main/java/smoketest/websocket/undertow/snake/SnakeWebSocketHandler.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-websocket-undertow/src/main/java/smoketest/websocket/undertow/snake/SnakeWebSocketHandler.java
@@ -74,7 +74,7 @@ public class SnakeWebSocketHandler extends TextWebSocketHandler {
 				sb.append(',');
 			}
 		}
-		SnakeTimer.broadcast(String.format("{'type': 'join','data':[%s]}", sb.toString()));
+		SnakeTimer.broadcast(String.format("{'type': 'join','data':[%s]}", sb));
 	}
 
 	@Override


### PR DESCRIPTION
1. use `.isEmpty()` where feasible
2. remove unnecessary `static` modifier of inner record or interface type
3. remove unnecessary `final` modifier of private or static method
4. remove unnecessary `toString()`