### PR TITLE
Use ConcurrentHashMap.newKeySet where feasible

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/task/ScheduledBeanLazyInitializationExcludeFilter.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/task/ScheduledBeanLazyInitializationExcludeFilter.java
@@ -18,7 +18,6 @@ package org.springframework.boot.autoconfigure.task;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -43,7 +42,7 @@ import org.springframework.util.ClassUtils;
  */
 class ScheduledBeanLazyInitializationExcludeFilter implements LazyInitializationExcludeFilter {
 
-	private final Set<Class<?>> nonAnnotatedClasses = Collections.newSetFromMap(new ConcurrentHashMap<>(64));
+	private final Set<Class<?>> nonAnnotatedClasses = ConcurrentHashMap.newKeySet(64);
 
 	ScheduledBeanLazyInitializationExcludeFilter() {
 		// Ignore AOP infrastructure such as scoped proxies.

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/JarUrlClassLoader.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/JarUrlClassLoader.java
@@ -22,7 +22,6 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.Set;
@@ -47,7 +46,7 @@ public abstract class JarUrlClassLoader extends URLClassLoader {
 
 	private final Map<URL, JarFile> jarFiles = new ConcurrentHashMap<>();
 
-	private final Set<String> undefinablePackages = Collections.newSetFromMap(new ConcurrentHashMap<>());
+	private final Set<String> undefinablePackages = ConcurrentHashMap.newKeySet();
 
 	/**
 	 * Create a new {@link LaunchedClassLoader} instance.


### PR DESCRIPTION
This PR changes to use `ConcurrentHashMap.newKeySet()` where feasible.

See https://github.com/spring-projects/spring-framework/pull/32294