### PR TITLE
Delay interaction with Lazy CqlSession bean until first required usage

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraDataAutoConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.domain.EntityScanPackages;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
 import org.springframework.data.cassandra.CassandraManagedTypes;
 import org.springframework.data.cassandra.SessionFactory;
@@ -54,6 +55,7 @@ import org.springframework.data.cassandra.core.mapping.SimpleUserTypeResolver;
  * @author Eddú Meléndez
  * @author Mark Paluch
  * @author Madhura Bhave
+ * @author Christoph Strobl
  * @since 1.3.0
  */
 @AutoConfiguration(after = CassandraAutoConfiguration.class)
@@ -63,7 +65,7 @@ public class CassandraDataAutoConfiguration {
 
 	private final CqlSession session;
 
-	public CassandraDataAutoConfiguration(CqlSession session) {
+	public CassandraDataAutoConfiguration(@Lazy CqlSession session) {
 		this.session = session;
 	}
 
@@ -95,7 +97,7 @@ public class CassandraDataAutoConfiguration {
 	public CassandraConverter cassandraConverter(CassandraMappingContext mapping,
 			CassandraCustomConversions conversions) {
 		MappingCassandraConverter converter = new MappingCassandraConverter(mapping);
-		converter.setCodecRegistry(this.session.getContext().getCodecRegistry());
+		converter.setCodecRegistry(() -> this.session.getContext().getCodecRegistry());
 		converter.setCustomConversions(conversions);
 		converter.setUserTypeResolver(new SimpleUserTypeResolver(this.session));
 		return converter;


### PR DESCRIPTION
Though the `CqlSession` provided by the `CassandraAutoConfiguration` can be lazy, the configuration for data-cassandra triggers early bean instantiation. 
This PR uses changed API in the data-cassandra project to make use of the intended lazy bean initialization and therefore prevents the application from failing already at startup when cassandra might not (yet) be ready.

Requires: Upgrade to `spring-data:2024.0.0-RC1`
Depends on: spring-projects/spring-data-cassandra#1485 

