### PR TITLE
Refactor BasicJsonParser to simplify JSON parsing logic

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
@@ -52,7 +52,7 @@ public class BasicJsonParser extends AbstractJsonParser {
 
 	private List<Object> parseListInternal(int nesting, String json) {
 		List<Object> list = new ArrayList<>();
-		json = trimLeadingCharacter(trimTrailingCharacter(json, ']'), '[').trim();
+		json = trimEdges(json, '[', ']').trim();
 		for (String value : tokenize(json)) {
 			list.add(parseInternal(nesting + 1, value));
 		}
@@ -70,7 +70,7 @@ public class BasicJsonParser extends AbstractJsonParser {
 			return parseMapInternal(nesting + 1, json);
 		}
 		if (json.startsWith("\"")) {
-			return trimTrailingCharacter(trimLeadingCharacter(json, '"'), '"');
+			return trimEdges(json, '"', '"');
 		}
 		try {
 			return Long.valueOf(json);
@@ -89,12 +89,12 @@ public class BasicJsonParser extends AbstractJsonParser {
 
 	private Map<String, Object> parseMapInternal(int nesting, String json) {
 		Map<String, Object> map = new LinkedHashMap<>();
-		json = trimLeadingCharacter(trimTrailingCharacter(json, '}'), '{').trim();
+		json = trimEdges(json, '{', '}').trim();
 		for (String pair : tokenize(json)) {
 			String[] values = StringUtils.trimArrayElements(StringUtils.split(pair, ":"));
 			Assert.state(values[0].startsWith("\"") && values[0].endsWith("\""),
 					"Expecting double-quotes around field names");
-			String key = trimLeadingCharacter(trimTrailingCharacter(values[0], '"'), '"');
+			String key = trimEdges(values[0], '"', '"');
 			Object value = parseInternal(nesting, values[1]);
 			map.put(key, value);
 		}
@@ -113,6 +113,10 @@ public class BasicJsonParser extends AbstractJsonParser {
 			return string.substring(1);
 		}
 		return string;
+	}
+
+	private static String trimEdges(String string, char leadingChar, char trailingChar) {
+		return trimTrailingCharacter(trimLeadingCharacter(string, leadingChar), trailingChar);
 	}
 
 	private List<String> tokenize(String json) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
@@ -72,19 +72,7 @@ public class BasicJsonParser extends AbstractJsonParser {
 		if (json.startsWith("\"")) {
 			return trimEdges(json, '"', '"');
 		}
-		try {
-			return Long.valueOf(json);
-		}
-		catch (NumberFormatException ex) {
-			// ignore
-		}
-		try {
-			return Double.valueOf(json);
-		}
-		catch (NumberFormatException ex) {
-			// ignore
-		}
-		return json;
+		return parseNumber(json);
 	}
 
 	private Map<String, Object> parseMapInternal(int nesting, String json) {
@@ -99,6 +87,18 @@ public class BasicJsonParser extends AbstractJsonParser {
 			map.put(key, value);
 		}
 		return map;
+	}
+
+	private Object parseNumber(String json) {
+		try {
+			return Long.valueOf(json);
+		} catch (NumberFormatException e) {
+			try {
+				return Double.valueOf(json);
+			} catch (NumberFormatException ex) {
+				return json;
+			}
+		}
 	}
 
 	private static String trimTrailingCharacter(String string, char c) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
@@ -92,10 +92,12 @@ public class BasicJsonParser extends AbstractJsonParser {
 	private Object parseNumber(String json) {
 		try {
 			return Long.valueOf(json);
-		} catch (NumberFormatException e) {
+		}
+		catch (NumberFormatException e) {
 			try {
 				return Double.valueOf(json);
-			} catch (NumberFormatException ex) {
+			}
+			catch (NumberFormatException ex) {
 				return json;
 			}
 		}


### PR DESCRIPTION
This pull request refactors the `BasicJsonParser` class to simplify the JSON parsing logic.

The following changes are made:

- Consolidated `trimLeadingCharacter` and `trimTrailingCharacter` methods into a single `trimEdges` method to reduce code duplication and improve clarity.
- Extracted the number parsing logic into a new `parseNumber` method to separate concerns and enhance maintainability.

These changes aim to improve code readability and make future maintenance easier.
No functional changes are introduced.

Thank you for reviewing this pull request!