### PR TITLE
Add support for Pulsar default tenant/namespace

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfiguration.java
@@ -52,6 +52,7 @@ import org.springframework.pulsar.core.PulsarConsumerFactory;
 import org.springframework.pulsar.core.PulsarProducerFactory;
 import org.springframework.pulsar.core.PulsarReaderFactory;
 import org.springframework.pulsar.core.PulsarTemplate;
+import org.springframework.pulsar.core.PulsarTopicBuilder;
 import org.springframework.pulsar.core.ReaderBuilderCustomizer;
 import org.springframework.pulsar.core.SchemaResolver;
 import org.springframework.pulsar.core.TopicResolver;
@@ -88,24 +89,30 @@ public class PulsarAutoConfiguration {
 	@ConditionalOnMissingBean(PulsarProducerFactory.class)
 	@ConditionalOnProperty(name = "spring.pulsar.producer.cache.enabled", havingValue = "false")
 	DefaultPulsarProducerFactory<?> pulsarProducerFactory(PulsarClient pulsarClient, TopicResolver topicResolver,
-			ObjectProvider<ProducerBuilderCustomizer<?>> customizersProvider) {
+			ObjectProvider<ProducerBuilderCustomizer<?>> customizersProvider,
+			PulsarTopicBuilder topicBuilder) {
 		List<ProducerBuilderCustomizer<Object>> lambdaSafeCustomizers = lambdaSafeProducerBuilderCustomizers(
 				customizersProvider);
-		return new DefaultPulsarProducerFactory<>(pulsarClient, this.properties.getProducer().getTopicName(),
+		DefaultPulsarProducerFactory<?> producerFactory = new DefaultPulsarProducerFactory<>(pulsarClient, this.properties.getProducer().getTopicName(),
 				lambdaSafeCustomizers, topicResolver);
+		producerFactory.setTopicBuilder(topicBuilder);
+		return producerFactory;
 	}
 
 	@Bean
 	@ConditionalOnMissingBean(PulsarProducerFactory.class)
 	@ConditionalOnProperty(name = "spring.pulsar.producer.cache.enabled", havingValue = "true", matchIfMissing = true)
 	CachingPulsarProducerFactory<?> cachingPulsarProducerFactory(PulsarClient pulsarClient, TopicResolver topicResolver,
-			ObjectProvider<ProducerBuilderCustomizer<?>> customizersProvider) {
+			ObjectProvider<ProducerBuilderCustomizer<?>> customizersProvider,
+			PulsarTopicBuilder topicBuilder) {
 		PulsarProperties.Producer.Cache cacheProperties = this.properties.getProducer().getCache();
 		List<ProducerBuilderCustomizer<Object>> lambdaSafeCustomizers = lambdaSafeProducerBuilderCustomizers(
 				customizersProvider);
-		return new CachingPulsarProducerFactory<>(pulsarClient, this.properties.getProducer().getTopicName(),
+		CachingPulsarProducerFactory<?> producerFactory = new CachingPulsarProducerFactory<>(pulsarClient, this.properties.getProducer().getTopicName(),
 				lambdaSafeCustomizers, topicResolver, cacheProperties.getExpireAfterAccess(),
 				cacheProperties.getMaximumSize(), cacheProperties.getInitialCapacity());
+		producerFactory.setTopicBuilder(topicBuilder);
+		return producerFactory;
 	}
 
 	private List<ProducerBuilderCustomizer<Object>> lambdaSafeProducerBuilderCustomizers(
@@ -138,13 +145,16 @@ public class PulsarAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(PulsarConsumerFactory.class)
 	DefaultPulsarConsumerFactory<?> pulsarConsumerFactory(PulsarClient pulsarClient,
-			ObjectProvider<ConsumerBuilderCustomizer<?>> customizersProvider) {
+			ObjectProvider<ConsumerBuilderCustomizer<?>> customizersProvider,
+			PulsarTopicBuilder topicBuilder) {
 		List<ConsumerBuilderCustomizer<?>> customizers = new ArrayList<>();
 		customizers.add(this.propertiesMapper::customizeConsumerBuilder);
 		customizers.addAll(customizersProvider.orderedStream().toList());
 		List<ConsumerBuilderCustomizer<Object>> lambdaSafeCustomizers = List
 			.of((builder) -> applyConsumerBuilderCustomizers(customizers, builder));
-		return new DefaultPulsarConsumerFactory<>(pulsarClient, lambdaSafeCustomizers);
+		DefaultPulsarConsumerFactory<?> consumerFactory = new DefaultPulsarConsumerFactory<>(pulsarClient, lambdaSafeCustomizers);
+		consumerFactory.setTopicBuilder(topicBuilder);
+		return consumerFactory;
 	}
 
 	@Bean
@@ -181,13 +191,16 @@ public class PulsarAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(PulsarReaderFactory.class)
 	DefaultPulsarReaderFactory<?> pulsarReaderFactory(PulsarClient pulsarClient,
-			ObjectProvider<ReaderBuilderCustomizer<?>> customizersProvider) {
+			ObjectProvider<ReaderBuilderCustomizer<?>> customizersProvider,
+			PulsarTopicBuilder topicBuilder) {
 		List<ReaderBuilderCustomizer<?>> customizers = new ArrayList<>();
 		customizers.add(this.propertiesMapper::customizeReaderBuilder);
 		customizers.addAll(customizersProvider.orderedStream().toList());
 		List<ReaderBuilderCustomizer<Object>> lambdaSafeCustomizers = List
 			.of((builder) -> applyReaderBuilderCustomizers(customizers, builder));
-		return new DefaultPulsarReaderFactory<>(pulsarClient, lambdaSafeCustomizers);
+		DefaultPulsarReaderFactory<?> readerFactory = new DefaultPulsarReaderFactory<>(pulsarClient, lambdaSafeCustomizers);
+		readerFactory.setTopicBuilder(topicBuilder);
+		return readerFactory;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfiguration.java
@@ -89,12 +89,11 @@ public class PulsarAutoConfiguration {
 	@ConditionalOnMissingBean(PulsarProducerFactory.class)
 	@ConditionalOnProperty(name = "spring.pulsar.producer.cache.enabled", havingValue = "false")
 	DefaultPulsarProducerFactory<?> pulsarProducerFactory(PulsarClient pulsarClient, TopicResolver topicResolver,
-			ObjectProvider<ProducerBuilderCustomizer<?>> customizersProvider,
-			PulsarTopicBuilder topicBuilder) {
+			ObjectProvider<ProducerBuilderCustomizer<?>> customizersProvider, PulsarTopicBuilder topicBuilder) {
 		List<ProducerBuilderCustomizer<Object>> lambdaSafeCustomizers = lambdaSafeProducerBuilderCustomizers(
 				customizersProvider);
-		DefaultPulsarProducerFactory<?> producerFactory = new DefaultPulsarProducerFactory<>(pulsarClient, this.properties.getProducer().getTopicName(),
-				lambdaSafeCustomizers, topicResolver);
+		DefaultPulsarProducerFactory<?> producerFactory = new DefaultPulsarProducerFactory<>(pulsarClient,
+				this.properties.getProducer().getTopicName(), lambdaSafeCustomizers, topicResolver);
 		producerFactory.setTopicBuilder(topicBuilder);
 		return producerFactory;
 	}
@@ -103,14 +102,14 @@ public class PulsarAutoConfiguration {
 	@ConditionalOnMissingBean(PulsarProducerFactory.class)
 	@ConditionalOnProperty(name = "spring.pulsar.producer.cache.enabled", havingValue = "true", matchIfMissing = true)
 	CachingPulsarProducerFactory<?> cachingPulsarProducerFactory(PulsarClient pulsarClient, TopicResolver topicResolver,
-			ObjectProvider<ProducerBuilderCustomizer<?>> customizersProvider,
-			PulsarTopicBuilder topicBuilder) {
+			ObjectProvider<ProducerBuilderCustomizer<?>> customizersProvider, PulsarTopicBuilder topicBuilder) {
 		PulsarProperties.Producer.Cache cacheProperties = this.properties.getProducer().getCache();
 		List<ProducerBuilderCustomizer<Object>> lambdaSafeCustomizers = lambdaSafeProducerBuilderCustomizers(
 				customizersProvider);
-		CachingPulsarProducerFactory<?> producerFactory = new CachingPulsarProducerFactory<>(pulsarClient, this.properties.getProducer().getTopicName(),
-				lambdaSafeCustomizers, topicResolver, cacheProperties.getExpireAfterAccess(),
-				cacheProperties.getMaximumSize(), cacheProperties.getInitialCapacity());
+		CachingPulsarProducerFactory<?> producerFactory = new CachingPulsarProducerFactory<>(pulsarClient,
+				this.properties.getProducer().getTopicName(), lambdaSafeCustomizers, topicResolver,
+				cacheProperties.getExpireAfterAccess(), cacheProperties.getMaximumSize(),
+				cacheProperties.getInitialCapacity());
 		producerFactory.setTopicBuilder(topicBuilder);
 		return producerFactory;
 	}
@@ -145,14 +144,14 @@ public class PulsarAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(PulsarConsumerFactory.class)
 	DefaultPulsarConsumerFactory<?> pulsarConsumerFactory(PulsarClient pulsarClient,
-			ObjectProvider<ConsumerBuilderCustomizer<?>> customizersProvider,
-			PulsarTopicBuilder topicBuilder) {
+			ObjectProvider<ConsumerBuilderCustomizer<?>> customizersProvider, PulsarTopicBuilder topicBuilder) {
 		List<ConsumerBuilderCustomizer<?>> customizers = new ArrayList<>();
 		customizers.add(this.propertiesMapper::customizeConsumerBuilder);
 		customizers.addAll(customizersProvider.orderedStream().toList());
 		List<ConsumerBuilderCustomizer<Object>> lambdaSafeCustomizers = List
 			.of((builder) -> applyConsumerBuilderCustomizers(customizers, builder));
-		DefaultPulsarConsumerFactory<?> consumerFactory = new DefaultPulsarConsumerFactory<>(pulsarClient, lambdaSafeCustomizers);
+		DefaultPulsarConsumerFactory<?> consumerFactory = new DefaultPulsarConsumerFactory<>(pulsarClient,
+				lambdaSafeCustomizers);
 		consumerFactory.setTopicBuilder(topicBuilder);
 		return consumerFactory;
 	}
@@ -191,14 +190,14 @@ public class PulsarAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(PulsarReaderFactory.class)
 	DefaultPulsarReaderFactory<?> pulsarReaderFactory(PulsarClient pulsarClient,
-			ObjectProvider<ReaderBuilderCustomizer<?>> customizersProvider,
-			PulsarTopicBuilder topicBuilder) {
+			ObjectProvider<ReaderBuilderCustomizer<?>> customizersProvider, PulsarTopicBuilder topicBuilder) {
 		List<ReaderBuilderCustomizer<?>> customizers = new ArrayList<>();
 		customizers.add(this.propertiesMapper::customizeReaderBuilder);
 		customizers.addAll(customizersProvider.orderedStream().toList());
 		List<ReaderBuilderCustomizer<Object>> lambdaSafeCustomizers = List
 			.of((builder) -> applyReaderBuilderCustomizers(customizers, builder));
-		DefaultPulsarReaderFactory<?> readerFactory = new DefaultPulsarReaderFactory<>(pulsarClient, lambdaSafeCustomizers);
+		DefaultPulsarReaderFactory<?> readerFactory = new DefaultPulsarReaderFactory<>(pulsarClient,
+				lambdaSafeCustomizers);
 		readerFactory.setTopicBuilder(topicBuilder);
 		return readerFactory;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfiguration.java
@@ -182,9 +182,10 @@ class PulsarConfiguration {
 	@Bean
 	@Scope("prototype")
 	@ConditionalOnMissingBean
+	@ConditionalOnProperty(name = "spring.pulsar.defaults.topic.enabled", havingValue = "true", matchIfMissing = true)
 	PulsarTopicBuilder pulsarTopicBuilder() {
-		return new PulsarTopicBuilder(TopicDomain.persistent, this.properties.getDefaults().getTenant(),
-				this.properties.getDefaults().getNamespace());
+		return new PulsarTopicBuilder(TopicDomain.persistent, this.properties.getDefaults().getTopic().getTenant(),
+				this.properties.getDefaults().getTopic().getNamespace());
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfiguration.java
@@ -23,6 +23,7 @@ import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.schema.SchemaType;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -41,6 +42,7 @@ import org.springframework.pulsar.core.PulsarAdminBuilderCustomizer;
 import org.springframework.pulsar.core.PulsarAdministration;
 import org.springframework.pulsar.core.PulsarClientBuilderCustomizer;
 import org.springframework.pulsar.core.PulsarClientFactory;
+import org.springframework.pulsar.core.PulsarTopicBuilder;
 import org.springframework.pulsar.core.SchemaResolver;
 import org.springframework.pulsar.core.SchemaResolver.SchemaResolverCustomizer;
 import org.springframework.pulsar.core.TopicResolver;
@@ -174,6 +176,13 @@ class PulsarConfiguration {
 		PulsarProperties.Function properties = this.properties.getFunction();
 		return new PulsarFunctionAdministration(pulsarAdministration, pulsarFunctions, pulsarSinks, pulsarSources,
 				properties.isFailFast(), properties.isPropagateFailures(), properties.isPropagateStopFailures());
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(PulsarTopicBuilder.class)
+	PulsarTopicBuilder pulsarTopicBuilder() {
+		return new PulsarTopicBuilder(TopicDomain.persistent, this.properties.getDefaults().getTenant(),
+				this.properties.getDefaults().getNamespace());
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.util.LambdaSafe;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 import org.springframework.pulsar.core.DefaultPulsarClientFactory;
 import org.springframework.pulsar.core.DefaultSchemaResolver;
 import org.springframework.pulsar.core.DefaultTopicResolver;
@@ -179,7 +180,8 @@ class PulsarConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(PulsarTopicBuilder.class)
+	@Scope("prototype")
+	@ConditionalOnMissingBean
 	PulsarTopicBuilder pulsarTopicBuilder() {
 		return new PulsarTopicBuilder(TopicDomain.persistent, this.properties.getDefaults().getTenant(),
 				this.properties.getDefaults().getNamespace());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarProperties.java
@@ -251,11 +251,41 @@ public class PulsarProperties {
 	public static class Defaults {
 
 		/**
+		 * Default tenant to use when producing or consuming messages against a
+		 * non-fully-qualified topic URL. When not specified Pulsar uses a default tenant
+		 * of 'public'.
+		 */
+		private String tenant;
+
+		/**
+		 * Default namespace to use when producing or consuming messages against a
+		 * non-fully-qualified topic URL. When not specified Pulsar uses a default
+		 * namespace of 'default'.
+		 */
+		private String namespace;
+
+		/**
 		 * List of mappings from message type to topic name and schema info to use as a
 		 * defaults when a topic name and/or schema is not explicitly specified when
 		 * producing or consuming messages of the mapped type.
 		 */
 		private List<TypeMapping> typeMappings = new ArrayList<>();
+
+		public String getTenant() {
+			return this.tenant;
+		}
+
+		public void setTenant(String tenant) {
+			this.tenant = tenant;
+		}
+
+		public String getNamespace() {
+			return this.namespace;
+		}
+
+		public void setNamespace(String namespace) {
+			this.namespace = namespace;
+		}
 
 		public List<TypeMapping> getTypeMappings() {
 			return this.typeMappings;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarProperties.java
@@ -251,40 +251,20 @@ public class PulsarProperties {
 	public static class Defaults {
 
 		/**
-		 * Default tenant to use when producing or consuming messages against a
-		 * non-fully-qualified topic URL. When not specified Pulsar uses a default tenant
-		 * of 'public'.
-		 */
-		private String tenant;
-
-		/**
-		 * Default namespace to use when producing or consuming messages against a
-		 * non-fully-qualified topic URL. When not specified Pulsar uses a default
-		 * namespace of 'default'.
-		 */
-		private String namespace;
-
-		/**
 		 * List of mappings from message type to topic name and schema info to use as a
 		 * defaults when a topic name and/or schema is not explicitly specified when
 		 * producing or consuming messages of the mapped type.
 		 */
 		private List<TypeMapping> typeMappings = new ArrayList<>();
 
-		public String getTenant() {
-			return this.tenant;
+		private Topic topic = new Topic();
+
+		public Topic getTopic() {
+			return this.topic;
 		}
 
-		public void setTenant(String tenant) {
-			this.tenant = tenant;
-		}
-
-		public String getNamespace() {
-			return this.namespace;
-		}
-
-		public void setNamespace(String namespace) {
-			this.namespace = namespace;
+		public void setTopic(Topic topic) {
+			this.topic = topic;
 		}
 
 		public List<TypeMapping> getTypeMappings() {
@@ -327,6 +307,40 @@ public class PulsarProperties {
 				Assert.isTrue(schemaType != SchemaType.NONE, "schemaType 'NONE' not supported");
 				Assert.isTrue(messageKeyType == null || schemaType == SchemaType.KEY_VALUE,
 						"messageKeyType can only be set when schemaType is KEY_VALUE");
+			}
+
+		}
+
+		public static class Topic {
+
+			/**
+			 * Default tenant to use when producing or consuming messages against a
+			 * non-fully-qualified topic URL. When not specified Pulsar uses a default
+			 * tenant of 'public'.
+			 */
+			private String tenant;
+
+			/**
+			 * Default namespace to use when producing or consuming messages against a
+			 * non-fully-qualified topic URL. When not specified Pulsar uses a default
+			 * namespace of 'default'.
+			 */
+			private String namespace;
+
+			public String getTenant() {
+				return this.tenant;
+			}
+
+			public void setTenant(String tenant) {
+				this.tenant = tenant;
+			}
+
+			public String getNamespace() {
+				return this.namespace;
+			}
+
+			public void setNamespace(String namespace) {
+				this.namespace = namespace;
 			}
 
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactiveAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactiveAutoConfiguration.java
@@ -146,8 +146,8 @@ public class PulsarReactiveAutoConfiguration {
 		customizers.addAll(customizersProvider.orderedStream().toList());
 		List<ReactiveMessageConsumerBuilderCustomizer<Object>> lambdaSafeCustomizers = List
 			.of((builder) -> applyMessageConsumerBuilderCustomizers(customizers, builder));
-		DefaultReactivePulsarConsumerFactory<?> consumerFactory =
-				new DefaultReactivePulsarConsumerFactory<>(pulsarReactivePulsarClient, lambdaSafeCustomizers);
+		DefaultReactivePulsarConsumerFactory<?> consumerFactory = new DefaultReactivePulsarConsumerFactory<>(
+				pulsarReactivePulsarClient, lambdaSafeCustomizers);
 		consumerFactory.setTopicBuilder(topicBuilder);
 		return consumerFactory;
 	}
@@ -181,7 +181,8 @@ public class PulsarReactiveAutoConfiguration {
 		customizers.addAll(customizersProvider.orderedStream().toList());
 		List<ReactiveMessageReaderBuilderCustomizer<Object>> lambdaSafeCustomizers = List
 			.of((builder) -> applyMessageReaderBuilderCustomizers(customizers, builder));
-		DefaultReactivePulsarReaderFactory<?> readerFactory = new DefaultReactivePulsarReaderFactory<>(reactivePulsarClient, lambdaSafeCustomizers);
+		DefaultReactivePulsarReaderFactory<?> readerFactory = new DefaultReactivePulsarReaderFactory<>(
+				reactivePulsarClient, lambdaSafeCustomizers);
 		readerFactory.setTopicBuilder(topicBuilder);
 		return readerFactory;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactiveAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactiveAutoConfiguration.java
@@ -41,6 +41,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.pulsar.config.PulsarAnnotationSupportBeanNames;
+import org.springframework.pulsar.core.PulsarTopicBuilder;
 import org.springframework.pulsar.core.SchemaResolver;
 import org.springframework.pulsar.core.TopicResolver;
 import org.springframework.pulsar.reactive.config.DefaultReactivePulsarListenerContainerFactory;
@@ -112,7 +113,8 @@ public class PulsarReactiveAutoConfiguration {
 	@ConditionalOnMissingBean(ReactivePulsarSenderFactory.class)
 	DefaultReactivePulsarSenderFactory<?> reactivePulsarSenderFactory(ReactivePulsarClient reactivePulsarClient,
 			ObjectProvider<ReactiveMessageSenderCache> reactiveMessageSenderCache, TopicResolver topicResolver,
-			ObjectProvider<ReactiveMessageSenderBuilderCustomizer<?>> customizersProvider) {
+			ObjectProvider<ReactiveMessageSenderBuilderCustomizer<?>> customizersProvider,
+			PulsarTopicBuilder topicBuilder) {
 		List<ReactiveMessageSenderBuilderCustomizer<?>> customizers = new ArrayList<>();
 		customizers.add(this.propertiesMapper::customizeMessageSenderBuilder);
 		customizers.addAll(customizersProvider.orderedStream().toList());
@@ -122,6 +124,7 @@ public class PulsarReactiveAutoConfiguration {
 			.withDefaultConfigCustomizers(lambdaSafeCustomizers)
 			.withMessageSenderCache(reactiveMessageSenderCache.getIfAvailable())
 			.withTopicResolver(topicResolver)
+			.withTopicBuilder(topicBuilder)
 			.build();
 	}
 
@@ -136,13 +139,17 @@ public class PulsarReactiveAutoConfiguration {
 	@ConditionalOnMissingBean(ReactivePulsarConsumerFactory.class)
 	DefaultReactivePulsarConsumerFactory<?> reactivePulsarConsumerFactory(
 			ReactivePulsarClient pulsarReactivePulsarClient,
-			ObjectProvider<ReactiveMessageConsumerBuilderCustomizer<?>> customizersProvider) {
+			ObjectProvider<ReactiveMessageConsumerBuilderCustomizer<?>> customizersProvider,
+			PulsarTopicBuilder topicBuilder) {
 		List<ReactiveMessageConsumerBuilderCustomizer<?>> customizers = new ArrayList<>();
 		customizers.add(this.propertiesMapper::customizeMessageConsumerBuilder);
 		customizers.addAll(customizersProvider.orderedStream().toList());
 		List<ReactiveMessageConsumerBuilderCustomizer<Object>> lambdaSafeCustomizers = List
 			.of((builder) -> applyMessageConsumerBuilderCustomizers(customizers, builder));
-		return new DefaultReactivePulsarConsumerFactory<>(pulsarReactivePulsarClient, lambdaSafeCustomizers);
+		DefaultReactivePulsarConsumerFactory<?> consumerFactory =
+				new DefaultReactivePulsarConsumerFactory<>(pulsarReactivePulsarClient, lambdaSafeCustomizers);
+		consumerFactory.setTopicBuilder(topicBuilder);
+		return consumerFactory;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -167,13 +174,16 @@ public class PulsarReactiveAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(ReactivePulsarReaderFactory.class)
 	DefaultReactivePulsarReaderFactory<?> reactivePulsarReaderFactory(ReactivePulsarClient reactivePulsarClient,
-			ObjectProvider<ReactiveMessageReaderBuilderCustomizer<?>> customizersProvider) {
+			ObjectProvider<ReactiveMessageReaderBuilderCustomizer<?>> customizersProvider,
+			PulsarTopicBuilder topicBuilder) {
 		List<ReactiveMessageReaderBuilderCustomizer<?>> customizers = new ArrayList<>();
 		customizers.add(this.propertiesMapper::customizeMessageReaderBuilder);
 		customizers.addAll(customizersProvider.orderedStream().toList());
 		List<ReactiveMessageReaderBuilderCustomizer<Object>> lambdaSafeCustomizers = List
 			.of((builder) -> applyMessageReaderBuilderCustomizers(customizers, builder));
-		return new DefaultReactivePulsarReaderFactory<>(reactivePulsarClient, lambdaSafeCustomizers);
+		DefaultReactivePulsarReaderFactory<?> readerFactory = new DefaultReactivePulsarReaderFactory<>(reactivePulsarClient, lambdaSafeCustomizers);
+		readerFactory.setTopicBuilder(topicBuilder);
+		return readerFactory;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -2069,6 +2069,12 @@
       "defaultValue": "bolt://localhost:7687"
     },
     {
+      "name": "spring.pulsar.defaults.topic.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable default tenant and namespace support for topics.",
+      "defaultValue": true
+    },
+    {
       "name": "spring.pulsar.function.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to enable function support.",

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfigurationTests.java
@@ -67,6 +67,7 @@ import org.springframework.pulsar.core.PulsarConsumerFactory;
 import org.springframework.pulsar.core.PulsarProducerFactory;
 import org.springframework.pulsar.core.PulsarReaderFactory;
 import org.springframework.pulsar.core.PulsarTemplate;
+import org.springframework.pulsar.core.PulsarTopicBuilder;
 import org.springframework.pulsar.core.ReaderBuilderCustomizer;
 import org.springframework.pulsar.core.SchemaResolver;
 import org.springframework.pulsar.core.TopicResolver;
@@ -219,7 +220,8 @@ class PulsarAutoConfigurationTests {
 						"spring.pulsar.producer.cache.enabled=false")
 				.run((context) -> assertThat(context).getBean(DefaultPulsarProducerFactory.class)
 					.hasFieldOrPropertyWithValue("pulsarClient", context.getBean(PulsarClient.class))
-					.hasFieldOrPropertyWithValue("topicResolver", context.getBean(TopicResolver.class)));
+					.hasFieldOrPropertyWithValue("topicResolver", context.getBean(TopicResolver.class))
+					.hasFieldOrPropertyWithValue("topicBuilder", context.getBean(PulsarTopicBuilder.class)));
 		}
 
 		@ParameterizedTest
@@ -375,7 +377,8 @@ class PulsarAutoConfigurationTests {
 		@Test
 		void injectsExpectedBeans() {
 			this.contextRunner.run((context) -> assertThat(context).getBean(DefaultPulsarConsumerFactory.class)
-				.hasFieldOrPropertyWithValue("pulsarClient", context.getBean(PulsarClient.class)));
+				.hasFieldOrPropertyWithValue("pulsarClient", context.getBean(PulsarClient.class))
+				.hasFieldOrPropertyWithValue("topicBuilder", context.getBean(PulsarTopicBuilder.class)));
 		}
 
 		@Test
@@ -574,7 +577,8 @@ class PulsarAutoConfigurationTests {
 		@Test
 		void injectsExpectedBeans() {
 			this.contextRunner.run((context) -> assertThat(context).getBean(DefaultPulsarReaderFactory.class)
-				.hasFieldOrPropertyWithValue("pulsarClient", context.getBean(PulsarClient.class)));
+				.hasFieldOrPropertyWithValue("pulsarClient", context.getBean(PulsarClient.class))
+				.hasFieldOrPropertyWithValue("topicBuilder", context.getBean(PulsarTopicBuilder.class)));
 		}
 
 		@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarAutoConfigurationTests.java
@@ -67,7 +67,6 @@ import org.springframework.pulsar.core.PulsarConsumerFactory;
 import org.springframework.pulsar.core.PulsarProducerFactory;
 import org.springframework.pulsar.core.PulsarReaderFactory;
 import org.springframework.pulsar.core.PulsarTemplate;
-import org.springframework.pulsar.core.PulsarTopicBuilder;
 import org.springframework.pulsar.core.ReaderBuilderCustomizer;
 import org.springframework.pulsar.core.SchemaResolver;
 import org.springframework.pulsar.core.TopicResolver;
@@ -221,7 +220,8 @@ class PulsarAutoConfigurationTests {
 				.run((context) -> assertThat(context).getBean(DefaultPulsarProducerFactory.class)
 					.hasFieldOrPropertyWithValue("pulsarClient", context.getBean(PulsarClient.class))
 					.hasFieldOrPropertyWithValue("topicResolver", context.getBean(TopicResolver.class))
-					.hasFieldOrPropertyWithValue("topicBuilder", context.getBean(PulsarTopicBuilder.class)));
+					.extracting("topicBuilder")
+					.isNotNull()); // prototype so only check not-null
 		}
 
 		@ParameterizedTest
@@ -378,7 +378,8 @@ class PulsarAutoConfigurationTests {
 		void injectsExpectedBeans() {
 			this.contextRunner.run((context) -> assertThat(context).getBean(DefaultPulsarConsumerFactory.class)
 				.hasFieldOrPropertyWithValue("pulsarClient", context.getBean(PulsarClient.class))
-				.hasFieldOrPropertyWithValue("topicBuilder", context.getBean(PulsarTopicBuilder.class)));
+				.extracting("topicBuilder")
+				.isNotNull()); // prototype so only check not-null
 		}
 
 		@Test
@@ -578,7 +579,8 @@ class PulsarAutoConfigurationTests {
 		void injectsExpectedBeans() {
 			this.contextRunner.run((context) -> assertThat(context).getBean(DefaultPulsarReaderFactory.class)
 				.hasFieldOrPropertyWithValue("pulsarClient", context.getBean(PulsarClient.class))
-				.hasFieldOrPropertyWithValue("topicBuilder", context.getBean(PulsarTopicBuilder.class)));
+				.extracting("topicBuilder")
+				.isNotNull()); // prototype so only check not-null
 		}
 
 		@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfigurationTests.java
@@ -330,7 +330,7 @@ class PulsarConfigurationTests {
 		void whenHasUserDefinedBeanDoesNotAutoConfigureBean() {
 			PulsarTopicBuilder topicBuilder = mock(PulsarTopicBuilder.class);
 			this.contextRunner.withBean("customPulsarTopicBuilder", PulsarTopicBuilder.class, () -> topicBuilder)
-					.run((context) -> assertThat(context).getBean(PulsarTopicBuilder.class).isSameAs(topicBuilder));
+				.run((context) -> assertThat(context).getBean(PulsarTopicBuilder.class).isSameAs(topicBuilder));
 		}
 
 		@Test
@@ -339,16 +339,16 @@ class PulsarConfigurationTests {
 			properties.add("spring.pulsar.defaults.tenant=my-tenant");
 			properties.add("spring.pulsar.defaults.namespace=my-namespace");
 			this.contextRunner.withPropertyValues(properties.toArray(String[]::new))
-					.run((context) -> assertThat(context).getBean(PulsarTopicBuilder.class)
-							.asInstanceOf(InstanceOfAssertFactories.type(PulsarTopicBuilder.class))
-							.satisfies((topicBuilder -> {
-								assertThat(topicBuilder).hasFieldOrPropertyWithValue("defaultTenant", "my-tenant");
-								assertThat(topicBuilder).hasFieldOrPropertyWithValue("defaultNamespace", "my-namespace");
-							})));
+				.run((context) -> assertThat(context).getBean(PulsarTopicBuilder.class)
+					.asInstanceOf(InstanceOfAssertFactories.type(PulsarTopicBuilder.class))
+					.satisfies((topicBuilder -> {
+						assertThat(topicBuilder).hasFieldOrPropertyWithValue("defaultTenant", "my-tenant");
+						assertThat(topicBuilder).hasFieldOrPropertyWithValue("defaultNamespace", "my-namespace");
+					})));
 		}
 
 	}
-	
+
 	@Nested
 	class FunctionAdministrationTests {
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfigurationTests.java
@@ -49,6 +49,7 @@ import org.springframework.pulsar.core.PulsarAdminBuilderCustomizer;
 import org.springframework.pulsar.core.PulsarAdministration;
 import org.springframework.pulsar.core.PulsarClientBuilderCustomizer;
 import org.springframework.pulsar.core.PulsarClientFactory;
+import org.springframework.pulsar.core.PulsarTopicBuilder;
 import org.springframework.pulsar.core.SchemaResolver;
 import org.springframework.pulsar.core.SchemaResolver.SchemaResolverCustomizer;
 import org.springframework.pulsar.core.TopicResolver;
@@ -320,6 +321,34 @@ class PulsarConfigurationTests {
 
 	}
 
+	@Nested
+	class TopicBuilderTests {
+
+		private final ApplicationContextRunner contextRunner = PulsarConfigurationTests.this.contextRunner;
+
+		@Test
+		void whenHasUserDefinedBeanDoesNotAutoConfigureBean() {
+			PulsarTopicBuilder topicBuilder = mock(PulsarTopicBuilder.class);
+			this.contextRunner.withBean("customPulsarTopicBuilder", PulsarTopicBuilder.class, () -> topicBuilder)
+					.run((context) -> assertThat(context).getBean(PulsarTopicBuilder.class).isSameAs(topicBuilder));
+		}
+
+		@Test
+		void whenHasDefaultsTenantAndNamespaceAppliedToTopicBuilder() {
+			List<String> properties = new ArrayList<>();
+			properties.add("spring.pulsar.defaults.tenant=my-tenant");
+			properties.add("spring.pulsar.defaults.namespace=my-namespace");
+			this.contextRunner.withPropertyValues(properties.toArray(String[]::new))
+					.run((context) -> assertThat(context).getBean(PulsarTopicBuilder.class)
+							.asInstanceOf(InstanceOfAssertFactories.type(PulsarTopicBuilder.class))
+							.satisfies((topicBuilder -> {
+								assertThat(topicBuilder).hasFieldOrPropertyWithValue("defaultTenant", "my-tenant");
+								assertThat(topicBuilder).hasFieldOrPropertyWithValue("defaultNamespace", "my-namespace");
+							})));
+		}
+
+	}
+	
 	@Nested
 	class FunctionAdministrationTests {
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfigurationTests.java
@@ -341,10 +341,10 @@ class PulsarConfigurationTests {
 			this.contextRunner.withPropertyValues(properties.toArray(String[]::new))
 				.run((context) -> assertThat(context).getBean(PulsarTopicBuilder.class)
 					.asInstanceOf(InstanceOfAssertFactories.type(PulsarTopicBuilder.class))
-					.satisfies((topicBuilder -> {
+					.satisfies((topicBuilder) -> {
 						assertThat(topicBuilder).hasFieldOrPropertyWithValue("defaultTenant", "my-tenant");
 						assertThat(topicBuilder).hasFieldOrPropertyWithValue("defaultNamespace", "my-namespace");
-					})));
+					}));
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfigurationTests.java
@@ -353,6 +353,12 @@ class PulsarConfigurationTests {
 					}));
 		}
 
+		@Test
+		void beanHasScopePrototype() {
+			this.contextRunner.run((context) -> assertThat(context.getBean(PulsarTopicBuilder.class))
+				.isNotSameAs(context.getBean(PulsarTopicBuilder.class)));
+		}
+
 	}
 
 	@Nested

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarConfigurationTests.java
@@ -334,10 +334,16 @@ class PulsarConfigurationTests {
 		}
 
 		@Test
+		void whenHasDefaultsTopicDisabledPropertyDoesNotCreateBean() {
+			this.contextRunner.withPropertyValues("spring.pulsar.defaults.topic.enabled=false")
+				.run((context) -> assertThat(context).doesNotHaveBean(PulsarTopicBuilder.class));
+		}
+
+		@Test
 		void whenHasDefaultsTenantAndNamespaceAppliedToTopicBuilder() {
 			List<String> properties = new ArrayList<>();
-			properties.add("spring.pulsar.defaults.tenant=my-tenant");
-			properties.add("spring.pulsar.defaults.namespace=my-namespace");
+			properties.add("spring.pulsar.defaults.topic.tenant=my-tenant");
+			properties.add("spring.pulsar.defaults.topic.namespace=my-namespace");
 			this.contextRunner.withPropertyValues(properties.toArray(String[]::new))
 				.run((context) -> assertThat(context).getBean(PulsarTopicBuilder.class)
 					.asInstanceOf(InstanceOfAssertFactories.type(PulsarTopicBuilder.class))

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesTests.java
@@ -247,7 +247,7 @@ class PulsarPropertiesTests {
 
 		@Test
 		void bindWhenValuesNotSpecified() {
-			assertThat(new PulsarProperties().getDefaults()).satisfies((defaults) -> {
+			assertThat(new PulsarProperties().getDefaults().getTopic()).satisfies((defaults) -> {
 				assertThat(defaults.getTenant()).isNull();
 				assertThat(defaults.getNamespace()).isNull();
 			});
@@ -256,9 +256,9 @@ class PulsarPropertiesTests {
 		@Test
 		void bindWhenValuesSpecified() {
 			Map<String, String> map = new HashMap<>();
-			map.put("spring.pulsar.defaults.tenant", "my-tenant");
-			map.put("spring.pulsar.defaults.namespace", "my-namespace");
-			PulsarProperties.Defaults properties = bindProperties(map).getDefaults();
+			map.put("spring.pulsar.defaults.topic.tenant", "my-tenant");
+			map.put("spring.pulsar.defaults.topic.namespace", "my-namespace");
+			PulsarProperties.Defaults.Topic properties = bindProperties(map).getDefaults().getTopic();
 			assertThat(properties.getTenant()).isEqualTo("my-tenant");
 			assertThat(properties.getNamespace()).isEqualTo("my-namespace");
 		}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesTests.java
@@ -152,7 +152,7 @@ class PulsarPropertiesTests {
 	}
 
 	@Nested
-	class DefaultsProperties {
+	class DefaultsTypeMappingProperties {
 
 		@Test
 		void bindWhenNoTypeMappings() {
@@ -238,6 +238,29 @@ class PulsarPropertiesTests {
 		}
 
 		record TestMessage(String value) {
+		}
+
+	}
+
+	@Nested
+	class DefaultsTenantNamespaceProperties {
+
+		@Test
+		void bindWhenValuesNotSpecified() {
+			assertThat(new PulsarProperties().getDefaults()).satisfies((defaults) -> {
+				assertThat(defaults.getTenant()).isNull();
+				assertThat(defaults.getNamespace()).isNull();
+			});
+		}
+
+		@Test
+		void bindWhenValuesSpecified() {
+			Map<String, String> map = new HashMap<>();
+			map.put("spring.pulsar.defaults.tenant", "my-tenant");
+			map.put("spring.pulsar.defaults.namespace", "my-namespace");
+			PulsarProperties.Defaults properties = bindProperties(map).getDefaults();
+			assertThat(properties.getTenant()).isEqualTo("my-tenant");
+			assertThat(properties.getNamespace()).isEqualTo("my-namespace");
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactiveAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactiveAutoConfigurationTests.java
@@ -179,8 +179,8 @@ class PulsarReactiveAutoConfigurationTests {
 						.extracting("topicResolver", InstanceOfAssertFactories.type(TopicResolver.class))
 						.isSameAs(context.getBean(TopicResolver.class));
 					assertThat(senderFactory)
-							.extracting("topicBuilder", InstanceOfAssertFactories.type(PulsarTopicBuilder.class))
-							.isSameAs(context.getBean(PulsarTopicBuilder.class));
+						.extracting("topicBuilder", InstanceOfAssertFactories.type(PulsarTopicBuilder.class))
+						.isSameAs(context.getBean(PulsarTopicBuilder.class));
 				});
 		}
 
@@ -257,9 +257,8 @@ class PulsarReactiveAutoConfigurationTests {
 		void injectsExpectedBeans() {
 			ReactivePulsarClient client = mock(ReactivePulsarClient.class);
 			PulsarTopicBuilder topicBuilder = mock(PulsarTopicBuilder.class);
-			this.contextRunner
-					.withBean("customReactivePulsarClient", ReactivePulsarClient.class, () -> client)
-					.withBean("customTopicBuilder", PulsarTopicBuilder.class, () -> topicBuilder)
+			this.contextRunner.withBean("customReactivePulsarClient", ReactivePulsarClient.class, () -> client)
+				.withBean("customTopicBuilder", PulsarTopicBuilder.class, () -> topicBuilder)
 				.run((context) -> {
 					ReactivePulsarConsumerFactory<?> consumerFactory = context
 						.getBean(DefaultReactivePulsarConsumerFactory.class);
@@ -267,8 +266,8 @@ class PulsarReactiveAutoConfigurationTests {
 						.extracting("reactivePulsarClient", InstanceOfAssertFactories.type(ReactivePulsarClient.class))
 						.isSameAs(client);
 					assertThat(consumerFactory)
-							.extracting("topicBuilder", InstanceOfAssertFactories.type(PulsarTopicBuilder.class))
-							.isSameAs(topicBuilder);
+						.extracting("topicBuilder", InstanceOfAssertFactories.type(PulsarTopicBuilder.class))
+						.isSameAs(topicBuilder);
 				});
 		}
 
@@ -383,8 +382,8 @@ class PulsarReactiveAutoConfigurationTests {
 						.extracting("reactivePulsarClient", InstanceOfAssertFactories.type(ReactivePulsarClient.class))
 						.isSameAs(client);
 					assertThat(readerFactory)
-							.extracting("topicBuilder", InstanceOfAssertFactories.type(PulsarTopicBuilder.class))
-							.isSameAs(topicBuilder);
+						.extracting("topicBuilder", InstanceOfAssertFactories.type(PulsarTopicBuilder.class))
+						.isSameAs(topicBuilder);
 				});
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactiveAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactiveAutoConfigurationTests.java
@@ -178,9 +178,11 @@ class PulsarReactiveAutoConfigurationTests {
 					assertThat(senderFactory)
 						.extracting("topicResolver", InstanceOfAssertFactories.type(TopicResolver.class))
 						.isSameAs(context.getBean(TopicResolver.class));
-					assertThat(senderFactory)
-						.extracting("topicBuilder", InstanceOfAssertFactories.type(PulsarTopicBuilder.class))
-						.isSameAs(context.getBean(PulsarTopicBuilder.class));
+					assertThat(senderFactory).extracting("topicBuilder").isNotNull(); // prototype
+																						// so
+																						// only
+																						// check
+																						// not-null
 				});
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactiveAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactiveAutoConfigurationTests.java
@@ -48,6 +48,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.pulsar.core.DefaultSchemaResolver;
 import org.springframework.pulsar.core.DefaultTopicResolver;
 import org.springframework.pulsar.core.PulsarAdministration;
+import org.springframework.pulsar.core.PulsarTopicBuilder;
 import org.springframework.pulsar.core.SchemaResolver;
 import org.springframework.pulsar.core.TopicResolver;
 import org.springframework.pulsar.reactive.config.DefaultReactivePulsarListenerContainerFactory;
@@ -177,6 +178,9 @@ class PulsarReactiveAutoConfigurationTests {
 					assertThat(senderFactory)
 						.extracting("topicResolver", InstanceOfAssertFactories.type(TopicResolver.class))
 						.isSameAs(context.getBean(TopicResolver.class));
+					assertThat(senderFactory)
+							.extracting("topicBuilder", InstanceOfAssertFactories.type(PulsarTopicBuilder.class))
+							.isSameAs(context.getBean(PulsarTopicBuilder.class));
 				});
 		}
 
@@ -252,13 +256,19 @@ class PulsarReactiveAutoConfigurationTests {
 		@Test
 		void injectsExpectedBeans() {
 			ReactivePulsarClient client = mock(ReactivePulsarClient.class);
-			this.contextRunner.withBean("customReactivePulsarClient", ReactivePulsarClient.class, () -> client)
+			PulsarTopicBuilder topicBuilder = mock(PulsarTopicBuilder.class);
+			this.contextRunner
+					.withBean("customReactivePulsarClient", ReactivePulsarClient.class, () -> client)
+					.withBean("customTopicBuilder", PulsarTopicBuilder.class, () -> topicBuilder)
 				.run((context) -> {
 					ReactivePulsarConsumerFactory<?> consumerFactory = context
 						.getBean(DefaultReactivePulsarConsumerFactory.class);
 					assertThat(consumerFactory)
 						.extracting("reactivePulsarClient", InstanceOfAssertFactories.type(ReactivePulsarClient.class))
 						.isSameAs(client);
+					assertThat(consumerFactory)
+							.extracting("topicBuilder", InstanceOfAssertFactories.type(PulsarTopicBuilder.class))
+							.isSameAs(topicBuilder);
 				});
 		}
 
@@ -362,14 +372,19 @@ class PulsarReactiveAutoConfigurationTests {
 		@Test
 		void injectsExpectedBeans() {
 			ReactivePulsarClient client = mock(ReactivePulsarClient.class);
+			PulsarTopicBuilder topicBuilder = mock(PulsarTopicBuilder.class);
 			this.contextRunner.withPropertyValues("spring.pulsar.reader.name=test-reader")
 				.withBean("customReactivePulsarClient", ReactivePulsarClient.class, () -> client)
+				.withBean("customPulsarTopicBuilder", PulsarTopicBuilder.class, () -> topicBuilder)
 				.run((context) -> {
 					DefaultReactivePulsarReaderFactory<?> readerFactory = context
 						.getBean(DefaultReactivePulsarReaderFactory.class);
 					assertThat(readerFactory)
 						.extracting("reactivePulsarClient", InstanceOfAssertFactories.type(ReactivePulsarClient.class))
 						.isSameAs(client);
+					assertThat(readerFactory)
+							.extracting("topicBuilder", InstanceOfAssertFactories.type(PulsarTopicBuilder.class))
+							.isSameAs(topicBuilder);
 				});
 		}
 


### PR DESCRIPTION
This commit allows Pulsar users to configure a default tenant and/or namespace to be used when producing or consuming messages to topic URLs that are not fully-qualified.

The following changes accomplish this:
- add `tenant` and `namespace` config props to `spring.pulsar.defaults`
- auto-configure a `PulsarTopicBuilder` bean populated w/ above props
- provide above topic builder to producer/consumer/reader factories (imperative and reactive)
- add tests for all of the above

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
