### PR TITLE
Polish code to use 'switch' instead of 'if', remove unessary unboxing and remote redundant cast

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/antora/AntoraAsciidocAttributes.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/antora/AntoraAsciidocAttributes.java
@@ -56,7 +56,7 @@ public class AntoraAsciidocAttributes {
 	public AntoraAsciidocAttributes(Project project, BomExtension dependencyBom,
 			Map<String, String> dependencyVersions) {
 		this.version = String.valueOf(project.getVersion());
-		this.latestVersion = Boolean.valueOf(String.valueOf(project.findProperty("latestVersion")));
+		this.latestVersion = Boolean.parseBoolean(String.valueOf(project.findProperty("latestVersion")));
 		this.artifactRelease = ArtifactRelease.forProject(project);
 		this.libraries = dependencyBom.getLibraries();
 		this.dependencyVersions = dependencyVersions;

--- a/buildSrc/src/main/java/org/springframework/boot/build/classpath/CheckClasspathForProhibitedDependencies.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/classpath/CheckClasspathForProhibitedDependencies.java
@@ -70,34 +70,22 @@ public class CheckClasspathForProhibitedDependencies extends DefaultTask {
 
 	private boolean prohibited(ModuleVersionIdentifier id) {
 		String group = id.getGroup();
-		if (group.equals("javax.batch")) {
-			return false;
-		}
-		if (group.equals("javax.cache")) {
-			return false;
-		}
-		if (group.equals("javax.money")) {
-			return false;
-		}
-		if (group.equals("org.codehaus.groovy")) {
-			return true;
-		}
-		if (group.equals("org.eclipse.jetty.toolchain")) {
-			return true;
+		switch (group) {
+			case "javax.batch", "javax.cache", "javax.money" -> {
+				return false;
+			}
+			case "commons-logging", "org.codehaus.groovy", "org.eclipse.jetty.toolchain",
+					"org.apache.geronimo.specs" -> {
+				return true;
+			}
 		}
 		if (group.startsWith("javax")) {
-			return true;
-		}
-		if (group.equals("commons-logging")) {
 			return true;
 		}
 		if (group.equals("org.slf4j") && id.getName().equals("jcl-over-slf4j")) {
 			return true;
 		}
 		if (group.startsWith("org.jboss.spec")) {
-			return true;
-		}
-		if (group.equals("org.apache.geronimo.specs")) {
 			return true;
 		}
 		return group.equals("com.sun.activation");

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/InfinispanCacheConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/InfinispanCacheConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.cache;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Objects;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;
@@ -81,10 +82,7 @@ public class InfinispanCacheConfiguration {
 
 	private org.infinispan.configuration.cache.Configuration getDefaultCacheConfiguration(
 			ConfigurationBuilder defaultConfigurationBuilder) {
-		if (defaultConfigurationBuilder != null) {
-			return defaultConfigurationBuilder.build();
-		}
-		return new ConfigurationBuilder().build();
+		return Objects.requireNonNullElseGet(defaultConfigurationBuilder, ConfigurationBuilder::new).build();
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/InfinispanCacheConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/InfinispanCacheConfiguration.java
@@ -19,7 +19,6 @@ package org.springframework.boot.autoconfigure.cache;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Objects;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/InfinispanCacheConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/InfinispanCacheConfiguration.java
@@ -82,7 +82,10 @@ public class InfinispanCacheConfiguration {
 
 	private org.infinispan.configuration.cache.Configuration getDefaultCacheConfiguration(
 			ConfigurationBuilder defaultConfigurationBuilder) {
-		return Objects.requireNonNullElseGet(defaultConfigurationBuilder, ConfigurationBuilder::new).build();
+		if (defaultConfigurationBuilder != null) {
+			return defaultConfigurationBuilder.build();
+		}
+		return new ConfigurationBuilder().build();
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/test/java/org/springframework/boot/testsupport/classpath/ModifiedClassPathExtensionForkParameterizedTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support/src/test/java/org/springframework/boot/testsupport/classpath/ModifiedClassPathExtensionForkParameterizedTests.java
@@ -37,14 +37,10 @@ class ModifiedClassPathExtensionForkParameterizedTests {
 	@ParameterizedTest
 	@ValueSource(strings = { "one", "two", "three" })
 	void testIsInvokedOnceForEachArgument(String argument) {
-		if (argument.equals("one")) {
-			assertThat(arguments).isEmpty();
-		}
-		else if (argument.equals("two")) {
-			assertThat(arguments).doesNotContain("two", "three");
-		}
-		else if (argument.equals("three")) {
-			assertThat(arguments).doesNotContain("three");
+		switch (argument) {
+			case "one" -> assertThat(arguments).isEmpty();
+			case "two" -> assertThat(arguments).doesNotContain("two", "three");
+			case "three" -> assertThat(arguments).doesNotContain("three");
 		}
 		arguments.add(argument);
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
@@ -219,7 +219,7 @@ public class LoggingSystemProperties {
 		if (this.environment instanceof ConfigurableEnvironment configurableEnvironment) {
 			PropertySourcesPropertyResolver resolver = new PropertySourcesPropertyResolver(
 					configurableEnvironment.getPropertySources());
-			resolver.setConversionService(((ConfigurableEnvironment) this.environment).getConversionService());
+			resolver.setConversionService(configurableEnvironment.getConversionService());
 			resolver.setIgnoreUnresolvableNestedPlaceholders(true);
 			return resolver;
 		}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/NestedJarResourceSet.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/NestedJarResourceSet.java
@@ -128,7 +128,7 @@ class NestedJarResourceSet extends AbstractSingleArchiveResourceSet {
 				}
 			}
 		}
-		return this.multiRelease.booleanValue();
+		return this.multiRelease;
 	}
 
 	@Override


### PR DESCRIPTION
This PR has the following changes:
- Use `switch` instead of `if`
- Remove unnecessary (un)boxing