### PR TITLE
Launcher's ClassLoader is no longer parallel capable

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/JarUrlClassLoader.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/JarUrlClassLoader.java
@@ -40,6 +40,10 @@ import org.springframework.boot.loader.launch.LaunchedClassLoader;
  */
 public abstract class JarUrlClassLoader extends URLClassLoader {
 
+	static {
+		ClassLoader.registerAsParallelCapable();
+	}
+
 	private final URL[] urls;
 
 	private final boolean hasJarUrls;


### PR DESCRIPTION
While debugging deadlock in our application, I found that spring-boot's LaunchedClassLoader is not registered as parallel capable class loader. 

Even though LaunchedClassLoader register itself as parallel capable, ClassLoader only accepts registerAsParallelCapable if the super class is also parallel capable.

https://github.com/openjdk/jdk/blob/f174bbd3baf351ae9248b70454b3bc5a89acd7c6/src/java.base/share/classes/java/lang/ClassLoader.java#L270-L284
```
        static boolean register(Class<? extends ClassLoader> c) {
            synchronized (loaderTypes) {
                if (loaderTypes.contains(c.getSuperclass())) {
                    // register the class loader as parallel capable
                    // if and only if all of its super classes are.
                    // Note: given current classloading sequence, if
                    // the immediate super class is parallel capable,
                    // all the super classes higher up must be too.
                    loaderTypes.add(c);
                    return true;
                } else {
                    return false;
                }
            }
```

Looking at this issue (https://github.com/spring-projects/spring-boot/issues/7333), it seems LaunchedClassLoader is parallel capable. So this PR registers LaunchedClassLoader's parent class, JarUrlClassLoader as parallel capable.
