### PR TITLE
Harmonize use of StructuredLogEncoder (formerly StructuredLoggingEncoder)

### DIFF
--- a/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/structured-console-appender.xml
+++ b/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/structured-console-appender.xml
@@ -10,7 +10,7 @@ equivalent to the programmatic initialization performed by Boot
 		<filter class="ch.qos.logback.classic.filter.ThresholdFilter">
 			<level>${CONSOLE_LOG_THRESHOLD}</level>
 		</filter>
-		<encoder class="org.springframework.boot.logging.logback.StructuredLoggingEncoder">
+		<encoder class="org.springframework.boot.logging.logback.StructuredLogEncoder">
 			<format>${CONSOLE_LOG_STRUCTURED_FORMAT}</format>
 			<charset>${CONSOLE_LOG_CHARSET}</charset>
 		</encoder>

--- a/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/structured-file-appender.xml
+++ b/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/structured-file-appender.xml
@@ -10,7 +10,7 @@ equivalent to the programmatic initialization performed by Boot
 		<filter class="ch.qos.logback.classic.filter.ThresholdFilter">
 			<level>${FILE_LOG_THRESHOLD}</level>
 		</filter>
-		<encoder class="org.springframework.boot.logging.logback.StructuredLoggingEncoder">
+		<encoder class="org.springframework.boot.logging.logback.StructuredLogEncoder">
 			<format>${FILE_LOG_STRUCTURED_FORMAT}</format>
 			<charset>${FILE_LOG_CHARSET}</charset>
 		</encoder>


### PR DESCRIPTION
Fix Typo in Spring Boot structured logging, console + file