### PR TITLE
Replace string concatenation with StringBuilder in a loop

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/livereload/ConnectionInputStreamTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/livereload/ConnectionInputStreamTests.java
@@ -38,13 +38,13 @@ class ConnectionInputStreamTests {
 
 	@Test
 	void readHeader() throws Exception {
-		String header = "";
+		StringBuilder header = new StringBuilder();
 		for (int i = 0; i < 100; i++) {
-			header += "x-something-" + i + ": xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+			header.append("x-something-").append(i).append(": xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
 		}
 		String data = header + "\r\n\r\ncontent\r\n";
 		ConnectionInputStream inputStream = new ConnectionInputStream(new ByteArrayInputStream(data.getBytes()));
-		assertThat(inputStream.readHeader()).isEqualTo(header);
+		assertThat(inputStream.readHeader()).isEqualTo(header.toString());
 	}
 
 	@Test


### PR DESCRIPTION
I am aware that this is a Test class, and therefore there is no significant performance justification, but in any case there is no good reason to use string concatenation instead of StringBuilder **in a loop**. It has better performance and is more memory-efficient.