### PR TITLE
Auto-configured ConcurrentPulsarListenerContainerFactory and PulsarConsumerFactory cannot be injected into injection points with specific generic type information

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfiguration.java
@@ -65,6 +65,7 @@ import org.springframework.pulsar.reader.PulsarReaderContainerProperties;
  * @author Soby Chacko
  * @author Alexander Preuß
  * @author Phillip Webb
+ * @author Jonas Geiregat
  * @since 3.2.0
  */
 @AutoConfiguration
@@ -131,7 +132,7 @@ public class PulsarAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(PulsarConsumerFactory.class)
-	DefaultPulsarConsumerFactory<Object> pulsarConsumerFactory(PulsarClient pulsarClient,
+	DefaultPulsarConsumerFactory<?> pulsarConsumerFactory(PulsarClient pulsarClient,
 			ObjectProvider<ConsumerBuilderCustomizer<?>> customizersProvider) {
 		List<ConsumerBuilderCustomizer<?>> customizers = new ArrayList<>();
 		customizers.add(this.propertiesMapper::customizeConsumerBuilder);
@@ -150,7 +151,7 @@ public class PulsarAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(name = "pulsarListenerContainerFactory")
-	ConcurrentPulsarListenerContainerFactory<Object> pulsarListenerContainerFactory(
+	ConcurrentPulsarListenerContainerFactory<?> pulsarListenerContainerFactory(
 			PulsarConsumerFactory<Object> pulsarConsumerFactory, SchemaResolver schemaResolver,
 			TopicResolver topicResolver, Environment environment) {
 		PulsarContainerProperties containerProperties = new PulsarContainerProperties();

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfigurationTests.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -374,6 +375,14 @@ class PulsarAutoConfigurationTests {
 				});
 		}
 
+		@Test
+		void injectsExpectedBeanWithExplicitGenericType() {
+			this.contextRunner.withBean(ExplicitGenericTypeConfig.class)
+					.run((context) -> assertThat(context).getBean(ExplicitGenericTypeConfig.class)
+							.hasFieldOrPropertyWithValue("consumerFactory", context.getBean(PulsarConsumerFactory.class))
+							.hasFieldOrPropertyWithValue("containerFactory", context.getBean(ConcurrentPulsarListenerContainerFactory.class)));
+		}
+
 		@TestConfiguration(proxyBeanMethods = false)
 		static class ConsumerBuilderCustomizersConfig {
 
@@ -389,6 +398,16 @@ class PulsarAutoConfigurationTests {
 				return (builder) -> builder.consumerName("fromCustomizer1");
 			}
 
+		}
+
+		static class ExplicitGenericTypeConfig {
+			@Autowired
+			PulsarConsumerFactory<TestType> consumerFactory;
+
+			@Autowired
+			ConcurrentPulsarListenerContainerFactory<TestType> containerFactory;
+
+			static class TestType {}
 		}
 
 	}


### PR DESCRIPTION
It is not possible to inject a specifically typed `PulsarConsumerFactory` nor `ConcurrentPulsarListenerContainerFactory` where the former is blocking creating custom typed consumers. 
@onobc you probably have an opinion on this.