### PR TITLE
Make maxConnection property of Reactor Netty configurable

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/reactor/netty/ReactorNettyConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/reactor/netty/ReactorNettyConfigurations.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.autoconfigure.reactor.netty;
 
+import reactor.netty.resources.ConnectionProvider;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -27,6 +29,7 @@ import org.springframework.http.client.ReactorResourceFactory;
  * auto-configuration class.
  *
  * @author Moritz Halbritter
+ * @author Huseyin Aydin
  * @since 2.7.9
  */
 public final class ReactorNettyConfigurations {
@@ -45,6 +48,8 @@ public final class ReactorNettyConfigurations {
 			if (configurationProperties.getShutdownQuietPeriod() != null) {
 				reactorResourceFactory.setShutdownQuietPeriod(configurationProperties.getShutdownQuietPeriod());
 			}
+			reactorResourceFactory.setUseGlobalResources(false);
+			reactorResourceFactory.setConnectionProvider(ConnectionProvider.create("http", configurationProperties.getMaxConnection()));
 			return reactorResourceFactory;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/reactor/netty/ReactorNettyProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/reactor/netty/ReactorNettyProperties.java
@@ -24,6 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Configuration properties for Reactor Netty.
  *
  * @author Moritz Halbritter
+ * @author Huseyin Aydin
  * @since 2.7.9
  */
 @ConfigurationProperties(prefix = "spring.reactor.netty")
@@ -34,6 +35,8 @@ public class ReactorNettyProperties {
 	 */
 	private Duration shutdownQuietPeriod;
 
+	private Integer maxConnection = 500;
+
 	public Duration getShutdownQuietPeriod() {
 		return this.shutdownQuietPeriod;
 	}
@@ -42,4 +45,11 @@ public class ReactorNettyProperties {
 		this.shutdownQuietPeriod = shutdownQuietPeriod;
 	}
 
+	public Integer getMaxConnection() {
+		return this.maxConnection;
+	}
+
+	public void setMaxConnection(Integer maxConnection) {
+		this.maxConnection = maxConnection;
+	}
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -2173,6 +2173,15 @@
       }
     },
     {
+      "name": "spring.reactor.netty.shutdownQuietPeriod",
+      "type": "java.time.Duration"
+    },
+    {
+      "name": "spring.reactor.netty.maxConnection",
+      "type": "java.lang.Integer",
+      "defaultValue": "500"
+    },
+    {
       "name": "spring.redis.client-name",
       "type": "java.lang.String",
       "deprecation": {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

I was unable to set maxConnection configuration to my application. This way I will be able to manipulate it. We were having issues during peak times due to low connection limits. Alternetively we can set `useGlobalResources` to `false` and set `connectionProviderSupplier`