### PR TITLE
Introduce @BatchTransactionManager to make it easier to configure Spring Batch to use a custom transaction manager

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
@@ -65,6 +65,7 @@ import org.springframework.util.StringUtils;
  * @author Kazuki Shimizu
  * @author Mahmoud Ben Hassine
  * @author Lars Uffmann
+ * @author Lasse Wulff
  * @since 1.0.0
  */
 @AutoConfiguration(after = { HibernateJpaAutoConfiguration.class, TransactionAutoConfiguration.class })
@@ -108,11 +109,13 @@ public class BatchAutoConfiguration {
 		private final ExecutionContextSerializer executionContextSerializer;
 
 		SpringBootBatchConfiguration(DataSource dataSource, @BatchDataSource ObjectProvider<DataSource> batchDataSource,
-				PlatformTransactionManager transactionManager, BatchProperties properties,
+				PlatformTransactionManager transactionManager,
+				@BatchTransactionManager ObjectProvider<PlatformTransactionManager> batchTransactionManager,
+				BatchProperties properties,
 				ObjectProvider<BatchConversionServiceCustomizer> batchConversionServiceCustomizers,
 				ObjectProvider<ExecutionContextSerializer> executionContextSerializer) {
 			this.dataSource = batchDataSource.getIfAvailable(() -> dataSource);
-			this.transactionManager = transactionManager;
+			this.transactionManager = batchTransactionManager.getIfAvailable(() -> transactionManager);
 			this.properties = properties;
 			this.batchConversionServiceCustomizers = batchConversionServiceCustomizers.orderedStream().toList();
 			this.executionContextSerializer = executionContextSerializer

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchTransactionManager.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchTransactionManager.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.batch;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Qualifier annotation for a {@link PlatformTransactionManager
+ * PlatformTransactionManager} to be injected into Batch auto-configuration. Can be used
+ * on a secondary {@link PlatformTransactionManager PlatformTransactionManager}, if there
+ * is another one marked as {@link Primary @Primary}.
+ *
+ * @author Lasse Wulff
+ * @since 3.3.0
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier
+public @interface BatchTransactionManager {
+
+}

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/batch.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/batch.adoc
@@ -19,6 +19,14 @@ For more info about Spring Batch, see the {spring-batch}[Spring Batch project pa
 
 
 
+[[howto.batch.specifying-a-transaction-manager]]
+=== Specifying a Batch Transaction Manager
+Similar to <<howto.batch.specifying-a-data-source>> you can also define a `PlatformTransactionManager`
+for use in the batch processing by marking it as `@BatchTransactionManager`.
+If you do so and want two transaction managers, remember to mark the other one as `@Primary`.
+
+
+
 [[howto.batch.running-jobs-on-startup]]
 === Running Spring Batch Jobs on Startup
 Spring Batch auto-configuration is enabled by adding `spring-boot-starter-batch` to your application's classpath.


### PR DESCRIPTION
Add a new annotation for marking a second PlatformTransactionManager to be used in batch processing.

See gh-37650
