### PR TITLE
Modify toCharArray loop of parameterId

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/mavenplugin/DocumentPluginGoals.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/mavenplugin/DocumentPluginGoals.java
@@ -190,8 +190,11 @@ public class DocumentPluginGoals extends DefaultTask {
 	}
 
 	private String parameterId(String name) {
-		StringBuilder id = new StringBuilder(name.length() + 4);
-		for (char c : name.toCharArray()) {
+		final int length = name.length();
+		StringBuilder id = new StringBuilder(length + 4);
+
+		for (int i = 0; i < length; i++) {
+			char c = name.charAt(i);
 			if (Character.isLowerCase(c)) {
 				id.append(c);
 			}


### PR DESCRIPTION
I think using charAt rather than toCharArray can reduce the cost of creating a char array. Also, I think the number of calls can be reduced by declaring the length of name as a variable.