### PR TITLE
Add Spring Pulsar transaction support

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarProperties.java
@@ -103,6 +103,14 @@ public class PulsarProperties {
 		return this.template;
 	}
 
+	/**
+	 * Whether transactions are enabled for either the template or the listener.
+	 * @return whether transactions are enabled for either the template or the listener
+	 */
+	public boolean isTransactionEnabled() {
+		return this.template.getTransaction().isEnabled() || this.listener.getTransaction().isEnabled();
+	}
+
 	public static class Client {
 
 		/**
@@ -763,6 +771,11 @@ public class PulsarProperties {
 		 */
 		private boolean observationEnabled;
 
+		/**
+		 * Transaction settings.
+		 */
+		private final Transaction transaction = new Transaction();
+
 		public SchemaType getSchemaType() {
 			return this.schemaType;
 		}
@@ -777,6 +790,10 @@ public class PulsarProperties {
 
 		public void setObservationEnabled(boolean observationEnabled) {
 			this.observationEnabled = observationEnabled;
+		}
+
+		public Transaction getTransaction() {
+			return this.transaction;
 		}
 
 	}
@@ -858,12 +875,65 @@ public class PulsarProperties {
 		 */
 		private boolean observationsEnabled;
 
+		/**
+		 * Transaction settings.
+		 */
+		private final Transaction transaction = new Transaction();
+
 		public boolean isObservationsEnabled() {
 			return this.observationsEnabled;
 		}
 
 		public void setObservationsEnabled(boolean observationsEnabled) {
 			this.observationsEnabled = observationsEnabled;
+		}
+
+		public Transaction getTransaction() {
+			return this.transaction;
+		}
+
+	}
+
+	public static class Transaction {
+
+		/**
+		 * Whether the component supports transactions.
+		 */
+		private boolean enabled;
+
+		/**
+		 * Whether the component requires transactions.
+		 */
+		private boolean required;
+
+		/**
+		 * Duration representing the transaction timeout - null to use default timeout of
+		 * the underlying transaction system, or none if timeouts are not supported.
+		 */
+		private Duration timeout;
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public boolean isRequired() {
+			return this.required;
+		}
+
+		public void setRequired(boolean required) {
+			this.required = required;
+		}
+
+		public Duration getTimeout() {
+			return this.timeout;
+		}
+
+		public void setTimeout(Duration timeout) {
+			this.timeout = timeout;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
@@ -163,6 +163,7 @@ final class PulsarPropertiesMapper {
 
 	<T> void customizeTemplate(PulsarTemplate<T> template) {
 		PulsarProperties.Transaction properties = this.properties.getTemplate().getTransaction();
+		properties.validate();
 		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		map.from(properties::isEnabled).to(template.transactions()::setEnabled);
 		map.from(properties::isRequired).to(template.transactions()::setRequired);
@@ -213,6 +214,7 @@ final class PulsarPropertiesMapper {
 
 	private void customizePulsarContainerTransactionProperties(PulsarContainerProperties containerProperties) {
 		PulsarProperties.Transaction properties = this.properties.getListener().getTransaction();
+		properties.validate();
 		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		map.from(properties::isEnabled).to(containerProperties.transactions()::setEnabled);
 		map.from(properties::isRequired).to(containerProperties.transactions()::setRequired);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
@@ -65,8 +65,7 @@ final class PulsarPropertiesMapper {
 		map.from(properties::getConnectionTimeout).to(timeoutProperty(clientBuilder::connectionTimeout));
 		map.from(properties::getOperationTimeout).to(timeoutProperty(clientBuilder::operationTimeout));
 		map.from(properties::getLookupTimeout).to(timeoutProperty(clientBuilder::lookupTimeout));
-		if (this.properties.getTemplate().getTransaction().isEnabled()
-				|| this.properties.getListener().getTransaction().isEnabled()) {
+		if (this.properties.isTransactionEnabled()) {
 			clientBuilder.enableTransaction(true);
 		}
 		customizeAuthentication(properties.getAuthentication(), clientBuilder::authentication);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfigurationTests.java
@@ -673,7 +673,10 @@ class PulsarAutoConfigurationTests {
 				.run((context) -> assertThat(context).hasFailed()
 					.getFailure()
 					.hasMessageEndingWith(
-							"If transactions are required they must also be enabled - consult your 'spring.pulsar.template.transaction' properties."));
+							"Property spring.pulsar.template.transaction.required with value 'true' is invalid: "
+									+ "Transactions must be enabled in order to be required. Either set "
+									+ "spring.pulsar.template.transaction.enabled to 'true' or make transactions "
+									+ "optional by setting spring.pulsar.template.transaction.required to 'false'"));
 		}
 
 		@Test
@@ -684,7 +687,10 @@ class PulsarAutoConfigurationTests {
 				.run((context) -> assertThat(context).hasFailed()
 					.getFailure()
 					.hasMessageEndingWith(
-							"If transactions are required they must also be enabled - consult your 'spring.pulsar.listener.transaction' properties."));
+							"Property spring.pulsar.listener.transaction.required with value 'true' is invalid: "
+									+ "Transactions must be enabled in order to be required. Either set "
+									+ "spring.pulsar.listener.transaction.enabled to 'true' or make transactions "
+									+ "optional by setting spring.pulsar.listener.transaction.required to 'false'"));
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfigurationTests.java
@@ -665,6 +665,28 @@ class PulsarAutoConfigurationTests {
 				.run((context) -> assertThat(context).hasSingleBean(PulsarAwareTransactionManager.class));
 		}
 
+		@Test
+		void whenTemplateRequiresTransactionsThenTransactionsMustBeEnabled() {
+			this.contextRunner
+				.withPropertyValues("spring.pulsar.template.transaction.required=true",
+						"spring.pulsar.template.transaction.enabled=false")
+				.run((context) -> assertThat(context).hasFailed()
+					.getFailure()
+					.hasMessageEndingWith(
+							"If transactions are required they must also be enabled - consult your 'spring.pulsar.template.transaction' properties."));
+		}
+
+		@Test
+		void whenListenerRequiresTransactionsThenTransactionsMustBeEnabled() {
+			this.contextRunner
+				.withPropertyValues("spring.pulsar.listener.transaction.required=true",
+						"spring.pulsar.listener.transaction.enabled=false")
+				.run((context) -> assertThat(context).hasFailed()
+					.getFailure()
+					.hasMessageEndingWith(
+							"If transactions are required they must also be enabled - consult your 'spring.pulsar.listener.transaction' properties."));
+		}
+
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesTests.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.HashingScheme;
@@ -33,9 +32,6 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import org.springframework.boot.autoconfigure.pulsar.PulsarProperties.Defaults.SchemaInfo;
 import org.springframework.boot.autoconfigure.pulsar.PulsarProperties.Defaults.TypeMapping;

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesTests.java
@@ -415,19 +415,39 @@ class PulsarPropertiesTests {
 	@Nested
 	class TransactionProperties {
 
-		@ParameterizedTest
-		@MethodSource
-		void transactionsEnabledTests(boolean listenerEnablesTransactions, boolean templateEnablesTransactions,
-				boolean shouldTransactionsBeEnabled) {
+		@Test
+		void transactionsEnabledWhenListenerAndTemplateBothEnabled() {
 			PulsarProperties properties = new PulsarProperties();
-			properties.getListener().getTransaction().setEnabled(listenerEnablesTransactions);
-			properties.getTemplate().getTransaction().setEnabled(templateEnablesTransactions);
-			assertThat(properties.isTransactionEnabled()).isEqualTo(shouldTransactionsBeEnabled);
+			properties.getListener().getTransaction().setEnabled(true);
+			properties.getTemplate().getTransaction().setEnabled(true);
+			assertThat(properties.isTransactionEnabled()).isTrue();
+
 		}
 
-		static Stream<Arguments> transactionsEnabledTests() {
-			return Stream.of(Arguments.arguments(true, true, true), Arguments.arguments(true, false, true),
-					Arguments.arguments(false, true, true), Arguments.arguments(false, false, false));
+		@Test
+		void transactionsEnabledWhenListenerEnabledAndTemplateDisabled() {
+			PulsarProperties properties = new PulsarProperties();
+			properties.getListener().getTransaction().setEnabled(true);
+			properties.getTemplate().getTransaction().setEnabled(false);
+			assertThat(properties.isTransactionEnabled()).isTrue();
+
+		}
+
+		@Test
+		void transactionsEnabledWhenListenerDisabledAndTemplateEnabled() {
+			PulsarProperties properties = new PulsarProperties();
+			properties.getListener().getTransaction().setEnabled(false);
+			properties.getTemplate().getTransaction().setEnabled(true);
+			assertThat(properties.isTransactionEnabled()).isTrue();
+
+		}
+
+		void transactionsDisabledWhenListenerAndTemplateBothDisabled() {
+			PulsarProperties properties = new PulsarProperties();
+			properties.getListener().getTransaction().setEnabled(false);
+			properties.getTemplate().getTransaction().setEnabled(false);
+			assertThat(properties.isTransactionEnabled()).isFalse();
+
 		}
 
 	}

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1950,7 +1950,7 @@ bom {
 			releaseNotes("https://github.com/spring-projects/spring-ldap/releases/tag/{version}")
 		}
 	}
-	library("Spring Pulsar", "1.1.0-M2") {
+	library("Spring Pulsar", "1.1.0-SNAPSHOT") {
 		considerSnapshots()
 		group("org.springframework.pulsar") {
 			imports = [


### PR DESCRIPTION
Adds auto-config for Spring for Apache Pulsar transactions.

Introduces new txn config props for template and listener under the `spring.pulsar.template.transaction` and
`spring.pulsar.listener.transaction` prefixes, respectively.

Disables transaction support by default (opt-in feature).

> [!NOTE]
> I still need to update/add docs for this but wanted to get this front-loaded as I will be out of pocket at DevNexus this week. 

**TODO**
- [ ] Update ref docs w/ info about transaction support

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
