### PR TITLE
Replace hard-coded links to Micrometer in documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/metrics.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/metrics.adoc
@@ -545,7 +545,7 @@ scrape_configs:
 https://prometheus.io/docs/prometheus/latest/feature_flags/#exemplars-storage[Prometheus Exemplars] are also supported.
 To enable this feature, a `SpanContext` bean should be present.
 If you're using the deprecated Prometheus simpleclient support and want to enable that feature, a `SpanContextSupplier` bean should be present.
-If you use https://micrometer.io/docs/tracing[Micrometer Tracing], this will be auto-configured for you, but you can always create your own if you want.
+If you use {url-micrometer-tracing-docs}[Micrometer Tracing], this will be auto-configured for you, but you can always create your own if you want.
 Please check the https://prometheus.io/docs/prometheus/latest/feature_flags/#exemplars-storage[Prometheus Docs], since this feature needs to be explicitly enabled on Prometheus' side, and it is only supported using the https://github.com/OpenObservability/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#exemplars[OpenMetrics] format.
 
 For ephemeral or batch jobs that may not exist long enough to be scraped, you can use https://github.com/prometheus/pushgateway[Prometheus Pushgateway] support to expose the metrics to Prometheus.

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/observability.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/observability.adoc
@@ -4,7 +4,7 @@
 Observability is the ability to observe the internal state of a running system from the outside.
 It consists of the three pillars logging, metrics and traces.
 
-For metrics and traces, Spring Boot uses https://micrometer.io/docs/observation[Micrometer Observation].
+For metrics and traces, Spring Boot uses {url-micrometer-docs}/observation[Micrometer Observation].
 To create your own observations (which will lead to metrics and traces), you can inject an `ObservationRegistry`.
 
 include-code::MyCustomObservation[]
@@ -18,7 +18,7 @@ Observability support relies on the https://github.com/micrometer-metrics/contex
 By default, `ThreadLocal` values are not automatically reinstated in reactive operators.
 This behavior is controlled with the configprop:spring.reactor.context-propagation[] property, which can be set to `auto` to enable automatic propagation.
 
-For more details about observations please see the https://micrometer.io/docs/observation[Micrometer Observation documentation].
+For more details about observations please see the {url-micrometer-docs}/observation[Micrometer Observation documentation].
 
 TIP: Observability for JDBC can be configured using a separate project.
 The https://github.com/jdbc-observations/datasource-micrometer[Datasource Micrometer project] provides a Spring Boot starter which automatically creates observations when JDBC operations are invoked.

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/tracing.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/tracing.adoc
@@ -1,9 +1,9 @@
 [[actuator.micrometer-tracing]]
 = Tracing
 
-Spring Boot Actuator provides dependency management and auto-configuration for https://micrometer.io/docs/tracing[Micrometer Tracing], a facade for popular tracer libraries.
+Spring Boot Actuator provides dependency management and auto-configuration for {url-micrometer-tracing-docs}[Micrometer Tracing], a facade for popular tracer libraries.
 
-TIP: To learn more about Micrometer Tracing capabilities, see its https://micrometer.io/docs/tracing[reference documentation].
+TIP: To learn more about Micrometer Tracing capabilities, see its {url-micrometer-tracing-docs}[reference documentation].
 
 
 
@@ -34,7 +34,7 @@ Now we have to add the following dependencies:
 
 * `org.springframework.boot:spring-boot-starter-actuator`
 * `io.micrometer:micrometer-tracing-bridge-otel` - bridges the Micrometer Observation API to OpenTelemetry.
-* `io.opentelemetry:opentelemetry-exporter-zipkin` - reports https://micrometer.io/docs/tracing#_glossary[traces] to Zipkin.
+* `io.opentelemetry:opentelemetry-exporter-zipkin` - reports {url-micrometer-tracing-docs}/glossary[traces] to Zipkin.
 
 Add the following application properties:
 
@@ -192,7 +192,7 @@ include-code::CustomObservation[]
 
 This will create an observation named "some-operation" with the tag "some-tag=some-value".
 
-TIP: If you want to create a span without creating a metric, you need to use the https://micrometer.io/docs/tracing#_using_micrometer_tracing_directly[lower-level `Tracer` API] from Micrometer.
+TIP: If you want to create a span without creating a metric, you need to use the {url-micrometer-tracing-docs}/api[lower-level `Tracer` API] from Micrometer.
 
 
 


### PR DESCRIPTION
Hi Team,

This PR updates the documentation links to use placeholders for versioning.

### Changes
+ Changed the Micrometer Tracing documentation URL to {url-micrometer-tracing-docs}.
+ Changed the Micrometer main documentation URL to {url-micrometer-docs}.
+ Ensured links are version-specific for easier referencing.

Related Issue
[spring-projects/spring-boot#40916](https://github.com/spring-projects/spring-boot/issues/40916)

For this fix to work correctly, the Micrometer and Micrometer Tracing documentation must support URLs with fixed version numbers.
