### PR TITLE
spring-boot-dependencies should not manage org.flywaydb:flyway-community-db-support as it is not released as part of Flyway

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -389,7 +389,6 @@ bom {
 		group("org.flywaydb") {
 			modules = [
 				"flyway-commandline",
-				"flyway-community-db-support",
 				"flyway-core",
 				"flyway-database-db2",
 				"flyway-database-derby",


### PR DESCRIPTION
`org.flywaydb:flyway-community-db-support` is not provided anymore as part of the flyway release. Now, it is an independent project and the version is not aligned with flyway-core. See https://github.com/flyway/flyway-community-db-support

Also, see https://github.com/flyway/flyway-community-db-support/issues/33