### PR TITLE
Add note regarding mixing of bundle-based and direct SSL configuration

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/ssl.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/ssl.adoc
@@ -43,7 +43,7 @@ When used to secure a client-side connection, a `truststore` is typically config
 
 See {spring-boot-autoconfigure-module-code}/ssl/JksSslBundleProperties.java[JksSslBundleProperties] for the full set of supported properties.
 
-
+NOTE: When using SSL with Java KeyStore Files, only the bundle-based configurations will be applied as mixing of bundle-based configurations and directly configuring the server's SSL settings is not supported.
 
 [[features.ssl.pem]]
 === Configuring SSL With PEM-encoded Certificates

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/ssl.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/ssl.adoc
@@ -43,7 +43,7 @@ When used to secure a client-side connection, a `truststore` is typically config
 
 See {spring-boot-autoconfigure-module-code}/ssl/JksSslBundleProperties.java[JksSslBundleProperties] for the full set of supported properties.
 
-NOTE: When using SSL with Java KeyStore Files, only the bundle-based configurations will be applied as mixing of bundle-based configurations and directly configuring the server's SSL settings is not supported.
+
 
 [[features.ssl.pem]]
 === Configuring SSL With PEM-encoded Certificates

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/webserver.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/howto/webserver.adoc
@@ -155,8 +155,7 @@ The following example shows setting SSL properties using a Java KeyStore file:
 Using configuration such as the preceding example means the application no longer supports a plain HTTP connector at port 8080.
 Spring Boot does not support the configuration of both an HTTP connector and an HTTPS connector through `application.properties`.
 If you want to have both, you need to configure one of them programmatically.
-We recommend using `application.properties` to configure HTTPS, as the HTTP connector is the easier of the two to configure programmatically.
-
+We recommend using `application.properties` to configure HTTPS, as the HTTP connector is the easier of the two to configure programmatically. Also note that Spring Boot does not support the mixing of different configuration methods of SSL for embedded web servers, as such the use of the `ssl.bundle` property can't be combined with the discrete JKS or PEM property options under `server.ssl`.
 
 
 [[howto.webserver.configure-ssl.pem-files]]


### PR DESCRIPTION
### Change Summary
- Clarify that mixing of bundle-based configuration and directly configuring the server's SSL settings is not supported and that you should only use one or the other.

### Issue
- https://github.com/spring-projects/spring-boot/issues/39310
