### PR TITLE
Clarify devtools restart class loader

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/using/devtools.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/using/devtools.adoc
@@ -239,21 +239,24 @@ For IntelliJ IDEA, you can follow the https://www.jetbrains.com/help/idea/spring
 === Customizing the Restart Classloader
 
 As described earlier in the xref:#using.devtools.restart.restart-vs-reload[] section, restart functionality is implemented by using two classloaders.
-If this causes issues, you might need to customize what gets loaded by which classloader.
+If this causes issues, you can diagnose the problem by using the `spring.devtools.restart.enabled` system property, and if the app works with restart switched off, you might need to customize what gets loaded by which classloader.
 
 By default, any open project in your IDE is loaded with the "`restart`" classloader, and any regular `.jar` file is loaded with the "`base`" classloader.
 The same is true if you use `mvn spring-boot:run` or `gradle bootRun`: the project containing your `@SpringBootApplication` is loaded with the "`restart`" classloader, and everything else with the "`base`" classloader.
+The classpath is printed on the console when you start the app, which can help to identify any problematic entries.
+Classes used reflectively, especially annotations, can be loaded into the parent (fixed) classloader on startup before the application classes which uses them, and this might lead to them not being detected by Spring in the application.
 
 You can instruct Spring Boot to load parts of your project with a different classloader by creating a `META-INF/spring-devtools.properties` file.
 The `spring-devtools.properties` file can contain properties prefixed with `restart.exclude` and `restart.include`.
 The `include` elements are items that should be pulled up into the "`restart`" classloader, and the `exclude` elements are items that should be pushed down into the "`base`" classloader.
-The value of the property is a regex pattern that is applied to the classpath, as shown in the following example:
+The value of the property is a regex pattern that is applied to the classpath passed to the JVM on startup.
+Here is an example where some local class files are excluded and some extra libraries are included in the restart class loader:
 
 [source,properties]
 ----
 restart:
   exclude:
-    companycommonlibs: "/mycorp-common-[\\w\\d-\\.]+\\.jar"
+    companycommonlibs: "/mycorp-common-[\\w\\d-\\.]/(build|bin|out|target)/"
   include:
     projectcommon: "/mycorp-myproj-[\\w\\d-\\.]+\\.jar"
 ----
@@ -263,6 +266,7 @@ As long as a property starts with `restart.include.` or `restart.exclude.` it is
 
 TIP: All `META-INF/spring-devtools.properties` from the classpath are loaded.
 You can package files inside your project, or in the libraries that the project consumes.
+System properties can not be used, only the properties file.
 
 
 


### PR DESCRIPTION
I read the section in the user guide and it helpfully suggested setting spring.devtools.restart.enabled=false to eliminate possible sources of failure. And that fixed it. But now I want to switch it back on, and I don't know how to craft the right configuration.

This change would help.