### PR TITLE
Deprecate @MockBean and @SpyBean

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -22,7 +22,7 @@ new File(projectDir.parentFile, "gradle.properties").withInputStream {
 	}
 }
 versions["jackson"] = "2.15.3"
-versions["springFramework"] = "6.0.12"
+versions["springFramework"] = "6.2.0-SNAPSHOT"
 ext.set("versions", versions)
 if (versions.springFramework.contains("-")) {
 	repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ junitJupiterVersion=5.10.2
 kotlinVersion=1.9.22
 mavenVersion=3.9.4
 nativeBuildToolsVersion=0.10.1
-springFrameworkVersion=6.1.4
+springFrameworkVersion=6.2.0-SNAPSHOT
 tomcatVersion=10.1.19
 
 kotlin.stdlib.default.dependency=false

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -178,6 +178,7 @@ dependencies {
 	testImplementation("org.springframework.restdocs:spring-restdocs-webtestclient")
 	testImplementation("org.springframework.security:spring-security-test")
 	testImplementation("org.yaml:snakeyaml")
+	testImplementation("org.springframework:spring-test")
 
 	testRuntimeOnly("jakarta.management.j2ee:jakarta.management.j2ee-api")
 	testRuntimeOnly("jakarta.transaction:jakarta.transaction-api")

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/AuditEventsEndpointDocumentationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/AuditEventsEndpointDocumentationTests.java
@@ -26,10 +26,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.boot.actuate.audit.AuditEventsEndpoint;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.bean.override.mockito.MockitoBean;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -49,7 +49,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 class AuditEventsEndpointDocumentationTests extends MockMvcEndpointDocumentationTests {
 
-	@MockBean
+	@MockitoBean
 	private AuditEventRepository repository;
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/HttpExchangesEndpointDocumentationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/HttpExchangesEndpointDocumentationTests.java
@@ -41,6 +41,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.bean.override.mockito.MockitoBean;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -57,7 +58,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 class HttpExchangesEndpointDocumentationTests extends MockMvcEndpointDocumentationTests {
 
-	@MockBean
+	@MockitoBean
 	private HttpExchangeRepository repository;
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/LoggersEndpointDocumentationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/LoggersEndpointDocumentationTests.java
@@ -37,6 +37,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.bean.override.mockito.MockitoBean;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -63,7 +64,7 @@ class LoggersEndpointDocumentationTests extends MockMvcEndpointDocumentationTest
 			.type(JsonFieldType.STRING)
 			.optional(), fieldWithPath("members").description("Loggers that are part of this group"));
 
-	@MockBean
+	@MockitoBean
 	private LoggingSystem loggingSystem;
 
 	@Autowired

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/QuartzEndpointDocumentationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/QuartzEndpointDocumentationTests.java
@@ -179,7 +179,7 @@ class QuartzEndpointDocumentationTests extends MockMvcEndpointDocumentationTests
 				.type(JsonFieldType.OBJECT)
 				.description("Job data map keyed by name, if any.") };
 
-	@MockBean
+	@MockitoBean
 	private Scheduler scheduler;
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/SessionsEndpointDocumentationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/SessionsEndpointDocumentationTests.java
@@ -34,6 +34,7 @@ import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.MapSession;
 import org.springframework.session.Session;
+import org.springframework.test.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.TestPropertySource;
 
 import static org.mockito.BDDMockito.given;
@@ -73,7 +74,7 @@ class SessionsEndpointDocumentationTests extends MockMvcEndpointDocumentationTes
 				.description("Maximum permitted period of inactivity, in seconds, before the session will expire."),
 			fieldWithPath("expired").description("Whether the session has expired."));
 
-	@MockBean
+	@MockitoBean
 	private FindByIndexNameSessionRepository<Session> sessionRepository;
 
 	@Test

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/kotlin.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/kotlin.adoc
@@ -137,7 +137,7 @@ JUnit 5 enables a test class to be instantiated once and reused for all of the c
 This makes it possible to use `@BeforeAll` and `@AfterAll` annotations on non-static methods, which is a good fit for Kotlin.
 
 To mock Kotlin classes, https://mockk.io/[MockK] is recommended.
-If you need the `MockK` equivalent of the Mockito specific <<features#features.testing.spring-boot-applications.mocking-beans,`@MockBean` and `@SpyBean` annotations>>, you can use https://github.com/Ninja-Squad/springmockk[SpringMockK] which provides similar `@MockkBean` and `@SpykBean` annotations.
+If you need the `MockK` equivalent of the Mockito specific <<features#features.testing.spring-boot-applications.mocking-beans,`@MockitoBean` and `@MockitoSpyBean` annotations>>, you can use https://github.com/Ninja-Squad/springmockk[SpringMockK] which provides similar `@MockkBean` and `@SpykBean` annotations.
 
 
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/testing/springbootapplications/springmvctests/MyControllerTests.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/testing/springbootapplications/springmvctests/MyControllerTests.java
@@ -20,8 +20,8 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.BDDMockito.given;
@@ -35,7 +35,7 @@ class MyControllerTests {
 	@Autowired
 	private MockMvc mvc;
 
-	@MockBean
+	@MockitoBean
 	private UserVehicleService userVehicleService;
 
 	@Test

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/testing/springbootapplications/springmvctests/MyHtmlUnitTests.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/testing/springbootapplications/springmvctests/MyHtmlUnitTests.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.bean.override.mockito.MockitoBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -33,7 +33,7 @@ class MyHtmlUnitTests {
 	@Autowired
 	private WebClient webClient;
 
-	@MockBean
+	@MockitoBean
 	private UserVehicleService userVehicleService;
 
 	@Test

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/testing/springbootapplications/springwebfluxtests/MyControllerTests.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/testing/springbootapplications/springwebfluxtests/MyControllerTests.java
@@ -20,8 +20,8 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import static org.mockito.BDDMockito.given;
@@ -32,7 +32,7 @@ class MyControllerTests {
 	@Autowired
 	private WebTestClient webClient;
 
-	@MockBean
+	@MockitoBean
 	private UserVehicleService userVehicleService;
 
 	@Test

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/springmvctests/MyControllerTests.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/springmvctests/MyControllerTests.kt
@@ -20,8 +20,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
+import org.springframework.test.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -29,7 +29,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 @WebMvcTest(UserVehicleController::class)
 class MyControllerTests(@Autowired val mvc: MockMvc) {
 
-	@MockBean
+	@MockitoBean
 	lateinit var userVehicleService: UserVehicleService
 
 	@Test

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/springmvctests/MyHtmlUnitTests.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/springmvctests/MyHtmlUnitTests.kt
@@ -23,12 +23,12 @@ import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.bean.override.mockito.MockitoBean
 
 @WebMvcTest(UserVehicleController::class)
 class MyHtmlUnitTests(@Autowired val webClient: WebClient) {
 
-	@MockBean
+	@MockitoBean
 	lateinit var userVehicleService: UserVehicleService
 
 	@Test

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/springwebfluxtests/MyControllerTests.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/springwebfluxtests/MyControllerTests.kt
@@ -20,15 +20,15 @@ import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
+import org.springframework.test.bean.override.mockito.MockitoBean
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 
 @WebFluxTest(UserVehicleController::class)
 class MyControllerTests(@Autowired val webClient: WebTestClient) {
 
-	@MockBean
+	@MockitoBean
 	lateinit var userVehicleService: UserVehicleService
 
 	@Test

--- a/spring-boot-project/spring-boot-test/build.gradle
+++ b/spring-boot-project/spring-boot-test/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 	testImplementation("org.spockframework:spock-core")
 	testImplementation("org.springframework:spring-webmvc")
 	testImplementation("org.springframework:spring-core-test")
+	testImplementation("org.springframework:spring-test")
 	testImplementation("org.testng:testng")
 
 	testRuntimeOnly("org.junit.vintage:junit-vintage-engine")

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/Definition.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/Definition.java
@@ -23,7 +23,9 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Phillip Webb
  * @see DefinitionsParser
+ * @deprecated since 3.4.0. See {@link SpyBean} and {@link MockBean} for more details.
  */
+@Deprecated(since = "3.4.0")
 abstract class Definition {
 
 	private static final int MULTIPLIER = 31;

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/DefinitionsParser.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/DefinitionsParser.java
@@ -41,7 +41,10 @@ import org.springframework.util.StringUtils;
  *
  * @author Phillip Webb
  * @author Stephane Nicoll
+ * @deprecated since 3.4.0. See {@link SpyBean} and {@link MockBean} for more details.
  */
+
+@Deprecated(since = "3.4.0")
 class DefinitionsParser {
 
 	private final Set<Definition> definitions;

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockBean.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockBean.java
@@ -91,11 +91,14 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @author Phillip Webb
  * @since 1.4.0
  * @see MockitoPostProcessor
+ * @deprecated since 3.4.0 in favor of
+ * {@link org.springframework.test.bean.override.mockito.MockitoBean}
  */
 @Target({ ElementType.TYPE, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Repeatable(MockBeans.class)
+@Deprecated(since = "3.4.0")
 public @interface MockBean {
 
 	/**

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockBeans.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockBeans.java
@@ -33,10 +33,13 @@ import java.lang.annotation.Target;
  *
  * @author Phillip Webb
  * @since 1.4.0
+ * @deprecated since 3.4.0 in favor of
+ * {@link org.springframework.test.bean.override.mockito.MockitoBean}
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Documented
+@Deprecated(since = "3.4.0")
 public @interface MockBeans {
 
 	/**

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockDefinition.java
@@ -37,7 +37,9 @@ import static org.mockito.Mockito.mock;
  * A complete definition that can be used to create a Mockito mock.
  *
  * @author Phillip Webb
+ * @deprecated since 3.4.0. See {@link MockBean} for more details.
  */
+@Deprecated(since = "3.4.0")
 class MockDefinition extends Definition {
 
 	private static final int MULTIPLIER = 31;

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockReset.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockReset.java
@@ -35,7 +35,11 @@ import org.springframework.util.Assert;
  * @author Phillip Webb
  * @since 1.4.0
  * @see ResetMocksTestExecutionListener
+ * @deprecated since 3.4.0 in favor of
+ * {@link org.springframework.test.bean.override.mockito.MockReset}
  */
+
+@Deprecated(since = "3.4.0")
 public enum MockReset {
 
 	/**

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoBeans.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoBeans.java
@@ -24,7 +24,9 @@ import java.util.List;
  * Beans created using Mockito.
  *
  * @author Andy Wilkinson
+ * @deprecated since 3.4.0. See {@link MockBean} for more details.
  */
+@Deprecated(since = "3.4.0")
 class MockitoBeans implements Iterable<Object> {
 
 	private final List<Object> beans = new ArrayList<>();

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoContextCustomizer.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoContextCustomizer.java
@@ -28,7 +28,10 @@ import org.springframework.test.context.MergedContextConfiguration;
  * A {@link ContextCustomizer} to add Mockito support.
  *
  * @author Phillip Webb
+ * @deprecated since 3.4.0 in favor of
+ * {@link org.springframework.test.bean.override.BeanOverrideContextCustomizerFactory}
  */
+@Deprecated(since = "3.4.0")
 class MockitoContextCustomizer implements ContextCustomizer {
 
 	private final Set<Definition> definitions;

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoContextCustomizerFactory.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoContextCustomizerFactory.java
@@ -27,7 +27,10 @@ import org.springframework.test.context.TestContextAnnotationUtils;
  * A {@link ContextCustomizerFactory} to add Mockito support.
  *
  * @author Phillip Webb
+ * @deprecated since 3.4.0 in favor of
+ * {@link org.springframework.test.bean.override.BeanOverrideContextCustomizerFactory}
  */
+@Deprecated(since = "3.4.0")
 class MockitoContextCustomizerFactory implements ContextCustomizerFactory {
 
 	@Override

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoPostProcessor.java
@@ -76,7 +76,10 @@ import org.springframework.util.StringUtils;
  * @author Stephane Nicoll
  * @author Andreas Neiser
  * @since 1.4.0
+ * @deprecated since 3.4.0 in favor of
+ * {@link org.springframework.test.bean.override.BeanOverrideBeanPostProcessor}
  */
+@Deprecated(since = "3.4.0")
 public class MockitoPostProcessor implements InstantiationAwareBeanPostProcessor, BeanClassLoaderAware,
 		BeanFactoryAware, BeanFactoryPostProcessor, Ordered {
 

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoTestExecutionListener.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/MockitoTestExecutionListener.java
@@ -46,7 +46,11 @@ import org.springframework.util.ReflectionUtils.FieldCallback;
  * @author Moritz Halbritter
  * @since 1.4.2
  * @see ResetMocksTestExecutionListener
+ * @deprecated since 3.4.0 in favor of
+ * {@link org.springframework.test.bean.override.mockito.MockitoTestExecutionListener}
  */
+
+@Deprecated(since = "3.4.0")
 public class MockitoTestExecutionListener extends AbstractTestExecutionListener {
 
 	private static final String MOCKS_ATTRIBUTE_NAME = MockitoTestExecutionListener.class.getName() + ".mocks";

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/QualifierDefinition.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/QualifierDefinition.java
@@ -34,7 +34,10 @@ import org.springframework.core.annotation.MergedAnnotations;
  * @author Phillip Webb
  * @author Stephane Nicoll
  * @see Definition
+ * @deprecated since 3.4.0. See {@link SpyBean} and {@link MockBean} for more details.
  */
+
+@Deprecated(since = "3.4.0")
 class QualifierDefinition {
 
 	private final Field field;

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/ResetMocksTestExecutionListener.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/ResetMocksTestExecutionListener.java
@@ -43,7 +43,10 @@ import org.springframework.util.ClassUtils;
  * @author Phillip Webb
  * @since 1.4.0
  * @see MockitoTestExecutionListener
+ * @deprecated since 3.4.0 in favor of
+ * {@link org.springframework.test.bean.override.mockito.MockitoResetTestExecutionListener}
  */
+@Deprecated(since = "3.4.0")
 public class ResetMocksTestExecutionListener extends AbstractTestExecutionListener {
 
 	private static final boolean MOCKITO_IS_PRESENT = ClassUtils.isPresent("org.mockito.MockSettings",

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyBean.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyBean.java
@@ -89,7 +89,10 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @author Phillip Webb
  * @since 1.4.0
  * @see MockitoPostProcessor
+ * @deprecated since 3.4.0 in favor of
+ * {@link org.springframework.test.bean.override.mockito.MockitoSpyBean}
  */
+@Deprecated(since = "3.4.0")
 @Target({ ElementType.TYPE, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyBeans.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyBeans.java
@@ -33,10 +33,13 @@ import java.lang.annotation.Target;
  *
  * @author Phillip Webb
  * @since 1.4.0
+ * @deprecated since 3.4.0 in favor of
+ * {@link org.springframework.test.bean.override.mockito.MockitoSpyBean}
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Documented
+@Deprecated(since = "3.4.0")
 public @interface SpyBeans {
 
 	/**

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyDefinition.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/mock/mockito/SpyDefinition.java
@@ -37,7 +37,10 @@ import static org.mockito.Mockito.mock;
  * A complete definition that can be used to create a Mockito spy.
  *
  * @author Phillip Webb
+ * @deprecated since 3.4.0. See {@link SpyBean} for more details.
  */
+
+@Deprecated(since = "3.4.0")
 class SpyDefinition extends Definition {
 
 	private static final int MULTIPLIER = 31;

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/nestedtests/InheritedNestedTestConfigurationTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/nestedtests/InheritedNestedTestConfigurationTests.java
@@ -27,6 +27,7 @@ import org.springframework.boot.test.context.nestedtests.InheritedNestedTestConf
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
+import org.springframework.test.bean.override.mockito.MockitoBean;
 
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
@@ -41,7 +42,7 @@ import static org.mockito.Mockito.times;
 @Import(ActionPerformer.class)
 class InheritedNestedTestConfigurationTests {
 
-	@MockBean
+	@MockitoBean
 	Action action;
 
 	@Autowired

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataEnvironmentContributorPlaceholdersResolver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataEnvironmentContributorPlaceholdersResolver.java
@@ -51,7 +51,8 @@ class ConfigDataEnvironmentContributorPlaceholdersResolver implements Placeholde
 		this.activeContributor = activeContributor;
 		this.failOnResolveFromInactiveContributor = failOnResolveFromInactiveContributor;
 		this.helper = new PropertyPlaceholderHelper(SystemPropertyUtils.PLACEHOLDER_PREFIX,
-				SystemPropertyUtils.PLACEHOLDER_SUFFIX, SystemPropertyUtils.VALUE_SEPARATOR, true);
+				SystemPropertyUtils.PLACEHOLDER_SUFFIX, SystemPropertyUtils.VALUE_SEPARATOR,
+				SystemPropertyUtils.ESCAPE_CHARACTER, true);
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/PropertySourcesPlaceholdersResolver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/PropertySourcesPlaceholdersResolver.java
@@ -47,8 +47,10 @@ public class PropertySourcesPlaceholdersResolver implements PlaceholdersResolver
 
 	public PropertySourcesPlaceholdersResolver(Iterable<PropertySource<?>> sources, PropertyPlaceholderHelper helper) {
 		this.sources = sources;
-		this.helper = (helper != null) ? helper : new PropertyPlaceholderHelper(SystemPropertyUtils.PLACEHOLDER_PREFIX,
-				SystemPropertyUtils.PLACEHOLDER_SUFFIX, SystemPropertyUtils.VALUE_SEPARATOR, true);
+		this.helper = (helper != null) ? helper
+				: new PropertyPlaceholderHelper(SystemPropertyUtils.PLACEHOLDER_PREFIX,
+						SystemPropertyUtils.PLACEHOLDER_SUFFIX, SystemPropertyUtils.VALUE_SEPARATOR,
+						SystemPropertyUtils.ESCAPE_CHARACTER, true);
 	}
 
 	@Override

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-test/src/test/java/smoketest/test/SampleTestApplicationWebIntegrationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-test/src/test/java/smoketest/test/SampleTestApplicationWebIntegrationTests.java
@@ -26,9 +26,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.bean.override.mockito.MockitoBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -48,7 +48,7 @@ class SampleTestApplicationWebIntegrationTests {
 	@Autowired
 	private TestRestTemplate restTemplate;
 
-	@MockBean
+	@MockitoBean
 	private VehicleDetailsService vehicleDetailsService;
 
 	@BeforeEach

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-test/src/test/java/smoketest/test/web/UserVehicleControllerApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-test/src/test/java/smoketest/test/web/UserVehicleControllerApplicationTests.java
@@ -24,9 +24,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.MediaType;
+import org.springframework.test.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,7 +51,7 @@ class UserVehicleControllerApplicationTests {
 	@Autowired
 	private ApplicationContext applicationContext;
 
-	@MockBean
+	@MockitoBean
 	private UserVehicleService userVehicleService;
 
 	@Test

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-test/src/test/java/smoketest/test/web/UserVehicleControllerHtmlUnitTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-test/src/test/java/smoketest/test/web/UserVehicleControllerHtmlUnitTests.java
@@ -23,7 +23,7 @@ import smoketest.test.service.VehicleDetails;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.bean.override.mockito.MockitoBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -39,7 +39,7 @@ class UserVehicleControllerHtmlUnitTests {
 	@Autowired
 	private WebClient webClient;
 
-	@MockBean
+	@MockitoBean
 	private UserVehicleService userVehicleService;
 
 	@Test

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-test/src/test/java/smoketest/test/web/UserVehicleControllerSeleniumTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-test/src/test/java/smoketest/test/web/UserVehicleControllerSeleniumTests.java
@@ -24,7 +24,7 @@ import smoketest.test.service.VehicleDetails;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.bean.override.mockito.MockitoBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -40,7 +40,7 @@ class UserVehicleControllerSeleniumTests {
 	@Autowired
 	private WebDriver webDriver;
 
-	@MockBean
+	@MockitoBean
 	private UserVehicleService userVehicleService;
 
 	@Test

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-test/src/test/java/smoketest/test/web/UserVehicleControllerTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-test/src/test/java/smoketest/test/web/UserVehicleControllerTests.java
@@ -25,9 +25,9 @@ import smoketest.test.service.VehicleIdentificationNumberNotFoundException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.MediaType;
+import org.springframework.test.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -53,7 +53,7 @@ class UserVehicleControllerTests {
 	@Autowired
 	private ApplicationContext applicationContext;
 
-	@MockBean
+	@MockitoBean
 	private UserVehicleService userVehicleService;
 
 	@Test

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webservices/src/test/java/smoketest/webservices/WebServiceServerTestSampleWsApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webservices/src/test/java/smoketest/webservices/WebServiceServerTestSampleWsApplicationTests.java
@@ -29,9 +29,9 @@ import smoketest.webservices.service.HumanResourceService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.webservices.server.WebServiceServerTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.test.bean.override.mockito.MockitoBean;
 import org.springframework.ws.test.server.MockWebServiceClient;
 import org.springframework.ws.test.server.RequestCreators;
 import org.springframework.ws.test.server.ResponseMatchers;
@@ -48,7 +48,7 @@ import static org.mockito.BDDMockito.then;
 @ExtendWith(OutputCaptureExtension.class)
 class WebServiceServerTestSampleWsApplicationTests {
 
-	@MockBean
+	@MockitoBean
 	HumanResourceService service;
 
 	@Autowired


### PR DESCRIPTION
### Change Summary
- Deprecate Deprecate @MockBean and @SpyBean in favor of Spring Framekworks 6.2.0 @MockitoBean and @MockitoSpy. See https://github.com/spring-projects/spring-framework/commit/e1bbdf09139dca7c21ec64e140bcc3bda463b2f6
- Migrate usages of @MockBean and @SpyBean to @MockitoBean an d @MockitoSpy

### Issue
- https://github.com/spring-projects/spring-boot/issues/39860
