### PR TITLE
Add reference to Nostr Spring Boot Starter

### DIFF
--- a/spring-boot-project/spring-boot-starters/README.adoc
+++ b/spring-boot-project/spring-boot-starters/README.adoc
@@ -176,6 +176,9 @@ do as they were designed before this was clarified.
 | https://developer.nexmo.com/[Nexmo]
 | https://github.com/nexmo/nexmo-spring-boot-starter
 
+| https://github.com/nostr-protocol/nostr[Nostr]
+| https://github.com/theborakompanioni/nostr-spring-boot-starter
+
 | https://github.com/nutzam/nutz[Nutz]
 | https://github.com/nutzam/nutzmore
 


### PR DESCRIPTION
Add reference to Nostr Spring Boot Starter to `spring-boot-project/spring-boot-starters/README.adoc`

Nostr: https://github.com/nostr-protocol/nostr
nostr-spring-boot-starter: https://github.com/theborakompanioni/nostr-spring-boot-starter
