### PR TITLE
Add support for optional trust certificates

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/PropertiesSslBundle.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/PropertiesSslBundle.java
@@ -29,6 +29,7 @@ import org.springframework.boot.ssl.pem.PemSslStoreBundle;
 import org.springframework.boot.ssl.pem.PemSslStoreDetails;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link SslBundle} backed by {@link JksSslBundleProperties} or
@@ -39,6 +40,8 @@ import org.springframework.util.Assert;
  * @since 3.1.0
  */
 public final class PropertiesSslBundle implements SslBundle {
+
+	private static final String OPTIONAL_URL_PREFIX = "optional:";
 
 	private final SslStoreBundle stores;
 
@@ -118,8 +121,19 @@ public final class PropertiesSslBundle implements SslBundle {
 	}
 
 	private static PemSslStoreDetails asPemSslStoreDetails(PemSslBundleProperties.Store properties) {
-		return new PemSslStoreDetails(properties.getType(), properties.getCertificate(), properties.getPrivateKey(),
-				properties.getPrivateKeyPassword());
+		return new PemSslStoreDetails(properties.getType(), getRawCertificate(properties.getCertificate()), properties.getPrivateKey(),
+			properties.getPrivateKeyPassword(), isCertificateOptional(properties.getCertificate()));
+	}
+
+	private static boolean isCertificateOptional(String certificate) {
+		return StringUtils.hasText(certificate) && certificate.startsWith(OPTIONAL_URL_PREFIX);
+	}
+
+	private static String getRawCertificate(String certificate)	{
+		if (isCertificateOptional(certificate)) {
+			return certificate.substring(OPTIONAL_URL_PREFIX.length());
+		}
+		return certificate;
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/WatchablePath.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/WatchablePath.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.ssl;
+
+import java.nio.file.Path;
+
+record WatchablePath(Path path, Boolean optional) {
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/LoadedPemSslStore.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/LoadedPemSslStore.java
@@ -58,7 +58,7 @@ final class LoadedPemSslStore implements PemSslStore {
 	}
 
 	private static List<X509Certificate> loadCertificates(PemSslStoreDetails details) throws IOException {
-		PemContent pemContent = PemContent.load(details.certificates());
+		PemContent pemContent = PemContent.load(details.certificates(), details.optional());
 		if (pemContent == null) {
 			return null;
 		}
@@ -70,6 +70,11 @@ final class LoadedPemSslStore implements PemSslStore {
 	private static PrivateKey loadPrivateKey(PemSslStoreDetails details) throws IOException {
 		PemContent pemContent = PemContent.load(details.privateKey());
 		return (pemContent != null) ? pemContent.getPrivateKey(details.privateKeyPassword()) : null;
+	}
+
+	@Override
+	public boolean optional() {
+		return this.details.optional();
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/PemContent.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/PemContent.java
@@ -108,6 +108,21 @@ public final class PemContent {
 	 * Load {@link PemContent} from the given content (either the PEM content itself or a
 	 * reference to the resource to load).
 	 * @param content the content to load
+	 * @param isOptional the content to load may be optional
+	 * @return a new {@link PemContent} instance
+	 * @throws IOException on IO error
+	 */
+	static PemContent load(String content, Boolean isOptional) throws IOException {
+		if (isOptional && !Files.exists(Path.of(content))) {
+			return null;
+		}
+		return load(content);
+	}
+
+	/**
+	 * Load {@link PemContent} from the given content (either the PEM content itself or a
+	 * reference to the resource to load).
+	 * @param content the content to load
 	 * @return a new {@link PemContent} instance
 	 * @throws IOException on IO error
 	 */

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/PemSslStore.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/PemSslStore.java
@@ -33,6 +33,9 @@ import org.springframework.util.Assert;
  */
 public interface PemSslStore {
 
+
+	boolean optional();
+
 	/**
 	 * The key store type, for example {@code JKS} or {@code PKCS11}. A {@code null} value
 	 * will use {@link KeyStore#getDefaultType()}).
@@ -162,6 +165,11 @@ public interface PemSslStore {
 			@Override
 			public PrivateKey privateKey() {
 				return privateKey;
+			}
+
+			@Override
+			public boolean optional() {
+				return false; //TODO
 			}
 
 		};

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/PemSslStoreBundle.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/PemSslStoreBundle.java
@@ -82,7 +82,7 @@ public class PemSslStoreBundle implements SslStoreBundle {
 	}
 
 	private static KeyStore createKeyStore(String name, PemSslStore pemSslStore) {
-		if (pemSslStore == null) {
+		if (pemSslStore == null || pemSslStore.optional() && pemSslStore.certificates() == null) {
 			return null;
 		}
 		try {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/PemSslStoreDetails.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/PemSslStoreDetails.java
@@ -29,20 +29,20 @@ import org.springframework.util.StringUtils;
  * @param password the password used
  * {@link KeyStore#setKeyEntry(String, java.security.Key, char[], java.security.cert.Certificate[])
  * setting key entries} in the {@link KeyStore}
- * @param certificates the certificates content (either the PEM content itself or a
+ * @param certificates the certificates content (either the PEM content itself or or a
  * reference to the resource to load). When a {@link #privateKey() private key} is present
  * this value is treated as a certificate chain, otherwise it is treated a list of
  * certificates that should all be registered.
  * @param privateKey the private key content (either the PEM content itself or a reference
  * to the resource to load)
  * @param privateKeyPassword a password used to decrypt an encrypted private key
+ * @param optional certificates/privateKey may be optional
  * @author Scott Frederick
  * @author Phillip Webb
  * @since 3.1.0
  * @see PemSslStore#load(PemSslStoreDetails)
  */
-public record PemSslStoreDetails(String type, String alias, String password, String certificates, String privateKey,
-		String privateKeyPassword) {
+public record PemSslStoreDetails(String type, String alias, String password, String certificates, String privateKey, String privateKeyPassword, boolean optional) {
 
 	/**
 	 * Create a new {@link PemSslStoreDetails} instance.
@@ -71,9 +71,10 @@ public record PemSslStoreDetails(String type, String alias, String password, Str
 	 * @param privateKey the private key content (either the PEM content itself or a
 	 * reference to the resource to load)
 	 * @param privateKeyPassword a password used to decrypt an encrypted private key
+	 * @param optional certificates/privateKey may be optional
 	 */
-	public PemSslStoreDetails(String type, String certificate, String privateKey, String privateKeyPassword) {
-		this(type, null, null, certificate, privateKey, privateKeyPassword);
+	public PemSslStoreDetails(String type, String certificate, String privateKey, String privateKeyPassword, boolean optional) {
+		this(type, null, null, certificate, privateKey, privateKeyPassword, optional);
 	}
 
 	/**
@@ -86,7 +87,7 @@ public record PemSslStoreDetails(String type, String alias, String password, Str
 	 * reference to the resource to load)
 	 */
 	public PemSslStoreDetails(String type, String certificate, String privateKey) {
-		this(type, certificate, privateKey, null);
+		this(type, certificate, privateKey, null, false);
 	}
 
 	/**
@@ -96,8 +97,7 @@ public record PemSslStoreDetails(String type, String alias, String password, Str
 	 * @since 3.2.0
 	 */
 	public PemSslStoreDetails withAlias(String alias) {
-		return new PemSslStoreDetails(this.type, alias, this.password, this.certificates, this.privateKey,
-				this.privateKeyPassword);
+		return new PemSslStoreDetails(this.type, alias, this.password, this.certificates, this.privateKey, this.privateKeyPassword, this.optional);
 	}
 
 	/**
@@ -107,8 +107,7 @@ public record PemSslStoreDetails(String type, String alias, String password, Str
 	 * @since 3.2.0
 	 */
 	public PemSslStoreDetails withPassword(String password) {
-		return new PemSslStoreDetails(this.type, this.alias, password, this.certificates, this.privateKey,
-				this.privateKeyPassword);
+		return new PemSslStoreDetails(this.type, this.alias, password, this.certificates, this.privateKey, this.privateKeyPassword, this.optional);
 	}
 
 	/**
@@ -117,8 +116,7 @@ public record PemSslStoreDetails(String type, String alias, String password, Str
 	 * @return a new {@link PemSslStoreDetails} instance
 	 */
 	public PemSslStoreDetails withPrivateKey(String privateKey) {
-		return new PemSslStoreDetails(this.type, this.alias, this.password, this.certificates, privateKey,
-				this.privateKeyPassword);
+		return new PemSslStoreDetails(this.type, this.alias, this.password, this.certificates, privateKey, this.privateKeyPassword, this.optional);
 	}
 
 	/**
@@ -127,8 +125,7 @@ public record PemSslStoreDetails(String type, String alias, String password, Str
 	 * @return a new {@link PemSslStoreDetails} instance
 	 */
 	public PemSslStoreDetails withPrivateKeyPassword(String privateKeyPassword) {
-		return new PemSslStoreDetails(this.type, this.alias, this.password, this.certificates, this.privateKey,
-				privateKeyPassword);
+		return new PemSslStoreDetails(this.type, this.alias, this.password, this.certificates, this.privateKey, privateKeyPassword, this.optional);
 	}
 
 	boolean isEmpty() {


### PR DESCRIPTION
**Problem Statement**

The challenge is the dynamic updating and management of certificates in an application that supports mTLS and interacts with client services that are frequently added and removed.

Suppose your application needs to support mTLS with two well-known client services, `foo` and `bar`, each having a specific intermediate CA (Certificate Authority). Client services are dynamically installed/removed from the cluster. For improved resiliency/manageability, you do not want to change the deployment of your application whenever a new client service is installed in the cluster: the client CAs must be dynamically added/removed to your server truststore as their services installed/removed from the cluster.

**Proposed Solution**

This PR aims to address this issue by allowing certificates to be marked as optional. With this feature, the application can start and continue running regardless of the availability of these certificates.

**Current Status**

This pull request is currently a draft/proof of concept. It does not yet include tests or documentation and is intended to gather feedback. The implementation includes several TODOs, such as:


- Adjust the validation for cases that involve PEM content used directly.

An example of `application.yaml` with optionality would look like:

```
spring.ssl.bundle.pem.server.reload-on-update=true
spring.ssl.bundle.pem.server.truststore.certificate=optional:/var/run/secrets/foo/ca.crt

```

**Related Issue**

This PR is related to this [comment](https://github.com/spring-projects/spring-boot/issues/38754#issuecomment-2274269939) in the [issue #38754](https://github.com/spring-projects/spring-boot/issues/38754)