### PR TITLE
SslBundle implementations do not provide useful toString() results

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/PropertiesSslBundle.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/PropertiesSslBundle.java
@@ -146,8 +146,8 @@ public final class PropertiesSslBundle implements SslBundle {
 
 	@Override
 	public String toString() {
-		return "PropertiesSslBundle{" + "key=" + this.key + ", protocol='" + this.protocol + '\'' + ", ciphers="
-				+ Arrays.toString(this.options.getCiphers()) + ", enabled-protocols="
+		return "PropertiesSslBundle{" + "key-alias=" + this.key.getAlias() + ", protocol='" + this.protocol + '\''
+				+ ", ciphers=" + Arrays.toString(this.options.getCiphers()) + ", enabled-protocols="
 				+ Arrays.toString(this.options.getEnabledProtocols()) + '}';
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/PropertiesSslBundle.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/PropertiesSslBundle.java
@@ -29,6 +29,7 @@ import org.springframework.boot.ssl.jks.JksSslStoreDetails;
 import org.springframework.boot.ssl.pem.PemSslStore;
 import org.springframework.boot.ssl.pem.PemSslStoreBundle;
 import org.springframework.boot.ssl.pem.PemSslStoreDetails;
+import org.springframework.core.style.ToStringCreator;
 import org.springframework.util.Assert;
 
 /**
@@ -146,12 +147,15 @@ public final class PropertiesSslBundle implements SslBundle {
 
 	@Override
 	public String toString() {
-		return "PropertiesSslBundle{" + "key-alias=" + this.key.getAlias() + ", protocol='" + this.protocol + '\''
-				+ ", keystore-type=" + this.stores.getKeyStore().getType()
-				+ ((this.stores.getTrustStore() != null) ? ", truststore-type=" + this.stores.getTrustStore().getType()
-						: ", truststore=null")
-				+ ", ciphers=" + Arrays.toString(this.options.getCiphers()) + ", enabled-protocols="
-				+ Arrays.toString(this.options.getEnabledProtocols()) + '}';
+		ToStringCreator creator = new ToStringCreator(this);
+		creator.append("key-alias", this.key.getAlias());
+		creator.append("protocol", this.protocol);
+		creator.append("keystore-type", this.stores.getKeyStore().getType());
+		creator.append("truststore-type",
+				(this.stores.getTrustStore() != null) ? this.stores.getTrustStore().getType() : "");
+		creator.append("ciphers", Arrays.toString(this.options.getCiphers()));
+		creator.append("enabled-protocols", Arrays.toString(this.options.getEnabledProtocols()));
+		return creator.toString();
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/PropertiesSslBundle.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/PropertiesSslBundle.java
@@ -147,6 +147,9 @@ public final class PropertiesSslBundle implements SslBundle {
 	@Override
 	public String toString() {
 		return "PropertiesSslBundle{" + "key-alias=" + this.key.getAlias() + ", protocol='" + this.protocol + '\''
+				+ ", keystore-type=" + this.stores.getKeyStore().getType()
+				+ ((this.stores.getTrustStore() != null) ? ", truststore-type=" + this.stores.getTrustStore().getType()
+						: ", truststore=null")
 				+ ", ciphers=" + Arrays.toString(this.options.getCiphers()) + ", enabled-protocols="
 				+ Arrays.toString(this.options.getEnabledProtocols()) + '}';
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/PropertiesSslBundle.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/PropertiesSslBundle.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.autoconfigure.ssl;
 
+import java.util.Arrays;
+
 import org.springframework.boot.autoconfigure.ssl.SslBundleProperties.Key;
 import org.springframework.boot.ssl.SslBundle;
 import org.springframework.boot.ssl.SslBundleKey;
@@ -140,6 +142,13 @@ public final class PropertiesSslBundle implements SslBundle {
 	private static JksSslStoreDetails asStoreDetails(JksSslBundleProperties.Store properties) {
 		return new JksSslStoreDetails(properties.getType(), properties.getProvider(), properties.getLocation(),
 				properties.getPassword());
+	}
+
+	@Override
+	public String toString() {
+		return "PropertiesSslBundle{" + "key=" + this.key + ", protocol='" + this.protocol + '\'' + ", ciphers="
+				+ Arrays.toString(this.options.getCiphers()) + ", enabled-protocols="
+				+ Arrays.toString(this.options.getEnabledProtocols()) + '}';
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/WebServerSslBundle.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/WebServerSslBundle.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.web.server;
 
+import java.util.Arrays;
+
 import org.springframework.boot.ssl.NoSuchSslBundleException;
 import org.springframework.boot.ssl.SslBundle;
 import org.springframework.boot.ssl.SslBundleKey;
@@ -148,6 +150,13 @@ public final class WebServerSslBundle implements SslBundle {
 	private static boolean hasJavaKeyStoreProperties(Ssl ssl) {
 		return Ssl.isEnabled(ssl) && ssl.getKeyStore() != null
 				|| (ssl.getKeyStoreType() != null && ssl.getKeyStoreType().equals("PKCS11"));
+	}
+
+	@Override
+	public String toString() {
+		return "WebServerSslBundle{" + "key=" + this.key + ", protocol='" + this.protocol + '\'' + ", ciphers="
+				+ Arrays.toString(this.options.getCiphers()) + ", enabled-protocols="
+				+ Arrays.toString(this.options.getEnabledProtocols()) + '}';
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/WebServerSslBundle.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/WebServerSslBundle.java
@@ -155,6 +155,9 @@ public final class WebServerSslBundle implements SslBundle {
 	@Override
 	public String toString() {
 		return "WebServerSslBundle{" + "key-alias=" + this.key.getAlias() + ", protocol='" + this.protocol + '\''
+				+ ", keystore-type=" + this.stores.getKeyStore().getType()
+				+ ((this.stores.getTrustStore() != null) ? ", truststore-type=" + this.stores.getTrustStore().getType()
+						: ", truststore=null")
 				+ ", ciphers=" + Arrays.toString(this.options.getCiphers()) + ", enabled-protocols="
 				+ Arrays.toString(this.options.getEnabledProtocols()) + '}';
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/WebServerSslBundle.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/WebServerSslBundle.java
@@ -154,8 +154,8 @@ public final class WebServerSslBundle implements SslBundle {
 
 	@Override
 	public String toString() {
-		return "WebServerSslBundle{" + "key=" + this.key + ", protocol='" + this.protocol + '\'' + ", ciphers="
-				+ Arrays.toString(this.options.getCiphers()) + ", enabled-protocols="
+		return "WebServerSslBundle{" + "key-alias=" + this.key.getAlias() + ", protocol='" + this.protocol + '\''
+				+ ", ciphers=" + Arrays.toString(this.options.getCiphers()) + ", enabled-protocols="
 				+ Arrays.toString(this.options.getEnabledProtocols()) + '}';
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/WebServerSslBundle.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/WebServerSslBundle.java
@@ -29,6 +29,7 @@ import org.springframework.boot.ssl.jks.JksSslStoreBundle;
 import org.springframework.boot.ssl.jks.JksSslStoreDetails;
 import org.springframework.boot.ssl.pem.PemSslStoreBundle;
 import org.springframework.boot.ssl.pem.PemSslStoreDetails;
+import org.springframework.core.style.ToStringCreator;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -154,12 +155,15 @@ public final class WebServerSslBundle implements SslBundle {
 
 	@Override
 	public String toString() {
-		return "WebServerSslBundle{" + "key-alias=" + this.key.getAlias() + ", protocol='" + this.protocol + '\''
-				+ ", keystore-type=" + this.stores.getKeyStore().getType()
-				+ ((this.stores.getTrustStore() != null) ? ", truststore-type=" + this.stores.getTrustStore().getType()
-						: ", truststore=null")
-				+ ", ciphers=" + Arrays.toString(this.options.getCiphers()) + ", enabled-protocols="
-				+ Arrays.toString(this.options.getEnabledProtocols()) + '}';
+		ToStringCreator creator = new ToStringCreator(this);
+		creator.append("key-alias", this.key.getAlias());
+		creator.append("protocol", this.protocol);
+		creator.append("keystore-type", this.stores.getKeyStore().getType());
+		creator.append("truststore-type",
+				(this.stores.getTrustStore() != null) ? this.stores.getTrustStore().getType() : "");
+		creator.append("ciphers", Arrays.toString(this.options.getCiphers()));
+		creator.append("enabled-protocols", Arrays.toString(this.options.getEnabledProtocols()));
+		return creator.toString();
 	}
 
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Fixes #39057

Change proposed :

I have added a toString() method in the implementations for SslBundle interface.
There were two implementations :
1. PropertiesSslBundle
2. WebServerSslBundle

This toString() method prints the following attributes of the respective class:
1. alias of key
2. protocol
3. ciphers
4. enabledProtocols

Attaching a screenshot of the line printed when object is logged :

<img width="1046" alt="image" src="https://github.com/spring-projects/spring-boot/assets/37299522/715dbff9-70bc-4c08-a516-825dc8a09ec5">


