### PR TITLE
Auto-configure SpringLiquibase with Liquibase Customizer

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -100,8 +100,7 @@ public class LiquibaseAutoConfiguration {
 		@Bean
 		public SpringLiquibase liquibase(ObjectProvider<DataSource> dataSource,
 				@LiquibaseDataSource ObjectProvider<DataSource> liquibaseDataSource, LiquibaseProperties properties,
-				ObjectProvider<Customizer<Liquibase>> customizer,
-				LiquibaseConnectionDetails connectionDetails) {
+				ObjectProvider<Customizer<Liquibase>> customizer, LiquibaseConnectionDetails connectionDetails) {
 			SpringLiquibase liquibase = createSpringLiquibase(liquibaseDataSource.getIfAvailable(),
 					dataSource.getIfUnique(), connectionDetails);
 			liquibase.setChangeLog(properties.getChangeLog());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -128,7 +128,7 @@ public class LiquibaseAutoConfiguration {
 			if (properties.getUiService() != null) {
 				liquibase.setUiService(UIServiceEnum.valueOf(properties.getUiService().name()));
 			}
-			liquibase.setCustomizer(customizer.getIfAvailable());
+			customizer.ifAvailable(liquibase::setCustomizer);
 			return liquibase;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -18,9 +18,11 @@ package org.springframework.boot.autoconfigure.liquibase;
 
 import javax.sql.DataSource;
 
+import liquibase.Liquibase;
 import liquibase.UpdateSummaryEnum;
 import liquibase.UpdateSummaryOutputEnum;
 import liquibase.change.DatabaseChange;
+import liquibase.integration.spring.Customizer;
 import liquibase.integration.spring.SpringLiquibase;
 import liquibase.ui.UIServiceEnum;
 
@@ -66,6 +68,7 @@ import org.springframework.util.StringUtils;
  * @author Ferenc Gratzer
  * @author Evgeniy Cheban
  * @author Moritz Halbritter
+ * @author Ahmed Ashour
  * @since 1.1.0
  */
 @AutoConfiguration(after = { DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class })
@@ -97,6 +100,7 @@ public class LiquibaseAutoConfiguration {
 		@Bean
 		public SpringLiquibase liquibase(ObjectProvider<DataSource> dataSource,
 				@LiquibaseDataSource ObjectProvider<DataSource> liquibaseDataSource, LiquibaseProperties properties,
+				ObjectProvider<Customizer<Liquibase>> customizer,
 				LiquibaseConnectionDetails connectionDetails) {
 			SpringLiquibase liquibase = createSpringLiquibase(liquibaseDataSource.getIfAvailable(),
 					dataSource.getIfUnique(), connectionDetails);
@@ -125,6 +129,7 @@ public class LiquibaseAutoConfiguration {
 			if (properties.getUiService() != null) {
 				liquibase.setUiService(UIServiceEnum.valueOf(properties.getUiService().name()));
 			}
+			liquibase.setCustomizer(customizer.getIfAvailable());
 			return liquibase;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
@@ -536,7 +536,7 @@ class LiquibaseAutoConfigurationTests {
 	}
 
 	@Test
-	void customizer() {
+	void whenCustomizerBeanIsDefinedThenItIsConfiguredOnSpringLiquibase() {
 		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class, CustomizerConfiguration.class)
 			.run(assertLiquibase((liquibase) -> {
 				assertThat(liquibase.getCustomizer()).isNotNull();

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfigurationTests.java
@@ -33,6 +33,7 @@ import liquibase.Liquibase;
 import liquibase.UpdateSummaryEnum;
 import liquibase.UpdateSummaryOutputEnum;
 import liquibase.command.core.helpers.ShowSummaryArgument;
+import liquibase.integration.spring.Customizer;
 import liquibase.integration.spring.SpringLiquibase;
 import liquibase.ui.UIServiceEnum;
 import org.junit.jupiter.api.Test;
@@ -69,7 +70,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.contentOf;
-import liquibase.integration.spring.*;
 
 /**
  * Tests for {@link LiquibaseAutoConfiguration}.
@@ -538,9 +538,9 @@ class LiquibaseAutoConfigurationTests {
 	@Test
 	void customizer() {
 		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class, CustomizerConfiguration.class)
-				.run(assertLiquibase((liquibase) -> {
-					assertThat(liquibase.getCustomizer()).isNotNull();
-				}));
+			.run(assertLiquibase((liquibase) -> {
+				assertThat(liquibase.getCustomizer()).isNotNull();
+			}));
 	}
 
 	private ContextConsumer<AssertableApplicationContext> assertLiquibase(Consumer<SpringLiquibase> consumer) {

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1054,7 +1054,7 @@ bom {
 			releaseNotes("https://github.com/lettuce-io/lettuce-core/releases/tag/{version}")
 		}
 	}
-	library("Liquibase", "4.27.0") {
+	library("Liquibase", "4.28.0") {
 		group("org.liquibase") {
 			modules = [
 				"liquibase-cdi",


### PR DESCRIPTION
This PR considers a recently added Liquibase `Customizer`.

Fixes #38055

It includes an upgrade of `Liquibase` to `4.28.0`, which can be separately done.