### PR TITLE
Use Spring Pulsar BOM

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1578,13 +1578,11 @@ bom {
 			]
 		}
 	}
-	library("Spring Pulsar", "1.0.1") {
+	library("Spring Pulsar", "1.0.2-SNAPSHOT") {
+		considerSnapshots()
 		group("org.springframework.pulsar") {
-			modules = [
-				"spring-pulsar",
-				"spring-pulsar-cache-provider",
-				"spring-pulsar-cache-provider-caffeine",
-				"spring-pulsar-reactive"
+			imports = [
+				"spring-pulsar-bom"
 			]
 		}
 	}


### PR DESCRIPTION
Spring Pulsar started providing a BOM in version `1.0.2-SNAPSHOT`. 

This replaces the module specific list w/ the new BOM. 


