### PR TITLE
Fix StatsD link typo on Metrics documentation page

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/metrics.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/metrics.adoc
@@ -20,7 +20,7 @@ Spring Boot Actuator provides dependency management and auto-configuration for {
 - xref:actuator/metrics.adoc#actuator.metrics.export.signalfx[]
 - xref:actuator/metrics.adoc#actuator.metrics.export.simple[] (in-memory)
 - xref:actuator/metrics.adoc#actuator.metrics.export.stackdriver[]
-- xref:actuator/metrics.adoc#actuator.metrics.export.statsd[D]
+- xref:actuator/metrics.adoc#actuator.metrics.export.statsd[]
 - xref:actuator/metrics.adoc#actuator.metrics.export.wavefront[]
 
 TIP: To learn more about Micrometer's capabilities, see its {url-micrometer-docs}[reference documentation], in particular the {url-micrometer-docs-concepts}[concepts section].


### PR DESCRIPTION
The documentation link for StatsD metrics has incorrect anchor text.