### PR TITLE
Neo4jReactiveDataAutoConfiguration creates incorrectly named bean

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jReactiveDataAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/neo4j/Neo4jReactiveDataAutoConfiguration.java
@@ -71,7 +71,7 @@ public class Neo4jReactiveDataAutoConfiguration {
 
 	@Bean(ReactiveNeo4jRepositoryConfigurationExtension.DEFAULT_TRANSACTION_MANAGER_BEAN_NAME)
 	@ConditionalOnMissingBean(ReactiveTransactionManager.class)
-	ReactiveNeo4jTransactionManager rectiveNeo4jTransactionManager(Driver driver,
+	ReactiveNeo4jTransactionManager reactiveNeo4jTransactionManager(Driver driver,
 			ReactiveDatabaseSelectionProvider databaseNameProvider) {
 		return new ReactiveNeo4jTransactionManager(driver, databaseNameProvider);
 	}


### PR DESCRIPTION
Fix typo in Neo4jReactiveDataAutoConfiguration class