### PR TITLE
Unify 'observation-enabled' property defaults

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarProperties.java
@@ -761,7 +761,7 @@ public class PulsarProperties {
 		 * Whether to record observations for when the Observations API is available and
 		 * the client supports it.
 		 */
-		private boolean observationEnabled = true;
+		private boolean observationEnabled;
 
 		public SchemaType getSchemaType() {
 			return this.schemaType;
@@ -856,7 +856,7 @@ public class PulsarProperties {
 		/**
 		 * Whether to record observations for when the Observations API is available.
 		 */
-		private boolean observationsEnabled = true;
+		private boolean observationsEnabled;
 
 		public boolean isObservationsEnabled() {
 			return this.observationsEnabled;

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfigurationTests.java
@@ -304,7 +304,7 @@ class PulsarAutoConfigurationTests {
 		@Test
 		void whenNoPropertiesEnablesObservation() {
 			this.contextRunner.run((context) -> assertThat(context).getBean(PulsarTemplate.class)
-				.hasFieldOrPropertyWithValue("observationEnabled", true));
+				.hasFieldOrPropertyWithValue("observationEnabled", false));
 		}
 
 		@Test
@@ -451,7 +451,7 @@ class PulsarAutoConfigurationTests {
 		void whenNoPropertiesEnablesObservation() {
 			this.contextRunner
 				.run((context) -> assertThat(context).getBean(ConcurrentPulsarListenerContainerFactory.class)
-					.hasFieldOrPropertyWithValue("containerProperties.observationEnabled", true));
+					.hasFieldOrPropertyWithValue("containerProperties.observationEnabled", false));
 		}
 
 		@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapperTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapperTests.java
@@ -219,12 +219,12 @@ class PulsarPropertiesMapperTests {
 		PulsarProperties properties = new PulsarProperties();
 		properties.getConsumer().getSubscription().setType(SubscriptionType.Shared);
 		properties.getListener().setSchemaType(SchemaType.AVRO);
-		properties.getListener().setObservationEnabled(false);
+		properties.getListener().setObservationEnabled(true);
 		PulsarContainerProperties containerProperties = new PulsarContainerProperties("my-topic-pattern");
 		new PulsarPropertiesMapper(properties).customizeContainerProperties(containerProperties);
 		assertThat(containerProperties.getSubscriptionType()).isEqualTo(SubscriptionType.Shared);
 		assertThat(containerProperties.getSchemaType()).isEqualTo(SchemaType.AVRO);
-		assertThat(containerProperties.isObservationEnabled()).isFalse();
+		assertThat(containerProperties.isObservationEnabled()).isTrue();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesTests.java
@@ -354,10 +354,10 @@ class PulsarPropertiesTests {
 		void bind() {
 			Map<String, String> map = new HashMap<>();
 			map.put("spring.pulsar.listener.schema-type", "avro");
-			map.put("spring.pulsar.listener.observation-enabled", "false");
+			map.put("spring.pulsar.listener.observation-enabled", "true");
 			PulsarProperties.Listener properties = bindPropeties(map).getListener();
 			assertThat(properties.getSchemaType()).isEqualTo(SchemaType.AVRO);
-			assertThat(properties.isObservationEnabled()).isFalse();
+			assertThat(properties.isObservationEnabled()).isTrue();
 		}
 
 	}
@@ -389,9 +389,9 @@ class PulsarPropertiesTests {
 		@Test
 		void bind() {
 			Map<String, String> map = new HashMap<>();
-			map.put("spring.pulsar.template.observations-enabled", "false");
+			map.put("spring.pulsar.template.observations-enabled", "true");
 			PulsarProperties.Template properties = bindPropeties(map).getTemplate();
-			assertThat(properties.isObservationsEnabled()).isFalse();
+			assertThat(properties.isObservationsEnabled()).isTrue();
 		}
 
 	}


### PR DESCRIPTION
change spring.pulsar.listener.observation-enabled and spring.pulsar.template.observations-enabled to false

Closes #38737 