### PR TITLE
Links to Spring Batch javadoc for EnableBatchProcessing and DefaultBatchConfiguration are broken

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1821,7 +1821,7 @@ bom {
 		links {
 			site("https://spring.io/projects/spring-batch")
 			github("https://github.com/spring-projects/spring-batch")
-			javadoc("https://docs.spring.io/spring-batch/docs/{version}/api/org/springframework/batch")
+			javadoc("https://docs.spring.io/spring-batch/docs/{version}/api")
 			docs { version -> "https://docs.spring.io/spring-batch/reference/%s"
 				.formatted(version.forAntora()) }
 			releaseNotes("https://github.com/spring-projects/spring-batch/releases/tag/v{version}")

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1821,7 +1821,7 @@ bom {
 		links {
 			site("https://spring.io/projects/spring-batch")
 			github("https://github.com/spring-projects/spring-batch")
-			javadoc("https://docs.spring.io/spring-batch/docs/{version}/api")
+			javadoc("https://docs.spring.io/spring-batch/docs/{version}/api/org/springframework/batch")
 			docs { version -> "https://docs.spring.io/spring-batch/reference/%s"
 				.formatted(version.forAntora()) }
 			releaseNotes("https://github.com/spring-projects/spring-batch/releases/tag/v{version}")

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/batch.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/batch.adoc
@@ -14,8 +14,8 @@ Spring Batch expects a single `DataSource` by default.
 To have it use a `DataSource` other than the application’s main `DataSource`, declare a `DataSource` bean, annotating its `@Bean` method with `@BatchDataSource`.
 If you do so and want two data sources, remember to mark the other one `@Primary`.
 To take greater control, add `@EnableBatchProcessing` to one of your `@Configuration` classes or extend `DefaultBatchConfiguration`.
-See the Javadoc of {url-spring-batch-javadoc}/core/configuration/annotation/EnableBatchProcessing.html[`@EnableBatchProcessing`]
-and {url-spring-batch-javadoc}/core/configuration/support/DefaultBatchConfiguration.html[`DefaultBatchConfiguration`] for more details.
+See the Javadoc of {url-spring-batch-javadoc}/org/springframework/batch/core/configuration/annotation/EnableBatchProcessing.html[`@EnableBatchProcessing`]
+and {url-spring-batch-javadoc}/org/springframework/batch/core/configuration/support/DefaultBatchConfiguration.html[`DefaultBatchConfiguration`] for more details.
 
 For more info about Spring Batch, see the {url-spring-batch-site}[Spring Batch project page].
 


### PR DESCRIPTION
Fixed broken API links in batch.adoc

This is a fix for https://github.com/spring-projects/spring-boot/issues/40039

In main branch I found /api/ is there but `/org/springframework/batch` is missing. Check:
https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-dependencies/build.gradle#L1824

So the broken URL was like: https://docs.spring.io/spring-batch/docs/5.1.1/api/core/configuration/annotation/EnableBatchProcessing.html

This PR fixed the issue in main branch, I tested locally. Thanks


<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
