### PR TITLE
Adding unit tests for classes in config package

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataLocationBindHandlerSapientGeneratedTest.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataLocationBindHandlerSapientGeneratedTest.java
@@ -1,0 +1,212 @@
+package org.springframework.boot.context.config;
+
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.bind.BindContext;
+import org.springframework.boot.origin.Origin;
+import org.springframework.boot.context.properties.source.ConfigurationProperty;
+import org.springframework.util.Assert;
+import org.springframework.boot.context.properties.bind.Bindable;
+
+import org.mockito.MockedStatic;
+
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+
+import java.util.ArrayList;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.doReturn;
+import static org.hamcrest.Matchers.is;
+
+@Timeout(value = 5, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+class ConfigDataLocationBindHandlerSapientGeneratedTest {
+
+	private final BindContext bindContextMock = mock(BindContext.class);
+
+	private final Bindable<?> bindableMock = mock(Bindable.class);
+
+	private final ConfigDataLocation configDataLocationMock = mock(ConfigDataLocation.class);
+
+	private final ConfigurationProperty configurationPropertyMock = mock(ConfigurationProperty.class);
+
+	private final ConfigurationPropertyName configurationPropertyNameMock = mock(ConfigurationPropertyName.class);
+
+	private final BindContext contextMock = mock(BindContext.class);
+
+	private final Origin originMock = mock(Origin.class);
+
+	private final ConfigDataLocation resultMock = mock(ConfigDataLocation.class);
+
+	//Sapient generated method id: ${6eedb967-f586-3173-b97a-0d19567e5214}
+	@Test()
+	void onSuccessWhenResultGetOriginIsNotNull() {
+		/* Branches:
+		 * (result instanceof ConfigDataLocation location) : true
+		 * (result.getOrigin() != null) : true  #  inside withOrigin method
+		 */
+		//Arrange Statement(s)
+		doReturn(originMock).when(resultMock).getOrigin();
+		ConfigDataLocationBindHandler target = new ConfigDataLocationBindHandler();
+
+		//Act Statement(s)
+		Object result = target.onSuccess(configurationPropertyNameMock, bindableMock, bindContextMock, resultMock);
+
+		//Assert statement(s)
+		assertAll("result", () -> {
+			assertThat(result, equalTo(resultMock));
+			verify(resultMock).getOrigin();
+		});
+	}
+
+	//Sapient generated method id: ${c1747cdb-cfa5-3814-9b27-1c2705e19c83}
+	@Test()
+	void onSuccessWhenResultGetOriginIsNull() {
+		/* Branches:
+		 * (result instanceof ConfigDataLocation location) : true
+		 * (result.getOrigin() != null) : false  #  inside withOrigin method
+		 */
+		//Arrange Statement(s)
+		try (MockedStatic<Origin> origin = mockStatic(Origin.class)) {
+			doReturn(configurationPropertyMock).when(contextMock).getConfigurationProperty();
+			doReturn(null).when(resultMock).getOrigin();
+			doReturn(configDataLocationMock).when(resultMock).withOrigin(originMock);
+			origin.when(() -> Origin.from(configurationPropertyMock)).thenReturn(originMock);
+			ConfigDataLocationBindHandler target = new ConfigDataLocationBindHandler();
+			//Act Statement(s)
+			Object result = target.onSuccess(configurationPropertyNameMock, bindableMock, contextMock, resultMock);
+			//Assert statement(s)
+			assertAll("result", () -> {
+				assertThat(result, equalTo(configDataLocationMock));
+				verify(contextMock).getConfigurationProperty();
+				verify(resultMock).getOrigin();
+				verify(resultMock).withOrigin(originMock);
+				origin.verify(() -> Origin.from(configurationPropertyMock), atLeast(1));
+			});
+		}
+	}
+
+	//Sapient generated method id: ${479edc22-1303-388d-815e-7e24e9773547}
+	@Test()
+	void onSuccessWhenElementNotInstanceOfConfigDataLocation() {
+		/* Branches:
+		 * (result instanceof ConfigDataLocation location) : false
+		 * (result instanceof List<?> list) : true
+		 * (element instanceof ConfigDataLocation location) : false  #  inside lambda$onSuccess$0 method
+		 */
+		//Arrange Statement(s)
+		ConfigDataLocationBindHandler target = new ConfigDataLocationBindHandler();
+		Object object = new Object();
+		List<Object> anyList = new ArrayList<>();
+		anyList.add(object);
+
+		//Act Statement(s)
+		Object result = target.onSuccess(configurationPropertyNameMock, bindableMock, bindContextMock, anyList);
+
+		//Assert statement(s)
+		assertAll("result", () -> assertThat(result, is(notNullValue())));
+	}
+
+	//Sapient generated method id: ${28dab3de-a044-3f7b-ae11-f48f4b19735f}
+	@Test()
+	void onSuccessWhenResultInstanceOfConfigDataLocationArray() {
+		/* Branches:
+		 * (result instanceof ConfigDataLocation location) : false
+		 * (result instanceof List<?> list) : false
+		 * (result instanceof ConfigDataLocation[] unfilteredLocations) : true
+		 */
+		//Arrange Statement(s)
+		ConfigDataLocationBindHandler target = new ConfigDataLocationBindHandler();
+		ConfigDataLocation[] configDataLocationArray = new ConfigDataLocation[] {};
+
+		//Act Statement(s)
+		Object result = target.onSuccess(configurationPropertyNameMock, bindableMock, bindContextMock, configDataLocationArray);
+
+		//Assert statement(s)
+		assertAll("result", () -> assertThat(result, is(notNullValue())));
+	}
+
+	//Sapient generated method id: ${976e011e-2dfb-32a6-aad0-08e064c5bcb1}
+	@Test()
+	void onSuccessWhenResultNotInstanceOfConfigDataLocationArray() {
+		/* Branches:
+		 * (result instanceof ConfigDataLocation location) : false
+		 * (result instanceof List<?> list) : false
+		 * (result instanceof ConfigDataLocation[] unfilteredLocations) : false
+		 */
+		//Arrange Statement(s)
+		ConfigDataLocationBindHandler target = new ConfigDataLocationBindHandler();
+		Object object = new Object();
+
+		//Act Statement(s)
+		Object result = target.onSuccess(configurationPropertyNameMock, bindableMock, bindContextMock, object);
+
+		//Assert statement(s)
+		assertAll("result", () -> assertThat(result, equalTo(object)));
+	}
+
+	//Sapient generated method id: ${f33e4889-ecfa-3a4c-b9fc-4faa32df4ab3}
+	@Test()
+	void onSuccessWhenElementInstanceOfConfigDataLocationAndResultGetOriginIsNotNull() {
+		/* Branches:
+		 * (result instanceof ConfigDataLocation location) : false
+		 * (result instanceof List<?> list) : true
+		 * (element instanceof ConfigDataLocation location) : true  #  inside lambda$onSuccess$0 method
+		 * (result.getOrigin() != null) : true  #  inside withOrigin method
+		 */
+		//Arrange Statement(s)
+		doReturn(originMock).when(resultMock).getOrigin();
+		ConfigDataLocationBindHandler target = new ConfigDataLocationBindHandler();
+		List<Object> anyList = new ArrayList<>();
+		anyList.add(resultMock);
+
+		//Act Statement(s)
+		Object result = target.onSuccess(configurationPropertyNameMock, bindableMock, bindContextMock, anyList);
+
+		//Assert statement(s)
+		assertAll("result", () -> {
+			assertThat(result, is(notNullValue()));
+			verify(resultMock).getOrigin();
+		});
+	}
+
+	//Sapient generated method id: ${62f5beb5-b5bd-34dd-a481-891b92eaa275}
+	@Test()
+	void onSuccessWhenElementInstanceOfConfigDataLocationAndResultGetOriginIsNull() {
+		/* Branches:
+		 * (result instanceof ConfigDataLocation location) : false
+		 * (result instanceof List<?> list) : true
+		 * (element instanceof ConfigDataLocation location) : true  #  inside lambda$onSuccess$0 method
+		 * (result.getOrigin() != null) : false  #  inside withOrigin method
+		 */
+		//Arrange Statement(s)
+		try (MockedStatic<Origin> origin = mockStatic(Origin.class)) {
+			doReturn(configurationPropertyMock).when(contextMock).getConfigurationProperty();
+			doReturn(null).when(resultMock).getOrigin();
+			doReturn(configDataLocationMock).when(resultMock).withOrigin(originMock);
+			origin.when(() -> Origin.from(configurationPropertyMock)).thenReturn(originMock);
+			ConfigDataLocationBindHandler target = new ConfigDataLocationBindHandler();
+			List<Object> anyList = new ArrayList<>();
+			anyList.add(resultMock);
+			//Act Statement(s)
+			Object result = target.onSuccess(configurationPropertyNameMock, bindableMock, contextMock, anyList);
+			//Assert statement(s)
+			assertAll("result", () -> {
+				assertThat(result, is(notNullValue()));
+				verify(contextMock).getConfigurationProperty();
+				verify(resultMock).getOrigin();
+				verify(resultMock).withOrigin(originMock);
+				origin.verify(() -> Origin.from(configurationPropertyMock), atLeast(1));
+			});
+		}
+	}
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataPropertiesSapientGeneratedTest.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataPropertiesSapientGeneratedTest.java
@@ -1,0 +1,92 @@
+package org.springframework.boot.context.config;
+
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.bind.BindResult;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+
+import java.util.ArrayList;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doReturn;
+
+import org.junit.jupiter.api.Disabled;
+
+@Timeout(value = 5, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+class ConfigDataPropertiesSapientGeneratedTest {
+
+	private final ConfigDataProperties.Activate activateMock = mock(ConfigDataProperties.Activate.class, "activate");
+
+	private final ConfigDataActivationContext configDataActivationContextMock = mock(ConfigDataActivationContext.class);
+
+	//Sapient generated method id: ${a7686ba3-4398-3c4f-8a12-0630458f6b73}
+	@Test()
+	void isActiveWhenThisActivateIsActiveActivationContext() {
+		/* Branches:
+		 * (this.activate == null) : false
+		 * (this.activate.isActive(activationContext)) : true
+		 */
+		//Arrange Statement(s)
+		List<ConfigDataLocation> configDataLocationList = new ArrayList<>();
+		ConfigDataProperties target = new ConfigDataProperties(configDataLocationList, activateMock);
+		doReturn(true).when(activateMock).isActive(configDataActivationContextMock);
+		//Act Statement(s)
+		boolean result = target.isActive(configDataActivationContextMock);
+		//Assert statement(s)
+		assertAll("result", () -> {
+			assertThat(result, equalTo(Boolean.TRUE));
+			verify(activateMock).isActive(configDataActivationContextMock);
+		});
+	}
+
+	//Sapient generated method id: ${367670c8-7071-3de6-ae86-91f98de36d72}
+	@Test()
+	void isActiveWhenThisActivateNotIsActiveActivationContext() {
+		/* Branches:
+		 * (this.activate == null) : false
+		 * (this.activate.isActive(activationContext)) : false
+		 */
+		//Arrange Statement(s)
+		List<ConfigDataLocation> configDataLocationList = new ArrayList<>();
+		ConfigDataProperties target = new ConfigDataProperties(configDataLocationList, activateMock);
+		doReturn(false).when(activateMock).isActive(configDataActivationContextMock);
+		//Act Statement(s)
+		boolean result = target.isActive(configDataActivationContextMock);
+		//Assert statement(s)
+		assertAll("result", () -> {
+			assertThat(result, equalTo(Boolean.FALSE));
+			verify(activateMock).isActive(configDataActivationContextMock);
+		});
+	}
+
+
+	//Sapient generated method id: ${9c25887d-767d-38e9-b5ae-c2e4012c49be}
+	@Test()
+	void getTest() {
+		//Arrange Statement(s)
+		Binder binderMock = mock(Binder.class);
+		BindResult bindResultMock = mock(BindResult.class);
+		doReturn(bindResultMock).when(binderMock).bind((ConfigurationPropertyName) any(), (Bindable) any(), (ConfigDataLocationBindHandler) any());
+		ConfigDataProperties configDataPropertiesMock = mock(ConfigDataProperties.class);
+		doReturn(configDataPropertiesMock).when(bindResultMock).orElse(null);
+		//Act Statement(s)
+		ConfigDataProperties result = ConfigDataProperties.get(binderMock);
+		//Assert statement(s)
+		assertAll("result", () -> {
+			assertThat(result, equalTo(configDataPropertiesMock));
+			verify(binderMock).bind((ConfigurationPropertyName) any(), (Bindable) any(), (ConfigDataLocationBindHandler) any());
+			verify(bindResultMock).orElse(null);
+		});
+	}
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/InactiveConfigDataAccessExceptionSapientGeneratedTest.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/InactiveConfigDataAccessExceptionSapientGeneratedTest.java
@@ -1,0 +1,80 @@
+package org.springframework.boot.context.config;
+
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.origin.Origin;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.context.properties.source.ConfigurationProperty;
+import org.springframework.core.env.PropertySource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doReturn;
+import static org.hamcrest.Matchers.is;
+
+@Timeout(value = 5, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+class InactiveConfigDataAccessExceptionSapientGeneratedTest {
+
+	private final ConfigurationPropertyName configurationPropertyNameMock = mock(ConfigurationPropertyName.class);
+
+	private final ConfigDataEnvironmentContributor contributorMock = mock(ConfigDataEnvironmentContributor.class);
+
+	//Sapient generated method id: ${a01f0178-a50a-33c2-887d-886bec5903b0}
+	@Test()
+	void throwIfPropertyFoundWhenSourceIsNullAndPropertyIsNull() {
+		/* Branches:
+		 * (source != null) : false
+		 * (property != null) : false
+		 */
+		//Arrange Statement(s)
+		doReturn(null).when(contributorMock).getConfigurationPropertySource();
+
+		//Act Statement(s)
+		InactiveConfigDataAccessException.throwIfPropertyFound(contributorMock, configurationPropertyNameMock);
+
+		//Assert statement(s)
+		assertAll("result", () -> verify(contributorMock).getConfigurationPropertySource());
+	}
+
+	//Sapient generated method id: ${f751bede-fa12-3072-9148-50b80904ccd0}
+	@Test()
+	void throwIfPropertyFoundWhenOriginIsNotNullThrowsInactiveConfigDataAccessException() {
+		/* Branches:
+		 * (source != null) : true
+		 * (property != null) : true
+		 * (location != null) : true  #  inside getMessage method
+		 * (origin != null) : true  #  inside getMessage method
+		 */
+		//Arrange Statement(s)
+		ConfigurationPropertySource configurationPropertySourceMock = mock(ConfigurationPropertySource.class);
+		doReturn(configurationPropertySourceMock).when(contributorMock).getConfigurationPropertySource();
+		Object object = new Object();
+		Origin originMock = mock(Origin.class, "throwIfPropertyFound_origin1");
+		ConfigurationProperty configurationProperty = new ConfigurationProperty(configurationPropertyNameMock, object, originMock);
+		ConfigurationPropertyName configurationPropertyNameMock2 = mock(ConfigurationPropertyName.class, "throwIfPropertyFound_configurationPropertyName1");
+		doReturn(configurationProperty).when(configurationPropertySourceMock).getConfigurationProperty(configurationPropertyNameMock2);
+		PropertySource propertySource = PropertySource.named("A");
+		doReturn(propertySource).when(contributorMock).getPropertySource();
+		ConfigDataResource configDataResourceMock = mock(ConfigDataResource.class, "throwIfPropertyFound_configDataResource1");
+		doReturn(configDataResourceMock).when(contributorMock).getResource();
+		//Act Statement(s)
+		final InactiveConfigDataAccessException result = assertThrows(InactiveConfigDataAccessException.class, () -> {
+			InactiveConfigDataAccessException.throwIfPropertyFound(contributorMock, configurationPropertyNameMock2);
+		});
+
+		//Assert statement(s)
+		assertAll("result", () -> {
+			assertThat(result, is(notNullValue()));
+			verify(contributorMock).getConfigurationPropertySource();
+			verify(configurationPropertySourceMock).getConfigurationProperty(configurationPropertyNameMock2);
+			verify(contributorMock).getPropertySource();
+			verify(contributorMock).getResource();
+		});
+	}
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLoaderSapientGeneratedTest.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLoaderSapientGeneratedTest.java
@@ -1,0 +1,76 @@
+package org.springframework.boot.context.config;
+
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.mockito.stubbing.Answer;
+
+import org.springframework.boot.origin.Origin;
+import org.springframework.boot.origin.OriginTrackedResource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.Resource;
+import org.springframework.boot.env.PropertySourceLoader;
+
+import org.mockito.MockedStatic;
+
+import java.util.ArrayList;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.Disabled;
+
+@Timeout(value = 5, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+class StandardConfigDataLoaderSapientGeneratedTest {
+
+	private final ConfigDataLoaderContext configDataLoaderContextMock = mock(ConfigDataLoaderContext.class);
+
+	private final ConfigDataLocation configDataLocationMock = mock(ConfigDataLocation.class);
+
+	private final ConfigDataLocation configDataLocationMock2 = mock(ConfigDataLocation.class, "load_configDataLocation2");
+
+	private final Origin originMock = mock(Origin.class);
+
+	private final OriginTrackedResource originTrackedResourceMock = mock(OriginTrackedResource.class);
+
+	private final PropertySourceLoader propertySourceLoaderMock = mock(PropertySourceLoader.class);
+
+	private final StandardConfigDataResource resourceMock = mock(StandardConfigDataResource.class, "load_standardConfigDataResource1");
+
+	private final Resource resourceMock2 = mock(Resource.class);
+
+	private final Resource resourceMock3 = mock(Resource.class);
+
+	private final StandardConfigDataReference standardConfigDataReferenceMock = mock(StandardConfigDataReference.class);
+
+	//Sapient generated method id: ${309763d6-5197-33fd-8789-218a32b01068}
+	@Test()
+	void loadWhenResourceIsEmptyDirectory() throws IOException, ConfigDataNotFoundException {
+		/* Branches:
+		 * (resource.isEmptyDirectory()) : true
+		 */
+		//Arrange Statement(s)
+		StandardConfigDataResource resourceMock = mock(StandardConfigDataResource.class);
+		doReturn(true).when(resourceMock).isEmptyDirectory();
+		StandardConfigDataLoader target = new StandardConfigDataLoader();
+		//Act Statement(s)
+		ConfigData result = target.load(configDataLoaderContextMock, resourceMock);
+		ConfigData configData = ConfigData.EMPTY;
+		//Assert statement(s)
+		//TODO: Please implement equals method in ConfigData for verification to succeed or you need to adjust respective assertion statements
+		assertAll("result", () -> {
+			assertThat(result, equalTo(configData));
+			verify(resourceMock).isEmptyDirectory();
+		});
+	}
+}


### PR DESCRIPTION
To enhance bug leakages and detect the issues earlier in the release lifecycle I added unit tests for context package for these classes:
- ConfigDataLocationBindHandler.java
- ConfigDataProperties.java
- InactiveConfigDataAccessException.java
- StandardConfigDataLoader.java
These are generated using the sapient.ai plugin.
More: https://plugins.jetbrains.com/plugin/21709-sapient-ai-test-coder