### PR TITLE
Add Javadoc for ServerProperties.mimeMappings

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -117,6 +117,9 @@ public class ServerProperties {
 	@NestedConfigurationProperty
 	private final Compression compression = new Compression();
 
+	/**
+	 * Custom MIME mappings in addition to the default MIME mappings.
+	 */
 	private final MimeMappings mimeMappings = MimeMappings.lazyCopy(MimeMappings.DEFAULT);
 
 	@NestedConfigurationProperty


### PR DESCRIPTION
This PR adds Javadoc for the `ServerProperties.mimeMappings` as it seems to have been missed.

See gh-39430