### PR TITLE
Error mark in the log message for PatternParseException is in the wrong place

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/PatternParseFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/PatternParseFailureAnalyzer.java
@@ -30,7 +30,7 @@ class PatternParseFailureAnalyzer extends AbstractFailureAnalyzer<PatternParseEx
 
 	@Override
 	protected FailureAnalysis analyze(Throwable rootFailure, PatternParseException cause) {
-		return new FailureAnalysis("Invalid mapping pattern detected: " + cause.toDetailedString(),
+		return new FailureAnalysis("Invalid mapping pattern detected:\n" + cause.toDetailedString(),
 				"Fix this pattern in your application or switch to the legacy parser implementation with "
 						+ "'spring.mvc.pathmatch.matching-strategy=ant_path_matcher'.",
 				cause);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/PatternParseFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/PatternParseFailureAnalyzerTests.java
@@ -36,10 +36,14 @@ class PatternParseFailureAnalyzerTests {
 	@Test
 	void patternParseFailureQuotesPattern() {
 		FailureAnalysis failureAnalysis = performAnalysis("/spring/**/framework");
-		assertThat(failureAnalysis.getDescription()).contains("Invalid mapping pattern detected: /spring/**/framework");
+		assertThat(failureAnalysis.getDescription()).contains("""
+				Invalid mapping pattern detected:
+				/spring/**/framework
+				       ^
+				""");
 		assertThat(failureAnalysis.getAction())
-			.contains("Fix this pattern in your application or switch to the legacy parser"
-					+ " implementation with 'spring.mvc.pathmatch.matching-strategy=ant_path_matcher'.");
+				.contains("Fix this pattern in your application or switch to the legacy parser"
+						+ " implementation with 'spring.mvc.pathmatch.matching-strategy=ant_path_matcher'.");
 	}
 
 	private FailureAnalysis performAnalysis(String pattern) {


### PR DESCRIPTION
When a PatternParseException for [a regexp path pattern](https://docs.spring.io/spring-framework/docs/6.1.2/javadoc-api/org/springframework/web/util/pattern/PathPattern.html) occurs in a Spring MVC application launched by Spring Boot, the PatternParseFailureAnalyzer logs a message like this in console :

```
Description:

Invalid mapping pattern detected: /{path:\w+/\w+}
          ^
Expected close capture character after variable name }

...
```

At line 4, the mark '^' which indicates the error in the pattern is misplaced because the string returned by PatternParseException.toDetailedString() is appended to "Invalid mapping pattern detected:".

So this PR proposes to insert a "\n" after "Invalid mapping pattern detected:" . The error mark will be well positioned like this :
```
Description:

Invalid mapping pattern detected:
/{path:\w+/\w+}
          ^
Expected close capture character after variable name }

```

The only change in the main code is th addition of "\n". The rest of the changes adapts the test PatternParseFailureAnalyzerTests.

NB : I was not able to run the ` ./gradlew check` for the whole project (8 tests failed for Task :buildSrc:test) but I ran tests for the module spring-boot-project/spring-boot and the number of failling tests is the same after the change
