### PR TITLE
Fixed the hyperlink of Reference Guides breadcrumb in page headers

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/index.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/index.adoc
@@ -1,0 +1,3 @@
+= Reference Guides
+
+This section provides Reference Guides to help you get started using Spring Boot.

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/partials/nav-reference.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/partials/nav-reference.adoc
@@ -1,5 +1,4 @@
-* Reference Guides
-
+* xref:reference:index.adoc[]
 ** xref:reference:using/index.adoc[]
 *** xref:reference:using/build-systems.adoc[]
 *** xref:reference:using/structuring-your-code.adoc[]


### PR DESCRIPTION
Fixed the hyperlink of Reference Guides breadcrumb in page headers

This is a fix for https://github.com/spring-projects/spring-boot/issues/40123

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
