### PR TITLE
When using Maven, configuring the spring-boot.excludes or spring-boot-includes user properties causes the build to fail with "Cannot find default setter"

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/JarIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/JarIntegrationTests.java
@@ -195,8 +195,23 @@ class JarIntegrationTests extends AbstractArchiveIntegrationTests {
 				.hasEntryWithNameStartingWith("BOOT-INF/lib/spring-context")
 				.hasEntryWithNameStartingWith("BOOT-INF/lib/spring-core")
 				.hasEntryWithNameStartingWith("BOOT-INF/lib/spring-jcl")
-				.doesNotHaveEntryWithName("BOOT-INF/lib/servlet-api-2.5.jar");
+				.doesNotHaveEntryWithNameStartingWith("BOOT-INF/lib/jakarta.servlet-api-");
 		});
+	}
+
+	@TestTemplate
+	void whenAnEntryIsExcludedWithPropertyItDoesNotAppearInTheRepackagedJar(MavenBuild mavenBuild) {
+		mavenBuild.project("jar")
+			.systemProperty("spring-boot.excludes", "jakarta.servlet:jakarta.servlet-api")
+			.goals("install")
+			.execute((project) -> {
+				File repackaged = new File(project, "target/jar-0.0.1.BUILD-SNAPSHOT.jar");
+				assertThat(jar(repackaged)).hasEntryWithNameStartingWith("BOOT-INF/classes/")
+					.hasEntryWithNameStartingWith("BOOT-INF/lib/spring-context")
+					.hasEntryWithNameStartingWith("BOOT-INF/lib/spring-core")
+					.hasEntryWithNameStartingWith("BOOT-INF/lib/spring-jcl")
+					.doesNotHaveEntryWithNameStartingWith("BOOT-INF/lib/jakarta.servlet-api-");
+			});
 	}
 
 	@TestTemplate

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractDependencyFilterMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractDependencyFilterMojo.java
@@ -82,7 +82,8 @@ public abstract class AbstractDependencyFilterMojo extends AbstractMojo {
 	/**
 	 * Collection of artifact definitions to exclude. The {@link Exclude} element defines
 	 * mandatory {@code groupId} and {@code artifactId} properties and an optional
-	 * {@code classifier} property.
+	 * {@code classifier} property. If passing in excludes as a property the syntax is
+	 * <pre>-Dspring-boot.excludes=groupId1:artifactId1,groupId2:artifactId2:optional-qualifier</pre>
 	 * @since 1.1.0
 	 */
 	@Parameter(property = "spring-boot.excludes")

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/Exclude.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/Exclude.java
@@ -24,4 +24,12 @@ package org.springframework.boot.maven;
  */
 public class Exclude extends FilterableDependency {
 
+	// Maven looks for this public method if giving excludes as property
+	// e.g. -Dspring-boot.excludes=foo:bar,foo:baz
+	public void set(String propertyInput) {
+		String[] parts = propertyInput.split(":");
+		setGroupId(parts[0]);
+		setArtifactId(parts[1]);
+	}
+
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/Exclude.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/Exclude.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.maven;
 
+import org.springframework.util.Assert;
+
 /**
  * A model for a dependency to exclude.
  *
@@ -25,11 +27,16 @@ package org.springframework.boot.maven;
 public class Exclude extends FilterableDependency {
 
 	// Maven looks for this public method if giving excludes as property
-	// e.g. -Dspring-boot.excludes=foo:bar,foo:baz
+	// e.g. -Dspring-boot.excludes=myGroupId:myArtifactId:my-optional-classifier,foo:baz
 	public void set(String propertyInput) {
 		String[] parts = propertyInput.split(":");
+		Assert.isTrue(parts.length == 2 || parts.length == 3,
+				"Exclude must be in the form groupId:artifactId:optional-classifier");
 		setGroupId(parts[0]);
 		setArtifactId(parts[1]);
+		if (parts.length == 3) {
+			setClassifier(parts[2]);
+		}
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/FilterableDependency.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/FilterableDependency.java
@@ -68,12 +68,4 @@ abstract class FilterableDependency {
 		this.classifier = classifier;
 	}
 
-	// Maven looks for this method if giving excludes as property
-	// e.g. -Dspring-boot.excludes=foo:bar,foo:baz
-	public void set(String propertyInput) {
-		String[] parts = propertyInput.split(":");
-		groupId = parts[0];
-		artifactId = parts[1];
-	}
-
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/FilterableDependency.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/FilterableDependency.java
@@ -68,4 +68,12 @@ abstract class FilterableDependency {
 		this.classifier = classifier;
 	}
 
+	// Maven looks for this method if giving excludes as property
+	// e.g. -Dspring-boot.excludes=foo:bar,foo:baz
+	public void set(String propertyInput) {
+		String[] parts = propertyInput.split(":");
+		groupId = parts[0];
+		artifactId = parts[1];
+	}
+
 }


### PR DESCRIPTION
The change makes excludes configurable via CLI.

For example this:

    mvn install -Dspring-boot.excludes=foo:bar,foo:baz

Would equal to following pom.xml configuration:

    <excludes>
        <exclude>
            <groupId>foo</groupId>
            <artifactId>bar</artifactId>
        </exclude>
        <exclude>
            <groupId>foo</groupId>
            <artifactId>baz</artifactId>
        </exclude>
    </excludes>
