### PR TITLE
Avoid use of bean overriding in tests

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/RemoteDevToolsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/RemoteDevToolsAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,6 @@ import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.boot.web.servlet.context.AnnotationConfigServletWebApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.mock.web.MockFilterChain;
@@ -241,14 +240,14 @@ class RemoteDevToolsAutoConfigurationTests {
 	private AnnotationConfigServletWebApplicationContext loadContext(String... properties) {
 		AnnotationConfigServletWebApplicationContext context = new AnnotationConfigServletWebApplicationContext();
 		context.setServletContext(new MockServletContext());
-		context.register(Config.class, PropertyPlaceholderAutoConfiguration.class);
+		context.register(Config.class, SecurityAutoConfiguration.class, RemoteDevToolsAutoConfiguration.class,
+				PropertyPlaceholderAutoConfiguration.class);
 		TestPropertyValues.of(properties).applyTo(context);
 		context.refresh();
 		return context;
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@Import({ SecurityAutoConfiguration.class, RemoteDevToolsAutoConfiguration.class })
 	static class Config {
 
 		@Bean

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesBeanRegistrationAotProcessorTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesBeanRegistrationAotProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,7 +117,7 @@ class ConfigurationPropertiesBeanRegistrationAotProcessorTests {
 	@Test
 	@CompileWithForkedClassLoader
 	void aotContributedInitializerBindsJavaBean() {
-		compile(createContext(JavaBeanSampleBeanConfiguration.class), (freshContext) -> {
+		compile(createContext(), (freshContext) -> {
 			TestPropertySourceUtils.addInlinedPropertiesToEnvironment(freshContext, "test.name=Hello");
 			freshContext.refresh();
 			JavaBeanSampleBean bean = freshContext.getBean(JavaBeanSampleBean.class);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
@@ -261,7 +261,7 @@ class ConfigurationPropertiesTests {
 	@Test
 	void loadWhenBindingWithDefaultsInXmlShouldBind() {
 		removeSystemProperties();
-		load(new Class<?>[] { BasicConfiguration.class, DefaultsInXmlConfiguration.class });
+		load(new Class<?>[] { DefaultsInXmlConfiguration.class });
 		BasicProperties bean = this.context.getBean(BasicProperties.class);
 		assertThat(bean.name).isEqualTo("bar");
 	}
@@ -1354,6 +1354,7 @@ class ConfigurationPropertiesTests {
 	}
 
 	@Configuration(proxyBeanMethods = false)
+	@EnableConfigurationProperties
 	@ImportResource("org/springframework/boot/context/properties/testProperties.xml")
 	static class DefaultsInXmlConfiguration {
 


### PR DESCRIPTION
While working on https://github.com/spring-projects/spring-framework/issues/31288, I wanted to get a feeling of how disruptive the change was going to be.

I've noticed a number of legitimate use cases and some that simply look an oversight. It's not the full list but here's a few for a start.