### PR TITLE
Update the Debugging Documentation of the Spring Boot Maven Plugin 

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/using/running-your-application.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/using/running-your-application.adoc
@@ -40,7 +40,7 @@ Doing so lets you attach a debugger to your packaged application, as shown in th
 
 [source,shell,indent=0,subs="verbatim"]
 ----
-	$ java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=n \
+	$ java -agentlib:jdwp=server=y,transport=dt_socket,address=8000,suspend=n \
 	       -jar target/myapplication-0.0.1-SNAPSHOT.jar
 ----
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/running.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/asciidoc/running.adoc
@@ -79,11 +79,11 @@ The following configuration suspend the process until a debugger has joined on p
 include::../maven/running/debug-pom.xml[tags=debug]
 ----
 
-These arguments can be specified on the command line as well, make sure to wrap that properly, that is:
+These arguments can be specified on the command line as well:
 
 [indent=0]
 ----
-	$ mvn spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005"
+	$ mvn spring-boot:run -Dspring-boot.run.jvmArguments=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
 ----
 
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/maven/running/debug-pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/maven/running/debug-pom.xml
@@ -8,7 +8,7 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
 					<jvmArguments>
-						-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005
+						-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005
 					</jvmArguments>
 				</configuration>
 			</plugin>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/RunArgumentsTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/RunArgumentsTests.java
@@ -63,11 +63,10 @@ class RunArgumentsTests {
 	}
 
 	@Test
-	void parseDebugFlags() {
-		String[] args = parseArgs("-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005");
-		assertThat(args).hasSize(2);
-		assertThat(args[0]).isEqualTo("-Xdebug");
-		assertThat(args[1]).isEqualTo("-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005");
+	void parseDebugFlag() {
+		String[] args = parseArgs("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
+		assertThat(args).hasSize(1);
+		assertThat(args[0]).isEqualTo("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
 	}
 
 	@Test


### PR DESCRIPTION
Replaced the old JVM Argument -Xdebug (which does nothing according to documentation) with newer ones as described in  #39388. 