### PR TITLE
Using configureEach instead of all to avoid unnecessary configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 		}
 	}
 
-	configurations.all {
+	configurations.configureEach {
 		resolutionStrategy.cacheChangingModulesFor 0, "minutes"
 	}
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -71,7 +71,7 @@ dependencies {
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
-configurations.all {
+configurations.configureEach {
 	exclude group:"org.slf4j", module:"slf4j-api"
 	exclude group:"ch.qos.logback", module:"logback-classic"
 	exclude group:"ch.qos.logback", module:"logback-core"

--- a/spring-boot-project/spring-boot-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-autoconfigure/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 description = "Spring Boot AutoConfigure"
 
-configurations.all {
+configurations.configureEach {
 	resolutionStrategy.eachDependency { DependencyResolveDetails details ->
 		if (details.requested.module.group == "org.apache.kafka" && details.requested.module.name == "kafka-server-common") {
 			details.artifactSelection {

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/managing-dependencies/configure-platform.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/managing-dependencies/configure-platform.gradle
@@ -17,7 +17,7 @@ repositories {
 	maven { url 'repository' }
 }
 
-configurations.all {
+configurations.configureEach {
 	resolutionStrategy {
 		eachDependency {
 			if (it.requested.group == 'org.springframework.boot') {

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/managing-dependencies/configure-platform.gradle.kts
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/managing-dependencies/configure-platform.gradle.kts
@@ -19,7 +19,7 @@ repositories {
 	}
 }
 
-configurations.all {
+configurations.configureEach {
 	resolutionStrategy {
 		eachDependency {
 			if (requested.group == "org.springframework.boot") {

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/managing-dependencies/custom-version-with-platform.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/managing-dependencies/custom-version-with-platform.gradle
@@ -12,7 +12,7 @@ repositories {
 	maven { url 'repository' }
 }
 
-configurations.all {
+configurations.configureEach {
 	resolutionStrategy {
 		eachDependency {
 			if (it.requested.group == 'org.springframework.boot') {
@@ -23,7 +23,7 @@ configurations.all {
 }
 
 // tag::custom-version[]
-configurations.all {
+configurations.configureEach {
 	resolutionStrategy.eachDependency { DependencyResolveDetails details ->
 		if (details.requested.group == 'org.slf4j') {
 			details.useVersion '1.7.20'

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/managing-dependencies/custom-version-with-platform.gradle.kts
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/managing-dependencies/custom-version-with-platform.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 	}
 }
 
-configurations.all {
+configurations.configureEach {
 	resolutionStrategy {
 		eachDependency {
 			if (requested.group == "org.springframework.boot") {
@@ -25,7 +25,7 @@ configurations.all {
 }
 
 // tag::custom-version[]
-configurations.all {
+configurations.configureEach {
     resolutionStrategy.eachDependency {
         if (requested.group == "org.slf4j") {
             useVersion("1.7.20")

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/SpringBootAotPluginIntegrationTests-processTestAotDoesNotHaveDevelopmentOnlyDependenciesOnItsClasspath.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/SpringBootAotPluginIntegrationTests-processTestAotDoesNotHaveDevelopmentOnlyDependenciesOnItsClasspath.gradle
@@ -10,7 +10,7 @@ repositories {
 	maven { url 'repository' }
 }
 
-configurations.all {
+configurations.configureEach {
 	resolutionStrategy {
 		eachDependency {
 			if (it.requested.group == 'org.springframework.boot') {

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/SpringBootAotPluginIntegrationTests-processTestAotHasLibraryResourcesOnItsClasspath.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/SpringBootAotPluginIntegrationTests-processTestAotHasLibraryResourcesOnItsClasspath.gradle
@@ -9,7 +9,7 @@ repositories {
 	maven { url 'repository' }
 }
 
-configurations.all {
+configurations.configureEach {
 	resolutionStrategy {
 		eachDependency {
 			if (it.requested.group == 'org.springframework.boot') {

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/SpringBootAotPluginIntegrationTests-processTestAotHasTestAndDevelopmentOnlyDependenciesOnItsClasspath.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/SpringBootAotPluginIntegrationTests-processTestAotHasTestAndDevelopmentOnlyDependenciesOnItsClasspath.gradle
@@ -10,7 +10,7 @@ repositories {
 	maven { url 'repository' }
 }
 
-configurations.all {
+configurations.configureEach {
 	resolutionStrategy {
 		eachDependency {
 			if (it.requested.group == 'org.springframework.boot') {

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/SpringBootAotPluginIntegrationTests-processTestAotHasTransitiveRuntimeDependenciesOnItsClasspath.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/SpringBootAotPluginIntegrationTests-processTestAotHasTransitiveRuntimeDependenciesOnItsClasspath.gradle
@@ -9,7 +9,7 @@ repositories {
 	maven { url 'repository' }
 }
 
-configurations.all {
+configurations.configureEach {
 	resolutionStrategy {
 		eachDependency {
 			if (it.requested.group == 'org.springframework.boot') {

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-duplicatesAreHandledGracefully.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-duplicatesAreHandledGracefully.gradle
@@ -12,7 +12,7 @@ configurations {
 	provided
 }
 
-sourceSets.all {
+sourceSets.configureEach {
 	compileClasspath += configurations.provided
 	runtimeClasspath += configurations.provided
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootWarIntegrationTests-duplicatesAreHandledGracefully.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootWarIntegrationTests-duplicatesAreHandledGracefully.gradle
@@ -12,7 +12,7 @@ configurations {
 	provided
 }
 
-sourceSets.all {
+sourceSets.configureEach {
 	compileClasspath += configurations.provided
 	runtimeClasspath += configurations.provided
 }

--- a/spring-boot-system-tests/spring-boot-deployment-tests/build.gradle
+++ b/spring-boot-system-tests/spring-boot-deployment-tests/build.gradle
@@ -12,7 +12,7 @@ configurations {
 	}
 }
 
-configurations.all {
+configurations.configureEach {
 	exclude module: "spring-boot-starter-logging"
 }
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator-log4j2/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator-log4j2/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = "Spring Boot Actuator Log4j 2 smoke test"
 
-configurations.all {
+configurations.configureEach {
 	exclude module: "spring-boot-starter-logging"
 }
 

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-kafka/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-kafka/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 description = "Spring Boot Kafka smoke test"
 
-configurations.all {
+configurations.configureEach {
 	resolutionStrategy.eachDependency { DependencyResolveDetails details ->
 		if (details.requested.module.group == "org.apache.kafka" && details.requested.module.name == "kafka-server-common") {
 			details.artifactSelection {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-structure-logging-log4j2/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-structure-logging-log4j2/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = "Spring Boot structure logging Log4j2 smoke test"
 
-configurations.all {
+configurations.configureEach {
 	exclude module: "spring-boot-starter-logging"
 }
 


### PR DESCRIPTION
Resolving all configurations is usually bad practice, because it might trigger work that could be avoided, which will make the build slower.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
