### PR TITLE
Upgrade to Zipkin Reporter 3.4.0

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -122,7 +122,7 @@ bom {
 				.formatted(version.major(), version.minor()) }
 		}
 	}
-	library("Zipkin Reporter", "3.3.0") {
+	library("Zipkin Reporter", "3.4.0") {
 		group("io.zipkin.reporter2") {
 			imports = [
 				"zipkin-reporter-bom"


### PR DESCRIPTION
I'm only raising this manually for documentation:

Spring currently configures the Brave `AsyncSpanHandler` with default settings. These defaults included 3 thresholds to flush a backlog, whichever comes first.

The estimated size in bytes threshold (`queuedMaxBytes=1pct memory`) has been disabled by default and deprecated, due to appearing pinned when virtual threads are in use (`-Djdk.tracePinnedThreads`). This is effectively no impact due to the other two flush thresholds (`queuedMaxSpans=10000`,`messageTimeout=1s`), most importantly that in the default case (such as spring-boot not setting anything), you are much more likely to hit 1s timeout prior to 1pct of memory of 10k spans.

See https://github.com/openzipkin/zipkin-reporter-java/releases/tag/3.4.0 for more


### Trivia time

OpenTelemetry's defaults are also in use in `BatchSpanProcessorBuilder`. There is no  `queuedMaxBytes` analogue in their setup (in hindsight a good thing probably).
* otel `maxQueueSize=2048` vs zipkin-reporter `queuedMaxSpans=10000`
* otel `scheduleDelay=5s` vs zipkin-reporter `messageTimeout=1s`

My unsolicited 2p is that the `maxQueueSize=2048` while arbitrary is better than the `queuedMaxSpans=10000` in zipkin-reporter.. I thought it was 10 year old from original brave, but that was 500 🤷. I raised [this issue](https://github.com/openzipkin/zipkin-reporter-java/issues/266) as 2048 is good, even if maybe smaller could be better.

`scheduleDelay=5s` might not be a great default though. I do remember changing  zipkin-reporter to `messageTimeout=1s`, as beginning devs are impatient and wondered what was wrong prior to 5s :p

