### PR TITLE
Remove unnecessary null check for expectedDeprecationMessages

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-test-support/src/main/java/org/springframework/boot/testsupport/gradle/testkit/GradleBuild.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-test-support/src/main/java/org/springframework/boot/testsupport/gradle/testkit/GradleBuild.java
@@ -198,10 +198,8 @@ public class GradleBuild {
 			if (this.expectDeprecationWarnings == null || (this.gradleVersion != null
 					&& this.expectDeprecationWarnings.compareTo(GradleVersion.version(this.gradleVersion)) > 0)) {
 				String buildOutput = result.getOutput();
-				if (this.expectedDeprecationMessages != null) {
-					for (String message : this.expectedDeprecationMessages) {
-						buildOutput = buildOutput.replaceAll(message, "");
-					}
+				for (String message : this.expectedDeprecationMessages) {
+					buildOutput = buildOutput.replaceAll(message, "");
 				}
 				assertThat(buildOutput).doesNotContainIgnoringCase("deprecated");
 			}


### PR DESCRIPTION
Removed the unnecessary null check for `expectedDeprecationMessages` as it's already initialized as an ArrayList and cannot be null.