### PR TITLE
ResolveMainClassName calls getProject() at execution time, making it incompatible with Gradle's configuration cache

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ResolveMainClassName.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ResolveMainClassName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ import org.springframework.boot.loader.tools.MainClassFinder;
  * {@link Task} for resolving the name of the application's main class.
  *
  * @author Andy Wilkinson
+ * @author Yanming Zhou
  * @since 2.4
  */
 @DisableCachingByDefault(because = "Not worth caching")
@@ -58,6 +59,8 @@ public class ResolveMainClassName extends DefaultTask {
 
 	private final Property<String> configuredMainClass;
 
+	private final Path projectDir;
+
 	private FileCollection classpath;
 
 	/**
@@ -66,6 +69,7 @@ public class ResolveMainClassName extends DefaultTask {
 	public ResolveMainClassName() {
 		this.outputFile = getProject().getObjects().fileProperty();
 		this.configuredMainClass = getProject().getObjects().property(String.class);
+		this.projectDir = getProject().getProjectDir().toPath();
 	}
 
 	/**
@@ -153,7 +157,7 @@ public class ResolveMainClassName extends DefaultTask {
 		String classpath = getClasspath().filter(File::isDirectory)
 			.getFiles()
 			.stream()
-			.map((directory) -> getProject().getProjectDir().toPath().relativize(directory.toPath()))
+			.map((directory) -> this.projectDir.relativize(directory.toPath()))
 			.map(Path::toString)
 			.collect(Collectors.joining(","));
 		return this.outputFile.map(new ClassNameReader(classpath));


### PR DESCRIPTION
>> A task must not use any Project objects at execution time. This includes calling Task.getProject() while the task is running.

See https://docs.gradle.org/7.0/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution

Fix GH-39635

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
