### PR TITLE
Add a property for configuring additional livereload paths

### DIFF
--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
@@ -30,6 +30,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Phillip Webb
  * @author Stephane Nicoll
+ * @author Akshay Dubey
  * @since 1.3.0
  */
 @ConfigurationProperties(prefix = "spring.devtools")
@@ -198,6 +199,22 @@ public class DevToolsProperties {
 		 */
 		private int port = 35729;
 
+		/**
+		 * Additional paths to watch for changes.
+		 */
+		private List<File> additionalPaths = new ArrayList<>();
+
+		/**
+		 * Amount of time to wait between polling for classpath changes.
+		 */
+		private Duration pollInterval = Duration.ofSeconds(1);
+
+		/**
+		 * Amount of quiet time required without any classpath changes before a reload is
+		 * triggered.
+		 */
+		private Duration quietPeriod = Duration.ofMillis(400);
+
 		public boolean isEnabled() {
 			return this.enabled;
 		}
@@ -212,6 +229,30 @@ public class DevToolsProperties {
 
 		public void setPort(int port) {
 			this.port = port;
+		}
+
+		public List<File> getAdditionalPaths() {
+			return this.additionalPaths;
+		}
+
+		public void setAdditionalPaths(List<File> additionalPaths) {
+			this.additionalPaths = additionalPaths;
+		}
+
+		public Duration getPollInterval() {
+			return this.pollInterval;
+		}
+
+		public void setPollInterval(Duration pollInterval) {
+			this.pollInterval = pollInterval;
+		}
+
+		public Duration getQuietPeriod() {
+			return this.quietPeriod;
+		}
+
+		public void setQuietPeriod(Duration quietPeriod) {
+			this.quietPeriod = quietPeriod;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
@@ -204,6 +204,17 @@ public class DevToolsProperties {
 		 */
 		private List<File> additionalPaths = new ArrayList<>();
 
+		/**
+		 * Amount of time to wait between polling for classpath changes.
+		 */
+		private Duration pollInterval = Duration.ofSeconds(1);
+
+		/**
+		 * Amount of quiet time required without any classpath changes before a reload is
+		 * triggered.
+		 */
+		private Duration quietPeriod = Duration.ofMillis(400);
+
 		public boolean isEnabled() {
 			return this.enabled;
 		}
@@ -226,6 +237,22 @@ public class DevToolsProperties {
 
 		public void setAdditionalPaths(List<File> additionalPaths) {
 			this.additionalPaths = additionalPaths;
+		}
+
+		public Duration getPollInterval() {
+			return this.pollInterval;
+		}
+
+		public void setPollInterval(Duration pollInterval) {
+			this.pollInterval = pollInterval;
+		}
+
+		public Duration getQuietPeriod() {
+			return this.quietPeriod;
+		}
+
+		public void setQuietPeriod(Duration quietPeriod) {
+			this.quietPeriod = quietPeriod;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
@@ -204,17 +204,6 @@ public class DevToolsProperties {
 		 */
 		private List<File> additionalPaths = new ArrayList<>();
 
-		/**
-		 * Amount of time to wait between polling for classpath changes.
-		 */
-		private Duration pollInterval = Duration.ofSeconds(1);
-
-		/**
-		 * Amount of quiet time required without any classpath changes before a reload is
-		 * triggered.
-		 */
-		private Duration quietPeriod = Duration.ofMillis(400);
-
 		public boolean isEnabled() {
 			return this.enabled;
 		}
@@ -237,22 +226,6 @@ public class DevToolsProperties {
 
 		public void setAdditionalPaths(List<File> additionalPaths) {
 			this.additionalPaths = additionalPaths;
-		}
-
-		public Duration getPollInterval() {
-			return this.pollInterval;
-		}
-
-		public void setPollInterval(Duration pollInterval) {
-			this.pollInterval = pollInterval;
-		}
-
-		public Duration getQuietPeriod() {
-			return this.quietPeriod;
-		}
-
-		public void setQuietPeriod(Duration quietPeriod) {
-			this.quietPeriod = quietPeriod;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
@@ -95,7 +95,7 @@ public class LocalDevToolsAutoConfiguration {
 		LiveReloadForAdditionalPaths liveReloadForAdditionalPaths(LiveReloadServer liveReloadServer,
 				DevToolsProperties properties, FileSystemWatcher fileSystemWatcher) {
 			return new LiveReloadForAdditionalPaths(liveReloadServer,
-				properties.getLivereload().getAdditionalPaths(),fileSystemWatcher);
+				properties.getLivereload().getAdditionalPaths(), fileSystemWatcher);
 		}
 
 		@Bean
@@ -238,18 +238,21 @@ public class LocalDevToolsAutoConfiguration {
 
 		@Override
 		public void destroy() throws Exception {
-		if(this.fileSystemWatcher!=null)
-			this.fileSystemWatcher.stop();
+			if (this.fileSystemWatcher != null) {
+				this.fileSystemWatcher.stop();
+			}
 		}
 
-		public LiveReloadForAdditionalPaths( LiveReloadServer liveReloadServer, List<File> staticLocations, FileSystemWatcher fileSystemWatcher) {
+		LiveReloadForAdditionalPaths(LiveReloadServer liveReloadServer, List<File> staticLocations, FileSystemWatcher fileSystemWatcher) {
 			this.fileSystemWatcher = fileSystemWatcher;
 
 			for (File path : staticLocations) {
 				this.fileSystemWatcher.addSourceDirectory(path.getAbsoluteFile());
 			}
 
-			this.fileSystemWatcher.addListener(__ -> liveReloadServer.triggerReload());
+			this.fileSystemWatcher.addListener(__ -> { 
+				liveReloadServer.triggerReload();
+			});
 
 			this.fileSystemWatcher.start();
 		}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
@@ -250,7 +250,7 @@ public class LocalDevToolsAutoConfiguration {
 				this.fileSystemWatcher.addSourceDirectory(path.getAbsoluteFile());
 			}
 
-			this.fileSystemWatcher.addListener(__ -> { 
+			this.fileSystemWatcher.addListener((__) -> {
 				liveReloadServer.triggerReload();
 			});
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -99,7 +100,14 @@ public class LocalDevToolsAutoConfiguration {
 		}
 
 		@Bean
-		FileSystemWatcher fileSystemWatcher(DevToolsProperties properties, RestartConfiguration restartConfiguration) {
+		@ConditionalOnMissingBean(RestartConfiguration.class)
+		FileSystemWatcher newFileSystemWatcher(DevToolsProperties properties) {
+			return new FileSystemWatcher(true, properties.getLivereload().getPollInterval(), properties.getLivereload().getQuietPeriod());
+		}
+
+		@Bean
+		@ConditionalOnBean(RestartConfiguration.class)
+		FileSystemWatcher fileSystemWatcher(RestartConfiguration restartConfiguration) {
 			return restartConfiguration.newFileSystemWatcher();
 		}
 

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
@@ -99,9 +99,8 @@ public class LocalDevToolsAutoConfiguration {
 		}
 
 		@Bean
-		FileSystemWatcher fileSystemWatcher(DevToolsProperties properties) {
-			return new FileSystemWatcher(true, properties.getLivereload().getPollInterval(),
-					properties.getLivereload().getQuietPeriod());
+		FileSystemWatcher fileSystemWatcher(DevToolsProperties properties, RestartConfiguration restartConfiguration) {
+			return restartConfiguration.newFileSystemWatcher();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
@@ -95,15 +95,14 @@ public class LocalDevToolsAutoConfiguration {
 		LiveReloadForAdditionalPaths liveReloadForAdditionalPaths(LiveReloadServer liveReloadServer,
 				DevToolsProperties properties, FileSystemWatcher fileSystemWatcher) {
 			return new LiveReloadForAdditionalPaths(liveReloadServer,
-    				properties.getLivereload().getAdditionalPaths(),fileSystemWatcher);
+				properties.getLivereload().getAdditionalPaths(),fileSystemWatcher);
 		}
 
 		@Bean
- 		FileSystemWatcher fileSystemWatcher(DevToolsProperties properties) {
-   			return new FileSystemWatcher(true,
-     				properties.getLivereload().getPollInterval(),
-    				properties.getLivereload().getQuietPeriod()
-   			);
+		FileSystemWatcher fileSystemWatcher(DevToolsProperties properties) {
+			return new FileSystemWatcher(true,
+					properties.getLivereload().getPollInterval(),
+					properties.getLivereload().getQuietPeriod());
 		}
 
 	}
@@ -233,27 +232,27 @@ public class LocalDevToolsAutoConfiguration {
 
 	}
 
-		static class LiveReloadForAdditionalPaths implements DisposableBean {
+	static class LiveReloadForAdditionalPaths implements DisposableBean {
 
 		private final FileSystemWatcher fileSystemWatcher;
 
 		@Override
-  		public void destroy() throws Exception {
-   			if(this.fileSystemWatcher!=null)
-    			this.fileSystemWatcher.stop();
-  		}
+		public void destroy() throws Exception {
+		if(this.fileSystemWatcher!=null)
+			this.fileSystemWatcher.stop();
+		}
 
-  		public LiveReloadForAdditionalPaths( LiveReloadServer liveReloadServer, List<File> staticLocations, FileSystemWatcher fileSystemWatcher) {
-   			this.fileSystemWatcher = fileSystemWatcher;
+		public LiveReloadForAdditionalPaths( LiveReloadServer liveReloadServer, List<File> staticLocations, FileSystemWatcher fileSystemWatcher) {
+			this.fileSystemWatcher = fileSystemWatcher;
 
-   			for (File path : staticLocations) {
-   		 		this.fileSystemWatcher.addSourceDirectory(path.getAbsoluteFile());
-   			}
+			for (File path : staticLocations) {
+				this.fileSystemWatcher.addSourceDirectory(path.getAbsoluteFile());
+			}
 
-   			this.fileSystemWatcher.addListener(__ -> liveReloadServer.triggerReload());
+			this.fileSystemWatcher.addListener(__ -> liveReloadServer.triggerReload());
 
-   			this.fileSystemWatcher.start();
-  		}
+			this.fileSystemWatcher.start();
+		}
 	}
 
 }

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
@@ -250,9 +250,7 @@ public class LocalDevToolsAutoConfiguration {
 				this.fileSystemWatcher.addSourceDirectory(path.getAbsoluteFile());
 			}
 
-			this.fileSystemWatcher.addListener((__) -> {
-				liveReloadServer.triggerReload();
-			});
+			this.fileSystemWatcher.addListener((__) -> liveReloadServer.triggerReload());
 
 			this.fileSystemWatcher.start();
 		}

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -57,6 +58,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @author Andy Wilkinson
  * @author Vladimir Tsanev
+ * @author Akshay Dubey
  * @since 1.3.0
  */
 @AutoConfiguration
@@ -87,6 +89,21 @@ public class LocalDevToolsAutoConfiguration {
 		@Bean
 		LiveReloadServerEventListener liveReloadServerEventListener(OptionalLiveReloadServer liveReloadServer) {
 			return new LiveReloadServerEventListener(liveReloadServer);
+		}
+
+		@Bean
+		LiveReloadForAdditionalPaths liveReloadForAdditionalPaths(LiveReloadServer liveReloadServer,
+				DevToolsProperties properties, FileSystemWatcher fileSystemWatcher) {
+			return new LiveReloadForAdditionalPaths(liveReloadServer,
+    				properties.getLivereload().getAdditionalPaths(),fileSystemWatcher);
+		}
+
+		@Bean
+ 		FileSystemWatcher fileSystemWatcher(DevToolsProperties properties) {
+   			return new FileSystemWatcher(true,
+     				properties.getLivereload().getPollInterval(),
+    				properties.getLivereload().getQuietPeriod()
+   			);
 		}
 
 	}
@@ -214,6 +231,29 @@ public class LocalDevToolsAutoConfiguration {
 			}
 		}
 
+	}
+
+		static class LiveReloadForAdditionalPaths implements DisposableBean {
+
+		private final FileSystemWatcher fileSystemWatcher;
+
+		@Override
+  		public void destroy() throws Exception {
+   			if(this.fileSystemWatcher!=null)
+    			this.fileSystemWatcher.stop();
+  		}
+
+  		public LiveReloadForAdditionalPaths( LiveReloadServer liveReloadServer, List<File> staticLocations, FileSystemWatcher fileSystemWatcher) {
+   			this.fileSystemWatcher = fileSystemWatcher;
+
+   			for (File path : staticLocations) {
+   		 		this.fileSystemWatcher.addSourceDirectory(path.getAbsoluteFile());
+   			}
+
+   			this.fileSystemWatcher.addListener(__ -> liveReloadServer.triggerReload());
+
+   			this.fileSystemWatcher.start();
+  		}
 	}
 
 }

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
@@ -102,7 +102,8 @@ public class LocalDevToolsAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean(RestartConfiguration.class)
 		FileSystemWatcher newFileSystemWatcher(DevToolsProperties properties) {
-			return new FileSystemWatcher(true, properties.getLivereload().getPollInterval(), properties.getLivereload().getQuietPeriod());
+			return new FileSystemWatcher(true, properties.getLivereload().getPollInterval(),
+					properties.getLivereload().getQuietPeriod());
 		}
 
 		@Bean

--- a/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
@@ -94,14 +94,13 @@ public class LocalDevToolsAutoConfiguration {
 		@Bean
 		LiveReloadForAdditionalPaths liveReloadForAdditionalPaths(LiveReloadServer liveReloadServer,
 				DevToolsProperties properties, FileSystemWatcher fileSystemWatcher) {
-			return new LiveReloadForAdditionalPaths(liveReloadServer,
-				properties.getLivereload().getAdditionalPaths(), fileSystemWatcher);
+			return new LiveReloadForAdditionalPaths(liveReloadServer, properties.getLivereload().getAdditionalPaths(),
+					fileSystemWatcher);
 		}
 
 		@Bean
 		FileSystemWatcher fileSystemWatcher(DevToolsProperties properties) {
-			return new FileSystemWatcher(true,
-					properties.getLivereload().getPollInterval(),
+			return new FileSystemWatcher(true, properties.getLivereload().getPollInterval(),
 					properties.getLivereload().getQuietPeriod());
 		}
 
@@ -243,7 +242,8 @@ public class LocalDevToolsAutoConfiguration {
 			}
 		}
 
-		LiveReloadForAdditionalPaths(LiveReloadServer liveReloadServer, List<File> staticLocations, FileSystemWatcher fileSystemWatcher) {
+		LiveReloadForAdditionalPaths(LiveReloadServer liveReloadServer, List<File> staticLocations,
+				FileSystemWatcher fileSystemWatcher) {
 			this.fileSystemWatcher = fileSystemWatcher;
 
 			for (File path : staticLocations) {
@@ -254,6 +254,7 @@ public class LocalDevToolsAutoConfiguration {
 
 			this.fileSystemWatcher.start();
 		}
+
 	}
 
 }

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
@@ -37,6 +37,7 @@ import org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfigura
 import org.springframework.boot.autoconfigure.web.WebProperties;
 import org.springframework.boot.autoconfigure.web.WebProperties.Resources;
 import org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryAutoConfiguration;
+import org.springframework.boot.devtools.autoconfigure.LocalDevToolsAutoConfiguration.LiveReloadForAdditionalPaths;
 import org.springframework.boot.devtools.classpath.ClassPathChangedEvent;
 import org.springframework.boot.devtools.classpath.ClassPathFileSystemWatcher;
 import org.springframework.boot.devtools.livereload.LiveReloadServer;
@@ -70,6 +71,7 @@ import static org.mockito.Mockito.reset;
  * @author Phillip Webb
  * @author Andy Wilkinson
  * @author Vladimir Tsanev
+ * @author Akshay Dubey
  */
 @ExtendWith(MockRestarter.class)
 class LocalDevToolsAutoConfigurationTests {
@@ -212,6 +214,20 @@ class LocalDevToolsAutoConfigurationTests {
 			.containsKey(new File("src/main/java").getAbsoluteFile())
 			.containsKey(new File("src/test/java").getAbsoluteFile());
 	}
+
+	@Test
+ 	void watchingAdditionalPathsForReload() throws Exception {
+  		Map<String, Object> properties = new HashMap<>();
+  		properties.put("spring.devtools.livereload.additional-paths", "src/main/java,src/test/java");
+  		this.context = getContext(() -> initializeAndRun(Config.class, properties));
+  		LiveReloadForAdditionalPaths liveReloadForAdditionalPaths = this.context.getBean(LiveReloadForAdditionalPaths.class);
+  		Object watcher = ReflectionTestUtils.getField(liveReloadForAdditionalPaths, "fileSystemWatcher");
+  		@SuppressWarnings("unchecked")
+  		Map<File, Object> directories = (Map<File, Object>) ReflectionTestUtils.getField(watcher, "directories");
+  		assertThat(directories).hasSize(2)
+    		.containsKey(new File("src/main/java").getAbsoluteFile())
+    		.containsKey(new File("src/test/java").getAbsoluteFile());
+ 	}
 
 	@Test
 	void devToolsSwitchesJspServletToDevelopmentMode() throws Exception {

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
@@ -216,18 +216,18 @@ class LocalDevToolsAutoConfigurationTests {
 	}
 
 	@Test
- 	void watchingAdditionalPathsForReload() throws Exception {
-  		Map<String, Object> properties = new HashMap<>();
-  		properties.put("spring.devtools.livereload.additional-paths", "src/main/java,src/test/java");
-  		this.context = getContext(() -> initializeAndRun(Config.class, properties));
-  		LiveReloadForAdditionalPaths liveReloadForAdditionalPaths = this.context.getBean(LiveReloadForAdditionalPaths.class);
-  		Object watcher = ReflectionTestUtils.getField(liveReloadForAdditionalPaths, "fileSystemWatcher");
-  		@SuppressWarnings("unchecked")
-  		Map<File, Object> directories = (Map<File, Object>) ReflectionTestUtils.getField(watcher, "directories");
-  		assertThat(directories).hasSize(2)
-    		.containsKey(new File("src/main/java").getAbsoluteFile())
-    		.containsKey(new File("src/test/java").getAbsoluteFile());
- 	}
+	void watchingAdditionalPathsForReload() throws Exception {
+		Map<String, Object> properties = new HashMap<>();
+		properties.put("spring.devtools.livereload.additional-paths", "src/main/java,src/test/java");
+		this.context = getContext(() -> initializeAndRun(Config.class, properties));
+		LiveReloadForAdditionalPaths liveReloadForAdditionalPaths = this.context.getBean(LiveReloadForAdditionalPaths.class);
+		Object watcher = ReflectionTestUtils.getField(liveReloadForAdditionalPaths, "fileSystemWatcher");
+		@SuppressWarnings("unchecked")
+		Map<File, Object> directories = (Map<File, Object>) ReflectionTestUtils.getField(watcher, "directories");
+		assertThat(directories).hasSize(2)
+			.containsKey(new File("src/main/java").getAbsoluteFile())
+			.containsKey(new File("src/test/java").getAbsoluteFile());
+	}
 
 	@Test
 	void devToolsSwitchesJspServletToDevelopmentMode() throws Exception {

--- a/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
@@ -220,7 +220,8 @@ class LocalDevToolsAutoConfigurationTests {
 		Map<String, Object> properties = new HashMap<>();
 		properties.put("spring.devtools.livereload.additional-paths", "src/main/java,src/test/java");
 		this.context = getContext(() -> initializeAndRun(Config.class, properties));
-		LiveReloadForAdditionalPaths liveReloadForAdditionalPaths = this.context.getBean(LiveReloadForAdditionalPaths.class);
+		LiveReloadForAdditionalPaths liveReloadForAdditionalPaths = this.context
+			.getBean(LiveReloadForAdditionalPaths.class);
 		Object watcher = ReflectionTestUtils.getField(liveReloadForAdditionalPaths, "fileSystemWatcher");
 		@SuppressWarnings("unchecked")
 		Map<File, Object> directories = (Map<File, Object>) ReflectionTestUtils.getField(watcher, "directories");


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR enhances the functionality related to issue #40342 by introducing configurable additional paths for live reload. This feature mirrors the existing capability for configuring additional paths for application restart.
