### PR TITLE
Add AnnotatedControllerConfigurerCustomizer modify the AnnotatedControllerConfigurer

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/GraphQlAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/GraphQlAutoConfiguration.java
@@ -38,6 +38,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.graphql.data.AnnotatedControllerConfigurerCustomizer;
 import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.convert.ApplicationConversionService;
@@ -154,11 +155,13 @@ public class GraphQlAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public AnnotatedControllerConfigurer annotatedControllerConfigurer(
-			@Qualifier(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME) ObjectProvider<Executor> executorProvider) {
+			@Qualifier(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME) ObjectProvider<Executor> executorProvider,
+			ObjectProvider<AnnotatedControllerConfigurerCustomizer> customizers) {
 		AnnotatedControllerConfigurer controllerConfigurer = new AnnotatedControllerConfigurer();
 		controllerConfigurer
 			.addFormatterRegistrar((registry) -> ApplicationConversionService.addBeans(registry, this.beanFactory));
 		executorProvider.ifAvailable(controllerConfigurer::setExecutor);
+		customizers.orderedStream().forEach((customizer) -> customizer.customize(controllerConfigurer));
 		return controllerConfigurer;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/data/AnnotatedControllerConfigurerCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/data/AnnotatedControllerConfigurerCustomizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.graphql.data;
+
+import org.springframework.graphql.data.method.annotation.support.AnnotatedControllerConfigurer;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize properties of
+ * {@link AnnotatedControllerConfigurer} whilst retaining default auto-configuration.
+ *
+ * @author Max Hovens
+ */
+@FunctionalInterface
+public interface AnnotatedControllerConfigurerCustomizer {
+
+	/**
+	 * Customize the {@link AnnotatedControllerConfigurer} instance.
+	 * @param configurer the configurer to customize
+	 */
+	void customize(AnnotatedControllerConfigurer configurer);
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/graphql/GraphQlAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/graphql/GraphQlAutoConfigurationTests.java
@@ -36,6 +36,8 @@ import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.graphql.GraphQlAutoConfiguration.GraphQlResourcesRuntimeHints;
+import org.springframework.boot.autoconfigure.graphql.GraphQlAutoConfigurationTests.AnnotatedControllerConfigurerCustomizerConfiguration.CustomAnnotatedControllerConfigurerCustomizer;
+import org.springframework.boot.autoconfigure.graphql.data.AnnotatedControllerConfigurerCustomizer;
 import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.system.CapturedOutput;
@@ -241,6 +243,15 @@ class GraphQlAutoConfigurationTests {
 		});
 	}
 
+	@Test
+	void whenAnnotatedControllerConfigurerCustomizerIsDefinedThenAnnotatedControllerConfigurerShouldUseIt() {
+		this.contextRunner.withUserConfiguration(CustomAnnotatedControllerConfigurerCustomizer.class).run((context) -> {
+			CustomAnnotatedControllerConfigurerCustomizer customizer = context
+				.getBean(CustomAnnotatedControllerConfigurerCustomizer.class);
+			assertThat(customizer.applied).isTrue();
+		});
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	static class CustomGraphQlBuilderConfiguration {
 
@@ -332,6 +343,27 @@ class GraphQlAutoConfigurationTests {
 		@Bean
 		Executor customExecutor() {
 			return mock(Executor.class);
+		}
+
+	}
+
+	static class AnnotatedControllerConfigurerCustomizerConfiguration {
+
+		@Bean
+		CustomAnnotatedControllerConfigurerCustomizer customAnnotatedControllerConfigurerCustomizer() {
+			return new CustomAnnotatedControllerConfigurerCustomizer();
+		}
+
+		public static class CustomAnnotatedControllerConfigurerCustomizer
+				implements AnnotatedControllerConfigurerCustomizer {
+
+			public boolean applied = false;
+
+			@Override
+			public void customize(AnnotatedControllerConfigurer configurer) {
+				this.applied = true;
+			}
+
 		}
 
 	}


### PR DESCRIPTION
Add an `AnnotatedControllerConfigurerCustomizer` to provide a friendly API to modify the autoconfigured`AnnotatedControllerConfigurer`. End users could provide `HandlerMethodArgumentResolver`s without having to override the entire `AnnotatedControllerConfigurer` bean.

This has been discussed in (amongst others) https://github.com/spring-projects/spring-graphql/issues/603, but there seems no way to customize the `AnnotatedControllerConfigurer`. This PR aims to improve the API for end users.