### PR TITLE
Add `org.hibernate.orm.jdbc.bind` to `sql` logging group

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/logging.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/logging.adoc
@@ -254,7 +254,7 @@ Spring Boot includes the following pre-defined logging groups that can be used o
 | `org.springframework.core.codec`, `org.springframework.http`, `org.springframework.web`, `org.springframework.boot.actuate.endpoint.web`, `org.springframework.boot.web.servlet.ServletContextInitializerBeans`
 
 | sql
-| `org.springframework.jdbc.core`, `org.hibernate.SQL`, `org.jooq.tools.LoggerListener`
+| `org.springframework.jdbc.core`, `org.hibernate.SQL`, `org.hibernate.orm.jdbc.bind`, `org.jooq.tools.LoggerListener`
 |===
 
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/logging/LoggingApplicationListener.java
@@ -153,6 +153,7 @@ public class LoggingApplicationListener implements GenericApplicationListener {
 		loggers.add("web", "org.springframework.boot.web.servlet.ServletContextInitializerBeans");
 		loggers.add("sql", "org.springframework.jdbc.core");
 		loggers.add("sql", "org.hibernate.SQL");
+		loggers.add("sql", "org.hibernate.orm.jdbc.bind");
 		loggers.add("sql", "org.jooq.tools.LoggerListener");
 		DEFAULT_GROUP_LOGGERS = Collections.unmodifiableMap(loggers);
 	}


### PR DESCRIPTION
It's reasonable to treat prepared statement parameters as part of sql.

See https://github.com/spring-projects/spring-boot/issues/36640#issuecomment-1657394103