### PR TITLE
Upgrade dependencies (Maven Install and Deploy plugin, Spring Retry)

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1210,7 +1210,7 @@ bom {
 			]
 		}
 	}
-	library("Maven Deploy Plugin", "3.1.2") {
+	library("Maven Deploy Plugin", "3.1.3") {
 		group("org.apache.maven.plugins") {
 			plugins = [
 				"maven-deploy-plugin"
@@ -1238,7 +1238,7 @@ bom {
 			]
 		}
 	}
-	library("Maven Install Plugin", "3.1.2") {
+	library("Maven Install Plugin", "3.1.3") {
 		group("org.apache.maven.plugins") {
 			plugins = [
 				"maven-install-plugin"
@@ -2081,7 +2081,7 @@ bom {
 			releaseNotes("https://github.com/spring-projects/spring-restdocs/releases/tag/v{version}")
 		}
 	}
-	library("Spring Retry", "2.0.7") {
+	library("Spring Retry", "2.0.8") {
 		considerSnapshots()
 		group("org.springframework.retry") {
 			modules = [


### PR DESCRIPTION
Dependency upgrades:

- Maven Install Plugin: 3.1.2 -> 3.1.3
- Maven Deploy Plugin: 3.1.2 -> 3.1.3
- Spring Retry: 2.0.7 -> 2.0.8

Closes #41942
Closes #41943
Closes #41944

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
