### PR TITLE
spring.rabbitmq.listener.stream.auto-startup property has no effect

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -45,6 +45,7 @@ import org.springframework.util.StringUtils;
  * @author Franjo Zilic
  * @author Eddú Meléndez
  * @author Rafael Carvalho
+ * @author Lasse Wulff
  * @since 1.0.0
  */
 @ConfigurationProperties(prefix = "spring.rabbitmq")
@@ -690,22 +691,14 @@ public class RabbitProperties {
 
 	public abstract static class BaseContainer {
 
+	}
+
+	public abstract static class AmqpContainer extends BaseContainer {
+
 		/**
 		 * Whether to start the container automatically on startup.
 		 */
 		private boolean autoStartup = true;
-
-		public boolean isAutoStartup() {
-			return this.autoStartup;
-		}
-
-		public void setAutoStartup(boolean autoStartup) {
-			this.autoStartup = autoStartup;
-		}
-
-	}
-
-	public abstract static class AmqpContainer extends BaseContainer {
 
 		/**
 		 * Acknowledge mode of container.
@@ -738,6 +731,14 @@ public class RabbitProperties {
 		 * Optional properties for a retry interceptor.
 		 */
 		private final ListenerRetry retry = new ListenerRetry();
+
+		public boolean isAutoStartup() {
+			return this.autoStartup;
+		}
+
+		public void setAutoStartup(boolean autoStartup) {
+			this.autoStartup = autoStartup;
+		}
 
 		public AcknowledgeMode getAcknowledgeMode() {
 			return this.acknowledgeMode;


### PR DESCRIPTION
Move the property 'autoStartup' from `BaseContainer` to `AmqpContainer`. Fix #38749

As described in the issue, this property is only used by the child classes of the `AmqpContainer`.
The empty `BaseContainer` class is kept, because in the main branch, other attributes have been added to it.

Because of the affected lines, there might appear merge conflicts with the main branch.
If needed, I can create a PR for that as well.
