### PR TITLE
Add nameIdFormat to Properties

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyProperties.java
@@ -31,6 +31,7 @@ import org.springframework.security.saml2.provider.service.registration.Saml2Mes
  * @author Madhura Bhave
  * @author Phillip Webb
  * @author Moritz Halbritter
+ * @author Lasse Wulff
  * @since 2.2.0
  */
 @ConfigurationProperties("spring.security.saml2.relyingparty")
@@ -72,6 +73,8 @@ public class Saml2RelyingPartyProperties {
 		 */
 		private final AssertingParty assertingparty = new AssertingParty();
 
+		private String nameIdFormat;
+
 		public String getEntityId() {
 			return this.entityId;
 		}
@@ -92,12 +95,20 @@ public class Saml2RelyingPartyProperties {
 			return this.decryption;
 		}
 
+		public Singlelogout getSinglelogout() {
+			return this.singlelogout;
+		}
+
 		public AssertingParty getAssertingparty() {
 			return this.assertingparty;
 		}
 
-		public Singlelogout getSinglelogout() {
-			return this.singlelogout;
+		public String getNameIdFormat() {
+			return this.nameIdFormat;
+		}
+
+		public void setNameIdFormat(String nameIdFormat) {
+			this.nameIdFormat = nameIdFormat;
 		}
 
 		public static class Acs {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyRegistrationConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyRegistrationConfiguration.java
@@ -56,6 +56,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @author Moritz Halbritter
  * @author Lasse Lindqvist
+ * @author Lasse Wulff
  */
 @Configuration(proxyBeanMethods = false)
 @Conditional(RegistrationConfiguredCondition.class)
@@ -104,6 +105,7 @@ class Saml2RelyingPartyRegistrationConfiguration {
 		builder.singleLogoutServiceResponseLocation(properties.getSinglelogout().getResponseUrl());
 		builder.singleLogoutServiceBinding(properties.getSinglelogout().getBinding());
 		builder.entityId(properties.getEntityId());
+		builder.nameIdFormat(properties.getNameIdFormat());
 		RelyingPartyRegistration registration = builder.build();
 		boolean signRequest = registration.getAssertingPartyDetails().getWantAuthnRequestsSigned();
 		validateSigningCredentials(properties, signRequest);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/saml2/Saml2RelyingPartyPropertiesTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link Saml2RelyingPartyProperties}.
  *
  * @author Madhura Bhave
+ * @author Lasse Wulff
  */
 class Saml2RelyingPartyPropertiesTests {
 
@@ -100,6 +101,13 @@ class Saml2RelyingPartyPropertiesTests {
 			.getAssertingparty()
 			.getSinglesignon()
 			.getSignRequest()).isNull();
+	}
+
+	@Test
+	void customizeNameIdFormat() {
+		bind("spring.security.saml2.relyingparty.registration.simplesamlphp.name-id-format", "sampleNameIdFormat");
+		assertThat(this.properties.getRegistration().get("simplesamlphp").getNameIdFormat())
+			.isEqualTo("sampleNameIdFormat");
 	}
 
 	private void bind(String name, String value) {


### PR DESCRIPTION
Add the new property nameIdFormat to the Saml2RelyingPartyProperties and the corresponding mapping to the Saml2RelyingPartyRegistrationConfiguration.

See #39343
