### PR TITLE
Fix incorrect command in Docker configuration for Colima

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/packaging-oci-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/packaging-oci-image.adoc
@@ -617,7 +617,12 @@ TIP: With the `podman` CLI installed, the command `podman info --format='{{.Host
 ==== Docker Configuration for Colima
 
 The plugin can communicate with the Docker daemon provided by https://github.com/abiosoft/colima[Colima].
-The `DOCKER_HOST` environment variable can be set by using the command `export DOCKER_HOST=$(docker context inspect colima -f '{{.Endpoints.docker.Host}}').`
+The `DOCKER_HOST` environment variable can be set by using the following command:
+
+[source,shell,subs="verbatim,attributes"]
+----
+$ export DOCKER_HOST=$(docker context inspect colima -f '{{.Endpoints.docker.Host}}')
+----
 
 The plugin can also be configured to use Colima daemon by providing connection details similar to those shown in the following example:
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/pages/build-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/pages/build-image.adoc
@@ -523,7 +523,12 @@ TIP: With the `colima` CLI installed, the command `podman info --format='{{.Host
 ==== Docker Configuration for Colima
 
 The plugin can communicate with the Docker daemon provided by https://github.com/abiosoft/colima[Colima].
-The `DOCKER_HOST` environment variable can be set by using the command `export DOCKER_HOST=$(docker context inspect colima -f '{{.Endpoints.docker.Host}}').`
+The `DOCKER_HOST` environment variable can be set by using the following command:
+
+[source,shell,subs="verbatim,attributes"]
+----
+$ export DOCKER_HOST=$(docker context inspect colima -f '{{.Endpoints.docker.Host}}')
+----
 
 The plugin can also be configured to use Colima daemon by providing connection details similar to those shown in the following example:
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
As the dot is currently included in the backticks in the docs, this suggests that it should be included in the commend that should be executed as well. However, this would be incorrect, as it would result in a path that would end with a dot as well.

I put the dot after the backticks to make it clear it doesn't belong to the command. As the dot was always present in other similar instances in the docs I kept it, but if it wasn't for consistency I would be inclined to remove it entirely to make it even more foolproof.