### PR TITLE
Fix typo in features doc

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/index.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/index.adoc
@@ -3,5 +3,5 @@
 
 This section dives into the details of Spring Boot.
 Here you can learn about the key features that you may want to use and customize.
-If you have not already done so, you might want to read the "xref:tutorial:index.adoc[Tutoral]" and "xref:using/index.adoc[Developing with Spring Boot]" sections, so that you have a good grounding of the basics.
+If you have not already done so, you might want to read the "xref:tutorial:index.adoc[Tutorial]" and "xref:using/index.adoc[Developing with Spring Boot]" sections, so that you have a good grounding of the basics.
 


### PR DESCRIPTION
Fixed typo: "Tutoral" in the features documentation