### PR TITLE
Document default value of management.zipkin.tracing.encoding

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -2259,6 +2259,12 @@
       ]
     },
     {
+      "name": "management.zipkin.tracing.encoding",
+      "defaultValue": [
+        "JSON"
+      ]
+    },
+    {
       "name": "micrometer.observations.annotations.enabled",
       "type": "java.lang.Boolean",
       "deprecation": {


### PR DESCRIPTION
This PR adds a configuration properties metadata entry for the default value of the `management.zipkin.tracing.encoding`.

See gh-39049