### PR TITLE
Make resolution algorithm of ConnectionDetailsFactory more explicit

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/service/connection/ConnectionDetailsFactories.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/service/connection/ConnectionDetailsFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,11 +122,28 @@ public class ConnectionDetailsFactories {
 		@SuppressWarnings("unchecked")
 		private static <S, D extends ConnectionDetails> Registration<S, D> get(ConnectionDetailsFactory<S, D> factory) {
 			ResolvableType type = ResolvableType.forClass(ConnectionDetailsFactory.class, factory.getClass());
-			if (!type.hasUnresolvableGenerics()) {
-				Class<?>[] generics = type.resolveGenerics();
+			Class<?>[] generics = resolveGenerics(type);
+			if (generics != null) {
 				return new Registration<>((Class<S>) generics[0], (Class<D>) generics[1], factory);
 			}
 			return null;
+		}
+
+		/**
+		 * Resolve the generics of the given {@link ResolvableType} or {@code null} if any
+		 * of them cannot be resolved.
+		 * @param type the type to inspect
+		 * @return the resolved generics if they can be loaded from the classpath,
+		 * {@code null} otherwise
+		 */
+		private static Class<?>[] resolveGenerics(ResolvableType type) {
+			Class<?>[] resolvedGenerics = type.resolveGenerics();
+			for (Class<?> genericRawType : resolvedGenerics) {
+				if (genericRawType == null) {
+					return null;
+				}
+			}
+			return resolvedGenerics;
 		}
 
 	}


### PR DESCRIPTION
This commit moves the resolution check for ConnectionDetailsFactory to a dedicated method to make it more clear that it is meant to verify that the implementation is resolved and can be loaded from the classpath.

The previous algorithm relied on a behavior of ResolvableType that only resolves the first level generics. Further improvements in Spring Framework 6.2 make this check invalid as some implementations use a Container that can hold a nested generic.

