### PR TITLE
Overloaded Constructor that are no longer needed

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/quartz/QuartzDataSourceScriptDatabaseInitializer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/quartz/QuartzDataSourceScriptDatabaseInitializer.java
@@ -57,9 +57,6 @@ public class QuartzDataSourceScriptDatabaseInitializer extends DataSourceScriptD
 	 * @param settings the database initialization settings
 	 * @see #getSettings
 	 */
-	public QuartzDataSourceScriptDatabaseInitializer(DataSource dataSource, DatabaseInitializationSettings settings) {
-		this(dataSource, settings, null);
-	}
 
 	private QuartzDataSourceScriptDatabaseInitializer(DataSource dataSource, DatabaseInitializationSettings settings,
 			List<String> commentPrefixes) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/metadata/CompositeDataSourcePoolMetadataProvider.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/metadata/CompositeDataSourcePoolMetadataProvider.java
@@ -40,8 +40,7 @@ public class CompositeDataSourcePoolMetadataProvider implements DataSourcePoolMe
 	 * @param providers the data source pool metadata providers
 	 */
 	public CompositeDataSourcePoolMetadataProvider(Collection<? extends DataSourcePoolMetadataProvider> providers) {
-		this.providers = (providers != null) ? Collections.unmodifiableList(new ArrayList<>(providers))
-				: Collections.emptyList();
+		this.providers = (providers != null) ? List.copyOf(providers) : Collections.emptyList();
 	}
 
 	@Override


### PR DESCRIPTION
QuartzDataSourceScriptDatabaseInitializer(DataSource dataSource, DatabaseInitializationSettings settings) This constructor is already defined above. I think it would be better to delete it since it is no longer used code.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
