### PR TITLE
Fix forward-headers-strategy documentation regarding cloud defaults

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/webserver.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/webserver.adoc
@@ -438,7 +438,7 @@ You can use them in your application by setting configprop:server.forward-header
 TIP: If you are using Tomcat and terminating SSL at the proxy, configprop:server.tomcat.redirect-context-root[] should be set to `false`.
 This allows the `X-Forwarded-Proto` header to be honored before any redirects are performed.
 
-NOTE: If your application runs in Cloud Foundry, Heroku or Kubernetes, the configprop:server.forward-headers-strategy[] property defaults to `NATIVE`.
+NOTE: If your application runs https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/cloud/CloudPlatform.html#enum-constant-summary[in a supported Cloud Platform], the configprop:server.forward-headers-strategy[] property defaults to `NATIVE`.
 In all other instances, it defaults to `NONE`.
 
 


### PR DESCRIPTION
forward-headers-strategy=NATIVE is actually used on all cloud platforms: https://github.com/spring-projects/spring-boot/blob/3abf43bb11edd7fdc7f0b35d7773aa32bb291505/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java#L219-L221

This PR adjusts for that. I didn't know how to correctly specify what are exactly those supported Cloud Platforms, though. I'm linking it to API docs, hopefully that's OK.