### PR TITLE
Use List.of() for immutable field azureEnvVariables instead of Arrays.asList()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
@@ -154,7 +154,7 @@ public enum CloudPlatform {
 	 */
 	AZURE_APP_SERVICE {
 
-		private final List<String> azureEnvVariables = Arrays.asList("WEBSITE_SITE_NAME", "WEBSITE_INSTANCE_ID",
+		private final List<String> azureEnvVariables = List.of("WEBSITE_SITE_NAME", "WEBSITE_INSTANCE_ID",
 				"WEBSITE_RESOURCE_GROUP", "WEBSITE_SKU");
 
 		@Override


### PR DESCRIPTION
The Arrays.asList method creates a List based on variable arguments, which can lead to heap pollution.
azureEnvVariables is an immutable field, so it has been improved to utilize Immutable List.