### PR TITLE
Upgrade to Logback 1.5.7

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1121,7 +1121,7 @@ bom {
 			releaseNotes("https://github.com/apache/logging-log4j2/releases/tag/rel%2F{version}")
 		}
 	}
-	library("Logback", "1.5.6") {
+	library("Logback", "1.5.7") {
 		group("ch.qos.logback") {
 			modules = [
 				"logback-classic",

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.logging.logback;
 
 import java.nio.charset.Charset;
+import java.util.concurrent.locks.ReentrantLock;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
@@ -44,6 +45,7 @@ import org.springframework.boot.logging.LogFile;
  * @author Robert Thornton
  * @author Scott Frederick
  * @author Jonatan Ivanov
+ * @author Mark Chesney
  */
 class DefaultLogbackConfiguration {
 
@@ -54,7 +56,9 @@ class DefaultLogbackConfiguration {
 	}
 
 	void apply(LogbackConfigurator config) {
-		synchronized (config.getConfigurationLock()) {
+		ReentrantLock lock = config.getConfigurationLock();
+		lock.lock();
+		try {
 			defaults(config);
 			Appender<ILoggingEvent> consoleAppender = consoleAppender(config);
 			if (this.logFile != null) {
@@ -64,6 +68,9 @@ class DefaultLogbackConfiguration {
 			else {
 				config.root(Level.INFO, consoleAppender);
 			}
+		}
+		finally {
+			lock.unlock();
 		}
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackConfigurator.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackConfigurator.java
@@ -18,6 +18,7 @@ package org.springframework.boot.logging.logback;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -35,6 +36,7 @@ import org.springframework.util.Assert;
  * Allows programmatic configuration of logback which is usually faster than parsing XML.
  *
  * @author Phillip Webb
+ * @author Mark Chesney
  */
 class LogbackConfigurator {
 
@@ -49,7 +51,7 @@ class LogbackConfigurator {
 		return this.context;
 	}
 
-	Object getConfigurationLock() {
+	ReentrantLock getConfigurationLock() {
 		return this.context.getConfigurationLock();
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemParallelInitializationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemParallelInitializationTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * control over how and when the logging system is initialized.
  *
  * @author Andy Wilkinson
+ * @author Mark Chesney
  */
 class LogbackLoggingSystemParallelInitializationTests {
 
@@ -45,6 +46,7 @@ class LogbackLoggingSystemParallelInitializationTests {
 	void cleanUp() {
 		this.loggingSystem.cleanUp();
 		((LoggerContext) LoggerFactory.getILoggerFactory()).stop();
+		((LoggerContext) LoggerFactory.getILoggerFactory()).reset();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -93,8 +94,9 @@ import static org.mockito.Mockito.times;
  * @author Scott Frederick
  * @author Jonatan Ivanov
  * @author Moritz Halbritter
+ * @author Mark Chesney
  */
-@ExtendWith(OutputCaptureExtension.class)
+@ExtendWith({ MockitoExtension.class, OutputCaptureExtension.class })
 @ClassPathExclusions({ "log4j-core-*.jar", "log4j-api-*.jar" })
 class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 
@@ -128,6 +130,7 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		System.getProperties().keySet().retainAll(this.systemPropertyNames);
 		this.loggingSystem.cleanUp();
 		((LoggerContext) LoggerFactory.getILoggerFactory()).stop();
+		((LoggerContext) LoggerFactory.getILoggerFactory()).reset();
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/SpringBootJoranConfiguratorTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/SpringBootJoranConfiguratorTests.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Phillip Webb
  * @author Eddú Meléndez
  * @author Stephane Nicoll
+ * @author Mark Chesney
  */
 @ExtendWith(OutputCaptureExtension.class)
 class SpringBootJoranConfiguratorTests {
@@ -72,6 +73,7 @@ class SpringBootJoranConfiguratorTests {
 	@AfterEach
 	void reset() {
 		this.context.stop();
+		this.context.reset();
 		new BasicConfigurator().configure((LoggerContext) LoggerFactory.getILoggerFactory());
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

**Upgrades Logback from 1.5.6 to 1.5.7.** 

The return type of **ch.qos.logback.core.ContextBase#getConfigurationLock#getConfigurationLock** has changed from **java.lang.Object** to **java.util.concurrent.locks.ReentrantLock**. It's noteworthy that this is a source compatible, binary incompatible change. The change necessitates replacing a synchronized block with a try-finally construct to ensure correct locking semantics going forward. There were also changes to the behavior of **ch.qos.logback.classic.LoggerContext#stop()** that necessitate calling **ch.qos.logback.classic.LoggerContext#reset()** where it wasn't already, in tests.

Closes #41887