### PR TITLE
Pulsar authentication param properties cause IllegalStateException with Pulsar Client 3.1.0 

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.pulsar;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -29,6 +30,7 @@ import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
 import org.apache.pulsar.client.api.ReaderBuilder;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.pulsar.listener.PulsarContainerProperties;
@@ -71,13 +73,23 @@ final class PulsarPropertiesMapper {
 
 	private void customizeAuthentication(AuthenticationConsumer authentication,
 			PulsarProperties.Authentication properties) {
-		if (StringUtils.hasText(properties.getPluginClassName())) {
+		if (!StringUtils.hasText(properties.getPluginClassName())) {
+			return;
+		}
+		try {
+			// sort keys for testing and readability
+			Map<String, String> params = new TreeMap<>(properties.getParam());
+			String authParamString;
 			try {
-				authentication.accept(properties.getPluginClassName(), properties.getParam());
+				authParamString = ObjectMapperFactory.create().writeValueAsString(params);
 			}
-			catch (UnsupportedAuthenticationException ex) {
-				throw new IllegalStateException("Unable to configure Pulsar authentication", ex);
+			catch (Exception ex) {
+				throw new IllegalStateException("Could not convert auth parameters to encoded string", ex);
 			}
+			authentication.accept(properties.getPluginClassName(), authParamString);
+		}
+		catch (UnsupportedAuthenticationException ex) {
+			throw new IllegalStateException("Unable to configure Pulsar authentication", ex);
 		}
 	}
 
@@ -158,7 +170,7 @@ final class PulsarPropertiesMapper {
 
 	private interface AuthenticationConsumer {
 
-		void accept(String authPluginClassName, Map<String, String> authParams)
+		void accept(String authPluginClassName, String authParamString)
 				throws UnsupportedAuthenticationException;
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
@@ -170,8 +170,7 @@ final class PulsarPropertiesMapper {
 
 	private interface AuthenticationConsumer {
 
-		void accept(String authPluginClassName, String authParamString)
-				throws UnsupportedAuthenticationException;
+		void accept(String authPluginClassName, String authParamString) throws UnsupportedAuthenticationException;
 
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapperTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapperTests.java
@@ -73,12 +73,13 @@ class PulsarPropertiesMapperTests {
 	void customizeClientBuilderWhenHasAuthentication() throws UnsupportedAuthenticationException {
 		PulsarProperties properties = new PulsarProperties();
 		Map<String, String> params = Map.of("param", "name");
+		String authParamString = "{\"param\":\"name\"}";
 		properties.getClient().getAuthentication().setPluginClassName("myclass");
 		properties.getClient().getAuthentication().setParam(params);
 		ClientBuilder builder = mock(ClientBuilder.class);
 		new PulsarPropertiesMapper(properties).customizeClientBuilder(builder,
 				new PropertiesPulsarConnectionDetails(properties));
-		then(builder).should().authentication("myclass", params);
+		then(builder).should().authentication("myclass", authParamString);
 	}
 
 	@Test
@@ -112,12 +113,13 @@ class PulsarPropertiesMapperTests {
 	void customizeAdminBuilderWhenHasAuthentication() throws UnsupportedAuthenticationException {
 		PulsarProperties properties = new PulsarProperties();
 		Map<String, String> params = Map.of("param", "name");
+		String authParamString = "{\"param\":\"name\"}";
 		properties.getAdmin().getAuthentication().setPluginClassName("myclass");
 		properties.getAdmin().getAuthentication().setParam(params);
 		PulsarAdminBuilder builder = mock(PulsarAdminBuilder.class);
 		new PulsarPropertiesMapper(properties).customizeAdminBuilder(builder,
 				new PropertiesPulsarConnectionDetails(properties));
-		then(builder).should().authentication("myclass", params);
+		then(builder).should().authentication("myclass", authParamString);
 	}
 
 	@Test


### PR DESCRIPTION
The Pulsar authentication is currently configured using a map of auth parameters. However, this avenue is deprecated in Pulsar and instead needs to use an encoded auth parameters string. This commit simply takes the auth params map and converts them to the expected encoded json string of auth parameters.

Resolves https://github.com/spring-projects/spring-pulsar/issues/500

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
