### PR TITLE
Add configuration key spring.rabbitmq.template.allowed-list-patterns

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -48,6 +48,7 @@ import org.springframework.util.unit.DataSize;
  * @author Rafael Carvalho
  * @author Scott Frederick
  * @author Lasse Wulff
+ * @author Yanming Zhou
  * @since 1.0.0
  */
 @ConfigurationProperties(prefix = "spring.rabbitmq")
@@ -1015,6 +1016,11 @@ public class RabbitProperties {
 		 */
 		private boolean observationEnabled;
 
+		/**
+		 * Simple patterns for allowable packages/classes for deserialization.
+		 */
+		private List<String> allowedListPatterns;
+
 		public Retry getRetry() {
 			return this.retry;
 		}
@@ -1073,6 +1079,14 @@ public class RabbitProperties {
 
 		public void setObservationEnabled(boolean observationEnabled) {
 			this.observationEnabled = observationEnabled;
+		}
+
+		public List<String> getAllowedListPatterns() {
+			return this.allowedListPatterns;
+		}
+
+		public void setAllowedListPatterns(List<String> allowedListPatterns) {
+			this.allowedListPatterns = allowedListPatterns;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitTemplateConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitTemplateConfigurer.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.AllowedListDeserializingMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.util.Assert;
@@ -29,6 +30,7 @@ import org.springframework.util.Assert;
  * Configure {@link RabbitTemplate} with sensible defaults.
  *
  * @author Stephane Nicoll
+ * @author Yanming Zhou
  * @since 2.3.0
  */
 public class RabbitTemplateConfigurer {
@@ -102,6 +104,12 @@ public class RabbitTemplateConfigurer {
 		map.from(templateProperties::getRoutingKey).to(template::setRoutingKey);
 		map.from(templateProperties::getDefaultReceiveQueue).whenNonNull().to(template::setDefaultReceiveQueue);
 		map.from(templateProperties::isObservationEnabled).to(template::setObservationEnabled);
+		if (templateProperties.getAllowedListPatterns() != null) {
+			MessageConverter messageConverter = template.getMessageConverter();
+			if (messageConverter instanceof AllowedListDeserializingMessageConverter mc) {
+				mc.setAllowedListPatterns(templateProperties.getAllowedListPatterns());
+			}
+		}
 	}
 
 	private boolean determineMandatoryFlag() {


### PR DESCRIPTION
Fix
```
java.lang.SecurityException: Attempt to deserialize unauthorized class com.example.domain.Message; add allowed class name patterns to the message converter or, if you trust the message orginiator, set environment variable 'SPRING_AMQP_DESERIALIZATION_TRUST_ALL' or system property 'spring.amqp.deserialization.trust.all' to true
```