### PR TITLE
Add ConnectionDetails and Service Connection and Docker-Compose support for LDAP

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfiguration.java
@@ -47,17 +47,24 @@ import org.springframework.ldap.core.support.LdapContextSource;
 public class LdapAutoConfiguration {
 
 	@Bean
+	@ConditionalOnMissingBean(LdapConnectionDetails.class)
+	PropertiesLdapConnectionDetails propertiesLdapConnectionDetails(LdapProperties properties,
+			Environment environment) {
+		return new PropertiesLdapConnectionDetails(properties, environment);
+	}
+
+	@Bean
 	@ConditionalOnMissingBean
-	public LdapContextSource ldapContextSource(LdapProperties properties, Environment environment,
+	public LdapContextSource ldapContextSource(LdapConnectionDetails connectionDetails, LdapProperties properties,
 			ObjectProvider<DirContextAuthenticationStrategy> dirContextAuthenticationStrategy) {
 		LdapContextSource source = new LdapContextSource();
 		dirContextAuthenticationStrategy.ifUnique(source::setAuthenticationStrategy);
 		PropertyMapper propertyMapper = PropertyMapper.get().alwaysApplyingWhenNonNull();
-		propertyMapper.from(properties.getUsername()).to(source::setUserDn);
-		propertyMapper.from(properties.getPassword()).to(source::setPassword);
+		propertyMapper.from(connectionDetails.getUsername()).to(source::setUserDn);
+		propertyMapper.from(connectionDetails.getPassword()).to(source::setPassword);
 		propertyMapper.from(properties.getAnonymousReadOnly()).to(source::setAnonymousReadOnly);
-		propertyMapper.from(properties.getBase()).to(source::setBase);
-		propertyMapper.from(properties.determineUrls(environment)).to(source::setUrls);
+		propertyMapper.from(connectionDetails.getBase()).to(source::setBase);
+		propertyMapper.from(connectionDetails.getUrls()).to(source::setUrls);
 		propertyMapper.from(properties.getBaseEnvironment())
 			.to((baseEnvironment) -> source.setBaseEnvironmentProperties(Collections.unmodifiableMap(baseEnvironment)));
 		return source;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapConnectionDetails.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/LdapConnectionDetails.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.ldap;
+
+import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
+
+/**
+ * Details required to establish a connection to a Ldap service.
+ *
+ * @author Philipp Kessler
+ * @since 3.3.0
+ */
+public interface LdapConnectionDetails extends ConnectionDetails {
+
+	/**
+	 * LDAP URLs of the server.
+	 * @return list of the LDAP urls to use
+	 */
+	String[] getUrls();
+
+	/**
+	 * Base suffix from which all operations should originate.
+	 * @return base suffix from which all operations should originate or null.
+	 */
+	default String getBase() {
+		return null;
+	}
+
+	/**
+	 * Login username of the server.
+	 * @return login username of the server or null.
+	 */
+	default String getUsername() {
+		return null;
+	}
+
+	/**
+	 * Login password of the server.
+	 * @return login password of the server or null.
+	 */
+	default String getPassword() {
+		return null;
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/PropertiesLdapConnectionDetails.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/PropertiesLdapConnectionDetails.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.ldap;
+
+import org.springframework.core.env.Environment;
+
+/**
+ * Adapts {@link LdapProperties} to {@link LdapConnectionDetails}.
+ *
+ * @author Philipp Kessler
+ * @since 3.3.0
+ */
+public class PropertiesLdapConnectionDetails implements LdapConnectionDetails {
+
+	private final LdapProperties properties;
+
+	private final Environment environment;
+
+	PropertiesLdapConnectionDetails(LdapProperties properties, Environment environment) {
+		this.properties = properties;
+		this.environment = environment;
+	}
+
+	@Override
+	public String[] getUrls() {
+		return this.properties.determineUrls(this.environment);
+	}
+
+	@Override
+	public String getBase() {
+		return this.properties.getBase();
+	}
+
+	@Override
+	public String getUsername() {
+		return this.properties.getUsername();
+	}
+
+	@Override
+	public String getPassword() {
+		return this.properties.getPassword();
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ldap/LdapAutoConfigurationTests.java
@@ -29,6 +29,7 @@ import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.ldap.core.support.SimpleDirContextAuthenticationStrategy;
 import org.springframework.ldap.pool2.factory.PoolConfig;
 import org.springframework.ldap.pool2.factory.PooledContextSource;
+import org.springframework.ldap.support.LdapUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -113,6 +114,25 @@ class LdapAutoConfigurationTests {
 	}
 
 	@Test
+	void definesPropertiesBasedConnectionDetailsByDefault() {
+		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(PropertiesLdapConnectionDetails.class));
+	}
+
+	@Test
+	void shouldUseCustomConnectionDetailsWhenDefined() {
+		this.contextRunner.withUserConfiguration(ConnectionDetailsConfiguration.class).run((context) -> {
+			assertThat(context).hasSingleBean(LdapContextSource.class)
+				.hasSingleBean(LdapConnectionDetails.class)
+				.doesNotHaveBean(PropertiesLdapConnectionDetails.class);
+			LdapContextSource contextSource = context.getBean(LdapContextSource.class);
+			assertThat(contextSource.getUrls()).isEqualTo(new String[] { "ldaps://ldap.example.com" });
+			assertThat(contextSource.getBaseLdapName()).isEqualTo(LdapUtils.newLdapName("dc=base"));
+			assertThat(contextSource.getUserDn()).isEqualTo("ldap-user");
+			assertThat(contextSource.getPassword()).isEqualTo("ldap-password");
+		});
+	}
+
+	@Test
 	void templateExists() {
 		this.contextRunner.withPropertyValues("spring.ldap.urls:ldap://localhost:389").run((context) -> {
 			assertThat(context).hasSingleBean(LdapTemplate.class);
@@ -172,6 +192,37 @@ class LdapAutoConfigurationTests {
 					.isNotSameAs(context.getBean("anotherCustomDirContextAuthenticationStrategy"))
 					.isInstanceOf(SimpleDirContextAuthenticationStrategy.class);
 			});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ConnectionDetailsConfiguration {
+
+		@Bean
+		LdapConnectionDetails ldapConnectionDetails() {
+			return new LdapConnectionDetails() {
+
+				@Override
+				public String[] getUrls() {
+					return new String[] { "ldaps://ldap.example.com" };
+				}
+
+				@Override
+				public String getBase() {
+					return "dc=base";
+				}
+
+				@Override
+				public String getUsername() {
+					return "ldap-user";
+				}
+
+				@Override
+				public String getPassword() {
+					return "ldap-password";
+				}
+			};
+		}
+
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/ldap/LdapDockerComposeConnectionDetailsFactory.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/ldap/LdapDockerComposeConnectionDetailsFactory.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docker.compose.service.connection.ldap;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.autoconfigure.ldap.LdapConnectionDetails;
+import org.springframework.boot.docker.compose.core.RunningService;
+import org.springframework.boot.docker.compose.service.connection.DockerComposeConnectionDetailsFactory;
+import org.springframework.boot.docker.compose.service.connection.DockerComposeConnectionSource;
+
+/**
+ * {@link DockerComposeConnectionDetailsFactory} to create {@link LdapConnectionDetails}
+ * for an {@code ldap} service.
+ *
+ * @author Philipp Kessler
+ */
+class LdapDockerComposeConnectionDetailsFactory extends DockerComposeConnectionDetailsFactory<LdapConnectionDetails> {
+
+	protected LdapDockerComposeConnectionDetailsFactory() {
+		super("osixia/openldap");
+	}
+
+	@Override
+	protected LdapConnectionDetails getDockerComposeConnectionDetails(DockerComposeConnectionSource source) {
+		return new LdapDockerComposeConnectionDetails(source.getRunningService());
+	}
+
+	/**
+	 * {@link LdapConnectionDetails} backed by an {@code openldap} {@link RunningService}.
+	 */
+	static class LdapDockerComposeConnectionDetails extends DockerComposeConnectionDetails
+			implements LdapConnectionDetails {
+
+		private final String[] urls;
+
+		private final String base;
+
+		private final String username;
+
+		private final String password;
+
+		LdapDockerComposeConnectionDetails(RunningService service) {
+			super(service);
+			Map<String, String> env = service.env();
+			boolean usesTls = Boolean.parseBoolean(env.getOrDefault("LDAP_TLS", "true"));
+			String ldapPort = usesTls ? env.getOrDefault("LDAPS_PORT", "636") : env.getOrDefault("LDAP_PORT", "389");
+			this.urls = new String[] { "%s://%s:%d".formatted(usesTls ? "ldaps" : "ldap", service.host(),
+					service.ports().get(Integer.parseInt(ldapPort))) };
+			String baseDn = env.getOrDefault("LDAP_BASE_DN", null);
+			if (baseDn == null) {
+				baseDn = Arrays.stream(env.getOrDefault("LDAP_DOMAIN", "example.org").split("\\."))
+					.map("dc=%s"::formatted)
+					.collect(Collectors.joining(","));
+			}
+			this.base = baseDn;
+			this.password = env.getOrDefault("LDAP_ADMIN_PASSWORD", "admin");
+			this.username = "cn=admin,%s".formatted(this.base);
+		}
+
+		@Override
+		public String[] getUrls() {
+			return this.urls;
+		}
+
+		@Override
+		public String getBase() {
+			return this.base;
+		}
+
+		@Override
+		public String getUsername() {
+			return this.username;
+		}
+
+		@Override
+		public String getPassword() {
+			return this.password;
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/ldap/package-info.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/ldap/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for docker compose Ldap service connections.
+ */
+package org.springframework.boot.docker.compose.service.connection.ldap;

--- a/spring-boot-project/spring-boot-docker-compose/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/resources/META-INF/spring.factories
@@ -9,6 +9,7 @@ org.springframework.boot.docker.compose.service.connection.activemq.ActiveMQDock
 org.springframework.boot.docker.compose.service.connection.cassandra.CassandraDockerComposeConnectionDetailsFactory,\
 org.springframework.boot.docker.compose.service.connection.elasticsearch.ElasticsearchDockerComposeConnectionDetailsFactory,\
 org.springframework.boot.docker.compose.service.connection.flyway.JdbcAdaptingFlywayConnectionDetailsFactory,\
+org.springframework.boot.docker.compose.service.connection.ldap.LdapDockerComposeConnectionDetailsFactory,\
 org.springframework.boot.docker.compose.service.connection.liquibase.JdbcAdaptingLiquibaseConnectionDetailsFactory,\
 org.springframework.boot.docker.compose.service.connection.mariadb.MariaDbJdbcDockerComposeConnectionDetailsFactory,\
 org.springframework.boot.docker.compose.service.connection.mariadb.MariaDbR2dbcDockerComposeConnectionDetailsFactory,\

--- a/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/ldap/LdapDockerComposeConnectionDetailsFactoryIntegrationTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/ldap/LdapDockerComposeConnectionDetailsFactoryIntegrationTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docker.compose.service.connection.ldap;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.ldap.LdapConnectionDetails;
+import org.springframework.boot.docker.compose.service.connection.test.AbstractDockerComposeIntegrationTests;
+import org.springframework.boot.testsupport.testcontainers.DockerImageNames;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link LdapDockerComposeConnectionDetailsFactory}.
+ *
+ * @author Philipp Kessler
+ */
+class LdapDockerComposeConnectionDetailsFactoryIntegrationTests extends AbstractDockerComposeIntegrationTests {
+
+	LdapDockerComposeConnectionDetailsFactoryIntegrationTests() {
+		super("ldap-compose.yaml", DockerImageNames.ldap());
+	}
+
+	@Test
+	void runCreatesConnectionDetails() {
+		LdapConnectionDetails connectionDetails = run(LdapConnectionDetails.class);
+		assertThat(connectionDetails.getUsername()).isEqualTo("cn=admin,dc=ldap,dc=example,dc=org");
+		assertThat(connectionDetails.getPassword()).isEqualTo("somepassword");
+		assertThat(connectionDetails.getBase()).isEqualTo("dc=ldap,dc=example,dc=org");
+		assertThat(connectionDetails.getUrls()).hasSize(1);
+		assertThat(connectionDetails.getUrls()[0]).startsWith("ldaps://");
+	}
+
+}

--- a/spring-boot-project/spring-boot-docker-compose/src/test/resources/org/springframework/boot/docker/compose/service/connection/ldap/ldap-compose.yaml
+++ b/spring-boot-project/spring-boot-docker-compose/src/test/resources/org/springframework/boot/docker/compose/service/connection/ldap/ldap-compose.yaml
@@ -1,0 +1,11 @@
+services:
+  ldap:
+    image: '{imageName}'
+    environment:
+      - 'LDAP_DOMAIN=ldap.example.org'
+      - 'LDAP_ADMIN_PASSWORD=somepassword'
+      - 'LDAP_TLS=true'
+    hostname: ldap
+    ports:
+      - "389"
+      - "636"

--- a/spring-boot-project/spring-boot-testcontainers/build.gradle
+++ b/spring-boot-project/spring-boot-testcontainers/build.gradle
@@ -57,6 +57,7 @@ dependencies {
 	testImplementation("org.springframework:spring-r2dbc")
 	testImplementation("org.springframework.amqp:spring-rabbit")
 	testImplementation("org.springframework.kafka:spring-kafka")
+	testImplementation("org.springframework.ldap:spring-ldap-core")
 	testImplementation("org.springframework.pulsar:spring-pulsar")
 	testImplementation("org.testcontainers:junit-jupiter")
 

--- a/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/ldap/LdapContainerConnectionDetailsFactory.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/ldap/LdapContainerConnectionDetailsFactory.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.testcontainers.service.connection.ldap;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+
+import org.springframework.boot.autoconfigure.ldap.LdapConnectionDetails;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionDetailsFactory;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionSource;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+
+/**
+ * {@link ContainerConnectionDetailsFactory} to create {@link LdapConnectionDetails} from
+ * a {@link ServiceConnection @ServiceConnection}-annotated {@link GenericContainer} using
+ * the {@code "osixia/openldap"} image.
+ *
+ * @author Philipp Kessler
+ */
+class LdapContainerConnectionDetailsFactory
+		extends ContainerConnectionDetailsFactory<Container<?>, LdapConnectionDetails> {
+
+	LdapContainerConnectionDetailsFactory() {
+		super("osixia/openldap");
+	}
+
+	@Override
+	protected LdapConnectionDetails getContainerConnectionDetails(ContainerConnectionSource<Container<?>> source) {
+		return new LdapContainerConnectionDetailsFactory.LdapContainerConnectionDetails(source);
+	}
+
+	private static final class LdapContainerConnectionDetails extends ContainerConnectionDetails<Container<?>>
+			implements LdapConnectionDetails {
+
+		private LdapContainerConnectionDetails(ContainerConnectionSource<Container<?>> source) {
+			super(source);
+		}
+
+		@Override
+		public String[] getUrls() {
+			Map<String, String> env = getContainer().getEnvMap();
+			boolean usesTls = Boolean.parseBoolean(env.getOrDefault("LDAP_TLS", "true"));
+			String ldapPort = usesTls ? env.getOrDefault("LDAPS_PORT", "636") : env.getOrDefault("LDAP_PORT", "389");
+			return new String[] { "%s://%s:%d".formatted(usesTls ? "ldaps" : "ldap", getContainer().getHost(),
+					getContainer().getMappedPort(Integer.parseInt(ldapPort))) };
+		}
+
+		@Override
+		public String getBase() {
+			String baseDn = getContainer().getEnvMap().getOrDefault("LDAP_BASE_DN", null);
+			if (baseDn == null) {
+				baseDn = Arrays
+					.stream(getContainer().getEnvMap().getOrDefault("LDAP_DOMAIN", "example.org").split("\\."))
+					.map("dc=%s"::formatted)
+					.collect(Collectors.joining(","));
+			}
+			return baseDn;
+		}
+
+		@Override
+		public String getUsername() {
+			return "cn=admin,%s".formatted(getBase());
+		}
+
+		@Override
+		public String getPassword() {
+			return getContainer().getEnvMap().getOrDefault("LDAP_ADMIN_PASSWORD", "admin");
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/ldap/package-info.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/ldap/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for testcontainers Ldap service connections.
+ */
+package org.springframework.boot.testcontainers.service.connection.ldap;

--- a/spring-boot-project/spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
@@ -16,6 +16,7 @@ org.springframework.boot.testcontainers.service.connection.flyway.FlywayContaine
 org.springframework.boot.testcontainers.service.connection.elasticsearch.ElasticsearchContainerConnectionDetailsFactory,\
 org.springframework.boot.testcontainers.service.connection.jdbc.JdbcContainerConnectionDetailsFactory,\
 org.springframework.boot.testcontainers.service.connection.kafka.KafkaContainerConnectionDetailsFactory,\
+org.springframework.boot.testcontainers.service.connection.ldap.LdapContainerConnectionDetailsFactory,\
 org.springframework.boot.testcontainers.service.connection.liquibase.LiquibaseContainerConnectionDetailsFactory,\
 org.springframework.boot.testcontainers.service.connection.mongo.MongoContainerConnectionDetailsFactory,\
 org.springframework.boot.testcontainers.service.connection.neo4j.Neo4jContainerConnectionDetailsFactory,\

--- a/spring-boot-project/spring-boot-testcontainers/src/test/java/org/springframework/boot/testcontainers/service/connection/ldap/LdapContainerConnectionDetailsFactoryIntegrationTests.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/test/java/org/springframework/boot/testcontainers/service/connection/ldap/LdapContainerConnectionDetailsFactoryIntegrationTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.testcontainers.service.connection.ldap;
+
+import java.util.List;
+
+import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.testsupport.testcontainers.LdapContainer;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.ldap.core.AttributesMapper;
+import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.ldap.query.LdapQueryBuilder;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link LdapContainerConnectionDetailsFactory}.
+ *
+ * @author Philipp Kessler
+ */
+@SpringJUnitConfig
+@Testcontainers(disabledWithoutDocker = true)
+class LdapContainerConnectionDetailsFactoryIntegrationTests {
+
+	@Container
+	@ServiceConnection
+	static final LdapContainer openLdap = new LdapContainer().withEnv("LDAP_TLS", "false");
+
+	@Autowired
+	private LdapTemplate ldapTemplate;
+
+	@Test
+	void connectionCanBeMadeToLdapContainer() {
+		List<String> cn = this.ldapTemplate.search(LdapQueryBuilder.query().where("objectclass").is("dcObject"),
+				new AttributesMapper<String>() {
+					@Override
+					public String mapFromAttributes(Attributes attributes) throws NamingException {
+						return attributes.get("dc").get().toString();
+					}
+				});
+		assertThat(cn).hasSize(1);
+		assertThat(cn.get(0)).isEqualTo("example");
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportAutoConfiguration({ LdapAutoConfiguration.class })
+	static class TestConfiguration {
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/testcontainers/DockerImageNames.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/testcontainers/DockerImageNames.java
@@ -40,6 +40,8 @@ public final class DockerImageNames {
 
 	private static final String KAFKA_VERSION = "7.4.0";
 
+	private static final String LDAP_VERSION = "1.5.0";
+
 	private static final String MARIADB_VERSION = "10.10";
 
 	private static final String MONGO_VERSION = "5.0.17";
@@ -117,6 +119,14 @@ public final class DockerImageNames {
 	 */
 	public static DockerImageName kafka() {
 		return DockerImageName.parse("confluentinc/cp-kafka").withTag(KAFKA_VERSION);
+	}
+
+	/**
+	 * Return a {@link DockerImageName} suitable for running OpenLdap.
+	 * @return a docker image name for running OpenLdap
+	 */
+	public static DockerImageName ldap() {
+		return DockerImageName.parse("osixia/openldap").withTag(LDAP_VERSION);
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/testcontainers/LdapContainer.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/testcontainers/LdapContainer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.testsupport.testcontainers;
+
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * A {@link GenericContainer} for OpenLdap.
+ *
+ * @author Philipp Kessler
+ */
+public class LdapContainer extends GenericContainer<LdapContainer> {
+
+	private static final int DEFAULT_LDAP_PORT = 389;
+
+	public LdapContainer() {
+		super(DockerImageNames.ldap());
+		addExposedPorts(DEFAULT_LDAP_PORT);
+	}
+
+}


### PR DESCRIPTION
This PR includes:
*  Adding the `ConnectionDetails` abstraction for `LdapAutoConfiguration`
* Docker-Compose Support for the [osixia/openldap](https://github.com/osixia/docker-openldap) Image
* Testcontainer Support for the [osixia/openldap](https://github.com/osixia/docker-openldap) Image