### PR TITLE
otel tracing support for env vars

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -178,6 +178,8 @@ dependencies {
 	testImplementation("org.springframework.restdocs:spring-restdocs-webtestclient")
 	testImplementation("org.springframework.security:spring-security-test")
 	testImplementation("org.yaml:snakeyaml")
+	testImplementation("org.junit-pioneer:junit-pioneer:2.2.0")
+
 
 	testRuntimeOnly("jakarta.management.j2ee:jakarta.management.j2ee-api")
 	testRuntimeOnly("jakarta.transaction:jakarta.transaction-api")
@@ -229,6 +231,8 @@ artifacts {
 
 tasks.named("test") {
 	jvmArgs += "--add-opens=java.base/java.net=ALL-UNNAMED"
+	jvmArgs += "--add-opens=java.base/java.util=ALL-UNNAMED"
+	jvmArgs += "--add-opens=java.base/java.lang=ALL-UNNAMED"
 	filter {
 		excludeTestsMatching("org.springframework.boot.actuate.autoconfigure.endpoint.web.documentation.*")
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryAutoConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.opentelemetry;
 
+import io.micrometer.registry.otlp.OtlpConfig;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -79,6 +80,7 @@ public class OpenTelemetryAutoConfiguration {
 
 	private static Resource toResource(OpenTelemetryProperties properties) {
 		ResourceBuilder builder = Resource.builder();
+		((OtlpConfig) k -> null).resourceAttributes().forEach(builder::put);
 		properties.getResourceAttributes().forEach(builder::put);
 		return builder.build();
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/otlp/OtlpTracingConfigurations.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/otlp/OtlpTracingConfigurations.java
@@ -97,17 +97,17 @@ class OtlpTracingConfigurations {
 			return url;
 		}
 		Map<String, String> env = System.getenv();
-	            String endpoint = env.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-	            if (endpoint == null) {
-	                endpoint = env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
-	            }
-	            if (endpoint == null) {
-	                endpoint = "http://localhost:4318/v1/traces";
-	            }
-	            else if (!endpoint.endsWith("/v1/traces")) {
-	                endpoint = endpoint + "/v1/traces";
-	            }
-	            return endpoint;
+		String endpoint = env.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
+		if (endpoint == null) {
+			endpoint = env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
+		}
+		if (endpoint == null) {
+			endpoint = "http://localhost:4318/v1/traces";
+		}
+		else if (!endpoint.endsWith("/v1/traces")) {
+			endpoint = endpoint + "/v1/traces";
+		}
+		return endpoint;
 	}
 
 	private static Map<String, String> getHeaders(OtlpProperties properties) {
@@ -116,18 +116,19 @@ class OtlpTracingConfigurations {
 			return headers;
 		}
 
-            Map<String, String> env = System.getenv();
-            // common headers
+		Map<String, String> env = System.getenv();
+		// common headers
 		String headersString = env.getOrDefault("OTEL_EXPORTER_OTLP_HEADERS", "").trim();
-            String metricsHeaders = env.getOrDefault("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "").trim();
-            headersString = Objects.equals(headersString, "") ? metricsHeaders : headersString + "," + metricsHeaders;
+		String metricsHeaders = env.getOrDefault("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "").trim();
+		headersString = Objects.equals(headersString, "") ? metricsHeaders : headersString + "," + metricsHeaders;
 
-        String[] keyValues = Objects.equals(headersString, "") ? new String[] {} : headersString.split(",");
+		String[] keyValues = Objects.equals(headersString, "") ? new String[] {} : headersString.split(",");
 
-        return Arrays.stream(keyValues)
-            .map(String::trim)
-            .filter(keyValue -> keyValue.length() > 2 && keyValue.indexOf('=') > 0)
-            .collect(Collectors.toMap(keyValue -> keyValue.substring(0, keyValue.indexOf('=')).trim(),
-                    keyValue -> keyValue.substring(keyValue.indexOf('=') + 1).trim(), (l, r) -> r));
+		return Arrays.stream(keyValues)
+			.map(String::trim)
+			.filter(keyValue -> keyValue.length() > 2 && keyValue.indexOf('=') > 0)
+			.collect(Collectors.toMap(keyValue -> keyValue.substring(0, keyValue.indexOf('=')).trim(),
+					keyValue -> keyValue.substring(keyValue.indexOf('=') + 1).trim(), (l, r) -> r));
 	}
+
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/otlp/OtlpTracingConfigurations.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/otlp/OtlpTracingConfigurations.java
@@ -16,7 +16,11 @@
 
 package org.springframework.boot.actuate.autoconfigure.tracing.otlp;
 
+import java.util.Arrays;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder;
@@ -76,10 +80,10 @@ class OtlpTracingConfigurations {
 		OtlpHttpSpanExporter otlpHttpSpanExporter(OtlpProperties properties,
 				OtlpTracingConnectionDetails connectionDetails) {
 			OtlpHttpSpanExporterBuilder builder = OtlpHttpSpanExporter.builder()
-				.setEndpoint(connectionDetails.getUrl())
+				.setEndpoint(getUrl(connectionDetails))
 				.setTimeout(properties.getTimeout())
 				.setCompression(properties.getCompression().name().toLowerCase());
-			for (Entry<String, String> header : properties.getHeaders().entrySet()) {
+			for (Entry<String, String> header : getHeaders(properties).entrySet()) {
 				builder.addHeader(header.getKey(), header.getValue());
 			}
 			return builder.build();
@@ -87,4 +91,43 @@ class OtlpTracingConfigurations {
 
 	}
 
+	private static String getUrl(OtlpTracingConnectionDetails connectionDetails) {
+		String url = connectionDetails.getUrl();
+		if (url != null) {
+			return url;
+		}
+		Map<String, String> env = System.getenv();
+	            String endpoint = env.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
+	            if (endpoint == null) {
+	                endpoint = env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
+	            }
+	            if (endpoint == null) {
+	                endpoint = "http://localhost:4318/v1/traces";
+	            }
+	            else if (!endpoint.endsWith("/v1/traces")) {
+	                endpoint = endpoint + "/v1/traces";
+	            }
+	            return endpoint;
+	}
+
+	private static Map<String, String> getHeaders(OtlpProperties properties) {
+		Map<String, String> headers = properties.getHeaders();
+		if (!headers.isEmpty()) {
+			return headers;
+		}
+
+            Map<String, String> env = System.getenv();
+            // common headers
+		String headersString = env.getOrDefault("OTEL_EXPORTER_OTLP_HEADERS", "").trim();
+            String metricsHeaders = env.getOrDefault("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "").trim();
+            headersString = Objects.equals(headersString, "") ? metricsHeaders : headersString + "," + metricsHeaders;
+
+        String[] keyValues = Objects.equals(headersString, "") ? new String[] {} : headersString.split(",");
+
+        return Arrays.stream(keyValues)
+            .map(String::trim)
+            .filter(keyValue -> keyValue.length() > 2 && keyValue.indexOf('=') > 0)
+            .collect(Collectors.toMap(keyValue -> keyValue.substring(0, keyValue.indexOf('=')).trim(),
+                    keyValue -> keyValue.substring(keyValue.indexOf('=') + 1).trim(), (l, r) -> r));
+	}
 }


### PR DESCRIPTION
Fall back to otel env vars for tracing endpoint, headers, and resource attributes, in a similar way as micrometer does for metrics.

This gives users the option to use the same settings for tracing and metrics - and even the same as in other languages.

Why no spring properties?
- to make it more similar to metrics
- resource attributes and headers need to be parsed from a string - this approach doesn't require a converter.

Note: tests will be added later - need a hint how to test env vars.