### PR TITLE
Change format of git.commit.time used by git-commit-id-maven-plugin from RFC 822 to ISO 8601

### DIFF
--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
@@ -148,7 +148,7 @@ publishing.publications.withType(MavenPublication) {
 							}
 							configuration {
 								delegate.verbose('true')
-								delegate.dateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
+								delegate.dateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
 								delegate.generateGitPropertiesFile('true')
 								delegate.generateGitPropertiesFilename('${project.build.outputDirectory}/git.properties')
 							}


### PR DESCRIPTION
Related to https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/674.

This change is required to make the times produced by the git-commit-id-maven-plugin usable for Maven's [reproducible builds]( https://maven.apache.org/guides/mini/guide-reproducible-builds.html).

Timestamp for reproducible output archive entries must either formatted as ISO 8601 `yyyy-MM-dd'T'HH:mm:ssXXX` or as an int representing seconds since the [epoch](https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH)

Example usage might be
E.g.
```
   <properties>
     <project.build.outputTimestamp>${git.commit.time}</project.build.outputTimestamp>
   </properties>
```

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
