### PR TITLE
Remove obsolete JDK 9 check in spring-boot-smoke-test-jersey

### DIFF
--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jersey/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-jersey/build.gradle
@@ -10,9 +10,7 @@ dependencies {
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-jersey"))
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-tomcat"))
 
-	if (JavaVersion.current().java9Compatible) {
-		runtimeOnly("jakarta.xml.bind:jakarta.xml.bind-api")
-	}
+	runtimeOnly("jakarta.xml.bind:jakarta.xml.bind-api")
 
 	testImplementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-test"))
 }


### PR DESCRIPTION
Hi,

since the baseline was raised, the check for JDK 9 compatibility inside the `build.gradle` of `spring-boot-smoke-test-jersey` seems obsolete.

Cheers,
Christoph