### PR TITLE
Remove unused parameter.

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -90,8 +90,7 @@ public class LiquibaseAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(LiquibaseConnectionDetails.class)
-		PropertiesLiquibaseConnectionDetails liquibaseConnectionDetails(LiquibaseProperties properties,
-				ObjectProvider<JdbcConnectionDetails> jdbcConnectionDetails) {
+		PropertiesLiquibaseConnectionDetails liquibaseConnectionDetails(LiquibaseProperties properties) {
 			return new PropertiesLiquibaseConnectionDetails(properties);
 		}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -28,9 +28,9 @@ import org.springframework.util.StringUtils;
 
 /**
  * A configuration property name composed of elements separated by dots. User created
- * names may contain the characters "{@code a-z}" "{@code 0-9}" and "{@code -}", they
- * must be lower-case and must start with an alphanumeric character. The "{@code -}" is
- * used purely for formatting, i.e. "{@code foo-bar}" and "{@code foobar}" are considered
+ * names may contain the characters "{@code a-z}" "{@code 0-9}" and "{@code -}", they must
+ * be lower-case and must start with an alphanumeric character. The "{@code -}" is used
+ * purely for formatting, i.e. "{@code foo-bar}" and "{@code foobar}" are considered
  * equivalent.
  * <p>
  * The "{@code [}" and "{@code ]}" characters may be used to indicate an associative

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * A configuration property name composed of elements separated by dots. User created
- * names may contain the characters "{@code a-z}" "{@code 0-9}") and "{@code -}", they
+ * names may contain the characters "{@code a-z}" "{@code 0-9}" and "{@code -}", they
  * must be lower-case and must start with an alphanumeric character. The "{@code -}" is
  * used purely for formatting, i.e. "{@code foo-bar}" and "{@code foobar}" are considered
  * equivalent.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/server/Encoding.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/servlet/server/Encoding.java
@@ -60,7 +60,7 @@ public class Encoding {
 	private Boolean forceResponse;
 
 	/**
-	 * Mapping of locale to charset for response encoding..
+	 * Mapping of locale to charset for response encoding.
 	 */
 	private Map<Locale, Charset> mapping;
 


### PR DESCRIPTION
- Remove an unused parameter in `LiquibaseAutoConfiguration`.
- Remove an unmatched parenthesis in JavaDoc.
- Remove a redundant period in JavaDoc.