### PR TITLE
Delegate getExecutionContextSerializer() to DefaultBatchConfiguration if not provided

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.ExecutionContextSerializer;
 import org.springframework.batch.core.repository.JobRepository;
-import org.springframework.batch.core.repository.dao.DefaultExecutionContextSerializer;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -118,8 +117,7 @@ public class BatchAutoConfiguration {
 			this.transactionManager = batchTransactionManager.getIfAvailable(() -> transactionManager);
 			this.properties = properties;
 			this.batchConversionServiceCustomizers = batchConversionServiceCustomizers.orderedStream().toList();
-			this.executionContextSerializer = executionContextSerializer
-				.getIfAvailable(DefaultExecutionContextSerializer::new);
+			this.executionContextSerializer = executionContextSerializer.getIfAvailable();
 		}
 
 		@Override
@@ -155,7 +153,8 @@ public class BatchAutoConfiguration {
 
 		@Override
 		protected ExecutionContextSerializer getExecutionContextSerializer() {
-			return this.executionContextSerializer;
+			return (this.executionContextSerializer != null) ? this.executionContextSerializer
+					: super.getExecutionContextSerializer();
 		}
 
 	}


### PR DESCRIPTION
Like other delegations in `SpringBootBatchConfiguration`, it would be better to delegate `getExecutionContextSerializer()` to `DefaultBatchConfiguration` if a custom one is not provided rather than create one based on the current implementation of `DefaultBatchConfiguration.getExecutionContextSerializer()`.

See gh-38328