### PR TITLE
Apply instanceof pattern matching

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/builder/ParentContextApplicationContextInitializer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/builder/ParentContextApplicationContextInitializer.java
@@ -72,8 +72,8 @@ public class ParentContextApplicationContextInitializer
 		@Override
 		public void onApplicationEvent(ContextRefreshedEvent event) {
 			ApplicationContext context = event.getApplicationContext();
-			if (context instanceof ConfigurableApplicationContext && context == event.getSource()) {
-				context.publishEvent(new ParentContextAvailableEvent((ConfigurableApplicationContext) context));
+			if (context instanceof ConfigurableApplicationContext configurableApplicationContext && context == event.getSource()) {
+				context.publishEvent(new ParentContextAvailableEvent(configurableApplicationContext));
 			}
 		}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudFoundryVcapEnvironmentPostProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/cloud/CloudFoundryVcapEnvironmentPostProcessor.java
@@ -201,9 +201,8 @@ public class CloudFoundryVcapEnvironmentPostProcessor implements EnvironmentPost
 				// Need a compound key
 				flatten(properties, (Map<String, Object>) value, name);
 			}
-			else if (value instanceof Collection) {
+			else if (value instanceof Collection<?> collection) {
 				// Need a compound key
-				Collection<Object> collection = (Collection<Object>) value;
 				properties.put(name, StringUtils.collectionToCommaDelimitedString(collection));
 				int count = 0;
 				for (Object item : collection) {


### PR DESCRIPTION
Refactored the code to use instanceof pattern matching, replacing the older style of instanceof checks and casts. This change improves code readability and maintainability by reducing boilerplate code.

### Changes
- Applied `instanceof` pattern matching in relevant sections of the code where it was previously missing.
- Removed unnecessary explicit casting.