### PR TITLE
TracingProperties exposes package-private PropagationType from public methods

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/TracingProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/TracingProperties.java
@@ -251,7 +251,7 @@ public class TracingProperties {
 		/**
 		 * Supported propagation types. The declared order of the values matter.
 		 */
-		enum PropagationType {
+		public enum PropagationType {
 
 			/**
 			 * <a href="https://www.w3.org/TR/trace-context/">W3C</a> propagation.


### PR DESCRIPTION
PropagationType enum is non-public outside of TracingProperties class which makes it unusable. I would request you to make it accessible so that we can access it to make customisation in tracing needs within our services.