### PR TITLE
Package name and class location mismatch

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/usingmain/always/MyApplicationTests.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/features/testing/springbootapplications/usingmain/always/MyApplicationTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.docs.features.testing.springbootapplications.usingmain.custom.always
+package org.springframework.boot.docs.features.testing.springbootapplications.usingmain.always
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest


### PR DESCRIPTION
The class location and the package name should be the same.