### PR TITLE
Add a check for HTTP(S) resource URLs without the '.xml' suffix

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -306,9 +306,11 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 				connection.setRequestMethod("HEAD");
 				String contentType = connection.getHeaderField("Content-Type");
 				return contentType != null && (contentType.startsWith("application/xml") || contentType.startsWith("text/xml"));
-			} catch (IOException e) {
+			}
+			catch (IOException e) {
 				throw new IllegalArgumentException("Could not open URL [" + url + "].");
-			} finally {
+			}
+			finally {
 				if (connection != null) {
 					connection.disconnect();
 				}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -807,6 +807,15 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	@Test
+	void whenConfigLocationIsNotXmlWithoutSuffixThenIllegalArgumentExceptionShouldBeThrown() {
+		this.loggingSystem.beforeInitialize();
+		assertThatIllegalStateException()
+				.isThrownBy(() -> initialize(this.initializationContext, "https://spring.io/projects/spring-boot",
+						getLogFile(tmpDir() + "/tmp.log", null)))
+				.satisfies((ex) -> assertThat(ex.getCause()).isInstanceOf(IllegalArgumentException.class));
+	}
+
+	@Test
 	void shouldRespectConsoleThreshold(CapturedOutput output) {
 		this.environment.setProperty("logging.threshold.console", "warn");
 		this.loggingSystem.beforeInitialize();


### PR DESCRIPTION
Add a check for HTTP(S) resource URLs without the '.xml' suffix.

Currently, when loading logback configuration, the method of checking whether a URL refers to an XML file is as follows: 
```
if (url.getPath().endsWith(".xml") {
    // IS XML
} else {
    // IS NOT XML
}
```
However, some URLs' path referring to XML files do not end with ".xml". 

for example, 
`"http://${spring.cloud.nacos.config.server-addr}/nacos/v1/cs/configs?group=DEFAULT_GROUP&dataId=logback-common.xml"` refers to my logback configuration, but its path (`"/nacos/v1/cs/configs"`) doesn't end with ".xml", so it cannot be loaded correctly. 

Therefore, it is necessary to add an additional check.