### PR TITLE
fix: HttpMessageConverters addDefaultConverters should only add if there is not exists one.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/HttpMessageConverters.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/HttpMessageConverters.java
@@ -124,9 +124,12 @@ public class HttpMessageConverters implements Iterable<HttpMessageConverter<?>> 
 			while (iterator.hasNext()) {
 				HttpMessageConverter<?> candidate = iterator.next();
 				if (isReplacement(defaultConverter, candidate)) {
-					combined.add(candidate);
-					iterator.remove();
+					defaultConverter = null;
+					break;
 				}
+			}
+			if (defaultConverter == null) {
+				continue;
 			}
 			combined.add(defaultConverter);
 			if (defaultConverter instanceof AllEncompassingFormHttpMessageConverter allEncompassingConverter) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/http/HttpMessageConvertersTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/http/HttpMessageConvertersTests.java
@@ -73,7 +73,7 @@ class HttpMessageConvertersTests {
 			}
 		}
 		// The existing converter is still there, but with a lower priority
-		assertThat(httpConverters).hasSize(3);
+		assertThat(httpConverters).hasSize(2);
 		assertThat(httpConverters.indexOf(converter1)).isZero();
 		assertThat(httpConverters.indexOf(converter2)).isOne();
 		assertThat(converters.getConverters().indexOf(converter1)).isNotZero();


### PR DESCRIPTION


<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
