### PR TITLE
Set LOG_CORRELATION_PATTERN only when correlation ID is expected

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
@@ -239,7 +239,7 @@ public class LoggingSystemProperties {
 		setSystemProperty(LoggingSystemProperty.FILE_PATTERN, resolver);
 		setSystemProperty(LoggingSystemProperty.LEVEL_PATTERN, resolver);
 		setSystemProperty(LoggingSystemProperty.DATEFORMAT_PATTERN, resolver);
-		setSystemProperty(LoggingSystemProperty.CORRELATION_PATTERN, resolver);
+		setCorrelationPatternSystemProperty(resolver);
 		if (logFile != null) {
 			logFile.applyToSystemProperties();
 		}
@@ -252,6 +252,12 @@ public class LoggingSystemProperties {
 				setSystemProperty(LoggingSystemProperty.APPLICATION_NAME.getEnvironmentVariableName(),
 						"[%s] ".formatted(applicationName));
 			}
+		}
+	}
+
+	private void setCorrelationPatternSystemProperty(PropertyResolver resolver) {
+		if (resolver.getProperty(LoggingSystem.EXPECT_CORRELATION_ID_PROPERTY, Boolean.class, Boolean.FALSE)) {
+			setSystemProperty(LoggingSystemProperty.CORRELATION_PATTERN, resolver);
 		}
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LoggingSystemPropertiesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LoggingSystemPropertiesTests.java
@@ -118,17 +118,31 @@ class LoggingSystemPropertiesTests {
 	}
 
 	@Test
-	void correlationPatternIsSet() {
+	void correlationPatternIsSetWhenExpectCorrelationIdTrue() {
 		new LoggingSystemProperties(
-				new MockEnvironment().withProperty("logging.pattern.correlation", "correlation pattern"))
-			.apply(null);
+			new MockEnvironment()
+				.withProperty(LoggingSystem.EXPECT_CORRELATION_ID_PROPERTY, "true")
+				.withProperty("logging.pattern.correlation", "correlation pattern")
+		).apply(null);
 		assertThat(System.getProperty(LoggingSystemProperty.CORRELATION_PATTERN.getEnvironmentVariableName()))
 			.isEqualTo("correlation pattern");
 	}
 
 	@Test
+	void correlationPatternIsNotSetWhenExpectCorrelationIdFalse() {
+		new LoggingSystemProperties(
+			new MockEnvironment()
+				.withProperty(LoggingSystem.EXPECT_CORRELATION_ID_PROPERTY, "false")
+				.withProperty("logging.pattern.correlation", "correlation pattern")
+		).apply(null);
+		assertThat(System.getProperty(LoggingSystemProperty.CORRELATION_PATTERN.getEnvironmentVariableName()))
+			.isNull();
+	}
+
+	@Test
 	void defaultValueResolverIsUsed() {
-		MockEnvironment environment = new MockEnvironment();
+		MockEnvironment environment = new MockEnvironment()
+			.withProperty(LoggingSystem.EXPECT_CORRELATION_ID_PROPERTY, "true");
 		Map<String, String> defaultValues = Map
 			.of(LoggingSystemProperty.CORRELATION_PATTERN.getApplicationPropertyName(), "default correlation pattern");
 		new LoggingSystemProperties(environment, defaultValues::get, null).apply(null);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LoggingSystemPropertiesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/LoggingSystemPropertiesTests.java
@@ -120,10 +120,9 @@ class LoggingSystemPropertiesTests {
 	@Test
 	void correlationPatternIsSetWhenExpectCorrelationIdTrue() {
 		new LoggingSystemProperties(
-			new MockEnvironment()
-				.withProperty(LoggingSystem.EXPECT_CORRELATION_ID_PROPERTY, "true")
-				.withProperty("logging.pattern.correlation", "correlation pattern")
-		).apply(null);
+				new MockEnvironment().withProperty(LoggingSystem.EXPECT_CORRELATION_ID_PROPERTY, "true")
+					.withProperty("logging.pattern.correlation", "correlation pattern"))
+			.apply(null);
 		assertThat(System.getProperty(LoggingSystemProperty.CORRELATION_PATTERN.getEnvironmentVariableName()))
 			.isEqualTo("correlation pattern");
 	}
@@ -131,18 +130,16 @@ class LoggingSystemPropertiesTests {
 	@Test
 	void correlationPatternIsNotSetWhenExpectCorrelationIdFalse() {
 		new LoggingSystemProperties(
-			new MockEnvironment()
-				.withProperty(LoggingSystem.EXPECT_CORRELATION_ID_PROPERTY, "false")
-				.withProperty("logging.pattern.correlation", "correlation pattern")
-		).apply(null);
-		assertThat(System.getProperty(LoggingSystemProperty.CORRELATION_PATTERN.getEnvironmentVariableName()))
-			.isNull();
+				new MockEnvironment().withProperty(LoggingSystem.EXPECT_CORRELATION_ID_PROPERTY, "false")
+					.withProperty("logging.pattern.correlation", "correlation pattern"))
+			.apply(null);
+		assertThat(System.getProperty(LoggingSystemProperty.CORRELATION_PATTERN.getEnvironmentVariableName())).isNull();
 	}
 
 	@Test
 	void defaultValueResolverIsUsed() {
-		MockEnvironment environment = new MockEnvironment()
-			.withProperty(LoggingSystem.EXPECT_CORRELATION_ID_PROPERTY, "true");
+		MockEnvironment environment = new MockEnvironment().withProperty(LoggingSystem.EXPECT_CORRELATION_ID_PROPERTY,
+				"true");
 		Map<String, String> defaultValues = Map
 			.of(LoggingSystemProperty.CORRELATION_PATTERN.getApplicationPropertyName(), "default correlation pattern");
 		new LoggingSystemProperties(environment, defaultValues::get, null).apply(null);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
@@ -553,8 +553,9 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	@Test
-	void correlationLoggingToConsoleWhenHasCorrelationPattern(CapturedOutput output) {
+	void correlationLoggingToConsoleWhenHasCorrelationPatternAndExpectCorrelationIdTrue(CapturedOutput output) {
 		this.environment.setProperty("logging.pattern.correlation", "%correlationId{spanId(0),traceId(0)}");
+		this.environment.setProperty(LoggingSystem.EXPECT_CORRELATION_ID_PROPERTY, "true");
 		this.loggingSystem.setStandardConfigLocations(false);
 		this.loggingSystem.beforeInitialize();
 		this.loggingSystem.initialize(this.initializationContext, null, null);
@@ -562,6 +563,18 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 		this.logger.info("Hello world");
 		assertThat(getLineWithText(output, "Hello world"))
 			.contains(" [0123456789012345-01234567890123456789012345678901] ");
+	}
+
+	@Test
+	void correlationLoggingToConsoleWhenHasCorrelationPatternAndExpectCorrelationIdFalse(CapturedOutput output) {
+		this.environment.setProperty("logging.pattern.correlation", "%correlationId{spanId(0),traceId(0)}");
+		this.environment.setProperty(LoggingSystem.EXPECT_CORRELATION_ID_PROPERTY, "false");
+		this.loggingSystem.setStandardConfigLocations(false);
+		this.loggingSystem.beforeInitialize();
+		this.loggingSystem.initialize(this.initializationContext, null, null);
+		MDC.setContextMap(Map.of("traceId", "01234567890123456789012345678901", "spanId", "0123456789012345"));
+		this.logger.info("Hello world");
+		assertThat(getLineWithText(output, "Hello world")).doesNotContain("0123456789012345");
 	}
 
 	@Test


### PR DESCRIPTION
Prior to this commit, if `logging.pattern.correlation` has been set, then the correlation ID is logged regardless of the flag `logging.expect-correlation-id`. This is different from what happens with the default correlation patterns.

This commit updates LoggingSystemProperties so that the system property `LOG_CORRELATION_PATTERN` is set when `logging.expect-correlation-id` is `true`. If it is `false` then the correlation ID won't be logged in any cases.

This also follows gh-38641 from the perspective of logging.