### PR TITLE
Add clientId and subscriptionDurable to JmsProperties

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/DefaultJmsListenerContainerFactoryConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/DefaultJmsListenerContainerFactoryConfigurer.java
@@ -32,6 +32,7 @@ import org.springframework.util.Assert;
  *
  * @author Stephane Nicoll
  * @author Eddú Meléndez
+ * @author Lasse Wulff
  * @since 1.3.3
  */
 public final class DefaultJmsListenerContainerFactoryConfigurer {
@@ -101,6 +102,8 @@ public final class DefaultJmsListenerContainerFactoryConfigurer {
 		Assert.notNull(connectionFactory, "ConnectionFactory must not be null");
 		factory.setConnectionFactory(connectionFactory);
 		factory.setPubSubDomain(this.jmsProperties.isPubSubDomain());
+		factory.setSubscriptionDurable(this.jmsProperties.isSubscriptionDurable());
+		factory.setClientId(this.jmsProperties.getClientId());
 		if (this.transactionManager != null) {
 			factory.setTransactionManager(this.transactionManager);
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsProperties.java
@@ -26,6 +26,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Greg Turnquist
  * @author Phillip Webb
  * @author Stephane Nicoll
+ * @author Lasse Wulff
  * @since 1.0.0
  */
 @ConfigurationProperties(prefix = "spring.jms")
@@ -42,6 +43,16 @@ public class JmsProperties {
 	 */
 	private String jndiName;
 
+	/**
+	 * Whether the subscription is durable.
+	 */
+	private boolean subscriptionDurable = false;
+
+	/**
+	 * Client id of the connection.
+	 */
+	private String clientId;
+
 	private final Cache cache = new Cache();
 
 	private final Listener listener = new Listener();
@@ -54,6 +65,22 @@ public class JmsProperties {
 
 	public void setPubSubDomain(boolean pubSubDomain) {
 		this.pubSubDomain = pubSubDomain;
+	}
+
+	public boolean isSubscriptionDurable() {
+		return this.subscriptionDurable;
+	}
+
+	public void setSubscriptionDurable(boolean subscriptionDurable) {
+		this.subscriptionDurable = subscriptionDurable;
+	}
+
+	public String getClientId() {
+		return this.clientId;
+	}
+
+	public void setClientId(String clientId) {
+		this.clientId = clientId;
 	}
 
 	public String getJndiName() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
@@ -57,6 +57,7 @@ import static org.mockito.Mockito.mock;
  * @author Stephane Nicoll
  * @author Aurélien Leboulanger
  * @author Eddú Meléndez
+ * @author Lasse Wulff
  */
 class JmsAutoConfigurationTests {
 
@@ -144,7 +145,8 @@ class JmsAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(EnableJmsConfiguration.class)
 			.withPropertyValues("spring.jms.listener.autoStartup=false", "spring.jms.listener.acknowledgeMode=client",
 					"spring.jms.listener.concurrency=2", "spring.jms.listener.receiveTimeout=2s",
-					"spring.jms.listener.maxConcurrency=10")
+					"spring.jms.listener.maxConcurrency=10", "spring.jms.subscription-durable=true",
+					"spring.jms.client-id=exampleId")
 			.run(this::testJmsListenerContainerFactoryWithCustomSettings);
 	}
 
@@ -155,6 +157,8 @@ class JmsAutoConfigurationTests {
 		assertThat(container.getConcurrentConsumers()).isEqualTo(2);
 		assertThat(container.getMaxConcurrentConsumers()).isEqualTo(10);
 		assertThat(container).hasFieldOrPropertyWithValue("receiveTimeout", 2000L);
+		assertThat(container.isSubscriptionDurable()).isTrue();
+		assertThat(container.getClientId()).isEqualTo("exampleId");
 	}
 
 	@Test


### PR DESCRIPTION
This PR adds two new properties to the JmsProperties:
* subscription-durable
* client-id

This is an enhancement described in #38738
The new properties are also added to the corresponding unit test.

Since this is my first PR in this project, let me know, if I forgot anything :)