### PR TITLE
Update plexus-build-api as to not use plexus-utils 1.5.8

### DIFF
--- a/spring-boot-project/spring-boot-parent/build.gradle
+++ b/spring-boot-project/spring-boot-parent/build.gradle
@@ -159,8 +159,8 @@ bom {
 			]
 		}
 	}
-	library("Plexus Build API", "0.0.7") {
-		group("org.sonatype.plexus") {
+	library("Plexus Build API", "1.2.0") {
+		group("org.codehaus.plexus") {
 			modules = [
 				"plexus-build-api"
 			]

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/build.gradle
@@ -14,7 +14,7 @@ configurations {
 
 dependencies {
 	compileOnly("org.apache.maven.plugin-tools:maven-plugin-annotations")
-	compileOnly("org.sonatype.plexus:plexus-build-api")
+	compileOnly("org.codehaus.plexus:plexus-build-api")
 	compileOnly("org.apache.maven:maven-core") {
 		exclude(group: "javax.annotation", module: "javax.annotation-api")
 		exclude(group: "javax.inject", module: "javax.inject")
@@ -72,7 +72,7 @@ dependencies {
 	mavenRepository(project(path: ":spring-boot-project:spring-boot-devtools", configuration: "mavenRepository"))
 	mavenRepository(project(path: ":spring-boot-project:spring-boot-docker-compose", configuration: "mavenRepository"))
 
-	runtimeOnly("org.sonatype.plexus:plexus-build-api")
+	runtimeOnly("org.codehaus.plexus:plexus-build-api")
 
 	versionProperties(project(path: ":spring-boot-project:spring-boot-dependencies", configuration: "effectiveBom"))
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/build.gradle
@@ -15,6 +15,7 @@ configurations {
 dependencies {
 	compileOnly("org.apache.maven.plugin-tools:maven-plugin-annotations")
 	compileOnly("org.codehaus.plexus:plexus-build-api")
+	compileOnly("org.codehaus.plexus:plexus-xml")
 	compileOnly("org.apache.maven:maven-core") {
 		exclude(group: "javax.annotation", module: "javax.annotation-api")
 		exclude(group: "javax.inject", module: "javax.inject")
@@ -73,6 +74,7 @@ dependencies {
 	mavenRepository(project(path: ":spring-boot-project:spring-boot-docker-compose", configuration: "mavenRepository"))
 
 	runtimeOnly("org.codehaus.plexus:plexus-build-api")
+	runtimeOnly("org.codehaus.plexus:plexus-xml")
 
 	versionProperties(project(path: ":spring-boot-project:spring-boot-dependencies", configuration: "effectiveBom"))
 }


### PR DESCRIPTION
While performing builds with the latest version of Spring Boot 3.3.1 I noticed that the build was pulling in an insecure dependency. Specifically plexus-utils 1.5.8 which is quite old:

https://mvnrepository.com/artifact/org.codehaus.plexus/plexus-utils/1.5.8

The issue here is that plexus-utils 1.5.8 has CVEs and build pipelines that block the use of vulnerable artifacts will result in this build failing.

I know that straight forward dependency upgrades aren't meant to be here but this looks like it may have fallen through the cracks.  

It took me a while to determine where this dependency was coming from and why it was so old. It turns out that org.sonatype.plexus:plexus-build-api:0.0.7 is where this is being pulled from as a transitive dependency:
https://github.com/spring-projects/spring-boot/blob/0bbaa77530c757c75574456ba519831aab8e6d38/spring-boot-project/spring-boot-parent/build.gradle#L162

Looking at this dependency it is on the latest version available, but the artifact was actually moved.

https://mvnrepository.com/artifact/org.sonatype.plexus/plexus-build-api

This artifact moved from org.sonatype.plexus to org.codehaus.plexus.  This old version appears to be widely used and hasn't been updated since 2011. In this new location the latest version is not as widely used but is from 2023.

https://mvnrepository.com/artifact/org.codehaus.plexus/plexus-build-api

The proposal here is to update this dependency to the latest version:

https://mvnrepository.com/artifact/org.codehaus.plexus/plexus-build-api/1.2.0

There is a workaround for this is in the build that uses the spring-boot-maven-plugin you can force the plexus-utils dependency to a newer version, but ideally this would be addressed by updating Spring Boot itself.

```xml
    <plugin>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-maven-plugin</artifactId>
        <dependencies>
            <dependency>
                <groupId>org.codehaus.plexus</groupId>
                <artifactId>plexus-utils</artifactId>
                <version>4.0.0</version>
            </dependency>
        </dependencies>
    </plugin>
```