### PR TITLE
Enable netty leak detector

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1098,6 +1098,13 @@ bom {
 			]
 		}
 	}
+	library("netty-leak-detector-junit-extension", "0.0.2") {
+		group("io.github.nettyplus") {
+			modules = [
+				"netty-leak-detector-junit-extension"
+			]
+		}
+	}
 	library("OkHttp", "4.12.0") {
 		group("com.squareup.okhttp3") {
 			imports = [

--- a/spring-boot-project/spring-boot/build.gradle
+++ b/spring-boot-project/spring-boot/build.gradle
@@ -121,6 +121,7 @@ dependencies {
 	}
 	testImplementation("org.hsqldb:hsqldb")
 	testImplementation("org.junit.jupiter:junit-jupiter")
+	testImplementation("io.github.nettyplus:netty-leak-detector-junit-extension")
 	testImplementation("org.mariadb.jdbc:mariadb-java-client") {
 		exclude group: "org.slf4j", module: "jcl-over-slf4j"
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/netty/NettyReactiveWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/netty/NettyReactiveWebServerFactoryTests.java
@@ -21,10 +21,12 @@ import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.Arrays;
 
+import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 import io.netty.channel.Channel;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
@@ -66,6 +68,7 @@ import static org.mockito.Mockito.mock;
  * @author Chris Bono
  * @author Moritz Halbritter
  */
+@ExtendWith(NettyLeakDetectorExtension.class)
 class NettyReactiveWebServerFactoryTests extends AbstractReactiveWebServerFactoryTests {
 
 	@Test


### PR DESCRIPTION
Motivation:

detect Netty resource leaks using Netty's paranoid leak detector

Modifications:

- add Netty leak detector junit library
- enable junit extension on NettyReactiveWebServerFactoryTests

Result:

NettyReactiveWebServerFactoryTests will check for netty leaks


