### PR TITLE
Add CDS training run configuration documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/class-data-sharing.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/class-data-sharing.adoc
@@ -15,6 +15,9 @@ This will cause the buildpack to do a training run of the application, save the 
 
 The buildpack environment variable `BP_SPRING_AOT_ENABLED` can also be set to `true` to enable AOT mode along with CDS when running an application that has been xref:reference:packaging/aot.adoc[built with Ahead-of-Time processed].
 
-The Paketo Buildpack for Spring Boot https://github.com/paketo-buildpacks/spring-boot?tab=readme-ov-file#configuration[documentation] has information on other configuration options that can be enabled with builder environment variables.
+The Paketo Buildpack for Spring Boot https://github.com/paketo-buildpacks/spring-boot?tab=readme-ov-file#configuration[documentation] has information on other configuration options that can be enabled with builder environment variables, like `CDS_TRAINING_JAVA_TOOL_OPTIONS` that allows to override the default `JAVA_TOOL_OPTIONS`, only for the CDS training run.
 
+[[howto.class-data-sharing.training-run-configuration]]
+== Preventing remote services interaction during the training run
 
+When performing the training run, it may be needed to customize the Spring Boot application configuration in order to prevent connection to remote services that may happen before the Spring lifecycle is started. This can typically happen with early database interactions and can be handled via related configuration that can be applied by default to your application or specifically to the training run to prevent such interaction, see https://github.com/spring-projects/spring-lifecycle-smoke-tests/blob/main/README.adoc#training-run-configuration[related documentation].


### PR DESCRIPTION
As discussed in #40762 with @scottfrederick, this PR provides some documentation about configuration customization that may be needed to prevent remote service connections during the CDS training run.