### PR TITLE
Support @Name with JavaBean-based configuration properties

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/JavaBeanBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/JavaBeanBinder.java
@@ -46,6 +46,7 @@ import org.springframework.core.ResolvableType;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Lasse Wulff
  */
 class JavaBeanBinder implements DataObjectBinder {
 
@@ -92,7 +93,7 @@ class JavaBeanBinder implements DataObjectBinder {
 
 	private <T> boolean bind(BeanSupplier<T> beanSupplier, DataObjectPropertyBinder propertyBinder,
 			BeanProperty property) {
-		String propertyName = property.getName();
+		String propertyName = determinePropertyName(property);
 		ResolvableType type = property.getType();
 		Supplier<Object> value = property.getValue(beanSupplier);
 		Annotation[] annotations = property.getAnnotations();
@@ -108,6 +109,15 @@ class JavaBeanBinder implements DataObjectBinder {
 			throw new IllegalStateException("No setter found for property: " + property.getName());
 		}
 		return true;
+	}
+
+	private String determinePropertyName(BeanProperty property) {
+		return Arrays.stream((property.getAnnotations() != null) ? property.getAnnotations() : new Annotation[0])
+			.filter((annotation) -> annotation.annotationType() == Name.class)
+			.findFirst()
+			.map(Name.class::cast)
+			.map(Name::value)
+			.orElse(property.getName());
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Name.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Name.java
@@ -23,15 +23,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation that can be used to specify the name when binding to an immutable property.
- * This annotation may be required when binding to names that clash with reserved language
+ * Annotation that can be used to specify the name when binding to a property. This
+ * annotation may be required when binding to names that clash with reserved language
  * keywords.
  *
  * @author Phillip Webb
+ * @author Lasse Wulff
  * @since 2.4.0
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.PARAMETER)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
 @Documented
 public @interface Name {
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/JavaBeanBinderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/JavaBeanBinderTests.java
@@ -52,6 +52,7 @@ import static org.assertj.core.api.Assertions.entry;
  * @author Phillip Webb
  * @author Madhura Bhave
  * @author Andy Wilkinson
+ * @author Lasse Wulff
  */
 class JavaBeanBinderTests {
 
@@ -72,6 +73,27 @@ class JavaBeanBinderTests {
 		assertThat(bean.getLongValue()).isEqualTo(34);
 		assertThat(bean.getStringValue()).isEqualTo("foo");
 		assertThat(bean.getEnumValue()).isEqualTo(ExampleEnum.FOO_BAR);
+	}
+
+	@Test
+	void bindRenamedPropertyToClassBean() {
+		MockConfigurationPropertySource source = new MockConfigurationPropertySource();
+		source.put("renamed.public", "alpha");
+		this.sources.add(source);
+		ExampleRenamedPropertyBean bean = this.binder.bind("renamed", Bindable.of(ExampleRenamedPropertyBean.class))
+			.get();
+		assertThat(bean.getExampleProperty()).isEqualTo("alpha");
+	}
+
+	@Test
+	void bindRenamedPropertyToRecordBean() {
+		MockConfigurationPropertySource source = new MockConfigurationPropertySource();
+		source.put("renamed.class", "alpha");
+		this.sources.add(source);
+		ExampleRenamedPropertyRecordBean bean = this.binder
+			.bind("renamed", Bindable.of(ExampleRenamedPropertyRecordBean.class))
+			.get();
+		assertThat(bean.exampleProperty()).isEqualTo("alpha");
 	}
 
 	@Test
@@ -646,6 +668,24 @@ class JavaBeanBinderTests {
 			this.enumValue = enumValue;
 		}
 
+	}
+
+	static class ExampleRenamedPropertyBean {
+
+		@Name("public")
+		private String exampleProperty;
+
+		String getExampleProperty() {
+			return this.exampleProperty;
+		}
+
+		void setExampleProperty(String exampleProperty) {
+			this.exampleProperty = exampleProperty;
+		}
+
+	}
+
+	record ExampleRenamedPropertyRecordBean(@Name("class") String exampleProperty) {
 	}
 
 	static class ExampleDefaultsBean {

--- a/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/context/properties/KotlinConfigurationPropertiesTests.kt
+++ b/spring-boot-project/spring-boot/src/test/kotlin/org/springframework/boot/context/properties/KotlinConfigurationPropertiesTests.kt
@@ -26,11 +26,13 @@ import org.springframework.context.annotation.Import
 import org.springframework.test.context.support.TestPropertySourceUtils
 
 import org.assertj.core.api.Assertions.assertThat
+import org.springframework.boot.context.properties.bind.Name
 
 /**
  * Tests for {@link ConfigurationProperties @ConfigurationProperties}-annotated beans.
  *
  * @author Madhura Bhave
+ * @author Lasse Wulff
  */
 class KotlinConfigurationPropertiesTests {
 
@@ -60,6 +62,22 @@ class KotlinConfigurationPropertiesTests {
 	}
 
 	@Test
+	fun `renamed property can be bound`() {
+		this.context.register(EnableRenamedProperties::class.java)
+		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context, "renamed.fun=beta")
+		this.context.refresh()
+		assertThat(this.context.getBean(RenamedProperties::class.java).bar).isEqualTo("beta")
+	}
+
+	@Test
+	fun `renamed property can be bound to late init attribute`() {
+		this.context.register(EnableRenamedLateInitProperties::class.java)
+		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context, "renamed.var=beta")
+		this.context.refresh()
+		assertThat(this.context.getBean(RenamedLateInitProperties::class.java).bar).isEqualTo("beta")
+	}
+
+	@Test
 	fun `type with constructor bound lateinit property with default can be bound`() {
 		this.context.register(EnableLateInitPropertiesWithDefault::class.java)
 		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(this.context, "lateinit-with-default.inner.bravo=two")
@@ -79,6 +97,21 @@ class KotlinConfigurationPropertiesTests {
 
 	@ConfigurationProperties(prefix = "foo")
 	class BingProperties(@Suppress("UNUSED_PARAMETER") bar: String)
+
+	@ConfigurationProperties(prefix = "renamed")
+	class RenamedProperties(@Name("fun") val bar: String)
+
+	@EnableConfigurationProperties(RenamedProperties::class)
+	class EnableRenamedProperties
+
+	@ConfigurationProperties(prefix = "renamed")
+	class RenamedLateInitProperties{
+		@Name("var")
+		lateinit var bar: String
+	}
+
+	@EnableConfigurationProperties(RenamedLateInitProperties::class)
+	class EnableRenamedLateInitProperties
 
 	@EnableConfigurationProperties
 	class EnableConfigProperties


### PR DESCRIPTION
Makes the Name annotation applicable on fields and takes this name when looking up the corresponding property.

See #37105
