### PR TITLE
Log with Current ClassLoader

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
@@ -480,7 +480,8 @@ public class Log4J2LoggingSystem extends AbstractLoggingSystem {
 	}
 
 	private LoggerContext getLoggerContext() {
-		return (LoggerContext) LogManager.getContext(false);
+		return (LoggerContext) LogManager.getContext(Thread.currentThread().getContextClassLoader(),
+				false);
 	}
 
 	private boolean isAlreadyInitialized(LoggerContext loggerContext) {


### PR DESCRIPTION
In [koupleless](https://github.com/koupleless/koupleless), multiple spring boot applications run together in a single JVM, and these applications are isolated by different class loaders. 

In order to allow different spring boot applications to print logs according to their own configurations when application running, two issues need to be addressed:

1. Put the application's configuration into thread context, so that the application can read the log configuration from the current thread when it starts.
2. The spring boot applications use the LoggerContext corresponding to the current thread context's classloader.

I'm not sure if this is the best solution. If possible, I hope we can have more discussion.

