### PR TITLE
Do not use okhttp client

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/ClientHttpRequestFactories.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/client/ClientHttpRequestFactories.java
@@ -32,6 +32,8 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
 import okhttp3.OkHttpClient;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
@@ -80,6 +82,8 @@ public final class ClientHttpRequestFactories {
 
 	private static final boolean JETTY_CLIENT_PRESENT = ClassUtils.isPresent(JETTY_CLIENT_CLASS, null);
 
+	private static final Log logger = LogFactory.getLog(ClientHttpRequestFactories.class);
+
 	private ClientHttpRequestFactories() {
 	}
 
@@ -106,7 +110,7 @@ public final class ClientHttpRequestFactories {
 			return Jetty.get(settings);
 		}
 		if (OKHTTP_CLIENT_PRESENT) {
-			return OkHttp.get(settings);
+			logger.warn("OkHttpClient is deprecated in Spring Boot 3.2.0. Spring Boot chooses the default client.");
 		}
 		return Simple.get(settings);
 	}
@@ -150,7 +154,7 @@ public final class ClientHttpRequestFactories {
 			return (T) Simple.get(settings);
 		}
 		if (requestFactoryType == OkHttp3ClientHttpRequestFactory.class) {
-			return (T) OkHttp.get(settings);
+			logger.warn("OkHttpClient is deprecated in Spring Boot 3.2.0. Spring Boot chooses the default client.");
 		}
 		return get(() -> createRequestFactory(requestFactoryType), settings);
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/ClientHttpRequestFactoriesOkHttp3Tests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/ClientHttpRequestFactoriesOkHttp3Tests.java
@@ -19,6 +19,7 @@ package org.springframework.boot.web.client;
 import java.io.File;
 
 import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
@@ -34,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Andy Wilkinson
  */
+@Disabled
 @ClassPathOverrides("com.squareup.okhttp3:okhttp:3.14.9")
 @ClassPathExclusions({ "httpclient5-*.jar", "jetty-client-*.jar" })
 @Deprecated(since = "3.2.0")

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/ClientHttpRequestFactoriesOkHttp4Tests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/client/ClientHttpRequestFactoriesOkHttp4Tests.java
@@ -19,6 +19,7 @@ package org.springframework.boot.web.client;
 import java.io.File;
 
 import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
@@ -33,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Andy Wilkinson
  */
+@Disabled
 @ClassPathExclusions({ "httpclient5-*.jar", "jetty-client-*.jar" })
 @Deprecated(since = "3.2.0")
 @SuppressWarnings("removal")


### PR DESCRIPTION
In my project, Okhttp exists in the classpath. 
Therefore, when initializing RestTemplate, OkHttp is selected from ClientHttpRequestFactories.
However, starting from Spring 6.1, this client has been deprecated and _does not work_.

So I have to declare the requestFactory like code below.

```kotlin
        return RestTemplateBuilder()
            .requestFactory { _ -> SimpleClientHttpRequestFactory() }
```

But since Spring 6.2, OkHttpClient will be removed.
Therefore, there is no need to declare a requestFactory as the default client is chosen automatically.

So, it would be nice if there was no need to declare requestFactory even in spring 6.1.x version.