### PR TITLE
Consistently log default context paths for embedded servers

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatWebServer.java
@@ -256,7 +256,7 @@ public class TomcatWebServer implements WebServer {
 	}
 
 	String getStartedLogMessage() {
-		return "Tomcat started on " + getPortsDescription(true) + " with context path '" + getContextPath() + "'";
+		return "Tomcat started on " + getPortsDescription(true) + " with context path '" + getPathFromEmbeddedContext() + "'";
 	}
 
 	private void checkThatConnectorsHaveStarted() {
@@ -406,12 +406,21 @@ public class TomcatWebServer implements WebServer {
 		return -1;
 	}
 
-	private String getContextPath() {
+	private String getPathFromEmbeddedContext() {
 		return Arrays.stream(this.tomcat.getHost().findChildren())
-			.filter(TomcatEmbeddedContext.class::isInstance)
-			.map(TomcatEmbeddedContext.class::cast)
-			.map(TomcatEmbeddedContext::getPath)
-			.collect(Collectors.joining(" "));
+				.filter(TomcatEmbeddedContext.class::isInstance)
+				.map(TomcatEmbeddedContext.class::cast)
+				.map(this::getPathFromEmbeddedContext)
+				.collect(Collectors.joining(" "));
+	}
+
+	private String getPathFromEmbeddedContext(TomcatEmbeddedContext context) {
+		String path = context.getPath();
+		if (path.isEmpty()) {
+			// return slash if empty to be consistent with other servers
+			return "/";
+		}
+		return path;
 	}
 
 	/**


### PR DESCRIPTION
This PR is intended to fix #36149 with the aim to be consistent when the embedded servers start and log their context path as in `Jetty started on port 8080 (http/1.1) with context path '/'`.

My first approach is to output on every *start server* line the context path, which by default should be `/`. However, I've seen that some servers (underlying embedded servers) present some problems when I try to do so.

For example, for `undertow`, the only way to get the context path is during runtime (i.e., on receiving a request), context path can't be retrieved when building the object. If we want to set the context path, we need to modify more files. (there is a longer explanation regarding the context path in #36149 )
For `netty`, there is no concept of context path, the only reference to *path* is to the network address path.

So, for now, I'm only submitting changes for `tomcat`, as the default context path was *nothing*, I've changed it to `/`. This was already the case for `jetty`.

I am wondering if we should even log the context path and if it has any use at all.
