### PR TITLE
Add grpc starter and httpexchange starter to the community starters document

### DIFF
--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -113,7 +113,7 @@ do as they were designed before this was clarified.
 | https://github.com/dabla/grizzly-spring-boot-starter
 
 | https://www.grpc.io/[gRPC]
-| https://github.com/LogNet/grpc-spring-boot-starter & https://github.com/yidongnan/grpc-spring-boot-starter
+| https://github.com/LogNet/grpc-spring-boot-starter & https://github.com/yidongnan/grpc-spring-boot-starter & https://github.com/DanielLiu1123/grpc-starter
 
 | https://ha-jdbc.github.io/[HA JDBC]
 | https://github.com/lievendoclo/hajdbc-spring-boot
@@ -228,6 +228,9 @@ do as they were designed before this was clarified.
 
 | https://projects.spring.io/spring-batch/[Spring Batch] (Advanced usage)
 | https://github.com/codecentric/spring-boot-starter-batch-web
+
+| https://docs.spring.io/spring-framework/reference/integration/rest-clients.html#rest-http-interface[Spring Http Interface]
+| https://github.com/DanielLiu1123/httpexchange-spring-boot-starter
 
 | https://projects.spring.io/spring-shell/[Spring Shell]
 | https://github.com/fonimus/ssh-shell-spring-boot


### PR DESCRIPTION
Add [grpc-starter](https://github.com/DanielLiu1123/grpc-starter) and [httpexchange-spring-boot-starter](https://github.com/DanielLiu1123/grpc-starter) to the community starters document.

[grpc-starter](https://github.com/DanielLiu1123/grpc-starter) is a more modern grpc starter, integrating many technologies from the grpc ecosystem. This includes `@Autowired` support for grpc stubs, proto validation ([pgv](https://github.com/bufbuild/protoc-gen-validate), [protovalidate](https://github.com/bufbuild/protovalidate)), metrics, tracing, [JSON transcoder](https://danielliu1123.github.io/grpc-starter/#/en-us/extension/json-transcoder), and more.

[httpexchange-spring-boot-starter](https://github.com/DanielLiu1123/grpc-starter) is a starter for Spring 6 declarative HTTP client (Http interface), offering an experience similar to Spring Cloud OpenFeign without the need for annotations like `@FeignClient`. It supports Spring Cloud LoadBalancer, dynamic refresh, native image, and more.