### PR TITLE
 A newline character is missing from the start of the default banner

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringBootBanner.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringBootBanner.java
@@ -45,6 +45,7 @@ class SpringBootBanner implements Banner {
 
 	@Override
 	public void printBanner(Environment environment, Class<?> sourceClass, PrintStream printStream) {
+		printStream.println();
 		printStream.println(BANNER);
 		String version = String.format(" (v%s)", SpringBootVersion.getVersion());
 		StringBuilder padding = new StringBuilder();


### PR DESCRIPTION
Fixes #40888