### PR TITLE
Adding MIME Type Mapping for .mjs Extension in DefaultMimeMappings

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/MimeMappings.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/MimeMappings.java
@@ -260,6 +260,7 @@ public sealed class MimeMappings implements Iterable<MimeMappings.Mapping> {
 			mappings.add("jpeg", "image/jpeg");
 			mappings.add("jpg", "image/jpeg");
 			mappings.add("js", "text/javascript");
+			mappings.add("mjs", "text/javascript");
 			mappings.add("json", "application/json");
 			mappings.add("otf", "font/otf");
 			mappings.add("pdf", "application/pdf");


### PR DESCRIPTION
### Description

This pull request addresses the issue where the server responds with a MIME type of "application/octet-stream" for JavaScript module scripts with the ".mjs" extension. The problem manifests as the following error:

```
Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of "application/octet-stream". Strict MIME type checking is enforced for module scripts per HTML spec.
```

I have tested this change in a local environment using the pdfjs-dist component with the following dependency:

```xml
<dependency>
    <groupId>org.webjars.npm</groupId>
    <artifactId>pdfjs-dist</artifactId>
    <version>4.0.269</version>
</dependency>
```
and using script tag like :

```html
<script type="module" th:src="@{/webjars/pdfjs-dist/build/pdf.mjs}"></script>
<script type="module" th:src="@{/webjars/pdfjs-dist/build/pdf.worker.mjs}"></script>
<script type="module" th:src="@{/webjars/pdfjs-dist/web/pdf_viewer.mjs}"></script>
```

The test results confirm that the proposed changes resolve the reported issue.

To resolve this issue, I propose adding a default MIME type mapping for the ".mjs" extension to "text/javascript" directly within the Spring Boot application. This eliminates the need for a separate class like `CustomMimeMapping` with `WebServerFactoryCustomizer` like :

```java
@Override
public void customize (ConfigurableServletWebServerFactory factory){
    MimeMappings mappings = new MimeMappings(MimeMappings.DEFAULT);
    mappings.add("mjs","text/javascript");
    factory.setMimeMappings(mappings);
}

Changes Made

* Added MIME type mapping for ".mjs" extension to "text/javascript" directly in DefaultMimeMappings.

Thanks
