### PR TITLE
SpringProfile arbiter fails without a Spring's environment

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/SpringProfileArbiter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/SpringProfileArbiter.java
@@ -95,8 +95,7 @@ final class SpringProfileArbiter implements Arbiter {
 		public SpringProfileArbiter build() {
 			Environment environment = Log4J2LoggingSystem.getEnvironment(this.loggerContext);
 			if (environment == null) {
-				statusLogger.warn("Cannot create Arbiter, no Spring Environment available");
-				return null;
+				statusLogger.debug("Creating Arbiter without a Spring Environment");
 			}
 			String name = this.configuration.getStrSubstitutor().replace(this.name);
 			String[] profiles = StringUtils.trimArrayElements(StringUtils.commaDelimitedListToStringArray(name));


### PR DESCRIPTION
A issue has been raised and fixed in `apache/logging-log4j2`: https://github.com/apache/logging-log4j2/issues/1783

A detailed explanation of the proposed change may be found in this issue.

Basically, the null check for the environment _is not necessary_ in the builder as the `isCondition()` method already correctly checks for a null environment.