### PR TITLE
Add property spring.data.jdbc.dialect

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcDataProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcDataProperties.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.autoconfigure.data.jdbc;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.data.relational.core.dialect.Dialect;
 
 /**
  * Configuration properties for Spring Data JDBC.

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcDataProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcDataProperties.java
@@ -29,7 +29,8 @@ import org.springframework.data.relational.core.dialect.Dialect;
 public class JdbcDataProperties {
 
 	/**
-	 * Dialect to use. By default, the dialect is determined by inspecting the database connection.
+	 * Dialect to use. By default, the dialect is determined by inspecting the database
+	 * connection.
 	 */
 	private JdbcDatabaseDialect dialect;
 
@@ -40,4 +41,5 @@ public class JdbcDataProperties {
 	public void setDialect(JdbcDatabaseDialect dialect) {
 		this.dialect = dialect;
 	}
+
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcDataProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcDataProperties.java
@@ -31,14 +31,13 @@ public class JdbcDataProperties {
 	/**
 	 * Dialect to use. By default, the dialect is determined by inspecting the database connection.
 	 */
-	private Class<? extends Dialect> dialect;
+	private JdbcDatabaseDialect dialect;
 
-	public Class<? extends Dialect> getDialect() {
+	public JdbcDatabaseDialect getDialect() {
 		return this.dialect;
 	}
 
-	public void setDialect(Class<? extends Dialect> dialect) {
+	public void setDialect(JdbcDatabaseDialect dialect) {
 		this.dialect = dialect;
 	}
-
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcDataProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcDataProperties.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.jdbc;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.data.relational.core.dialect.Dialect;
+
+/**
+ * Configuration properties for Spring Data JDBC.
+ *
+ * @author Jens Schauder
+ * @since 3.3
+ */
+@ConfigurationProperties(prefix = "spring.data.jdbc")
+public class JdbcDataProperties {
+
+	/**
+	 * Dialect to use. By default, the dialect is determined by inspecting the database connection.
+	 */
+	private Class<? extends Dialect> dialect;
+
+	public Class<? extends Dialect> getDialect() {
+		return this.dialect;
+	}
+
+	public void setDialect(Class<? extends Dialect> dialect) {
+		this.dialect = dialect;
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcDatabaseDialect.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcDatabaseDialect.java
@@ -22,7 +22,6 @@ import org.springframework.data.jdbc.core.dialect.JdbcDb2Dialect;
 import org.springframework.data.jdbc.core.dialect.JdbcMySqlDialect;
 import org.springframework.data.jdbc.core.dialect.JdbcPostgresDialect;
 import org.springframework.data.jdbc.core.dialect.JdbcSqlServerDialect;
-import org.springframework.data.relational.core.dialect.Db2Dialect;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.dialect.H2Dialect;
 import org.springframework.data.relational.core.dialect.HsqlDbDialect;
@@ -37,36 +36,59 @@ import org.springframework.data.relational.core.dialect.OracleDialect;
  */
 public enum JdbcDatabaseDialect implements Supplier<Dialect> {
 
+	/**
+	 * Provides an instance of {@link JdbcDb2Dialect}.
+	 */
 	DB2 {
 		@Override
 		public Dialect get() {
 			return JdbcDb2Dialect.INSTANCE;
 		}
 	},
+
+	/**
+	 * Provides an instance of {@link H2Dialect}.
+	 */
 	H2 {
 		@Override
 		public Dialect get() {
 			return H2Dialect.INSTANCE;
 		}
 	},
+
+	/**
+	 * Provides an instance of {@link HsqlDbDialect}.
+	 */
 	HSQL {
 		@Override
 		public Dialect get() {
 			return HsqlDbDialect.INSTANCE;
 		}
 	},
+
+	/**
+	 * Provides an instance of {@link MariaDbDialect}.
+	 */
 	MARIA {
 		@Override
 		public Dialect get() {
 			return MariaDbDialect.INSTANCE;
 		}
 	},
+
+	/**
+	 * Provides an instance of {@link JdbcMySqlDialect}.
+	 */
 	MYSQL {
 		@Override
 		public Dialect get() {
 			return JdbcMySqlDialect.INSTANCE;
 		}
 	},
+
+	/**
+	 * Provides an instance of {@link OracleDialect}.
+	 */
 	ORACLE {
 		@Override
 		public Dialect get() {
@@ -74,12 +96,20 @@ public enum JdbcDatabaseDialect implements Supplier<Dialect> {
 
 		}
 	},
+
+	/**
+	 * Provides an instance of {@link JdbcPostgresDialect}.
+	 */
 	POSTGRESQL {
 		@Override
 		public Dialect get() {
 			return JdbcPostgresDialect.INSTANCE;
 		}
 	},
+
+	/**
+	 * Provides an instance of {@link JdbcSqlServerDialect}.
+	 */
 	SQL_SERVER {
 		@Override
 		public Dialect get() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcDatabaseDialect.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcDatabaseDialect.java
@@ -43,47 +43,48 @@ public enum JdbcDatabaseDialect implements Supplier<Dialect> {
 			return JdbcDb2Dialect.INSTANCE;
 		}
 	},
-	H2{
+	H2 {
 		@Override
 		public Dialect get() {
 			return H2Dialect.INSTANCE;
 		}
 	},
-	HSQL{
+	HSQL {
 		@Override
 		public Dialect get() {
 			return HsqlDbDialect.INSTANCE;
 		}
 	},
-	MARIA{
+	MARIA {
 		@Override
 		public Dialect get() {
 			return MariaDbDialect.INSTANCE;
 		}
 	},
-	MYSQL{
+	MYSQL {
 		@Override
 		public Dialect get() {
 			return JdbcMySqlDialect.INSTANCE;
 		}
 	},
-	ORACLE{
+	ORACLE {
 		@Override
 		public Dialect get() {
 			return OracleDialect.INSTANCE;
 
 		}
 	},
-	POSTGRESQL{
+	POSTGRESQL {
 		@Override
 		public Dialect get() {
 			return JdbcPostgresDialect.INSTANCE;
 		}
 	},
-	SQL_SERVER{
+	SQL_SERVER {
 		@Override
 		public Dialect get() {
 			return JdbcSqlServerDialect.INSTANCE;
 		}
 	}
+
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcDatabaseDialect.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcDatabaseDialect.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.data.jdbc;
+
+import java.util.function.Supplier;
+
+import org.springframework.data.jdbc.core.dialect.JdbcDb2Dialect;
+import org.springframework.data.jdbc.core.dialect.JdbcMySqlDialect;
+import org.springframework.data.jdbc.core.dialect.JdbcPostgresDialect;
+import org.springframework.data.jdbc.core.dialect.JdbcSqlServerDialect;
+import org.springframework.data.relational.core.dialect.Db2Dialect;
+import org.springframework.data.relational.core.dialect.Dialect;
+import org.springframework.data.relational.core.dialect.H2Dialect;
+import org.springframework.data.relational.core.dialect.HsqlDbDialect;
+import org.springframework.data.relational.core.dialect.MariaDbDialect;
+import org.springframework.data.relational.core.dialect.OracleDialect;
+
+/**
+ * List of database dialects that can be configured in Boot for use with Spring Data JDBC.
+ *
+ * @author Jens Schauder
+ * @since 3.3
+ */
+public enum JdbcDatabaseDialect implements Supplier<Dialect> {
+
+	DB2 {
+		@Override
+		public Dialect get() {
+			return JdbcDb2Dialect.INSTANCE;
+		}
+	},
+	H2{
+		@Override
+		public Dialect get() {
+			return H2Dialect.INSTANCE;
+		}
+	},
+	HSQL{
+		@Override
+		public Dialect get() {
+			return HsqlDbDialect.INSTANCE;
+		}
+	},
+	MARIA{
+		@Override
+		public Dialect get() {
+			return MariaDbDialect.INSTANCE;
+		}
+	},
+	MYSQL{
+		@Override
+		public Dialect get() {
+			return JdbcMySqlDialect.INSTANCE;
+		}
+	},
+	ORACLE{
+		@Override
+		public Dialect get() {
+			return OracleDialect.INSTANCE;
+
+		}
+	},
+	POSTGRESQL{
+		@Override
+		public Dialect get() {
+			return JdbcPostgresDialect.INSTANCE;
+		}
+	},
+	SQL_SERVER{
+		@Override
+		public Dialect get() {
+			return JdbcSqlServerDialect.INSTANCE;
+		}
+	}
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesAutoConfiguration.java
@@ -16,11 +16,9 @@
 
 package org.springframework.boot.autoconfigure.data.jdbc;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 import java.util.Set;
 
-import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesAutoConfiguration.java
@@ -149,16 +149,9 @@ public class JdbcRepositoriesAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean
 		public Dialect jdbcDialect(NamedParameterJdbcOperations operations) {
-			if (this.properties.getDialect() != null
-			) {
-				Class<?> dialectType = this.properties.getDialect();
-				try {
-					return (Dialect)dialectType.getDeclaredConstructor().newInstance();
-				}
-				catch (InstantiationException | IllegalAccessException |
-					   InvocationTargetException | NoSuchMethodException e) {
-					throw new BeanCreationException("Couldn't create instance of type " + dialectType, e);
-				}
+			JdbcDatabaseDialect dialectEnum = this.properties.getDialect();
+			if (dialectEnum != null) {
+				return dialectEnum.get();
 			}
 			return super.jdbcDialect(operations);
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesAutoConfigurationTests.java
@@ -40,6 +40,7 @@ import org.springframework.data.jdbc.core.JdbcAggregateTemplate;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.jdbc.core.convert.JdbcCustomConversions;
+import org.springframework.data.jdbc.core.dialect.JdbcPostgresDialect;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
@@ -58,6 +59,7 @@ import static org.mockito.Mockito.mock;
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  * @author Mark Paluch
+ * @author Jens Schauder
  */
 class JdbcRepositoriesAutoConfigurationTests {
 
@@ -179,6 +181,18 @@ class JdbcRepositoriesAutoConfigurationTests {
 	@Test
 	void allowsUserToDefineCustomDialect() {
 		allowsUserToDefineCustomBean(DialectConfiguration.class, Dialect.class, "customDialect");
+	}
+
+	@Test
+	void allowsConfigurationOfDialectByProperty() {
+		this.contextRunner.with(database())
+				.withPropertyValues("spring.data.jdbc.dialect:" + JdbcPostgresDialect.class.getName())
+				.withConfiguration(AutoConfigurations.of(JdbcTemplateAutoConfiguration.class,
+						DataSourceTransactionManagerAutoConfiguration.class))
+				.withUserConfiguration(TestConfiguration.class)
+				.run((context) -> {
+					assertThat(context).hasSingleBean(JdbcPostgresDialect.class);
+				});
 	}
 
 	private void allowsUserToDefineCustomBean(Class<?> configuration, Class<?> beanType, String beanName) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesAutoConfigurationTests.java
@@ -186,13 +186,13 @@ class JdbcRepositoriesAutoConfigurationTests {
 	@Test
 	void allowsConfigurationOfDialectByProperty() {
 		this.contextRunner.with(database())
-				.withPropertyValues("spring.data.jdbc.dialect=postgresql" )
-				.withConfiguration(AutoConfigurations.of(JdbcTemplateAutoConfiguration.class,
-						DataSourceTransactionManagerAutoConfiguration.class))
-				.withUserConfiguration(TestConfiguration.class)
-				.run((context) -> {
-					assertThat(context).hasSingleBean(JdbcPostgresDialect.class);
-				});
+			.withPropertyValues("spring.data.jdbc.dialect=postgresql")
+			.withConfiguration(AutoConfigurations.of(JdbcTemplateAutoConfiguration.class,
+					DataSourceTransactionManagerAutoConfiguration.class))
+			.withUserConfiguration(TestConfiguration.class)
+			.run((context) -> {
+				assertThat(context).hasSingleBean(JdbcPostgresDialect.class);
+			});
 	}
 
 	private void allowsUserToDefineCustomBean(Class<?> configuration, Class<?> beanType, String beanName) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesAutoConfigurationTests.java
@@ -186,7 +186,7 @@ class JdbcRepositoriesAutoConfigurationTests {
 	@Test
 	void allowsConfigurationOfDialectByProperty() {
 		this.contextRunner.with(database())
-				.withPropertyValues("spring.data.jdbc.dialect:" + JdbcPostgresDialect.class.getName())
+				.withPropertyValues("spring.data.jdbc.dialect=postgresql" )
 				.withConfiguration(AutoConfigurations.of(JdbcTemplateAutoConfiguration.class,
 						DataSourceTransactionManagerAutoConfiguration.class))
 				.withUserConfiguration(TestConfiguration.class)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/jdbc/JdbcRepositoriesAutoConfigurationTests.java
@@ -190,9 +190,7 @@ class JdbcRepositoriesAutoConfigurationTests {
 			.withConfiguration(AutoConfigurations.of(JdbcTemplateAutoConfiguration.class,
 					DataSourceTransactionManagerAutoConfiguration.class))
 			.withUserConfiguration(TestConfiguration.class)
-			.run((context) -> {
-				assertThat(context).hasSingleBean(JdbcPostgresDialect.class);
-			});
+			.run((context) -> assertThat(context).hasSingleBean(JdbcPostgresDialect.class));
 	}
 
 	private void allowsUserToDefineCustomBean(Class<?> configuration, Class<?> beanType, String beanName) {


### PR DESCRIPTION
The class valued property allows to configure a dialect to use for Spring Data JDBC, without relying on a database connection to determine it.

This is useful especially for CDS.
