### PR TITLE
Allow to enable the native profile via Maven property

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/native-image/developing-your-first-application.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/native-image/developing-your-first-application.adoc
@@ -210,6 +210,15 @@ With the `native` profile active, you can invoke the `native:compile` goal to tr
 $ mvn -Pnative native:compile
 ----
 
+The `native` profile can be activated by default by setting the Maven property `native` to `true` in the POM.
+
+[source,xml]
+----
+<properties>
+  <native>true</native>
+</properties>
+----
+
 The native image executable can be found in the `target` directory.
 
 

--- a/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
+++ b/spring-boot-project/spring-boot-starters/spring-boot-starter-parent/build.gradle
@@ -248,6 +248,12 @@ publishing.publications.withType(MavenPublication) {
 			profiles {
 				profile {
 					delegate.id("native")
+					activation {
+						property {
+							delegate.name('native')
+							delegate.value('true')
+						}
+					}
 					build {
 						pluginManagement {
 							plugins {


### PR DESCRIPTION
In some cases it could be desired to enable the `native` profile directly from Maven, so that the caller of Maven does not need to call Maven with `-Pnative`. To enable this behavior, I added an activation section to the generated POM with the profile definition.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
