### PR TITLE
@NestedConfigurationProperty doesn't work on records

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/RecordParameterPropertyDescriptor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/RecordParameterPropertyDescriptor.java
@@ -50,7 +50,7 @@ class RecordParameterPropertyDescriptor extends ParameterPropertyDescriptor {
 
 	@Override
 	protected boolean isMarkedAsNested(MetadataGenerationEnvironment environment) {
-		return false;
+		return environment.getNestedConfigurationPropertyAnnotation(this.recordComponent) != null;
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -23,6 +23,7 @@ import org.springframework.boot.configurationprocessor.metadata.ItemMetadata;
 import org.springframework.boot.configurationprocessor.metadata.Metadata;
 import org.springframework.boot.configurationsample.deprecation.Dbcp2Configuration;
 import org.springframework.boot.configurationsample.record.ExampleRecord;
+import org.springframework.boot.configurationsample.record.NestedPropertiesRecord;
 import org.springframework.boot.configurationsample.record.RecordWithGetter;
 import org.springframework.boot.configurationsample.recursive.RecursiveProperties;
 import org.springframework.boot.configurationsample.simple.ClassWithNestedProperties;
@@ -508,6 +509,15 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 		ConfigurationMetadata metadata = compile(RecordWithGetter.class);
 		assertThat(metadata).has(Metadata.withProperty("record-with-getter.alpha"));
 		assertThat(metadata).doesNotHave(Metadata.withProperty("record-with-getter.bravo"));
+	}
+
+	@Test
+	void recordNested() {
+		ConfigurationMetadata metadata = compile(NestedPropertiesRecord.class);
+		assertThat(metadata).has(Metadata.withGroup("record-nested.nested"));
+		assertThat(metadata).has(Metadata.withProperty("record-nested.nested.my-nested-property"));
+		assertThat(metadata).has(Metadata.withGroup("record-nested.inner.nested"));
+		assertThat(metadata).has(Metadata.withProperty("record-nested.inner.nested.my-nested-property"));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/NestedConfigurationProperty.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/NestedConfigurationProperty.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * @author Phillip Webb
  * @since 1.2.0
  */
-@Target(ElementType.FIELD)
+@Target({ ElementType.FIELD, ElementType.RECORD_COMPONENT })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface NestedConfigurationProperty {

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/record/NestedPropertiesRecord.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/record/NestedPropertiesRecord.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.configurationsample.record;
+
+import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+
+@ConfigurationProperties("record-nested")
+public record NestedPropertiesRecord(String myProperty, @NestedConfigurationProperty NestedRecord nested,
+		InnerPropertiesRecord inner) {
+
+	public record InnerPropertiesRecord(String myInnerProperty, @NestedConfigurationProperty NestedRecord nested) {
+	}
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/record/NestedRecord.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/record/NestedRecord.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.configurationsample.record;
+
+public record NestedRecord(String myNestedProperty) {
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/NestedConfigurationProperty.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/NestedConfigurationProperty.java
@@ -38,7 +38,7 @@ import org.springframework.boot.context.properties.bind.Nested;
  * @author Phillip Webb
  * @since 1.2.0
  */
-@Target(ElementType.FIELD)
+@Target({ ElementType.FIELD, ElementType.RECORD_COMPONENT })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Nested


### PR DESCRIPTION
Add `ElementType.RECORD_COMPONENT` to `NestedConfigurationProperty` and implement `isMarkedAsNested` for `RecordParameterPropertyDescriptor`.

This will allow nested record to be properly harvested for their properties.

I've added a test case which fails to retrieve nested record groups property using the `@NestedConfigurationProperty` annotation.

This change adds the support for nested record to be properly extracted into groups when using `@NestedConfigurationProperty`.
