### PR TITLE
Make DataSourceBuilder be able to derive driverClassName from derived url

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DataSourceBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DataSourceBuilder.java
@@ -186,8 +186,8 @@ public final class DataSourceBuilder<T extends DataSource> {
 		}
 		if (!applied.contains(DataSourceProperty.DRIVER_CLASS_NAME)
 				&& properties.canSet(DataSourceProperty.DRIVER_CLASS_NAME)
-				&& this.values.containsKey(DataSourceProperty.URL)) {
-			String url = this.values.get(DataSourceProperty.URL);
+				&& applied.contains(DataSourceProperty.URL)) {
+			String url = properties.get(dataSource, DataSourceProperty.URL);
 			DatabaseDriver driver = DatabaseDriver.fromJdbcUrl(url);
 			properties.set(dataSource, DataSourceProperty.DRIVER_CLASS_NAME, driver.getDriverClassName());
 		}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DataSourceBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DataSourceBuilderTests.java
@@ -457,6 +457,20 @@ class DataSourceBuilderTests {
 		assertThat(testSource.getPassword()).isEqualTo("secret");
 	}
 
+	@Test
+	void buildWhenDerivedFromCustomTypeDeriveDriverClassNameFromDerivedUrl() {
+		UrlCapableLimitedCustomDataSource dataSource = new UrlCapableLimitedCustomDataSource();
+		dataSource.setUsername("test");
+		dataSource.setPassword("secret");
+		dataSource.setUrl("jdbc:postgresql://localhost:5432/postgres");
+		DataSourceBuilder<?> builder = DataSourceBuilder.derivedFrom(dataSource).type(SimpleDriverDataSource.class);
+		SimpleDriverDataSource testSource = (SimpleDriverDataSource) builder.build();
+		assertThat(testSource.getUsername()).isEqualTo("test");
+		assertThat(testSource.getUrl()).isEqualTo("jdbc:postgresql://localhost:5432/postgres");
+		assertThat(testSource.getPassword()).isEqualTo("secret");
+		assertThat(testSource.getDriver()).isInstanceOf(org.postgresql.Driver.class);
+	}
+
 	@Test // gh-31920
 	void buildWhenC3P0TypeSpecifiedReturnsExpectedDataSource() {
 		this.dataSource = DataSourceBuilder.create()
@@ -620,11 +634,9 @@ class DataSourceBuilderTests {
 
 	}
 
-	static class CustomDataSource extends LimitedCustomDataSource {
+	static class UrlCapableLimitedCustomDataSource extends LimitedCustomDataSource {
 
 		private String url;
-
-		private String driverClassName;
 
 		String getUrl() {
 			return this.url;
@@ -633,6 +645,13 @@ class DataSourceBuilderTests {
 		void setUrl(String url) {
 			this.url = url;
 		}
+
+	}
+
+	static class CustomDataSource extends UrlCapableLimitedCustomDataSource {
+
+		private String driverClassName;
+
 
 		String getDriverClassName() {
 			return this.driverClassName;


### PR DESCRIPTION
When using DataSourceBuilder to "deriveFrom" another DataSource, it is possible that the other Datasource has a getter for url, but not driverClassName. In this case, when the url is derived from the the provided DataSource, the DataSourceBuilder should try to derive the driverClassName from this derived url.

The use case is that when using Liquibase it is possible that a pooling DataSource is used that does not provide a getDriverClassName().  When using different credentials to run Liquibase with a DataSource, the user and password of LiquibaseProperties should be used and the DataSource should be "derivedFrom" the provided DataSource. This DataSource may provide a getUrl() but not a getDriverClassName(). In this case the driverClassName could also be "derived from" the "derived" url. This way, other custom (Pooling) DataSources may be used to run Liquibase using different credentials to connect to the 'same' DataSource.