### PR TITLE
Add timeOffset to CacheProperties.Redis

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/CacheProperties.java
@@ -215,6 +215,11 @@ public class CacheProperties {
 		 * Entry expiration. By default the entries never expire.
 		 */
 		private Duration timeToLive;
+		
+		/**
+		 * Random time displacement to solve the cache avalanche issue.
+		 */
+		private Duration timeOffset;
 
 		/**
 		 * Allow caching null values.
@@ -242,6 +247,14 @@ public class CacheProperties {
 
 		public void setTimeToLive(Duration timeToLive) {
 			this.timeToLive = timeToLive;
+		}
+
+		public Duration getTimeOffset() {
+			return timeOffset;
+		}
+
+		public void setTimeOffset(Duration timeOffset) {
+			this.timeOffset = timeOffset;
 		}
 
 		public boolean isCacheNullValues() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/RedisCacheConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/RedisCacheConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.boot.autoconfigure.cache.CacheProperties.Redis;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.data.redis.RandomDurationTtlFunction;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
@@ -86,7 +87,7 @@ class RedisCacheConfiguration {
 		config = config
 			.serializeValuesWith(SerializationPair.fromSerializer(new JdkSerializationRedisSerializer(classLoader)));
 		if (redisProperties.getTimeToLive() != null) {
-			config = config.entryTtl(redisProperties.getTimeToLive());
+			config = config.entryTtl(new RandomDurationTtlFunction(redisProperties.getTimeToLive(), redisProperties.getTimeOffset()));
 		}
 		if (redisProperties.getKeyPrefix() != null) {
 			config = config.prefixCacheNameWith(redisProperties.getKeyPrefix());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RandomDurationTtlFunction.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RandomDurationTtlFunction.java
@@ -1,0 +1,33 @@
+package org.springframework.boot.autoconfigure.data.redis;
+
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.lang.Nullable;
+import org.springframework.data.redis.cache.RedisCacheWriter.TtlFunction;
+
+/**
+ * {@link TtlFunction} implementation returning the given, predetermined {@link Duration} used for per cache entry
+ * {@literal time-to-live (TTL) expiration}.
+ *
+ * @author liudaac
+ * @see java.time.Duration
+ * @see org.springframework.data.redis.cache.RedisCacheWriter.TtlFunction
+ * @since 3.2.1
+ */
+public record RandomDurationTtlFunction(Duration duration, Duration randomOffset) implements TtlFunction {
+
+	@Override
+	public Duration getTimeToLive(Object key, Object value) {
+		// TODO Auto-generated method stub
+		long expiration = duration.toMillis();
+		if (shouldExpireWithin(randomOffset)) {
+			expiration += ThreadLocalRandom.current().nextLong(randomOffset.toMillis());
+		}
+		return Duration.ofMillis(expiration);
+	}
+	
+	private static boolean shouldExpireWithin(@Nullable Duration ttl) {
+		return ttl != null && !ttl.isZero() && !ttl.isNegative();
+	}
+}


### PR DESCRIPTION
Add a new configuration option "timeOffset" in Redis to introduce a random time offset within the range [0, timeOffset) added to the specified timeToLive. This is aimed at effectively preventing cache avalanche issues at a specific time point in scenarios involving bulk cache refreshing.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
