### PR TITLE
Set all dispatch types for OncePerRequestFilter

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/FilterRegistrationBeanTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/FilterRegistrationBeanTests.java
@@ -28,6 +28,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.web.servlet.mock.MockFilter;
+import org.springframework.session.web.http.SessionRepositoryFilter;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -92,6 +93,17 @@ class FilterRegistrationBeanTests extends AbstractFilterRegistrationBeanTests {
 		FilterRegistrationBean<?> bean = new FilterRegistrationBean<>(this.oncePerRequestFilter);
 		bean.onStartup(this.servletContext);
 		then(this.servletContext).should().addFilter(eq("oncePerRequestFilter"), eq(this.oncePerRequestFilter));
+		then(this.registration).should().setAsyncSupported(true);
+		then(this.registration).should().addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), false, "/*");
+	}
+
+	@Test
+	void sessionRepositoryFilterHasAllDispatchTypes() throws Exception {
+		given(this.servletContext.addFilter(anyString(), any(Filter.class))).willReturn(this.registration);
+		Filter sessionRepositoryFilter = new SessionRepositoryFilter();
+		FilterRegistrationBean<?> bean = new FilterRegistrationBean<>(sessionRepositoryFilter);
+		bean.onStartup(this.servletContext);
+		then(this.servletContext).should().addFilter(eq("sessionRepositoryFilter"), eq(sessionRepositoryFilter));
 		then(this.registration).should().setAsyncSupported(true);
 		then(this.registration).should().addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), false, "/*");
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/session/web/http/OncePerRequestFilter.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/session/web/http/OncePerRequestFilter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.web.http;
+
+import org.springframework.boot.web.servlet.mock.MockFilter;
+
+/**
+ * Mimics OncePerRequestFilter from spring-session-core
+ * (just in that it's a Filter in the right package).
+ */
+public class OncePerRequestFilter extends MockFilter {
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/session/web/http/SessionRepositoryFilter.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/session/web/http/SessionRepositoryFilter.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.web.http;
+
+/**
+ * Mimics SessionRepositoryFilter from spring-session-core
+ * (just in that it's a OncePerRequestFilter in the right package).
+ */
+public class SessionRepositoryFilter extends OncePerRequestFilter {
+}


### PR DESCRIPTION
As I said in a Stack Overflow question that I posted yesterday, [Spring SessionRepositoryFilter is not applied to forwarded requests](https://stackoverflow.com/questions/78124343/spring-sessionrepositoryfilter-is-not-applied-to-forwarded-requests). 
When there's an error, then the request is forwarded to _/error_, with a dispatch type of `ERROR`, but `SessionRepositoryFilter` is only applied to requests with dispatch type `REQUEST`. That means that a new session ID is created by tomcat, and the client uses this on subsequent requests, which are then rejected as unauthorized by the session repository.
`AbstractFilterRegistrationBean#determineDispatcherTypes` sets all dispatch types for filters that extend `org.springframework.web.filter.OncePerRequestFilter` in `spring-web`, but `SessionRepositoryFilter` extends `org.springframework.session.web.http.OncePerRequestFilter` in `spring-session-core`.
This change sets all dispatch types for filters extending either `OncePerRequestFilter` class.
