### PR TITLE
PropertiesLdapConnectionDetails should not be public

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/PropertiesLdapConnectionDetails.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ldap/PropertiesLdapConnectionDetails.java
@@ -22,9 +22,8 @@ import org.springframework.core.env.Environment;
  * Adapts {@link LdapProperties} to {@link LdapConnectionDetails}.
  *
  * @author Philipp Kessler
- * @since 3.3.0
  */
-public class PropertiesLdapConnectionDetails implements LdapConnectionDetails {
+class PropertiesLdapConnectionDetails implements LdapConnectionDetails {
 
 	private final LdapProperties properties;
 


### PR DESCRIPTION
This PR changes to make the `PropertiesLdapConnectionDetails` package-private as given that the other `Properties...ConnectionDetails` classes except the `PropertiesMongoConnectionDetails` are package-private, it appears to be accidental.

I didn't change the `PropertiesMongoConnectionDetails` as it's already been technically `public` on releases.