### PR TITLE
BindValidationFailureAnalyzer uses wrong target

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/BindValidationFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/BindValidationFailureAnalyzer.java
@@ -47,9 +47,9 @@ class BindValidationFailureAnalyzer extends AbstractFailureAnalyzer<Throwable> {
 	private ExceptionDetails getBindValidationExceptionDetails(Throwable rootFailure) {
 		BindValidationException validationException = findCause(rootFailure, BindValidationException.class);
 		if (validationException != null) {
-			BindException target = findCause(rootFailure, BindException.class);
+			BindException bindException = findCause(rootFailure, BindException.class);
 			List<ObjectError> errors = validationException.getValidationErrors().getAllErrors();
-			return new ExceptionDetails(errors, target, validationException);
+			return new ExceptionDetails(errors, bindException.getTarget().getType(), validationException);
 		}
 		org.springframework.validation.BindException bindException = findCause(rootFailure,
 				org.springframework.validation.BindException.class);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BindValidationFailureAnalyzerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/diagnostics/analyzer/BindValidationFailureAnalyzerTests.java
@@ -63,9 +63,11 @@ class BindValidationFailureAnalyzerTests {
 	@Test
 	void bindExceptionWithFieldErrorsDueToValidationFailure() {
 		FailureAnalysis analysis = performAnalysis(FieldValidationFailureConfiguration.class);
-		assertThat(analysis.getDescription()).contains(failure("test.foo.foo", "null", "must not be null"));
-		assertThat(analysis.getDescription()).contains(failure("test.foo.value", "0", "at least five"));
-		assertThat(analysis.getDescription()).contains(failure("test.foo.nested.bar", "null", "must not be null"));
+		assertThat(analysis.getDescription()).contains(failure("test.foo.foo", "null", "must not be null"))
+			.contains(failure("test.foo.value", "0", "at least five"))
+			.contains(failure("test.foo.nested.bar", "null", "must not be null"))
+			.contains(
+					"Binding to target org.springframework.boot.diagnostics.analyzer.BindValidationFailureAnalyzerTests$FieldValidationFailureProperties failed:");
 	}
 
 	@Test


### PR DESCRIPTION
This PR fixes target in `BindValidationFailureAnalyzer.getBindValidationExceptionDetails()` as it seems to be using `BindException` accidentally.

For example, the following output is included in https://github.com/spring-projects/spring-boot/issues/39234#issuecomment-1898725399.

```
Binding to target org.springframework.boot.context.properties.bind.BindException: Failed to bind properties under 'client' to com.example.demo.ClientProperties failed:
```