### PR TITLE
spring.data.redis.cluster.nodes and spring.data.redis.sentinel.nodes do not handle IPv6 addresses correctly

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/PropertiesRedisConnectionDetails.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/PropertiesRedisConnectionDetails.java
@@ -113,9 +113,9 @@ class PropertiesRedisConnectionDetails implements RedisConnectionDetails {
 	}
 
 	private Node asNode(String node) {
-		var posLastColon = node.lastIndexOf(':');
-		var host = node.substring(0, posLastColon).replaceFirst("^\\[(.+)]$", "$1");
-		var port = Integer.parseInt(node.substring(posLastColon + 1));
+		int portSeparatorIndex = node.lastIndexOf(':');
+		String host = node.substring(0, portSeparatorIndex);
+		int port = Integer.parseInt(node.substring(portSeparatorIndex + 1));
 		return new Node(host, port);
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/PropertiesRedisConnectionDetails.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/PropertiesRedisConnectionDetails.java
@@ -113,8 +113,10 @@ class PropertiesRedisConnectionDetails implements RedisConnectionDetails {
 	}
 
 	private Node asNode(String node) {
-		String[] components = node.split(":");
-		return new Node(components[0], Integer.parseInt(components[1]));
+		var posLastColon = node.lastIndexOf(':');
+		var host = node.substring(0, posLastColon).replaceFirst("^\\[(.+)]$", "$1");
+		var port = Integer.parseInt(node.substring(posLastColon + 1));
+		return new Node(host, port);
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionConfiguration.java
@@ -162,7 +162,7 @@ abstract class RedisConnectionConfiguration {
 	private List<RedisNode> createSentinels(Sentinel sentinel) {
 		List<RedisNode> nodes = new ArrayList<>();
 		for (Node node : sentinel.getNodes()) {
-			nodes.add(new RedisNode(node.host(), node.port()));
+			nodes.add(RedisNode.fromString(node.asString()));
 		}
 		return nodes;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionConfiguration.java
@@ -139,7 +139,7 @@ abstract class RedisConnectionConfiguration {
 	}
 
 	private List<String> getNodes(Cluster cluster) {
-		return cluster.getNodes().stream().map((node) -> "%s:%d".formatted(node.host(), node.port())).toList();
+		return cluster.getNodes().stream().map(Node::asString).toList();
 	}
 
 	protected final RedisProperties getProperties() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionDetails.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionDetails.java
@@ -186,8 +186,7 @@ public interface RedisConnectionDetails extends ConnectionDetails {
 	record Node(String host, int port) {
 
 		String asString() {
-			return (this.host != null && this.host.contains(":")) ? "[" + this.host + "]:" + this.port
-					: this.host + ":" + this.port;
+			return this.host + ":" + this.port;
 		}
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionDetails.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisConnectionDetails.java
@@ -185,6 +185,10 @@ public interface RedisConnectionDetails extends ConnectionDetails {
 	 */
 	record Node(String host, int port) {
 
+		String asString() {
+			return (this.host != null && this.host.contains(":")) ? "[" + this.host + "]:" + this.port
+					: this.host + ":" + this.port;
+		}
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/PropertiesRedisConnectionDetailsTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/PropertiesRedisConnectionDetailsTests.java
@@ -124,7 +124,7 @@ class PropertiesRedisConnectionDetailsTests {
 		PropertiesRedisConnectionDetails connectionDetails = new PropertiesRedisConnectionDetails(this.properties);
 		assertThat(connectionDetails.getCluster().getNodes()).containsExactly(
 				new RedisConnectionDetails.Node("localhost", 1111), new RedisConnectionDetails.Node("127.0.0.1", 2222),
-				new RedisConnectionDetails.Node("::1", 3333));
+				new RedisConnectionDetails.Node("[::1]", 3333));
 	}
 
 	@Test
@@ -135,7 +135,7 @@ class PropertiesRedisConnectionDetailsTests {
 		PropertiesRedisConnectionDetails connectionDetails = new PropertiesRedisConnectionDetails(this.properties);
 		assertThat(connectionDetails.getSentinel().getNodes()).containsExactly(
 				new RedisConnectionDetails.Node("localhost", 1111), new RedisConnectionDetails.Node("127.0.0.1", 2222),
-				new RedisConnectionDetails.Node("::1", 3333));
+				new RedisConnectionDetails.Node("[::1]", 3333));
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/PropertiesRedisConnectionDetailsTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/PropertiesRedisConnectionDetailsTests.java
@@ -119,12 +119,23 @@ class PropertiesRedisConnectionDetailsTests {
 	@Test
 	void clusterIsConfigured() {
 		RedisProperties.Cluster cluster = new RedisProperties.Cluster();
-		cluster.setNodes(List.of("first:1111", "second:2222", "third:3333"));
+		cluster.setNodes(List.of("localhost:1111", "127.0.0.1:2222", "[::1]:3333"));
 		this.properties.setCluster(cluster);
 		PropertiesRedisConnectionDetails connectionDetails = new PropertiesRedisConnectionDetails(this.properties);
 		assertThat(connectionDetails.getCluster().getNodes()).containsExactly(
-				new RedisConnectionDetails.Node("first", 1111), new RedisConnectionDetails.Node("second", 2222),
-				new RedisConnectionDetails.Node("third", 3333));
+				new RedisConnectionDetails.Node("localhost", 1111), new RedisConnectionDetails.Node("127.0.0.1", 2222),
+				new RedisConnectionDetails.Node("::1", 3333));
+	}
+
+	@Test
+	void sentinelIsConfigured() {
+		RedisProperties.Sentinel sentinel = new RedisProperties.Sentinel();
+		sentinel.setNodes(List.of("localhost:1111", "127.0.0.1:2222", "[::1]:3333"));
+		this.properties.setSentinel(sentinel);
+		PropertiesRedisConnectionDetails connectionDetails = new PropertiesRedisConnectionDetails(this.properties);
+		assertThat(connectionDetails.getSentinel().getNodes()).containsExactly(
+				new RedisConnectionDetails.Node("localhost", 1111), new RedisConnectionDetails.Node("127.0.0.1", 2222),
+				new RedisConnectionDetails.Node("::1", 3333));
 	}
 
 }


### PR DESCRIPTION
When specifying colon-separated pairs of host and port with IPv6 addresses (i.e. `[::1]:6379`) for either `spring.data.redis.cluster.nodes` or `spring.data.redis.sentinel.nodes`, the parsing of these nodes/addresses was broken as the splitting of these strings was not performed explicitly on the last found colon. The behavior is fixed with this PR.