### PR TITLE
FIX - Catastrophic Backtracking for images with illegal char in tag

### DIFF
--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/Regex.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/Regex.java
@@ -50,7 +50,7 @@ final class Regex implements CharSequence {
 	private static final Regex PATH_COMPONENT;
 	static {
 		Regex segment = Regex.of("[a-z0-9]+");
-		Regex separator = Regex.group("[._]|__|[-]*");
+		Regex separator = Regex.group("[._-]{1,2}");
 		Regex separatedSegment = Regex.group(separator, segment).oneOrMoreTimes();
 		PATH_COMPONENT = Regex.of(segment, Regex.group(separatedSegment).zeroOrOnce());
 	}

--- a/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/ImageReferenceTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/ImageReferenceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,12 @@
 package org.springframework.boot.docker.compose.core;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Tests for {@link ImageReference}.
@@ -163,6 +166,28 @@ class ImageReferenceTests {
 		ImageReference r3 = ImageReference.of("docker.io/library/ubuntu:latest");
 		assertThat(r1).hasSameHashCodeAs(r2);
 		assertThat(r1).isEqualTo(r1).isEqualTo(r2).isNotEqualTo(r3);
+	}
+
+	@Test
+	void ofSimpleNameWithSingleCharacterSuffix() {
+		ImageReference reference = ImageReference.of("ubuntu-a");
+		assertThat(reference.getDomain()).isEqualTo("docker.io");
+		assertThat(reference.getName()).isEqualTo("library/ubuntu-a");
+		assertThat(reference.getTag()).isNull();
+		assertThat(reference.getDigest()).isNull();
+		assertThat(reference).hasToString("docker.io/library/ubuntu-a");
+	}
+
+	@Test
+	@Timeout(value = 1, threadMode = ThreadMode.SEPARATE_THREAD)
+	void ofWhenImageNameIsVeryLongAndHasIllegalCharacter() {
+		try {
+			ImageReference
+				.of("docker.io/library/this-image-has-a-long-name-with-an-invalid-tag-which-is-at-danger-of-catastrophic-backtracking:1.0.0+1234");
+			fail("Image Reference contains an illegal character and should have thrown an IllegalArgumentException");
+		}
+		catch (IllegalArgumentException ignored) {
+		}
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/Regex.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/type/Regex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ final class Regex implements CharSequence {
 	private static final Regex PATH_COMPONENT;
 	static {
 		Regex segment = Regex.of("[a-z0-9]+");
-		Regex separator = Regex.group("[._]|__|[-]*");
+		Regex separator = Regex.group("[._-]{1,2}");
 		Regex separatedSegment = Regex.group(separator, segment).oneOrMoreTimes();
 		PATH_COMPONENT = Regex.of(segment, Regex.group(separatedSegment).zeroOrOnce());
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/ImageReferenceTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/type/ImageReferenceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,13 @@ package org.springframework.boot.buildpack.platform.docker.type;
 import java.io.File;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Tests for {@link ImageReference}.
@@ -304,6 +307,28 @@ class ImageReferenceTests {
 		ImageReference reference = ImageReference.of("docker.io/library/ubuntu:bionic");
 		ImageReference updated = reference.inTaglessForm();
 		assertThat(updated).hasToString("docker.io/library/ubuntu");
+	}
+
+	@Test
+	void ofSimpleNameWithSingleCharacterSuffix() {
+		ImageReference reference = ImageReference.of("ubuntu-a");
+		assertThat(reference.getDomain()).isEqualTo("docker.io");
+		assertThat(reference.getName()).isEqualTo("library/ubuntu-a");
+		assertThat(reference.getTag()).isNull();
+		assertThat(reference.getDigest()).isNull();
+		assertThat(reference).hasToString("docker.io/library/ubuntu-a");
+	}
+
+	@Test
+	@Timeout(value = 1, threadMode = ThreadMode.SEPARATE_THREAD)
+	void ofWhenIsVeryLongAndHasIllegalCharacter() {
+		try {
+			ImageReference
+				.of("docker.io/library/this-image-has-a-long-name-with-an-invalid-tag-which-is-at-danger-of-catastrophic-backtracking:1.0.0+1234");
+			fail("Contains an illegal character and should have thrown an IllegalArgumentException");
+		}
+		catch (IllegalArgumentException ignored) {
+		}
 	}
 
 }


### PR DESCRIPTION
### Change Summary
- Simplify regular expression checking for validity of Image Reference to fix Catastrophic Backtracking for long custom images with illegal characters in tag


### Issue
- https://github.com/spring-projects/spring-boot/issues/39246