### PR TITLE
Remove reassignments for builders in GraphQL auto-configurations

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/reactive/GraphQlWebFluxAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/reactive/GraphQlWebFluxAutoConfiguration.java
@@ -112,14 +112,14 @@ public class GraphQlWebFluxAutoConfiguration {
 		RouterFunctions.Builder builder = RouterFunctions.route();
 		builder.route(GraphQlRequestPredicates.graphQlHttp(path), httpHandler::handleRequest);
 		builder.route(GraphQlRequestPredicates.graphQlSse(path), sseHandler::handleRequest);
-		builder = builder.GET(path, this::onlyAllowPost);
+		builder.GET(path, this::onlyAllowPost);
 		if (properties.getGraphiql().isEnabled()) {
 			GraphiQlHandler graphQlHandler = new GraphiQlHandler(path, properties.getWebsocket().getPath());
-			builder = builder.GET(properties.getGraphiql().getPath(), graphQlHandler::handleRequest);
+			builder.GET(properties.getGraphiql().getPath(), graphQlHandler::handleRequest);
 		}
 		if (properties.getSchema().getPrinter().isEnabled()) {
 			SchemaHandler schemaHandler = new SchemaHandler(graphQlSource);
-			builder = builder.GET(path + "/schema", schemaHandler::handleRequest);
+			builder.GET(path + "/schema", schemaHandler::handleRequest);
 		}
 		return builder.build();
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/servlet/GraphQlWebMvcAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/graphql/servlet/GraphQlWebMvcAutoConfiguration.java
@@ -117,14 +117,14 @@ public class GraphQlWebMvcAutoConfiguration {
 		RouterFunctions.Builder builder = RouterFunctions.route();
 		builder.route(GraphQlRequestPredicates.graphQlHttp(path), httpHandler::handleRequest);
 		builder.route(GraphQlRequestPredicates.graphQlSse(path), sseHandler::handleRequest);
-		builder = builder.GET(path, this::onlyAllowPost);
+		builder.GET(path, this::onlyAllowPost);
 		if (properties.getGraphiql().isEnabled()) {
 			GraphiQlHandler graphiQLHandler = new GraphiQlHandler(path, properties.getWebsocket().getPath());
-			builder = builder.GET(properties.getGraphiql().getPath(), graphiQLHandler::handleRequest);
+			builder.GET(properties.getGraphiql().getPath(), graphiQLHandler::handleRequest);
 		}
 		if (properties.getSchema().getPrinter().isEnabled()) {
 			SchemaHandler schemaHandler = new SchemaHandler(graphQlSource);
-			builder = builder.GET(path + "/schema", schemaHandler::handleRequest);
+			builder.GET(path + "/schema", schemaHandler::handleRequest);
 		}
 		return builder.build();
 	}


### PR DESCRIPTION
This PR removes reassignments for builders in GraphQL auto-configurations as it doesn't seem to be necessary.