### PR TITLE
Re-order route registration for GraphQL WebMvc / WebFlux

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/reactive/GraphQlWebFluxAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/reactive/GraphQlWebFluxAutoConfiguration.java
@@ -112,8 +112,8 @@ public class GraphQlWebFluxAutoConfiguration {
 		String path = properties.getPath();
 		logger.info(LogMessage.format("GraphQL endpoint HTTP POST %s", path));
 		RouterFunctions.Builder builder = RouterFunctions.route();
-		builder = builder.GET(path, this::onlyAllowPost);
 		builder = builder.POST(path, SUPPORTS_MEDIATYPES, httpHandler::handleRequest);
+		builder = builder.GET(path, this::onlyAllowPost);
 		if (properties.getGraphiql().isEnabled()) {
 			GraphiQlHandler graphQlHandler = new GraphiQlHandler(path, properties.getWebsocket().getPath());
 			builder = builder.GET(properties.getGraphiql().getPath(), graphQlHandler::handleRequest);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/servlet/GraphQlWebMvcAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/servlet/GraphQlWebMvcAutoConfiguration.java
@@ -112,9 +112,9 @@ public class GraphQlWebMvcAutoConfiguration {
 		String path = properties.getPath();
 		logger.info(LogMessage.format("GraphQL endpoint HTTP POST %s", path));
 		RouterFunctions.Builder builder = RouterFunctions.route();
-		builder = builder.GET(path, this::onlyAllowPost);
 		builder = builder.POST(path, RequestPredicates.contentType(MediaType.APPLICATION_JSON)
 			.and(RequestPredicates.accept(SUPPORTED_MEDIA_TYPES)), httpHandler::handleRequest);
+		builder = builder.GET(path, this::onlyAllowPost);
 		if (properties.getGraphiql().isEnabled()) {
 			GraphiQlHandler graphiQLHandler = new GraphiQlHandler(path, properties.getWebsocket().getPath());
 			builder = builder.GET(properties.getGraphiql().getPath(), graphiQLHandler::handleRequest);


### PR DESCRIPTION
Re-order the route registrations for GraphQL requests so that the most commonly matched path is evaluated first.

The common case is valid POST requests to the graphql endpoint, so add that handler first; we found there is some overhead in the request predicate evaluation (see [this issue](https://github.com/spring-projects/spring-framework/issues/32245)), so while it may seem like a micro-optimization, it's a trivial change and can avoid evaluating some predicates in the common case.