### PR TITLE
Avoid using ClientHttpRequestFactory which may not on the classpath

### DIFF
--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/TestRestTemplateTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/web/client/TestRestTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,6 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.http.client.JettyClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.http.client.MockClientHttpRequest;
@@ -95,7 +94,7 @@ class TestRestTemplateTests {
 
 	@Test
 	void useTheSameRequestFactoryClassWithBasicAuth() {
-		JettyClientHttpRequestFactory customFactory = new JettyClientHttpRequestFactory();
+		TestClientHttpRequestFactory customFactory = new TestClientHttpRequestFactory();
 		RestTemplateBuilder builder = new RestTemplateBuilder().requestFactory(() -> customFactory);
 		TestRestTemplate testRestTemplate = new TestRestTemplate(builder).withBasicAuth("test", "test");
 		RestTemplate restTemplate = testRestTemplate.getRestTemplate();
@@ -384,6 +383,10 @@ class TestRestTemplateTests {
 	interface TestRestTemplateCallback {
 
 		void doWithTestRestTemplate(TestRestTemplate testRestTemplate, URI relativeUri);
+
+	}
+
+	static class TestClientHttpRequestFactory extends SimpleClientHttpRequestFactory {
 
 	}
 


### PR DESCRIPTION
This commit fixes a test that uses a different `ClientHttpRequestFactory` implementation for the sole purpose of checking that it's not overridden. Previously, this used the Jetty implementation but jetty is not on the classpath so that might fail if the factory attempts to manipulate the underlying client.

This broke this test when testing against Spring Framework 6.2 and the purpose of this PR is to fix the test and limit the amount of change in upgrading to 6.2