### PR TITLE
Help information for spring init's build option has the wrong default

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/InitCommand.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/InitCommand.java
@@ -165,7 +165,7 @@ public class InitCommand extends OptionParsingCommand {
 			this.packaging = option(Arrays.asList("packaging", "p"), "Project packaging (for example 'jar')")
 				.withRequiredArg();
 			this.build = option("build", "Build system to use (for example 'maven' or 'gradle')").withRequiredArg()
-				.defaultsTo("maven");
+				.defaultsTo("gradle");
 			this.format = option("format", "Format of the generated content (for example 'build' for a build file, "
 					+ "'project' for a project archive)")
 				.withRequiredArg()


### PR DESCRIPTION
Spring Boot CLI (3.2.4) `init` help says default build system is `maven` but actually `gradle` is used:
```sh
$ spring --help init
spring init - Initialize a new project using Spring Initializr (start.spring.io)

usage: spring init [options] [location]

Option                       Description                                       
------                       -----------                                       
...
--build <String>             Build system to use (for example 'maven' or 'gradle') (default: maven)
...
```

```sh
$ spring init -a demo -g org.example
Using service at https://start.spring.io
Content saved to 'demo.zip'

$ unzip -l demo.zip
Archive:  demo.zip
Name
----
gradlew
HELP.md
.gitignore
settings.gradle
build.gradle
src/
src/test/
src/test/java/
src/test/java/org/
src/test/java/org/example/
src/test/java/org/example/demo/
src/test/java/org/example/demo/DemoApplicationTests.java
src/main/
src/main/java/
src/main/java/org/
src/main/java/org/example/
src/main/java/org/example/demo/
src/main/java/org/example/demo/DemoApplication.java
src/main/resources/
src/main/resources/application.properties
gradlew.bat
gradle/
gradle/wrapper/
gradle/wrapper/gradle-wrapper.properties
gradle/wrapper/gradle-wrapper.jar
-------
25 files
```