### PR TITLE
Code inclusion in Jersey documentation is broken

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/jersey.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/jersey.adoc
@@ -23,4 +23,4 @@ To use Jersey alongside another web framework, such as Spring MVC, it should be 
 First, configure Jersey to use a filter rather than a servlet by configuring the configprop:spring.jersey.type[] application property with a value of `filter`.
 Second, configure your `ResourceConfig` to forward requests that would have resulted in a 404, as shown in the following example.
 
-includ-code::alongsideanotherwebframework/JerseyConfig[]
+include-code::alongsideanotherwebframework/JerseyConfig[]


### PR DESCRIPTION
Fixed typo: "include-code" is written as "includ-code" to link the source code of JerseyConfig in jersey.adoc

Closes: https://github.com/spring-projects/spring-boot/issues/40628