### PR TITLE
Add possibility for custom MimeMappings

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -37,6 +37,7 @@ import org.springframework.boot.convert.DurationUnit;
 import org.springframework.boot.web.server.Compression;
 import org.springframework.boot.web.server.Cookie;
 import org.springframework.boot.web.server.Http2;
+import org.springframework.boot.web.server.MimeMappings;
 import org.springframework.boot.web.server.Shutdown;
 import org.springframework.boot.web.server.Ssl;
 import org.springframework.boot.web.servlet.server.Encoding;
@@ -71,6 +72,7 @@ import org.springframework.util.unit.DataSize;
  * @author Parviz Rozikov
  * @author Florian Storz
  * @author Michael Weidmann
+ * @author Lasse Wulff
  * @since 1.0.0
  */
 @ConfigurationProperties(prefix = "server", ignoreUnknownFields = true)
@@ -114,6 +116,8 @@ public class ServerProperties {
 
 	@NestedConfigurationProperty
 	private final Compression compression = new Compression();
+
+	private final MimeMappings mimeMappings = MimeMappings.lazyCopy(MimeMappings.DEFAULT);
 
 	@NestedConfigurationProperty
 	private final Http2 http2 = new Http2();
@@ -184,6 +188,14 @@ public class ServerProperties {
 
 	public Compression getCompression() {
 		return this.compression;
+	}
+
+	public MimeMappings getMimeMappings() {
+		return this.mimeMappings;
+	}
+
+	public void setMimeMappings(Map<String, String> customMappings) {
+		customMappings.forEach(this.mimeMappings::add);
 	}
 
 	public Http2 getHttp2() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryCustomizer.java
@@ -38,6 +38,7 @@ import org.springframework.util.CollectionUtils;
  * @author Olivier Lamy
  * @author Yunkun Huang
  * @author Scott Frederick
+ * @author Lasse Wulff
  * @since 2.0.0
  */
 public class ServletWebServerFactoryCustomizer
@@ -94,6 +95,7 @@ public class ServletWebServerFactoryCustomizer
 		map.from(() -> this.cookieSameSiteSuppliers)
 			.whenNot(CollectionUtils::isEmpty)
 			.to(factory::setCookieSameSiteSuppliers);
+		map.from(this.serverProperties::getMimeMappings).to(factory::setMimeMappings);
 		this.webListenerRegistrars.forEach((registrar) -> registrar.register(factory));
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -46,6 +46,8 @@ import org.springframework.boot.testsupport.web.servlet.DirtiesUrlFactories;
 import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
 import org.springframework.boot.web.embedded.jetty.JettyWebServer;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.MimeMappings;
+import org.springframework.boot.web.server.MimeMappings.Mapping;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.unit.DataSize;
 
@@ -66,6 +68,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Rafiullah Hamedy
  * @author Chris Bono
  * @author Parviz Rozikov
+ * @author Lasse Wulff
  */
 @DirtiesUrlFactories
 class ServerPropertiesTests {
@@ -180,6 +183,21 @@ class ServerPropertiesTests {
 	void testContextPathWithLeadingAndTrailingWhitespaceAndContextWithSpace() {
 		bind("server.servlet.context-path", "  /assets /copy/    ");
 		assertThat(this.properties.getServlet().getContextPath()).isEqualTo("/assets /copy");
+	}
+
+	@Test
+	void testDefaultMimeMapping() {
+		assertThat(this.properties.getMimeMappings())
+			.containsExactly(MimeMappings.DEFAULT.getAll().toArray(new Mapping[0]));
+	}
+
+	@Test
+	void testCustomizedMimeMapping() {
+		MimeMappings expectedMappings = MimeMappings.lazyCopy(MimeMappings.DEFAULT);
+		expectedMappings.add("mjs", "text/javascript");
+		bind("server.mime-mappings.mjs", "text/javascript");
+		assertThat(this.properties.getMimeMappings())
+			.containsExactly(expectedMappings.getAll().toArray(new Mapping[0]));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryCustomizerTests.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Brian Clozel
  * @author Yunkun Huang
+ * @author Lasse Wulff
  */
 class ServletWebServerFactoryCustomizerTests {
 
@@ -70,6 +71,13 @@ class ServletWebServerFactoryCustomizerTests {
 		this.properties.getServlet().setApplicationDisplayName("TestName");
 		this.customizer.customize(factory);
 		then(factory).should().setDisplayName("TestName");
+	}
+
+	@Test
+	void testCustomMimeMappings() {
+		ConfigurableServletWebServerFactory factory = mock(ConfigurableServletWebServerFactory.class);
+		this.customizer.customize(factory);
+		then(factory).should().setMimeMappings(this.properties.getMimeMappings());
 	}
 
 	@Test


### PR DESCRIPTION
Add a new property called 'mime-mappings' under the 'server' property. 
This is a key-value-map, which is added to the default MimeMappings.

If their is a need to adjust the documentation, just hit me up and I will add this.

See #38902

