### PR TITLE
chore(deps): update io.github.git-commit-id:git-commit-id-maven-plugin to v9.0.1

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -416,7 +416,7 @@ bom {
 				.formatted(version.toString("_")) }
 		}
 	}
-	library("Git Commit ID Maven Plugin", "8.0.2") {
+	library("Git Commit ID Maven Plugin", "9.0.1") {
 		group("io.github.git-commit-id") {
 			plugins = [
 				"git-commit-id-maven-plugin"


### PR DESCRIPTION
Dependency Upgrade:
- Update `io.github.git-commit-id:git-commit-id-maven-plugin` to v9.0.1
   - Fixes behavior when generating `git.properties` (or `git.json`, etc) in multi-module project that was broken in Spring Boot `3.3.0` - https://github.com/spring-projects/spring-boot/commit/53f850410f486af87a3848495df2fb60500770ee
 
Describing Your Changes:
- Update `io.github.git-commit-id:git-commit-id-maven-plugin` to latest version
   - Fix for https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/754
