### PR TITLE
Gradle plugin allows the use of Gradle 7.4 but the documented and tested minimum is 7.5

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/SpringBootPlugin.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/SpringBootPlugin.java
@@ -123,8 +123,8 @@ public class SpringBootPlugin implements Plugin<Project> {
 
 	private void verifyGradleVersion() {
 		GradleVersion currentVersion = GradleVersion.current();
-		if (currentVersion.compareTo(GradleVersion.version("7.4")) < 0) {
-			throw new GradleException("Spring Boot plugin requires Gradle 7.x (7.4 or later). "
+		if (currentVersion.compareTo(GradleVersion.version("7.5")) < 0) {
+			throw new GradleException("Spring Boot plugin requires Gradle 7.x (7.5 or later). "
 					+ "The current version is " + currentVersion);
 		}
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/SpringBootPluginIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/SpringBootPluginIntegrationTests.java
@@ -40,9 +40,9 @@ class SpringBootPluginIntegrationTests {
 	@Test
 	@DisabledForJreRange(min = JRE.JAVA_20)
 	void failFastWithVersionOfGradle7LowerThanRequired() {
-		BuildResult result = this.gradleBuild.gradleVersion("7.3.3").buildAndFail();
+		BuildResult result = this.gradleBuild.gradleVersion("7.4.1").buildAndFail();
 		assertThat(result.getOutput())
-			.contains("Spring Boot plugin requires Gradle 7.x (7.4 or later). The current version is Gradle 7.3.3");
+			.contains("Spring Boot plugin requires Gradle 7.x (7.5 or later). The current version is Gradle 7.4.1");
 	}
 
 }


### PR DESCRIPTION
### Change Summary
- Enforce Gradle version to be at least of v7.5 as the documented and tested minimum Gradle version is 7.5


### Issue
- https://github.com/spring-projects/spring-boot/issues/39453