### PR TITLE
Decode URL content before passing it to NestedLocation.parse method.

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/nested/NestedUrlConnection.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/nested/NestedUrlConnection.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.springframework.boot.loader.net.util.UrlDecoder;
 import org.springframework.boot.loader.ref.Cleaner;
 
 /**
@@ -76,7 +77,7 @@ class NestedUrlConnection extends URLConnection {
 
 	private NestedLocation parseNestedLocation(URL url) throws MalformedURLException {
 		try {
-			return NestedLocation.parse(url.getPath());
+			return NestedLocation.parse(UrlDecoder.decode(url.getPath()));
 		}
 		catch (IllegalArgumentException ex) {
 			throw new MalformedURLException(ex.getMessage());


### PR DESCRIPTION
URL can contains empty spaced encoded as %20, so it should be decoded before passing it to NestedLocation. NestedLocation expects file system path which should not contain URL encoded values.

Closes gh-39655
