### PR TITLE
Add memory info to ProcessInfo

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/ProcessInfo.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/ProcessInfo.java
@@ -16,6 +16,10 @@
 
 package org.springframework.boot.info;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+
 /**
  * Information about the process of the application.
  *
@@ -50,6 +54,24 @@ public class ProcessInfo {
 		return runtime.availableProcessors();
 	}
 
+	/**
+	 * Memory information for the process. These values can provide details about the
+	 * current memory usage and limits selected by the user or JVM ergonomics (init, max,
+	 * committed, used for heap and non-heap). If limits not set explicitly, it might not
+	 * be trivial to know what these values are runtime; especially in (containerized)
+	 * environments where resource usage can be isolated (for example using control
+	 * groups) or not necessarily trivial to discover. Other than that, these values can
+	 * indicate if the JVM can resize the heap (stop-the-world).
+	 * @return heap and non-heap memory information
+	 * @since 3.4.0
+	 * @see MemoryMXBean#getHeapMemoryUsage()
+	 * @see MemoryMXBean#getNonHeapMemoryUsage()
+	 * @see MemoryUsage
+	 */
+	public MemoryInfo getMemory() {
+		return new MemoryInfo();
+	}
+
 	public long getPid() {
 		return this.pid;
 	}
@@ -60,6 +82,55 @@ public class ProcessInfo {
 
 	public String getOwner() {
 		return this.owner;
+	}
+
+	public static class MemoryInfo {
+
+		private static final MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
+
+		private final MemoryUsageInfo heap;
+
+		private final MemoryUsageInfo nonHeap;
+
+		MemoryInfo() {
+			this.heap = new MemoryUsageInfo(memoryMXBean.getHeapMemoryUsage());
+			this.nonHeap = new MemoryUsageInfo(memoryMXBean.getNonHeapMemoryUsage());
+		}
+
+		public MemoryUsageInfo getHeap() {
+			return this.heap;
+		}
+
+		public MemoryUsageInfo getNonHeap() {
+			return this.nonHeap;
+		}
+
+		public static class MemoryUsageInfo {
+
+			private final MemoryUsage memoryUsage;
+
+			MemoryUsageInfo(MemoryUsage memoryUsage) {
+				this.memoryUsage = memoryUsage;
+			}
+
+			public long getInit() {
+				return this.memoryUsage.getInit();
+			}
+
+			public long getUsed() {
+				return this.memoryUsage.getUsed();
+			}
+
+			public long getCommited() {
+				return this.memoryUsage.getCommitted();
+			}
+
+			public long getMax() {
+				return this.memoryUsage.getMax();
+			}
+
+		}
+
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/info/ProcessInfoTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/info/ProcessInfoTests.java
@@ -18,6 +18,8 @@ package org.springframework.boot.info;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.info.ProcessInfo.MemoryInfo.MemoryUsageInfo;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -35,6 +37,17 @@ class ProcessInfoTests {
 		assertThat(processInfo.getPid()).isEqualTo(ProcessHandle.current().pid());
 		assertThat(processInfo.getParentPid())
 			.isEqualTo(ProcessHandle.current().parent().map(ProcessHandle::pid).orElse(null));
+
+		MemoryUsageInfo heapUsageInfo = processInfo.getMemory().getHeap();
+		MemoryUsageInfo nonHeapUsageInfo = processInfo.getMemory().getNonHeap();
+		assertThat(heapUsageInfo.getInit()).isPositive().isLessThanOrEqualTo(heapUsageInfo.getMax());
+		assertThat(heapUsageInfo.getUsed()).isPositive().isLessThanOrEqualTo(heapUsageInfo.getCommited());
+		assertThat(heapUsageInfo.getCommited()).isPositive().isLessThanOrEqualTo(heapUsageInfo.getMax());
+		assertThat(heapUsageInfo.getMax()).isPositive();
+		assertThat(nonHeapUsageInfo.getInit()).isPositive();
+		assertThat(nonHeapUsageInfo.getUsed()).isPositive().isLessThanOrEqualTo(heapUsageInfo.getCommited());
+		assertThat(nonHeapUsageInfo.getCommited()).isPositive();
+		assertThat(nonHeapUsageInfo.getMax()).isEqualTo(-1);
 	}
 
 }


### PR DESCRIPTION
These changes are closing the gap for `ProcessInfoContributor` that were left out of https://github.com/spring-projects/spring-boot/pull/38371. As it was stated in https://github.com/spring-projects/spring-boot/pull/38371, this information can give runtime insights about the current memory usage and limits selected by the user or JVM ergonomics. If limits not set explicitly, it might not be trivial to know what these values are runtime; especially in (containerized) environments where resource usage can be isolated (for example using control groups). Other than that, these values can indicate if the JVM can resize the heap (stop-the-world).

Its output looks like this:
```json
"process": {
  "pid": 13231,
  "parentPid": 12020,
  "owner": "jonatan",
  "cpus": 16,
  "memory": {
    "heap": {
      "max": 8589934592,
      "commited": 83886080,
      "used": 45954800,
      "init": 536870912
    },
    "nonHeap": {
      "max": -1,
      "commited": 72220672,
      "used": 69441072,
      "init": 7667712
    }
  }
}
```
