### PR TITLE
Use HtmlUnit release notes link for HtmlUnit 2.x

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1729,7 +1729,7 @@ bom {
 		}
 		links {
 			site("https://github.com/SeleniumHQ/htmlunit-driver")
-			releaseNotes("https://github.com/SeleniumHQ/htmlunit-driver/releases/tag/htmlunit3-driver-{version}")
+			releaseNotes("https://github.com/SeleniumHQ/htmlunit-driver/releases/tag/htmlunit-driver-{version}")
 		}
 	}
 	library("SendGrid", "4.10.2") {


### PR DESCRIPTION
This fixes the links to the release notes of the HtmlUnit integration. Selenium has a `htmlunit-driver`and a `htmlunit3-driver`. The latter is used but Spring Boot still uses HtmlUnit 2.x at the moment.

Because it's sharing the same version, this can be confusing as the current states links to a version of HtmlUnit that Spring Boot does not support yet.