### PR TITLE
Property placeholders aren't resolved when configuration property binding creates a Map from a property value using a converter

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
@@ -62,7 +62,10 @@ class MapBinder extends AggregateBinder<Map<Object, Object>> {
 				ConfigurationProperty property = source.getConfigurationProperty(name);
 				if (property != null && !hasDescendants) {
 					getContext().setConfigurationProperty(property);
-					return getContext().getConverter().convert(property.getValue(), target);
+					Object result = property.getValue();
+					result = getContext().getPlaceholdersResolver().resolvePlaceholders(result);
+					result = getContext().getConverter().convert(result, target);
+					return result;
 				}
 				source = source.filter(name::isAncestorOf);
 			}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/MapBinderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/MapBinderTests.java
@@ -610,6 +610,19 @@ class MapBinderTests {
 			.containsExactly("127.0.0.1", "127.0.0.2");
 	}
 
+	@Test
+	void bindToMapWithPlaceholdersShouldResolve() {
+		DefaultConversionService conversionService = new DefaultConversionService();
+		conversionService.addConverter(new MapConverter());
+		StandardEnvironment environment = new StandardEnvironment();
+		Binder binder = new Binder(this.sources, new PropertySourcesPlaceholdersResolver(environment), conversionService, null, null);
+		TestPropertySourceUtils.addInlinedPropertiesToEnvironment(environment, "bar=bc");
+		this.sources.add(new MockConfigurationPropertySource("foo", "a${bar},${bar}d"));
+		Map<String, String> map = binder.bind("foo", STRING_STRING_MAP).get();
+		assertThat(map).containsKey("abc");
+		assertThat(map).containsKey("bcd");
+	}
+
 	private <K, V> Bindable<Map<K, V>> getMapBindable(Class<K> keyGeneric, ResolvableType valueType) {
 		ResolvableType keyType = ResolvableType.forClass(keyGeneric);
 		return Bindable.of(ResolvableType.forClassWithGenerics(Map.class, keyType, valueType));


### PR DESCRIPTION
### Change Summary
- Add call to placeholder resolver to ensure property placeholders are resolved for the MapperBinder similar to [Binder.java](https://github.com/wanger26/spring-boot/blob/f6090227313fd8077b00851acd31c1fc6e860974/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Binder.java#L459-L465)

### Issue
- https://github.com/spring-projects/spring-boot/issues/39471
