### PR TITLE
Upgrade CI to Docker 26.1.2

### DIFF
--- a/ci/images/get-docker-url.sh
+++ b/ci/images/get-docker-url.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-version="26.1.1"
+version="26.1.2"
 echo "https://download.docker.com/linux/static/stable/x86_64/docker-$version.tgz";


### PR DESCRIPTION
Upgrade CI to Docker 26.1.2

Closes: https://github.com/spring-projects/spring-boot/issues/40768