### PR TITLE
Fix json path assertion

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/rsocket/RSocketWebSocketNettyRouteProviderTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/rsocket/RSocketWebSocketNettyRouteProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,14 @@ class RSocketWebSocketNettyRouteProviderTests {
 					.block(Duration.ofSeconds(3));
 				assertThat(rsocketResponse.getName()).isEqualTo("rsocket");
 				WebTestClient client = createWebTestClient(serverContext.getWebServer());
-				client.get().uri("/protocol").exchange().expectStatus().isOk().expectBody().jsonPath("name", "http");
+				client.get()
+					.uri("/protocol")
+					.exchange()
+					.expectStatus()
+					.isOk()
+					.expectBody()
+					.jsonPath("name")
+					.isEqualTo("http");
 			});
 	}
 


### PR DESCRIPTION
This commit fixes the json path assertion of a test. The second argument of `jsonpath` is an `Object[]` in case the expression is using placeholders.

We've had several tests not doing anything in the core framework for the same reason and we've decided to deprecate that method signature to require a fully-formed expression instead.