### PR TITLE
Startup failure when you have multiple @DynamicPropertySources in Spring Boot 3.2.2

### DIFF
--- a/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/properties/TestcontainersPropertySource.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/properties/TestcontainersPropertySource.java
@@ -115,7 +115,7 @@ public class TestcontainersPropertySource extends EnumerablePropertySource<Map<S
 		if (eventPublisher != null) {
 			propertySource.addEventPublisher(eventPublisher);
 		}
-		else if (registry != null) {
+		else if (registry != null && !registry.containsBeanDefinition(EventPublisherRegistrar.NAME)) {
 			registry.registerBeanDefinition(EventPublisherRegistrar.NAME, new RootBeanDefinition(
 					EventPublisherRegistrar.class, () -> new EventPublisherRegistrar(environment)));
 		}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

There was no check for existing EventPublisherRegistrar in registry, bug: https://github.com/spring-projects/spring-boot/issues/39282