### PR TITLE
Update "Amazon Redshift" DataSource for DatabaseDriver.java

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
@@ -87,7 +87,7 @@ public enum DatabaseDriver {
 	 * Amazon Redshift.
 	 * @since 2.2.0
 	 */
-	REDSHIFT("Redshift", "com.amazon.redshift.jdbc.Driver", null, "SELECT 1"),
+	REDSHIFT("Redshift", "com.amazon.redshift.jdbc.Driver", "com.amazon.redshift.jdbc.DataSource", "SELECT 1"),
 
 	/**
 	 * HANA - SAP HANA Database - HDB.


### PR DESCRIPTION
As the latest guide document at https://docs.aws.amazon.com/redshift/latest/mgmt/jdbc20-register-driver-class.html they are provide "Amazon Redshift" DataSource as "com.amazon.redshift.jdbc.DataSource" . I would like to update it into DatabaseDriver.java .
