### PR TITLE
Cross-link to the CDS how-to guide

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/class-data-sharing.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/class-data-sharing.adoc
@@ -21,4 +21,4 @@ To use the cache, you need to add an extra parameter when starting the applicati
 $ java -XX:SharedArchiveFile=application.jsa -jar my-app.jar
 ----
 
-NOTE: For more details about CDS, refer to the {url-spring-framework-docs}/integration/cds.html[Spring Framework reference documentation].
+NOTE: For more details about CDS, refer to the xref:how-to:class-data-sharing.adoc[CDS how-to guide] and the {url-spring-framework-docs}/integration/cds.html[Spring Framework reference documentation].


### PR DESCRIPTION
This allows to improve the discoverability of the CDS how-to guide.