### PR TITLE
As of Jetty12, Graceful shutdown is broken.

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/GracefulShutdown.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/GracefulShutdown.java
@@ -51,18 +51,16 @@ final class GracefulShutdown {
 
 	void shutDownGracefully(GracefulShutdownCallback callback) {
 		logger.info("Commencing graceful shutdown. Waiting for active requests to complete");
-		for (Graceful graceful : this.server.getBeans(Graceful.class)) {
-			shutdown(graceful);
-		}
+		shutdownGracefulComponents();
 		this.shuttingDown = true;
 		new Thread(() -> awaitShutdown(callback), "jetty-shutdown").start();
 
 	}
 
 	@SuppressWarnings("unchecked")
-	private void shutdown(Graceful graceful) {
+	private void shutdownGracefulComponents() {
 		try {
-			graceful.shutdown().get();
+			Graceful.shutdown(this.server).get();
 		}
 		catch (InterruptedException ex) {
 			Thread.currentThread().interrupt();

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyServletWebServerFactory.java
@@ -74,6 +74,7 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.GracefulHandler;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.eclipse.jetty.session.DefaultSessionCache;
 import org.eclipse.jetty.session.FileSessionDataStore;
@@ -196,9 +197,9 @@ public class JettyServletWebServerFactory extends AbstractServletWebServerFactor
 			new ForwardHeadersCustomizer().customize(server);
 		}
 		if (getShutdown() == Shutdown.GRACEFUL) {
-			StatisticsHandler statisticsHandler = new StatisticsHandler();
-			statisticsHandler.setHandler(server.getHandler());
-			server.setHandler(statisticsHandler);
+			GracefulHandler gracefulHandler = new GracefulHandler();
+			gracefulHandler.setHandler(server.getHandler());
+			server.setHandler(gracefulHandler);
 		}
 		return getJettyWebServer(server);
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.GracefulHandler;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
 
 import org.springframework.boot.web.server.GracefulShutdownCallback;
@@ -89,23 +90,23 @@ public class JettyWebServer implements WebServer {
 	}
 
 	private GracefulShutdown createGracefulShutdown(Server server) {
-		StatisticsHandler statisticsHandler = findStatisticsHandler(server);
-		if (statisticsHandler == null) {
+		GracefulHandler gracefulHandler = findGracefulHandler(server);
+		if (gracefulHandler == null) {
 			return null;
 		}
-		return new GracefulShutdown(server, statisticsHandler::getRequestsActive);
+		return new GracefulShutdown(server, gracefulHandler::getCurrentRequestCount);
 	}
 
-	private StatisticsHandler findStatisticsHandler(Server server) {
-		return findStatisticsHandler(server.getHandler());
+	private GracefulHandler findGracefulHandler(Server server) {
+		return findGracefulHandler(server.getHandler());
 	}
 
-	private StatisticsHandler findStatisticsHandler(Handler handler) {
-		if (handler instanceof StatisticsHandler statisticsHandler) {
-			return statisticsHandler;
+	private GracefulHandler findGracefulHandler(Handler handler) {
+		if (handler instanceof GracefulHandler gracefulHandler) {
+			return gracefulHandler;
 		}
 		if (handler instanceof Handler.Wrapper handlerWrapper) {
-			return findStatisticsHandler(handlerWrapper.getHandler());
+			return findGracefulHandler(handlerWrapper.getHandler());
 		}
 		return null;
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
@@ -29,6 +29,7 @@ import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.GracefulHandler;
+import org.eclipse.jetty.server.handler.StatisticsHandler;
 
 import org.springframework.boot.web.server.GracefulShutdownCallback;
 import org.springframework.boot.web.server.GracefulShutdownResult;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
@@ -29,7 +29,6 @@ import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.GracefulHandler;
-import org.eclipse.jetty.server.handler.StatisticsHandler;
 
 import org.springframework.boot.web.server.GracefulShutdownCallback;
 import org.springframework.boot.web.server.GracefulShutdownResult;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContext.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContext.java
@@ -170,12 +170,11 @@ public class ServletWebServerApplicationContext extends GenericWebApplicationCon
 	protected void doClose() {
 		if (isActive()) {
 			AvailabilityChangeEvent.publish(this, ReadinessState.REFUSING_TRAFFIC);
-			super.doClose();
-
-			WebServer webServer = this.webServer;
-			if (webServer != null) {
-				webServer.destroy();
-			}
+		}
+		super.doClose();
+		WebServer webServer = this.webServer;
+		if (webServer != null) {
+			webServer.destroy();
 		}
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContext.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/context/ServletWebServerApplicationContext.java
@@ -170,11 +170,12 @@ public class ServletWebServerApplicationContext extends GenericWebApplicationCon
 	protected void doClose() {
 		if (isActive()) {
 			AvailabilityChangeEvent.publish(this, ReadinessState.REFUSING_TRAFFIC);
-		}
-		super.doClose();
-		WebServer webServer = this.webServer;
-		if (webServer != null) {
-			webServer.destroy();
+			super.doClose();
+
+			WebServer webServer = this.webServer;
+			if (webServer != null) {
+				webServer.destroy();
+			}
 		}
 	}
 


### PR DESCRIPTION
Since Jetty12, StatisticHandler is no longer to check shutdown state. JettyServer failed to count active request count correctly. Insted of StatisticHandler, Jetty12 introduce GracefulHandler.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Spring-Boot uses StaticstaticHandler as a active request counter in Jetty11.
It was ok because StaticstaticHandler count active request count in acount of shutdown state internally.

https://github.com/jetty/jetty.project/blob/jetty-11.0.x/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java#L146-L168

But As of Jetty12 StaticstaticHandler doesn't see shutdown state.
https://github.com/jetty/jetty.project/blob/jetty-12.0.x/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java#L70-L74

We can use GracefulHandler instead of StaticsticHandler and it'll success to count
active request count on shutdown phase.
https://github.com/jetty/jetty.project/blob/jetty-12.0.x/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/GracefulHandler.java#L89-L116
