### PR TITLE
Refactor getElement method to clarify ignored exception in AnsiElement

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiPropertySource.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiPropertySource.java
@@ -150,7 +150,7 @@ public class AnsiPropertySource extends PropertySource<AnsiElement> {
 				try {
 					return this.factory.apply(Integer.parseInt(postfix));
 				}
-				catch (IllegalArgumentException ex) {
+				catch (IllegalArgumentException ignored) {
 				}
 			}
 			return null;


### PR DESCRIPTION

## Overview
Improved the logic in the `getElement` method that handles strings containing only digits, by changing the name of the exception variable from `ex` to `ignored`. This change clarifies that the exception is intentionally not being addressed.

## Changes
- Renamed the `IllegalArgumentException` variable to `ignored` to clearly indicate the intention behind the exception handling.

## Background
The `getElement` method checks if the given string's postfix consists only of numbers, and if so, attempts to create and return an `AnsiElement`. During this process, calling `Integer.parseInt(postfix)` may throw an `IllegalArgumentException`, which is currently ignored without any specific handling. By renaming the exception variable to `ignored`, we aim to make it clear that this exception is intentionally overlooked, thus improving the readability of the code.

## Expected Impact
This change is intended to enhance the clarity of the code's intent, assisting other developers in understanding and maintaining the code more efficiently. Additionally, it contributes to maintaining consistent exception handling practices within the code.

Thank you.
