### PR TITLE
Loading of custom deny-all filter can cause a StackOverflowError when deploying to Tomcat with Log4j2 configured to use a single JVM-wide logger context

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
@@ -31,9 +31,7 @@ import java.util.logging.Handler;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.Filter;
-import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.AbstractConfiguration;
@@ -42,14 +40,13 @@ import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.composite.CompositeConfiguration;
-import org.apache.logging.log4j.core.filter.AbstractFilter;
+import org.apache.logging.log4j.core.filter.DenyAllFilter;
 import org.apache.logging.log4j.core.net.UrlConnectionFactory;
 import org.apache.logging.log4j.core.net.ssl.SslConfiguration;
 import org.apache.logging.log4j.core.net.ssl.SslConfigurationFactory;
 import org.apache.logging.log4j.core.util.AuthorizationProvider;
 import org.apache.logging.log4j.core.util.NameUtil;
 import org.apache.logging.log4j.jul.Log4jBridgeHandler;
-import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.PropertiesUtil;
 
 import org.springframework.boot.context.properties.bind.BindResult;
@@ -107,29 +104,7 @@ public class Log4J2LoggingSystem extends AbstractLoggingSystem {
 		LEVELS.map(LogLevel.OFF, Level.OFF);
 	}
 
-	private static final Filter FILTER = new AbstractFilter() {
-
-		@Override
-		public Result filter(LogEvent event) {
-			return Result.DENY;
-		}
-
-		@Override
-		public Result filter(Logger logger, Level level, Marker marker, Message msg, Throwable t) {
-			return Result.DENY;
-		}
-
-		@Override
-		public Result filter(Logger logger, Level level, Marker marker, Object msg, Throwable t) {
-			return Result.DENY;
-		}
-
-		@Override
-		public Result filter(Logger logger, Level level, Marker marker, String msg, Object... params) {
-			return Result.DENY;
-		}
-
-	};
+	private static final Filter FILTER = DenyAllFilter.newBuilder().build();
 
 	public Log4J2LoggingSystem(ClassLoader classLoader) {
 		super(classLoader);


### PR DESCRIPTION
This PR replaces the custom "deny all" filter used by `Log4J2LoggingSystem` with the standard [`DenyAllFilter`](https://logging.apache.org/log4j/2.x/javadoc/log4j-core/org/apache/logging/log4j/core/filter/DenyAllFilter), which is available since Log4j Core 2.13.0.

The purpose of this change is:

- to simplify the code base,
- to work around a pesky interaction between the custom Spring Boot filter and Tomcat's classloader (cf. apache/logging-log4j2#1430). If Log4j Core is configured to use a **single** logger context for the whole JVM, Spring Boot will add its custom filter implementation (contained in Spring Boot's classloader) to the global logging system. Since Tomcat's classloader performs logging calls, this will cause a `StackOverflowException` while attempting to resolve the filter class. Using a class from Log4j Core (which must be in the system classloader in this configuration) will work around the problem.