### PR TITLE
Add hint for new dependencies required for Flyway

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/data-initialization.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/data-initialization.adoc
@@ -98,6 +98,7 @@ Spring Boot supports two higher-level migration tools: https://flywaydb.org/[Fly
 === Execute Flyway Database Migrations on Startup
 
 To automatically run Flyway database migrations on startup, add the `org.flywaydb:flyway-core` to your classpath.
+For some databases, a https://search.maven.org/search?q=g:org.flywaydb%20a:flyway-database-*[database-specific module] needs to be added additionally, e.g. `org.flywaydb:flyway-database-postgresql` for PostgreSQL.
 
 Typically, migrations are scripts in the form `V<VERSION>__<NAME>.sql` (with `<VERSION>` an underscore-separated version, such as '`1`' or '`2_1`').
 By default, they are in a directory called `classpath:db/migration`, but you can modify that location by setting `spring.flyway.locations`.

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/data-initialization.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/data-initialization.adoc
@@ -98,7 +98,7 @@ Spring Boot supports two higher-level migration tools: https://flywaydb.org/[Fly
 === Execute Flyway Database Migrations on Startup
 
 To automatically run Flyway database migrations on startup, add the `org.flywaydb:flyway-core` to your classpath.
-All databases that are not in-memory or file based need an additional dependency, e.g. `org.flywaydb:flyway-database-postgresql` is requiredd for PostgreSQL and `org.flywaydb:flyway-mysql` is required for MySQL (see https://documentation.red-gate.com/flyway/flyway-cli-and-api/supported-databases[Supported Databases in the Flyway Documentation] for details).
+All databases that are not in-memory or file based need an additional dependency, e.g. `org.flywaydb:flyway-database-postgresql` is required for PostgreSQL and `org.flywaydb:flyway-mysql` is required for MySQL (see https://documentation.red-gate.com/flyway/flyway-cli-and-api/supported-databases[Supported Databases in the Flyway Documentation] for details).
 
 Typically, migrations are scripts in the form `V<VERSION>__<NAME>.sql` (with `<VERSION>` an underscore-separated version, such as '`1`' or '`2_1`').
 By default, they are in a directory called `classpath:db/migration`, but you can modify that location by setting `spring.flyway.locations`.

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/data-initialization.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/data-initialization.adoc
@@ -98,7 +98,7 @@ Spring Boot supports two higher-level migration tools: https://flywaydb.org/[Fly
 === Execute Flyway Database Migrations on Startup
 
 To automatically run Flyway database migrations on startup, add the `org.flywaydb:flyway-core` to your classpath.
-For some databases, a https://search.maven.org/search?q=g:org.flywaydb%20a:flyway-database-*[database-specific module] needs to be added additionally, e.g. `org.flywaydb:flyway-database-postgresql` for PostgreSQL.
+All databases that are not in-memory or file based need an additional dependency, e.g. `org.flywaydb:flyway-database-postgresql` is requiredd for PostgreSQL and `org.flywaydb:flyway-mysql` is required for MySQL (see https://documentation.red-gate.com/flyway/flyway-cli-and-api/supported-databases[Supported Databases in the Flyway Documentation] for details).
 
 Typically, migrations are scripts in the form `V<VERSION>__<NAME>.sql` (with `<VERSION>` an underscore-separated version, such as '`1`' or '`2_1`').
 By default, they are in a directory called `classpath:db/migration`, but you can modify that location by setting `spring.flyway.locations`.


### PR DESCRIPTION
After following the documentation in https://docs.spring.io/spring-boot/how-to/data-initialization.html#howto.data-initialization.migration-tool.flyway for the setup of Flyway, I got the following error after attempting the app startup:

> org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'flywayInitializer' defined in class path resource [org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration$FlywayConfiguration.class]: Unsupported Database: PostgreSQL 16.3

It turns out that with Spring Boot 3.3, Flyway was upgraded to version 10 which requires an additional dependency for Posgres and some other databases:

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.3-Release-Notes#flyway-10

This PR is intended to provide a hint about this additional dependency in the documentation linked above.

Also see https://github.com/openrewrite/rewrite-spring/issues/532