### PR TITLE
Upgrade to MongoDB 5.0

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveAutoConfiguration.java
@@ -129,10 +129,8 @@ public class MongoReactiveAutoConfiguration {
 			}
 		}
 
-		@SuppressWarnings("deprecation")
 		private boolean isCustomTransportConfiguration(MongoClientSettings settings) {
-			return settings != null
-					&& (settings.getTransportSettings() != null || settings.getStreamFactoryFactory() != null);
+			return settings != null && settings.getTransportSettings() != null;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoReactiveAutoConfigurationTests.java
@@ -230,7 +230,6 @@ class MongoReactiveAutoConfigurationTests {
 				assertThat(settings.getApplicationName()).isEqualTo("custom-transport-settings");
 				assertThat(settings.getTransportSettings())
 					.isSameAs(SimpleTransportSettingsCustomizerConfig.transportSettings);
-				assertThat(settings.getStreamFactoryFactory()).isNull();
 			});
 	}
 

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1291,7 +1291,7 @@ bom {
 			releaseNotes("https://github.com/mockito/mockito/releases/tag/v{version}")
 		}
 	}
-	library("MongoDB", "4.11.1") {
+	library("MongoDB", "5.0.0") {
 		group("org.mongodb") {
 			modules = [
 				"bson",


### PR DESCRIPTION
The MongoDB 5.0 Java Driver ships with previously deprecated API now removed (mongodb/mongo-java-driver#1268). To allow users to downgrade if needed, calls to those parts of the driver need to be done reflectively.

Related to: spring-projects/spring-data-mongodb#4663 
