### PR TITLE
Clarify requirements for -parameters and constructor binding

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/features/external-config.adoc
@@ -742,7 +742,7 @@ include::code:nonnull/MyProperties[tag=*]
 NOTE: To use constructor binding the class must be enabled using `@EnableConfigurationProperties` or configuration property scanning.
 You cannot use constructor binding with beans that are created by the regular Spring mechanisms (for example `@Component` beans, beans created by using `@Bean` methods or beans loaded by using `@Import`)
 
-NOTE: To use constructor binding in a native image the class must be compiled with `-parameters`.
+NOTE: To use constructor binding the class must be compiled with `-parameters`.
 This will happen automatically if you use Spring Boot's Gradle plugin or if you use Maven and `spring-boot-starter-parent`.
 
 NOTE: The use of `java.util.Optional` with `@ConfigurationProperties` is not recommended as it is primarily intended for use as a return type.


### PR DESCRIPTION
This commit adapts an outdated note regarding `-parameters` and constructor binding. It is no longer specific to native image now that parameters resolution has been harmonized to require the use of `-parameters` on the JVM as well.