### PR TITLE
Add a customizer for ProxyConnectionFactory.Builder from r2dbc-proxy

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/r2dbc/R2dbcObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/r2dbc/R2dbcObservationAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,12 +33,15 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.r2dbc.ConnectionFactoryDecorator;
 import org.springframework.boot.r2dbc.OptionsCapableConnectionFactory;
+import org.springframework.boot.r2dbc.ProxyConnectionFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for R2DBC observability support.
  *
  * @author Moritz Halbritter
+ * @author Tadaya Tsuyukubo
  * @since 3.2.0
  */
 @AutoConfiguration(after = ObservationAutoConfiguration.class)
@@ -46,20 +49,37 @@ import org.springframework.context.annotation.Bean;
 @EnableConfigurationProperties(R2dbcObservationProperties.class)
 public class R2dbcObservationAutoConfiguration {
 
+	/**
+	 * {@code @Order} value of observation customizer.
+	 */
+	public static final int R2DBC_PROXY_OBSERVATION_CUSTOMIZER_ORDER = 1000;
+
 	@Bean
+	ConnectionFactoryDecorator connectionFactoryDecorator(
+			ObjectProvider<ProxyConnectionFactoryCustomizer> customizers) {
+		return (connectionFactory) -> {
+			ProxyConnectionFactory.Builder builder = ProxyConnectionFactory.builder(connectionFactory);
+			customizers.orderedStream().forEach((customizer) -> customizer.customize(builder));
+			return builder.build();
+		};
+	}
+
+	@Bean
+	@Order(R2DBC_PROXY_OBSERVATION_CUSTOMIZER_ORDER)
 	@ConditionalOnBean(ObservationRegistry.class)
-	ConnectionFactoryDecorator connectionFactoryDecorator(R2dbcObservationProperties properties,
+	ProxyConnectionFactoryCustomizer proxyConnectionFactoryObservationCustomizer(R2dbcObservationProperties properties,
 			ObservationRegistry observationRegistry,
 			ObjectProvider<QueryObservationConvention> queryObservationConvention,
 			ObjectProvider<QueryParametersTagProvider> queryParametersTagProvider) {
-		return (connectionFactory) -> {
+		return (builder) -> {
+			ConnectionFactory connectionFactory = builder.getConnectionFactory();
 			HostAndPort hostAndPort = extractHostAndPort(connectionFactory);
 			ObservationProxyExecutionListener listener = new ObservationProxyExecutionListener(observationRegistry,
 					connectionFactory, hostAndPort.host(), hostAndPort.port());
 			listener.setIncludeParameterValues(properties.isIncludeParameterValues());
 			queryObservationConvention.ifAvailable(listener::setQueryObservationConvention);
 			queryParametersTagProvider.ifAvailable(listener::setQueryParametersTagProvider);
-			return ProxyConnectionFactory.builder(connectionFactory).listener(listener).build();
+			builder.listener(listener);
 		};
 	}
 

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1611,7 +1611,7 @@ bom {
 			]
 		}
 	}
-	library("R2DBC Proxy", "1.1.4.RELEASE") {
+	library("R2DBC Proxy", "1.1.5.RELEASE") {
 		considerSnapshots()
 		group("io.r2dbc") {
 			modules = [

--- a/spring-boot-project/spring-boot/build.gradle
+++ b/spring-boot-project/spring-boot/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	optional("io.projectreactor:reactor-tools")
 	optional("io.projectreactor.netty:reactor-netty-http")
 	optional("io.r2dbc:r2dbc-pool")
+	optional("io.r2dbc:r2dbc-proxy")
 	optional("io.rsocket:rsocket-core")
 	optional("io.rsocket:rsocket-transport-netty")
 	optional("io.undertow:undertow-servlet")

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/r2dbc/ProxyConnectionFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/r2dbc/ProxyConnectionFactoryCustomizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.r2dbc;
+
+import io.r2dbc.proxy.ProxyConnectionFactory;
+
+/**
+ * Callback interface that can be used to customize a
+ * {@link ProxyConnectionFactory.Builder}.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 3.3
+ */
+public interface ProxyConnectionFactoryCustomizer {
+
+	/**
+	 * Callback to customize a {@link ProxyConnectionFactory.Builder} instance.
+	 * @param builder the builder to customize
+	 */
+	void customize(ProxyConnectionFactory.Builder builder);
+
+}


### PR DESCRIPTION
With upgrading to `r2dbc-proxy 1.1.5.RELEASE`(should be addressed by the dependency upgrade commits), this could be a change mentioned in https://github.com/spring-projects/spring-boot/issues/40010

NOTE:  
Now the `R2dbcObservationAutoConfiguration` is more generic to r2dbc-proxy. It could be renamed to `R2dbcProxyAutoConfiguration`.
