### PR TITLE
Fix link to Log4j2's JDK logging adapter documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/logging.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/logging.adoc
@@ -164,7 +164,7 @@ To do so, declare a dependency on the Log4j 2 starter and tell Gradle that any o
 
 NOTE: The Log4j starters gather together the dependencies for common logging requirements (such as having Tomcat use `java.util.logging` but configuring the output using Log4j 2).
 
-NOTE: To ensure that debug logging performed using `java.util.logging` is routed into Log4j 2, configure its https://logging.apache.org/log4j/2.x/log4j-jul/index.html[JDK logging adapter] by setting the `java.util.logging.manager` system property to `org.apache.logging.log4j.jul.LogManager`.
+NOTE: To ensure that debug logging performed using `java.util.logging` is routed into Log4j 2, configure its https://logging.apache.org/log4j/2.x/log4j-jul.html[JDK logging adapter] by setting the `java.util.logging.manager` system property to `org.apache.logging.log4j.jul.LogManager`.
 
 
 


### PR DESCRIPTION
update https://logging.apache.org/log4j/2.x/log4j-jul/index.html to https://logging.apache.org/log4j/2.x/log4j-jul.html
<img width="394" alt="Snipaste_2024-01-17_17-23-59" src="https://github.com/spring-projects/spring-boot/assets/17490205/f05e51d6-acbf-441d-8696-313917e7a59c">

