### PR TITLE
Pulsar auth parameters don't properly encode JSON values

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
@@ -137,12 +137,23 @@ final class PulsarPropertiesMapper {
 		try {
 			return sortedParams.entrySet()
 				.stream()
-				.map((entry) -> "\"%s\":\"%s\"".formatted(entry.getKey(), entry.getValue()))
+				.map((entry) -> "\"%s\":\"%s\"".formatted(entry.getKey(), escapeJson(entry.getValue())))
 				.collect(Collectors.joining(",", "{", "}"));
 		}
 		catch (Exception ex) {
 			throw new IllegalStateException("Could not convert auth parameters to encoded string", ex);
 		}
+	}
+
+	private String escapeJson(String raw) {
+		return raw.replace("\\", "\\\\")
+			.replace("\"", "\\\"")
+			.replace("/", "\\/")
+			.replace("\b", "\\b")
+			.replace("\t", "\\t")
+			.replace("\n", "\\n")
+			.replace("\f", "\\f")
+			.replace("\r", "\\r");
 	}
 
 	<T> void customizeProducerBuilder(ProducerBuilder<T> producerBuilder) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapperTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapperTests.java
@@ -81,8 +81,10 @@ class PulsarPropertiesMapperTests {
 	@Test
 	void customizeClientBuilderWhenHasAuthentication() throws UnsupportedAuthenticationException {
 		PulsarProperties properties = new PulsarProperties();
-		Map<String, String> params = Map.of("param", "name");
-		String authParamString = "{\"param\":\"name\"}";
+		Map<String, String> params = Map.of("simpleParam", "foo", "complexParam",
+				"{\n\t\"k1\" : \"v1\",\n\t\"k2\":\"v2\"\n}");
+		String authParamString = "{\"complexParam\":\"{\\n\\t\\\"k1\\\" : \\\"v1\\\",\\n\\t\\\"k2\\\":\\\"v2\\\"\\n}\""
+				+ ",\"simpleParam\":\"foo\"}";
 		properties.getClient().getAuthentication().setPluginClassName("myclass");
 		properties.getClient().getAuthentication().setParam(params);
 		ClientBuilder builder = mock(ClientBuilder.class);
@@ -166,8 +168,10 @@ class PulsarPropertiesMapperTests {
 	@Test
 	void customizeAdminBuilderWhenHasAuthentication() throws UnsupportedAuthenticationException {
 		PulsarProperties properties = new PulsarProperties();
-		Map<String, String> params = Map.of("param", "name");
-		String authParamString = "{\"param\":\"name\"}";
+		Map<String, String> params = Map.of("simpleParam", "foo", "complexParam",
+				"{\n\t\"k1\" : \"v1\",\n\t\"k2\":\"v2\"\n}");
+		String authParamString = "{\"complexParam\":\"{\\n\\t\\\"k1\\\" : \\\"v1\\\",\\n\\t\\\"k2\\\":\\\"v2\\\"\\n}\""
+				+ ",\"simpleParam\":\"foo\"}";
 		properties.getAdmin().getAuthentication().setPluginClassName("myclass");
 		properties.getAdmin().getAuthentication().setParam(params);
 		PulsarAdminBuilder builder = mock(PulsarAdminBuilder.class);


### PR DESCRIPTION
The values in the `spring.pulsar.client.authentication.param` config props map are not currently JSON encoded. For simple values this is fine. However, some custom auth modules may require more complex parameter values that may contain special characters that results in invalid JSON. This commmit encodes the parameter values using a very simple hand-rolled escape function.

Fixes #40492

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
