### PR TITLE
Simplify injection points declaration

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/session/SessionsEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/session/SessionsEndpointAutoConfiguration.java
@@ -54,8 +54,8 @@ public class SessionsEndpointAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		SessionsEndpoint sessionEndpoint(SessionRepository<? extends Session> sessionRepository,
-				ObjectProvider<FindByIndexNameSessionRepository<? extends Session>> indexedSessionRepository) {
+		SessionsEndpoint sessionEndpoint(SessionRepository<?> sessionRepository,
+				ObjectProvider<FindByIndexNameSessionRepository<?>> indexedSessionRepository) {
 			return new SessionsEndpoint(sessionRepository, indexedSessionRepository.getIfAvailable());
 		}
 
@@ -68,8 +68,8 @@ public class SessionsEndpointAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		ReactiveSessionsEndpoint sessionsEndpoint(ReactiveSessionRepository<? extends Session> sessionRepository,
-				ObjectProvider<ReactiveFindByIndexNameSessionRepository<? extends Session>> indexedSessionRepository) {
+		ReactiveSessionsEndpoint sessionsEndpoint(ReactiveSessionRepository<?> sessionRepository,
+				ObjectProvider<ReactiveFindByIndexNameSessionRepository<?>> indexedSessionRepository) {
 			return new ReactiveSessionsEndpoint(sessionRepository, indexedSessionRepository.getIfAvailable());
 		}
 


### PR DESCRIPTION
While working on Spring Framework `6.2.0-SNAPSHOT`, this lead to a problem due to our revised generics handling that was very helpful and the code as it is now works as expected thanks to https://github.com/spring-projects/spring-framework/issues/32327. 

However, since the redundant declaration does not bring any added value, I am submitted the change anyway. It works as is with both Spring Framework 6.1 and 6.2.