### PR TITLE
NoSuchMethod error when using the non-shaded Pulsar client and configuring authentications parameters

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
@@ -23,6 +23,7 @@ import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.api.ClientBuilder;
@@ -30,7 +31,6 @@ import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
 import org.apache.pulsar.client.api.ReaderBuilder;
-import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.pulsar.listener.PulsarContainerProperties;
@@ -87,7 +87,10 @@ final class PulsarPropertiesMapper {
 	private String getAuthenticationParamsJson(Map<String, String> params) {
 		Map<String, String> sortedParams = new TreeMap<>(params);
 		try {
-			return ObjectMapperFactory.create().writeValueAsString(sortedParams);
+			return sortedParams.entrySet()
+				.stream()
+				.map((e) -> "\"%s\":\"%s\"".formatted(e.getKey(), e.getValue()))
+				.collect(Collectors.joining(",", "{", "}"));
 		}
 		catch (Exception ex) {
 			throw new IllegalStateException("Could not convert auth parameters to encoded string", ex);


### PR DESCRIPTION
This commit removes the use of the Pulsar ObjectMapperFactory when converting the authentication config props map to a JSON string. The Pulsar factory operates on a shaded returned value of Jackson ObjectMapper which may not exist when users are using the non-shaded version of the Pulsar client lib.

See https://github.com/spring-projects/spring-pulsar/issues/562

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
