### PR TITLE
Enhancement Cache Properties Customization (#39350)

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/HazelcastJCacheCustomizationConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/HazelcastJCacheCustomizationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,27 +32,33 @@ import org.springframework.core.io.Resource;
  * JCache customization for Hazelcast.
  *
  * @author Stephane Nicoll
+ * @author Hayoon Lee
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(HazelcastInstance.class)
 class HazelcastJCacheCustomizationConfiguration {
 
 	@Bean
-	HazelcastPropertiesCustomizer hazelcastPropertiesCustomizer(ObjectProvider<HazelcastInstance> hazelcastInstance) {
-		return new HazelcastPropertiesCustomizer(hazelcastInstance.getIfUnique());
+	HazelcastPropertiesCustomizer hazelcastPropertiesCustomizer(ObjectProvider<HazelcastInstance> hazelcastInstance,
+			CacheProperties cacheProperties) {
+		return new HazelcastPropertiesCustomizer(hazelcastInstance.getIfUnique(), cacheProperties);
 	}
 
 	static class HazelcastPropertiesCustomizer implements JCachePropertiesCustomizer {
 
 		private final HazelcastInstance hazelcastInstance;
 
-		HazelcastPropertiesCustomizer(HazelcastInstance hazelcastInstance) {
+		private final CacheProperties cacheProperties;
+
+		HazelcastPropertiesCustomizer(HazelcastInstance hazelcastInstance, CacheProperties cacheProperties) {
 			this.hazelcastInstance = hazelcastInstance;
+			this.cacheProperties = cacheProperties;
 		}
 
 		@Override
-		public void customize(CacheProperties cacheProperties, Properties properties) {
-			Resource configLocation = cacheProperties.resolveConfigLocation(cacheProperties.getJcache().getConfig());
+		public void customize(Properties properties) {
+			Resource configLocation = this.cacheProperties
+					.resolveConfigLocation(this.cacheProperties.getJcache().getConfig());
 			if (configLocation != null) {
 				// Hazelcast does not use the URI as a mean to specify a custom config.
 				properties.setProperty("hazelcast.config.location", toUri(configLocation).toString());
@@ -61,7 +67,6 @@ class HazelcastJCacheCustomizationConfiguration {
 				properties.put("hazelcast.instance.itself", this.hazelcastInstance);
 			}
 		}
-
 		private static URI toUri(Resource config) {
 			try {
 				return config.getURI();
@@ -70,7 +75,5 @@ class HazelcastJCacheCustomizationConfiguration {
 				throw new IllegalArgumentException("Could not get URI from " + config, ex);
 			}
 		}
-
 	}
-
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/JCacheCacheConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/JCacheCacheConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Stephane Nicoll
  * @author Madhura Bhave
+ * @author Hayoon Lee
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass({ Caching.class, JCacheCacheManager.class })
@@ -95,7 +96,7 @@ class JCacheCacheConfiguration implements BeanClassLoaderAware {
 	private CacheManager createCacheManager(CacheProperties cacheProperties,
 			ObjectProvider<JCachePropertiesCustomizer> cachePropertiesCustomizers) throws IOException {
 		CachingProvider cachingProvider = getCachingProvider(cacheProperties.getJcache().getProvider());
-		Properties properties = createCacheManagerProperties(cachePropertiesCustomizers, cacheProperties);
+		Properties properties = createCacheManagerProperties(cachePropertiesCustomizers);
 		Resource configLocation = cacheProperties.resolveConfigLocation(cacheProperties.getJcache().getConfig());
 		if (configLocation != null) {
 			return cachingProvider.getCacheManager(configLocation.getURI(), this.beanClassLoader, properties);
@@ -111,10 +112,9 @@ class JCacheCacheConfiguration implements BeanClassLoaderAware {
 	}
 
 	private Properties createCacheManagerProperties(
-			ObjectProvider<JCachePropertiesCustomizer> cachePropertiesCustomizers, CacheProperties cacheProperties) {
+			ObjectProvider<JCachePropertiesCustomizer> cachePropertiesCustomizers) {
 		Properties properties = new Properties();
-		cachePropertiesCustomizers.orderedStream()
-			.forEach((customizer) -> customizer.customize(cacheProperties, properties));
+		cachePropertiesCustomizers.orderedStream().forEach((customizer) -> customizer.customize(properties));
 		return properties;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/JCachePropertiesCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cache/JCachePropertiesCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,16 +25,17 @@ import javax.cache.spi.CachingProvider;
  * Callback interface that can be implemented by beans wishing to customize the properties
  * used by the {@link CachingProvider} to create the {@link CacheManager}.
  *
+ * @see CachingProvider#getCacheManager(java.net.URI, ClassLoader, Properties)
  * @author Stephane Nicoll
+ * @author Hayoon Lee
+ * @since 3.3.0
  */
-interface JCachePropertiesCustomizer {
+public interface JCachePropertiesCustomizer {
 
 	/**
 	 * Customize the properties.
-	 * @param cacheProperties the cache properties
 	 * @param properties the current properties
-	 * @see CachingProvider#getCacheManager(java.net.URI, ClassLoader, Properties)
 	 */
-	void customize(CacheProperties cacheProperties, Properties properties);
+	void customize(Properties properties);
 
 }


### PR DESCRIPTION

'CacheProperties' are able to be passed directly to the 'HazelcastPropertiesCustomizer' constructor for more flexible cache customization.

Issue: #39350