### PR TITLE
feat: make finalName editable

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RepackageMojo.java
@@ -69,7 +69,7 @@ public class RepackageMojo extends AbstractPackagerMojo {
 	 * Name of the generated archive.
 	 * @since 1.0.0
 	 */
-	@Parameter(defaultValue = "${project.build.finalName}", readonly = true)
+	@Parameter(defaultValue = "${project.build.finalName}")
 	private String finalName;
 
 	/**


### PR DESCRIPTION
We recommend configuring finalName to change the artifact name but mark it as read-only. It's better to make it editable.