### PR TITLE
JarUrlConnection.getPermission() can throw NullPointerException if jarFileConnection is null

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/JarUrlConnection.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/JarUrlConnection.java
@@ -172,7 +172,7 @@ final class JarUrlConnection extends java.net.JarURLConnection {
 
 	@Override
 	public Permission getPermission() throws IOException {
-		return this.jarFileConnection.getPermission();
+		return (this.jarFileConnection != null) ? this.jarFileConnection.getPermission() : null;
 	}
 
 	@Override


### PR DESCRIPTION
Thank you for developing great springframework and spring-boot ecosystem, I appreciate development.

if given resource path is not found and JavaSecurityManager is enabled, NullPointerException is thrown internally.
Not only it is simply meaningless exception,
but also it might be cause of performance regression.

StackTrace is like bellow. 

```
java.lang.NullPointerException: Cannot invoke "java.net.URLConnection.getPermission()" because "this.jarFileConnection" is null
        at org.springframework.boot.loader.net.protocol.jar.JarUrlConnection.getPermission(JarUrlConnection.java:175)
        at java.base/jdk.internal.loader.URLClassPath.check(URLClassPath.java:553)
        at java.base/jdk.internal.loader.URLClassPath$Loader.findResource(URLClassPath.java:612)
        at java.base/jdk.internal.loader.URLClassPath.findResource(URLClassPath.java:296)
        at java.base/java.net.URLClassLoader$2.run(URLClassLoader.java:629)
        at java.base/java.net.URLClassLoader$2.run(URLClassLoader.java:627)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
        at java.base/java.net.URLClassLoader.findResource(URLClassLoader.java:626)
        at org.springframework.boot.loader.net.protocol.jar.JarUrlClassLoader.findResource(JarUrlClassLoader.java:70)
        at java.base/java.lang.ClassLoader.getResource(ClassLoader.java:1403)
        at java.base/java.net.URLClassLoader.getResourceAsStream(URLClassLoader.java:290)
        at java.base/java.lang.Class.getResourceAsStream(Class.java:2850)
```

I got above stacktrace with using debugger around `catch` statement in  `jdk.internal.loader.URLClassPath.Loader#findResource` and invoking `Exception#printStackTrace()`

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
