### PR TITLE
Document configuration property default for the show-values propertie…

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -31,6 +31,14 @@
       "defaultValue": true
     },
     {
+      "name": "management.endpoint.configprops.show-values",
+      "defaultValue": "never"
+    },
+    {
+      "name": "management.endpoint.env.show-values",
+      "defaultValue": "never"
+    },
+    {
       "name": "management.endpoint.health.probes.add-additional-paths",
       "type": "java.lang.Boolean",
       "description": "Whether to make the liveness and readiness health groups available on the main server port.",
@@ -60,6 +68,10 @@
       "type": "java.lang.Boolean",
       "description": "Whether to validate health group membership on startup. Validation fails if a group includes or excludes a health contributor that does not exist.",
       "defaultValue": true
+    },
+    {
+      "name": "management.endpoint.quartz.show-values",
+      "defaultValue": "never"
     },
     {
       "name": "management.endpoints.enabled-by-default",


### PR DESCRIPTION
Addressing: #39565

Dear @mhalbritter and team, I saw the ideal-for-contribution label and just gave it a try. Honestly, since there are just some lines of changes, I'm not sure if that is really what was requested.

Question for my understanding: Is the "When to show unsanitized values." line from the ref doc page parsed from the javadoc comment in the source? This metadata.json file has a `description` field, but not for all entries.

Targeting `3.1.x` branch, because of the milestone.

(Made a mistake in PR #39590 and created a new one, sorry.)

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
