### PR TITLE
Include metadata for management.metrics.export.atlas.aggrConfig replacement

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -460,6 +460,14 @@
       }
     },
     {
+      "name": "management.metrics.export.atlas.aggrConfig",
+      "type": "java.lang.String",
+      "deprecation": {
+        "level": "error",
+        "replacement": "management.atlas.metrics.export.aggrConfig"
+      }
+    },
+    {
       "name": "management.metrics.export.atlas.batch-size",
       "type": "java.lang.Integer",
       "deprecation": {


### PR DESCRIPTION
Upgrading some applications from boot 2.7 to 3.0+ I noticed this property has changed. I use OpenRewrite to usually catch such property renames and opened up this pull request with them to fix the missed rename and they redirected me here https://github.com/openrewrite/rewrite-spring/pull/517#issuecomment-2083266665

