### PR TITLE
Refactor Unnecessary return code modification

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/AbstractLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/AbstractLoggingSystem.java
@@ -76,12 +76,11 @@ public abstract class AbstractLoggingSystem extends LoggingSystem {
 		}
 		if (config == null) {
 			config = getSpringInitializationConfig();
+			loadDefaults(initializationContext, logFile);
 		}
 		if (config != null) {
 			loadConfiguration(initializationContext, config, logFile);
-			return;
 		}
-		loadDefaults(initializationContext, logFile);
 	}
 
 	/**


### PR DESCRIPTION
It seems like removing the return and moving the bottom code would make the code much easier to understand.