### PR TITLE
Fix NullPointerException Risk in Dependency Extraction in BomPlugin

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/BomPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/BomPlugin.java
@@ -140,10 +140,9 @@ public class BomPlugin implements Plugin<Project> {
 			Node dependencies = findChild(dependencyManagement, "dependencies");
 			if (dependencies != null) {
 				for (Node dependency : findChildren(dependencies, "dependency")) {
-					String groupId = findChild(dependency, "groupId").text();
-					String artifactId = findChild(dependency, "artifactId").text();
-					Node classifierNode = findChild(dependency, "classifier");
-					String classifier = (classifierNode != null) ? classifierNode.text() : "";
+					String groupId = extractText(findChild(dependency, "groupId"));
+					String artifactId = extractText(findChild(dependency, "artifactId"));
+					String classifier = extractText(findChild(dependency, "classifier"));
 					String versionProperty = this.bom.getArtifactVersionProperty(groupId, artifactId, classifier);
 					if (versionProperty != null) {
 						findChild(dependency, "version").setValue("${" + versionProperty + "}");
@@ -156,8 +155,8 @@ public class BomPlugin implements Plugin<Project> {
 			Node dependencies = findChild(dependencyManagement, "dependencies");
 			if (dependencies != null) {
 				for (Node dependency : findChildren(dependencies, "dependency")) {
-					String groupId = findChild(dependency, "groupId").text();
-					String artifactId = findChild(dependency, "artifactId").text();
+					String groupId = extractText(findChild(dependency, "groupId"));
+					String artifactId = extractText(findChild(dependency, "artifactId"));
 					this.bom.getLibraries()
 						.stream()
 						.flatMap((library) -> library.getGroups().stream())
@@ -179,8 +178,8 @@ public class BomPlugin implements Plugin<Project> {
 			Node dependencies = findChild(dependencyManagement, "dependencies");
 			if (dependencies != null) {
 				for (Node dependency : findChildren(dependencies, "dependency")) {
-					String groupId = findChild(dependency, "groupId").text();
-					String artifactId = findChild(dependency, "artifactId").text();
+					String groupId = extractText(findChild(dependency, "groupId"));
+					String artifactId = extractText(findChild(dependency, "artifactId"));
 					Set<String> types = this.bom.getLibraries()
 						.stream()
 						.flatMap((library) -> library.getGroups().stream())
@@ -207,9 +206,9 @@ public class BomPlugin implements Plugin<Project> {
 			Node dependencies = findChild(dependencyManagement, "dependencies");
 			if (dependencies != null) {
 				for (Node dependency : findChildren(dependencies, "dependency")) {
-					String groupId = findChild(dependency, "groupId").text();
-					String artifactId = findChild(dependency, "artifactId").text();
-					String version = findChild(dependency, "version").text();
+					String groupId = extractText(findChild(dependency, "groupId"));
+					String artifactId = extractText(findChild(dependency, "artifactId"));
+					String version = extractText(findChild(dependency, "version"));
 					Set<String> classifiers = this.bom.getLibraries()
 						.stream()
 						.flatMap((library) -> library.getGroups().stream())
@@ -294,6 +293,10 @@ public class BomPlugin implements Plugin<Project> {
 				return name.equals(node.name());
 			}
 			return false;
+		}
+
+		private String extractText(Node node) {
+			return (node != null) ? node.text() : "";
 		}
 
 	}


### PR DESCRIPTION
## Summary

This pull request addresses a potential NullPointerException issue in the BomPlugin class. The original code invoked the text() method on the result of findChild() without null-checking, which could lead to exceptions if findChild() returns null.

## Changes Made

Introduced a new method extractText() to safely handle null values when extracting text.
Updated the usage of the text() method to use extractText() to prevent NullPointerException.

## Details

The changes involve modifying the BomPlugin class as follows:

```java
String groupId = extractText(findChild(dependency, "groupId"));
String artifactId = extractText(findChild(dependency, "artifactId"));
```

The extractText() method ensures that if findChild() returns null, it will not cause a NullPointerException, thus improving the robustness of the code.

## Reason for Change

This modification enhances the stability of the code by handling potential null values gracefully, ensuring that the application can handle missing child elements without crashing.

Thank you for reviewing this pull request!