### PR TITLE
Add new ConditionalOnAnnotation for conditional bean loading

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotation.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotation.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.condition;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Conditional;
+
+/**
+ * {@link Conditional @Conditional} that only matches when the specified annotation is
+ * present on the classpath. This conditional annotation allows for configuration beans to
+ * be conditionally registered based on the presence of custom annotations.
+ *
+ * <p>
+ * The conditional annotation is particularly useful when you want to enable a certain
+ * configuration only if a specific custom annotation is declared anywhere within the
+ * application codebase. For example, you could activate certain auto-configuration beans
+ * if a custom {@code @EnableFeatureX} annotation is present on any of the configuration
+ * classes.
+ *
+ * <p>
+ * The annotated class will only be parsed and the bean will be registered if the
+ * annotation represented by {@code value()} is present and has a {@link RetentionPolicy}
+ * of {@link RetentionPolicy#RUNTIME}. If the annotation is not present or does not have a
+ * RUNTIME retention policy, the bean will not be registered.
+ *
+ * <p>
+ * Usage example: <pre class="code">
+ * &#64;Configuration
+ * &#64;ConditionalOnAnnotation(EnableFeatureX.class)
+ * public class FeatureXConfiguration {
+ *     // Bean definitions
+ * }
+ * </pre>
+ *
+ * <p>
+ * In the example above, {@code FeatureXConfiguration} will only be registered if
+ * {@code EnableFeatureX} annotation is available at runtime on any class in the
+ * application.
+ *
+ * @author Feng, Liu
+ * @since 3.4.0
+ * @see Conditional
+ * @see ConditionalOnExpression
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Documented
+@Conditional(OnAnnotationCondition.class)
+public @interface ConditionalOnAnnotation {
+
+	/**
+	 * The annotation that must be present in order for the condition to match. The
+	 * condition does not match if this annotation is not present or does not have a
+	 * RUNTIME retention policy.
+	 * @return the annotation class that must be present
+	 */
+	Class<? extends Annotation> value();
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnAnnotationCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnAnnotationCondition.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.condition;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * {@link Condition} that checks for a required {@link Annotation}.
+ *
+ * @author Feng, Liu
+ */
+public class OnAnnotationCondition extends SpringBootCondition {
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		Map<String, Object> attributes = metadata.getAnnotationAttributes(ConditionalOnAnnotation.class.getName());
+		var annotationType = (Class<? extends Annotation>) attributes.get("value");
+		return getMatchOutcome(context, annotationType);
+	}
+
+	private ConditionOutcome getMatchOutcome(ConditionContext context, Class<? extends Annotation> annotationType) {
+		ConditionMessage.Builder message = ConditionMessage.forCondition(ConditionalOnAnnotation.class);
+		if (annotationType == null) {
+			return ConditionOutcome.noMatch(message.didNotFind(annotationType.getName()).atAll());
+		}
+		var result = Arrays.stream(Objects.requireNonNull(context.getBeanFactory()).getBeanDefinitionNames())
+			.map(beanName -> context.getBeanFactory().getType(beanName))
+			.filter(Objects::nonNull)
+			.anyMatch(clazz -> clazz.isAnnotationPresent(annotationType));
+		if (result) {
+			return ConditionOutcome.match(message.foundExactly(annotationType.getName()));
+		}
+		return ConditionOutcome.noMatch(message.didNotFind(annotationType.getName()).atAll());
+	}
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnAnnotationTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.condition;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+import org.springframework.boot.autoconfigure.thread.Threading;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConditionalOnAnnotation}.
+ *
+ * @author Liu Feng
+ */
+class ConditionalOnAnnotationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
+
+	@Test
+	@EnabledForJreRange(max = JRE.JAVA_20)
+	void platformThreadsOnJdkBelow21IfVirtualThreadsPropertyIsEnabled() {
+		this.contextRunner.withUserConfiguration(OnConfigurationWithoutTestAnnotation.class, BasicConfiguration.class)
+			.run((context) -> assertThat(context).doesNotHaveBean(LOADED_BEAN));
+		this.contextRunner.withUserConfiguration(OnConfigurationWithTestAnnotation.class, BasicConfiguration.class)
+			.run((context) -> assertThat(context).hasBean(LOADED_BEAN));
+	}
+
+	static final String LOADED_BEAN = "loaded_bean";
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnAnnotation(TestConditionalOnAnnotation.class)
+	static class BasicConfiguration {
+
+		@Bean(LOADED_BEAN)
+		String loadWithAnnotation() {
+			return LOADED_BEAN;
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@TestConditionalOnAnnotation
+	static class OnConfigurationWithTestAnnotation {
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class OnConfigurationWithoutTestAnnotation {
+
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface TestConditionalOnAnnotation {
+
+	}
+
+}


### PR DESCRIPTION
This commit introduces the ConditionalOnAnnotation, a custom conditional annotation that enables bean registration based on the presence of a specified annotation with RUNTIME retention. It ensures beans are only loaded when the annotated class or method is marked with a user-defined annotation, facilitating feature toggling and modular configuration.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
