### PR TITLE
Add smoke test for InfoContributor

### DIFF
--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/SampleActuatorApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/SampleActuatorApplicationTests.java
@@ -186,7 +186,7 @@ class SampleActuatorApplicationTests {
 		assertThat(entity.getBody()).containsKey("build");
 		Map<String, Object> body = entity.getBody();
 		Map<String, Object> example = (Map<String, Object>) body.get("example");
-		assertThat(example).containsEntry("someKey","someValue");
+		assertThat(example).containsEntry("someKey", "someValue");
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/SampleActuatorApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/SampleActuatorApplicationTests.java
@@ -17,7 +17,6 @@
 package smoketest.actuator;
 
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/SampleActuatorApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/test/java/smoketest/actuator/SampleActuatorApplicationTests.java
@@ -17,6 +17,7 @@
 package smoketest.actuator;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -175,6 +176,18 @@ class SampleActuatorApplicationTests {
 				this.restTemplate.withBasicAuth("user", "password").getForEntity("/actuator/anotherlegacy", Map.class));
 		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
 		assertThat(entity.getBody()).contains(entry("legacy", "legacy"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testInfo() {
+		ResponseEntity<Map<String, Object>> entity = asMapEntity(
+				this.restTemplate.withBasicAuth("user", "password").getForEntity("/actuator/info", Map.class));
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(entity.getBody()).containsKey("build");
+		Map<String, Object> body = entity.getBody();
+		Map<String, Object> example = (Map<String, Object>) body.get("example");
+		assertThat(example).containsEntry("someKey","someValue");
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })


### PR DESCRIPTION
This is an unit test code coverage  a pre-existed `contribute` method located in `ExampleInfoContributor (smoketest.actuator)` 
Before
<img width="1340" alt="截屏2024-02-14 上午4 30 47" src="https://github.com/spring-projects/spring-boot/assets/114868594/4fee44f1-0086-49a0-b9fb-ce5b33d0fce6">
After
<img width="1344" alt="截屏2024-02-14 上午4 30 59" src="https://github.com/spring-projects/spring-boot/assets/114868594/c66a88e1-02ab-47e2-8ae0-310c5cbfc9ed">

