### PR TITLE
Connection leak when using jOOQ and spring.jooq.sql-dialect has not been set

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/SqlDialectLookup.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/SqlDialectLookup.java
@@ -46,8 +46,7 @@ final class SqlDialectLookup {
 	 * @return the most suitable {@link SQLDialect}
 	 */
 	static SQLDialect getDialect(DataSource dataSource) {
-		try {
-			Connection connection = (dataSource != null) ? dataSource.getConnection() : null;
+		try (Connection connection = (dataSource != null) ? dataSource.getConnection() : null) {
 			return JDBCUtils.dialect(connection);
 		}
 		catch (SQLException ex) {


### PR DESCRIPTION
`SqlDialectLookup` in jOOQ auto configuration doesn't close connection properly after obtaining it.

```
java.lang.Exception: Apparent connection leak detected
    at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:128)
    at org.springframework.boot.autoconfigure.jooq.SqlDialectLookup.getDialect(SqlDialectLookup.java:50)
    at org.springframework.boot.autoconfigure.jooq.JooqProperties.determineSqlDialect(JooqProperties.java:58)
    at org.springframework.boot.autoconfigure.jooq.JooqAutoConfiguration$DslContextConfiguration.jooqConfiguration(JooqAutoConfiguration.java:94)
...
```

This pull request wrap connection declaration in try-with-resource to fix connection leak.