### PR TITLE
Improve readability when listing three pillars of observability

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/observability.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/observability.adoc
@@ -2,7 +2,7 @@
 = Observability
 
 Observability is the ability to observe the internal state of a running system from the outside.
-It consists of the three pillars logging, metrics and traces.
+It consists of the three pillars: logging, metrics and traces.
 
 For metrics and traces, Spring Boot uses {url-micrometer-docs}/observation[Micrometer Observation].
 To create your own observations (which will lead to metrics and traces), you can inject an `ObservationRegistry`.


### PR DESCRIPTION
Adding ":" to sentence to improve its readability.