### PR TITLE
Support Otlp Tracing's GRPC port from service connections

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/otlp/OtlpTracingConfigurations.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/otlp/OtlpTracingConfigurations.java
@@ -24,6 +24,7 @@ import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 
 import org.springframework.boot.actuate.autoconfigure.tracing.ConditionalOnEnabledTracing;
+import org.springframework.boot.actuate.autoconfigure.tracing.otlp.OtlpProperties.Transport;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,6 +35,7 @@ import org.springframework.context.annotation.Configuration;
  * Configurations imported by {@link OtlpAutoConfiguration}.
  *
  * @author Moritz Halbritter
+ * @author Eddú Meléndez
  */
 class OtlpTracingConfigurations {
 
@@ -63,6 +65,11 @@ class OtlpTracingConfigurations {
 				return this.properties.getEndpoint();
 			}
 
+			@Override
+			public String getGrpcEndpoint() {
+				return this.properties.getEndpoint();
+			}
+
 		}
 
 	}
@@ -79,7 +86,7 @@ class OtlpTracingConfigurations {
 		OtlpHttpSpanExporter otlpHttpSpanExporter(OtlpProperties properties,
 				OtlpTracingConnectionDetails connectionDetails) {
 			OtlpHttpSpanExporterBuilder builder = OtlpHttpSpanExporter.builder()
-				.setEndpoint(connectionDetails.getUrl())
+				.setEndpoint(resolveEndpoint(properties.getTransport(), connectionDetails))
 				.setTimeout(properties.getTimeout())
 				.setCompression(properties.getCompression().name().toLowerCase());
 			for (Entry<String, String> header : properties.getHeaders().entrySet()) {
@@ -93,13 +100,18 @@ class OtlpTracingConfigurations {
 		OtlpGrpcSpanExporter otlpGrpcSpanExporter(OtlpProperties properties,
 				OtlpTracingConnectionDetails connectionDetails) {
 			OtlpGrpcSpanExporterBuilder builder = OtlpGrpcSpanExporter.builder()
-				.setEndpoint(connectionDetails.getUrl())
+				.setEndpoint(resolveEndpoint(properties.getTransport(), connectionDetails))
 				.setTimeout(properties.getTimeout())
 				.setCompression(properties.getCompression().name().toLowerCase());
 			for (Entry<String, String> header : properties.getHeaders().entrySet()) {
 				builder.addHeader(header.getKey(), header.getValue());
 			}
 			return builder.build();
+		}
+
+		private static String resolveEndpoint(OtlpProperties.Transport transport,
+				OtlpTracingConnectionDetails connectionDetails) {
+			return (transport == Transport.HTTP) ? connectionDetails.getUrl() : connectionDetails.getGrpcEndpoint();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/otlp/OtlpTracingConnectionDetails.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/otlp/OtlpTracingConnectionDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,5 +31,9 @@ public interface OtlpTracingConnectionDetails extends ConnectionDetails {
 	 * @return the address to where tracing will be published
 	 */
 	String getUrl();
+
+	default String getGrpcEndpoint() {
+		return "http://localhost:4317/v1/traces";
+	}
 
 }

--- a/spring-boot-project/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/service/connection/otlp/OpenTelemetryTracingDockerComposeConnectionDetailsFactoryIntegrationTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/service/connection/otlp/OpenTelemetryTracingDockerComposeConnectionDetailsFactoryIntegrationTests.java
@@ -32,6 +32,7 @@ class OpenTelemetryTracingDockerComposeConnectionDetailsFactoryIntegrationTests 
 
 	@DockerComposeTest(composeFile = "otlp-compose.yaml", image = TestImage.OPENTELEMETRY)
 	void runCreatesConnectionDetails(OtlpTracingConnectionDetails connectionDetails) {
+		assertThat(connectionDetails.getGrpcEndpoint()).startsWith("http://").endsWith("/v1/traces");
 		assertThat(connectionDetails.getUrl()).startsWith("http://").endsWith("/v1/traces");
 	}
 

--- a/spring-boot-project/spring-boot-docker-compose/src/dockerTest/resources/org/springframework/boot/docker/compose/service/connection/otlp/otlp-compose.yaml
+++ b/spring-boot-project/spring-boot-docker-compose/src/dockerTest/resources/org/springframework/boot/docker/compose/service/connection/otlp/otlp-compose.yaml
@@ -2,4 +2,5 @@ services:
   otlp:
     image: '{imageName}'
     ports:
+      - '4317'
       - '4318'

--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/otlp/OpenTelemetryTracingDockerComposeConnectionDetailsFactory.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/otlp/OpenTelemetryTracingDockerComposeConnectionDetailsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,9 @@ import org.springframework.boot.docker.compose.service.connection.DockerComposeC
 class OpenTelemetryTracingDockerComposeConnectionDetailsFactory
 		extends DockerComposeConnectionDetailsFactory<OtlpTracingConnectionDetails> {
 
-	private static final int OTLP_PORT = 4318;
+	private static final int OTLP_GRPC_PORT = 4317;
+
+	private static final int OTLP_HTTP_PORT = 4318;
 
 	OpenTelemetryTracingDockerComposeConnectionDetailsFactory() {
 		super("otel/opentelemetry-collector-contrib",
@@ -47,17 +49,25 @@ class OpenTelemetryTracingDockerComposeConnectionDetailsFactory
 
 		private final String host;
 
-		private final int port;
+		private final int grpcPort;
+
+		private final int httPort;
 
 		private OpenTelemetryTracingDockerComposeConnectionDetails(RunningService source) {
 			super(source);
 			this.host = source.host();
-			this.port = source.ports().get(OTLP_PORT);
+			this.grpcPort = source.ports().get(OTLP_GRPC_PORT);
+			this.httPort = source.ports().get(OTLP_HTTP_PORT);
 		}
 
 		@Override
 		public String getUrl() {
-			return "http://%s:%d/v1/traces".formatted(this.host, this.port);
+			return "http://%s:%d/v1/traces".formatted(this.host, this.httPort);
+		}
+
+		@Override
+		public String getGrpcEndpoint() {
+			return "http://%s:%d/v1/traces".formatted(this.host, this.grpcPort);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-testcontainers/src/dockerTest/java/org/springframework/boot/testcontainers/service/connection/otlp/OpenTelemetryTracingContainerConnectionDetailsFactoryIntegrationTests.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/dockerTest/java/org/springframework/boot/testcontainers/service/connection/otlp/OpenTelemetryTracingContainerConnectionDetailsFactoryIntegrationTests.java
@@ -43,13 +43,16 @@ class OpenTelemetryTracingContainerConnectionDetailsFactoryIntegrationTests {
 
 	@Container
 	@ServiceConnection
-	static final GenericContainer<?> container = TestImage.OPENTELEMETRY.genericContainer().withExposedPorts(4318);
+	static final GenericContainer<?> container = TestImage.OPENTELEMETRY.genericContainer()
+		.withExposedPorts(4317, 4318);
 
 	@Autowired
 	private OtlpTracingConnectionDetails connectionDetails;
 
 	@Test
 	void connectionCanBeMadeToOpenTelemetryContainer() {
+		assertThat(this.connectionDetails.getGrpcEndpoint())
+			.isEqualTo("http://" + container.getHost() + ":" + container.getMappedPort(4317) + "/v1/traces");
 		assertThat(this.connectionDetails.getUrl())
 			.isEqualTo("http://" + container.getHost() + ":" + container.getMappedPort(4318) + "/v1/traces");
 	}

--- a/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/otlp/OpenTelemetryTracingContainerConnectionDetailsFactory.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/otlp/OpenTelemetryTracingContainerConnectionDetailsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,10 @@ import org.springframework.boot.testcontainers.service.connection.ServiceConnect
 class OpenTelemetryTracingContainerConnectionDetailsFactory
 		extends ContainerConnectionDetailsFactory<Container<?>, OtlpTracingConnectionDetails> {
 
+	private static final int OTLP_GRPC_PORT = 4317;
+
+	private static final int OTLP_HTTP_PORT = 4318;
+
 	OpenTelemetryTracingContainerConnectionDetailsFactory() {
 		super("otel/opentelemetry-collector-contrib",
 				"org.springframework.boot.actuate.autoconfigure.tracing.otlp.OtlpAutoConfiguration");
@@ -55,7 +59,14 @@ class OpenTelemetryTracingContainerConnectionDetailsFactory
 
 		@Override
 		public String getUrl() {
-			return "http://%s:%d/v1/traces".formatted(getContainer().getHost(), getContainer().getMappedPort(4318));
+			return "http://%s:%d/v1/traces".formatted(getContainer().getHost(),
+					getContainer().getMappedPort(OTLP_HTTP_PORT));
+		}
+
+		@Override
+		public String getGrpcEndpoint() {
+			return "http://%s:%d/v1/traces".formatted(getContainer().getHost(),
+					getContainer().getMappedPort(OTLP_GRPC_PORT));
 		}
 
 	}


### PR DESCRIPTION
Otlp Tracing's exporter is configured using `Transport`. Current support for service connections read the mapped port for HTTP transport `4318`. This commits adds support to read port for GRPC transport `4317`.
