### PR TITLE
Use Objects.requireNonNullElse instead of "!= null "

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/web/servlet/springmvc/errorhandling/MyControllerAdvice.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/web/servlet/springmvc/errorhandling/MyControllerAdvice.java
@@ -39,7 +39,7 @@ public class MyControllerAdvice extends ResponseEntityExceptionHandler {
 	private HttpStatus getStatus(HttpServletRequest request) {
 		Integer code = (Integer) request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
 		HttpStatus status = HttpStatus.resolve(code);
-		return (status != null) ? status : HttpStatus.INTERNAL_SERVER_ERROR;
+		return Objects.requireNonNullElse(status, HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
 }


### PR DESCRIPTION
Using the ternary operator may not make the intention clear. While it might seem fine for one or two lines, as these instances increase, they can become code smells, diminishing code quality. Hence, it's advisable to anticipate future scenarios and refactor such code for clarity and maintainability.
There's no need to explicitly emphasize null-checking.
Since HttpStatus is an object, there's no need to verify if the object reference is null or not.
Therefore, I recommend refactoring the code accordingly.