### PR TITLE
Banner printing doesn't respect set charset

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplicationBannerPrinter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplicationBannerPrinter.java
@@ -96,8 +96,8 @@ class SpringApplicationBannerPrinter {
 	private String createStringFromBanner(Banner banner, Environment environment, Class<?> mainApplicationClass)
 			throws UnsupportedEncodingException {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		banner.printBanner(environment, mainApplicationClass, new PrintStream(baos));
 		String charset = environment.getProperty("spring.banner.charset", "UTF-8");
+		banner.printBanner(environment, mainApplicationClass, new PrintStream(baos, false, charset));
 		return baos.toString(charset);
 	}
 


### PR DESCRIPTION
Curently the printing of the banner in log mode (spring.main.banner-mode="log") only works correctly (correctly = displays unicode characters the correct way, without surrogate glyphs) 
if spring.banner.charset matches file.encoding.
The banner is read using the encoding specified by "spring.banner.charset", before it is written in a local dependent way (dependent on file.encoding) into the ByteArrayOutputStream. After that it is re-read using the 
original "spring.banner.charset". This leads to unwanted replacements. 

Proposed Solution -> Write banner into ByteArrayOutputStream using the original encoding and not the local dependent encoding. 

Affected method: 
"createStringFromBanner(Banner banner, Environment environment, Class<?> mainApplicationClass)"

Local dependent writing by using PrintStream constructor with single argument (no encoding specified)
"banner.printBanner(environment, mainApplicationClass, new PrintStream(baos));"

