### PR TITLE
Add public getUndertow method to UndertowWebServer

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowWebServer.java
@@ -298,6 +298,15 @@ public class UndertowWebServer implements WebServer {
 		return ports.get(0).getNumber();
 	}
 
+	/**
+	 * Returns the undertow of the WebServer. Note, the return value will be null until
+	 * the server has been started.
+	 * @return undertow of the WebServer.
+	 */
+	public Undertow getUndertow() {
+		return this.undertow;
+	}
+
 	@Override
 	public void shutDownGracefully(GracefulShutdownCallback callback) {
 		if (this.gracefulShutdown == null) {


### PR DESCRIPTION
### Change Summary
- getUndertow() to UndertowWebServer will be null until the server has been started. Issue #3016 would enable getUndertow() to behave in a similar way to getTomcat() on TomcatWebServer.

### Issue
- https://github.com/spring-projects/spring-boot/issues/39839