### PR TITLE
Use activemq-client dependency vs transitional activemq-client-jakarta

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -79,7 +79,7 @@ dependencies {
 	optional("jakarta.persistence:jakarta.persistence-api")
 	optional("jakarta.servlet:jakarta.servlet-api")
 	optional("javax.cache:cache-api")
-	optional("org.apache.activemq:activemq-client-jakarta")
+	optional("org.apache.activemq:activemq-client")
 	optional("org.apache.commons:commons-dbcp2") {
 		exclude group: "commons-logging", module: "commons-logging"
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-autoconfigure/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 	optional("jakarta.ws.rs:jakarta.ws.rs-api")
 	optional("javax.cache:cache-api")
 	optional("javax.money:money-api")
-	optional("org.apache.activemq:activemq-client-jakarta")
+	optional("org.apache.activemq:activemq-client")
 	optional("org.apache.activemq:artemis-jakarta-client") {
 		exclude group: "commons-logging", module: "commons-logging"
 	}

--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-activemq/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-activemq/build.gradle
@@ -7,5 +7,5 @@ description = "Starter for JMS messaging using Apache ActiveMQ"
 dependencies {
 	api(project(":spring-boot-project:spring-boot-starters:spring-boot-starter"))
 	api("org.springframework:spring-jms")
-	api("org.apache.activemq:activemq-client-jakarta")
+	api("org.apache.activemq:activemq-client")
 }

--- a/spring-boot-project/spring-boot-testcontainers/build.gradle
+++ b/spring-boot-project/spring-boot-testcontainers/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 	testImplementation("io.rest-assured:rest-assured") {
 		exclude group: "commons-logging", module: "commons-logging"
 	}
-	testImplementation("org.apache.activemq:activemq-client-jakarta")
+	testImplementation("org.apache.activemq:activemq-client")
 	testImplementation("org.apache.activemq:artemis-jakarta-client")  {
 		exclude group: "commons-logging", module: "commons-logging"
 	}


### PR DESCRIPTION
Use the activemq-client dependency per: #40027 

Ahead of adding embedded broker support in as part of [#38404]
