### PR TITLE
Add String to CronExpression conversion support

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/ApplicationConversionService.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/ApplicationConversionService.java
@@ -227,6 +227,7 @@ public class ApplicationConversionService extends FormattingConversionService {
 		registry.addConverter(new StringToDataSizeConverter());
 		registry.addConverter(new NumberToDataSizeConverter());
 		registry.addConverter(new StringToFileConverter());
+		registry.addConverter(new StringToCronExpressionConverter());
 		registry.addConverter(new InputStreamSourceToByteArrayConverter());
 		registry.addConverterFactory(new LenientStringToEnumConverterFactory());
 		registry.addConverterFactory(new LenientBooleanToEnumConverterFactory());

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/StringToCronExpressionConverter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/StringToCronExpressionConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.convert;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.scheduling.support.CronExpression;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@link Converter} to convert from a {@link String} to a {@link CronExpression}.
+ *
+ * @author Ahmad Amiri
+ */
+class StringToCronExpressionConverter implements Converter<String, CronExpression> {
+
+	@Override
+	public CronExpression convert(String source) {
+		if (StringUtils.hasLength(source)) {
+			return CronExpression.parse(source);
+		}
+		return null;
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/StringToCronExpressionConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/StringToCronExpressionConverterTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.convert;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.provider.Arguments;
+
+import org.springframework.core.convert.ConversionService;
+import org.springframework.scheduling.support.CronExpression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+/**
+ * Tests for {@link StringToCronExpressionConverter}.
+ *
+ * @author Ahmad Amiri
+ */
+class StringToCronExpressionConverterTest {
+
+	@ConversionServiceTest
+	void isValidExpression(ConversionService conversionService) {
+		assertThat(convert(conversionService, null)).isNull();
+		assertThat(convert(conversionService, "")).isNull();
+		assertThatThrownBy(() -> convert(conversionService, "*")).
+			isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Cron expression must consist of 6 fields");
+		assertThat(convert(conversionService, "* * * * * *")).isInstanceOf(CronExpression.class).isNotNull();
+	}
+
+	private CronExpression convert(ConversionService conversionService, String source) {
+		return conversionService.convert(source, CronExpression.class);
+	}
+
+	static Stream<? extends Arguments> conversionServices() {
+		return ConversionServiceArguments
+			.with((conversionService) -> conversionService.addConverter(new StringToCronExpressionConverter()));
+	}
+
+}


### PR DESCRIPTION
Add String to CronExpression conversion support.

This converter use `CronExpression` `parse ()` method to convert String to CronExpression.

For example, it helps us to use type-safe `CronExpression` in `ConfigurationProperties` classes.