### PR TITLE
Update Kotlin DSL examples that configure the environment of bootBuildImage to be additive

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/packaging/boot-build-image-env-proxy.gradle.kts
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/packaging/boot-build-image-env-proxy.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 // tag::env[]
 tasks.named<BootBuildImage>("bootBuildImage") {
-	environment.set(mapOf("HTTP_PROXY" to "http://proxy.example.com",
+	environment.putAll(mapOf("HTTP_PROXY" to "http://proxy.example.com",
 						"HTTPS_PROXY" to "https://proxy.example.com"))
 }
 // end::env[]

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/packaging/boot-build-image-env-runtime.gradle.kts
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/packaging/boot-build-image-env-runtime.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 // tag::env-runtime[]
 tasks.named<BootBuildImage>("bootBuildImage") {
-	environment.set(mapOf(
+	environment.putAll(mapOf(
 		"BPE_DELIM_JAVA_TOOL_OPTIONS" to " ",
 		"BPE_APPEND_JAVA_TOOL_OPTIONS" to "-XX:+HeapDumpOnOutOfMemoryError"
 	))

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/packaging/boot-build-image-env.gradle.kts
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/packaging/boot-build-image-env.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 // tag::env[]
 tasks.named<BootBuildImage>("bootBuildImage") {
-	environment.set(environment.get() + mapOf("BP_JVM_VERSION" to "17"))
+	environment.put("BP_JVM_VERSION", "17")
 }
 // end::env[]
 


### PR DESCRIPTION
Reading Gradle documentation and seeing other similar code samples, I don't think the `environment.get()` part is needed, and it looks not idiomatic.