### PR TITLE
Clarify that configuration properties only apply to the auto-configured OpenTelemetry Resource bean

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/observability.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator/observability.adoc
@@ -80,7 +80,7 @@ Spring Boot's actuator module includes basic support for https://opentelemetry.i
 
 It provides a bean of type `OpenTelemetry`, and if there are beans of type `SdkTracerProvider`, `ContextPropagators`, `SdkLoggerProvider` or `SdkMeterProvider` in the application context, they automatically get registered.
 Additionally, it provides a `Resource` bean.
-The attributes of the `Resource` can be configured via the configprop:management.opentelemetry.resource-attributes[] configuration property.
+The attributes of the `Resource` can be configured via the configprop:management.opentelemetry.resource-attributes[] configuration property if you have not defined and exposed your own Resource bean.
 
 NOTE: Spring Boot does not provide auto-configuration for OpenTelemetry metrics or logging.
 OpenTelemetry tracing is only auto-configured when used together with <<actuator#actuator.micrometer-tracing, Micrometer Tracing>>.


### PR DESCRIPTION
### Change Summary
- Adjust documentation to describe that exposing a Resource bean, will prevent management.opentelemetry.resource-attributes property from being able to provide attributes

### Issue
- https://github.com/spring-projects/spring-boot/issues/39372