### PR TITLE
Add link to Pulsar workaround when using environment variables for authentication

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/messaging/pulsar.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/messaging/pulsar.adoc
@@ -50,6 +50,9 @@ Spring Boot will not attempt any kind of relaxed binding for these entries.
 
 For example, if you want to configure the issuer url for the `AuthenticationOAuth2` auth plugin you must use `+spring.pulsar.client.authentication.param.issuerUrl+`.
 If you use other forms, such as `issuerurl` or `issuer-url`, the setting will not be applied to the plugin.
+
+This lack of relaxed binding also makes using environment variables for authentication parameters problematic because the case sensitivity is lost during translation.
+If you use environment variables for the parameters then you will need to follow {spring-pulsar-docs}reference/pulsar.html#client-authentication-env-vars[these steps] in the Spring for Apache Pulsar reference documentation for it to work properly.
 ====
 
 


### PR DESCRIPTION
There is a section in the Pulsar client authentication reference guide that warns users of the lack of relaxed binding for authentication parameter map keys.

This lack of relaxed binding prevents users from setting these auth parameters directly via env var as the casing is lost in translation.

The commit adds a link in this area of the reference guide to a workaround in the Spring Pulsar framework reference guide.

User reported issue: https://github.com/spring-projects/spring-pulsar/issues/575

### Sample
Notice the newly added sentences in the "Note" section of https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#messaging.pulsar.connecting.auth

<img width="903" alt="Screenshot 2024-02-19 at 18 30 31" src="https://github.com/spring-projects/spring-boot/assets/28907971/3bbe0507-05fc-41cd-b097-a823c5b99fb7">


This newly added link goes to this newly added page in the Spring Pulsar reference guide:

<img width="1074" alt="Screenshot 2024-02-19 at 18 30 08" src="https://github.com/spring-projects/spring-boot/assets/28907971/9852aaf8-10d1-4a39-8282-9513b6229101">
