### PR TITLE
Disable Artemis tests on Java 23

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/jms/JmsHealthContributorAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/jms/JmsHealthContributorAutoConfigurationTests.java
@@ -17,6 +17,8 @@
 package org.springframework.boot.actuate.autoconfigure.jms;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration;
 import org.springframework.boot.actuate.jms.JmsHealthIndicator;
@@ -32,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Phillip Webb
  */
+@EnabledForJreRange(max = JRE.JAVA_22, disabledReason = "https://issues.apache.org/jira/browse/ARTEMIS-4975")
 class JmsHealthContributorAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/JmsAutoConfigurationTests.java
@@ -24,6 +24,8 @@ import jakarta.jms.ExceptionListener;
 import jakarta.jms.Session;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
 import org.springframework.aot.test.generate.TestGenerationContext;
@@ -72,6 +74,7 @@ class JmsAutoConfigurationTests {
 		.withConfiguration(AutoConfigurations.of(ArtemisAutoConfiguration.class, JmsAutoConfiguration.class));
 
 	@Test
+	@EnabledForJreRange(max = JRE.JAVA_22, disabledReason = "https://issues.apache.org/jira/browse/ARTEMIS-4975")
 	void testDefaultJmsConfiguration() {
 		this.contextRunner.withUserConfiguration(TestConfiguration.class).run((context) -> {
 			assertThat(context).hasSingleBean(ConnectionFactory.class);
@@ -88,6 +91,7 @@ class JmsAutoConfigurationTests {
 	}
 
 	@Test
+	@EnabledForJreRange(max = JRE.JAVA_22, disabledReason = "https://issues.apache.org/jira/browse/ARTEMIS-4975")
 	void testConnectionFactoryBackOff() {
 		this.contextRunner.withUserConfiguration(TestConfiguration2.class)
 			.run((context) -> assertThat(context.getBeansOfType(ActiveMQConnectionFactory.class))
@@ -108,6 +112,7 @@ class JmsAutoConfigurationTests {
 	}
 
 	@Test
+	@EnabledForJreRange(max = JRE.JAVA_22, disabledReason = "https://issues.apache.org/jira/browse/ARTEMIS-4975")
 	void testJmsTemplateBackOffEverything() {
 		this.contextRunner
 			.withUserConfiguration(TestConfiguration2.class, TestConfiguration3.class, TestConfiguration5.class)

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisAutoConfigurationTests.java
@@ -41,7 +41,7 @@ import org.apache.activemq.artemis.jms.server.config.impl.JMSConfigurationImpl;
 import org.apache.activemq.artemis.jms.server.config.impl.JMSQueueConfigurationImpl;
 import org.apache.activemq.artemis.jms.server.config.impl.TopicConfigurationImpl;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.io.TempDir;
 import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;
@@ -66,7 +66,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Eddú Meléndez
  * @author Stephane Nicoll
  */
-@DisabledOnJre(value = JRE.OTHER, disabledReason = "https://issues.apache.org/jira/browse/ARTEMIS-4975")
+@EnabledForJreRange(max = JRE.JAVA_22, disabledReason = "https://issues.apache.org/jira/browse/ARTEMIS-4975")
 class ArtemisAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisEmbeddedConfigurationFactoryTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jms/artemis/ArtemisEmbeddedConfigurationFactoryTests.java
@@ -25,6 +25,8 @@ import org.apache.activemq.artemis.core.config.CoreAddressConfiguration;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Stephane Nicoll
  * @author Phillip Webb
  */
+@EnabledForJreRange(max = JRE.JAVA_22, disabledReason = "https://issues.apache.org/jira/browse/ARTEMIS-4975")
 class ArtemisEmbeddedConfigurationFactoryTests {
 
 	@Test

--- a/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/activemq/ArtemisEnvironmentTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/activemq/ArtemisEnvironmentTests.java
@@ -20,6 +20,8 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Eddú Meléndez
  */
+@EnabledForJreRange(max = JRE.JAVA_22, disabledReason = "https://issues.apache.org/jira/browse/ARTEMIS-4975")
 class ArtemisEnvironmentTests {
 
 	@Test


### PR DESCRIPTION
I completely disabled the following test on Java 23:
- `ArtemisAutoConfigurationTests`
- `ArtemisEmbeddedConfigurationFactoryTests`
- `ArtemisEnvironmentTests`
- `JmsHealthContributorAutoConfigurationTests`

Besides that I disabled the tests with Artemis context in the following test class:
- `JmsAutoConfigurationTests`

Because the `org.junit.jupiter.api.condition.JRE` does not contain a `JAVA_23` enum value yet, I used the `@EnabledForJreRange` annotation and not the `@DisabledOnJre` annotation.

This should close #41909

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
