### PR TITLE
Add Pulsar config props for startup policy

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarProperties.java
@@ -854,6 +854,7 @@ public class PulsarProperties {
 		public Startup getStartup() {
 			return this.startup;
 		}
+
 	}
 
 	public static class Reader {
@@ -932,6 +933,7 @@ public class PulsarProperties {
 		public Startup getStartup() {
 			return this.startup;
 		}
+
 	}
 
 	public static class Startup {
@@ -961,6 +963,7 @@ public class PulsarProperties {
 		public void setOnFailure(FailurePolicy onFailure) {
 			this.onFailure = onFailure;
 		}
+
 	}
 
 	public enum FailurePolicy {
@@ -973,6 +976,7 @@ public class PulsarProperties {
 
 		/** Retry startup asynchronously. */
 		RETRY;
+
 	}
 
 	public static class Template {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarProperties.java
@@ -822,6 +822,11 @@ public class PulsarProperties {
 		 */
 		private boolean observationEnabled;
 
+		/**
+		 * Startup settings.
+		 */
+		private final Startup startup = new Startup();
+
 		public SchemaType getSchemaType() {
 			return this.schemaType;
 		}
@@ -846,6 +851,9 @@ public class PulsarProperties {
 			this.observationEnabled = observationEnabled;
 		}
 
+		public Startup getStartup() {
+			return this.startup;
+		}
 	}
 
 	public static class Reader {
@@ -875,6 +883,11 @@ public class PulsarProperties {
 		 * backlog of a topic.
 		 */
 		private boolean readCompacted;
+
+		/**
+		 * Startup settings.
+		 */
+		private final Startup startup = new Startup();
 
 		public String getName() {
 			return this.name;
@@ -916,6 +929,50 @@ public class PulsarProperties {
 			this.readCompacted = readCompacted;
 		}
 
+		public Startup getStartup() {
+			return this.startup;
+		}
+	}
+
+	public static class Startup {
+
+		/**
+		 * The max time to wait for the container to start.
+		 */
+		private Duration timeout;
+
+		/**
+		 * The action to take when the container fails to start.
+		 */
+		private FailurePolicy onFailure;
+
+		public Duration getTimeout() {
+			return this.timeout;
+		}
+
+		public void setTimeout(Duration timeout) {
+			this.timeout = timeout;
+		}
+
+		public FailurePolicy getOnFailure() {
+			return this.onFailure;
+		}
+
+		public void setOnFailure(FailurePolicy onFailure) {
+			this.onFailure = onFailure;
+		}
+	}
+
+	public enum FailurePolicy {
+
+		/** Stop the container and throw exception. */
+		STOP,
+
+		/** Stop the container but do not throw exception. */
+		CONTINUE,
+
+		/** Retry startup asynchronously. */
+		RETRY;
 	}
 
 	public static class Template {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarProperties.java
@@ -975,7 +975,7 @@ public class PulsarProperties {
 		CONTINUE,
 
 		/** Retry startup asynchronously. */
-		RETRY;
+		RETRY
 
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapper.java
@@ -208,9 +208,9 @@ final class PulsarPropertiesMapper {
 		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		map.from(properties::getTimeout).to(containerProperties::setConsumerStartTimeout);
 		map.from(properties::getOnFailure)
-				.as(FailurePolicy::name)
-				.as(StartupFailurePolicy::valueOf)
-				.to(containerProperties::setStartupFailurePolicy);
+			.as(FailurePolicy::name)
+			.as(StartupFailurePolicy::valueOf)
+			.to(containerProperties::setStartupFailurePolicy);
 	}
 
 	<T> void customizeReaderBuilder(ReaderBuilder<T> readerBuilder) {
@@ -235,9 +235,9 @@ final class PulsarPropertiesMapper {
 		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		map.from(properties::getTimeout).to(readerContainerProperties::setReaderStartTimeout);
 		map.from(properties::getOnFailure)
-				.as(FailurePolicy::name)
-				.as(StartupFailurePolicy::valueOf)
-				.to(readerContainerProperties::setStartupFailurePolicy);
+			.as(FailurePolicy::name)
+			.as(StartupFailurePolicy::valueOf)
+			.to(readerContainerProperties::setStartupFailurePolicy);
 	}
 
 	private Consumer<Duration> timeoutProperty(BiConsumer<Integer, TimeUnit> setter) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactivePropertiesMapper.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactivePropertiesMapper.java
@@ -25,7 +25,6 @@ import org.apache.pulsar.reactive.client.api.ReactiveMessageSenderBuilder;
 import org.springframework.boot.autoconfigure.pulsar.PulsarProperties.FailurePolicy;
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.pulsar.config.StartupFailurePolicy;
-import org.springframework.pulsar.listener.PulsarContainerProperties;
 import org.springframework.pulsar.reactive.listener.ReactivePulsarContainerProperties;
 
 /**

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactivePropertiesMapper.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactivePropertiesMapper.java
@@ -106,9 +106,9 @@ final class PulsarReactivePropertiesMapper {
 		PulsarProperties.Startup properties = this.properties.getListener().getStartup();
 		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		map.from(properties::getOnFailure)
-				.as(FailurePolicy::name)
-				.as(StartupFailurePolicy::valueOf)
-				.to(containerProperties::setStartupFailurePolicy);
+			.as(FailurePolicy::name)
+			.as(StartupFailurePolicy::valueOf)
+			.to(containerProperties::setStartupFailurePolicy);
 	}
 
 	void customizeMessageReaderBuilder(ReactiveMessageReaderBuilder<?> builder) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactivePropertiesMapper.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactivePropertiesMapper.java
@@ -22,7 +22,10 @@ import org.apache.pulsar.reactive.client.api.ReactiveMessageConsumerBuilder;
 import org.apache.pulsar.reactive.client.api.ReactiveMessageReaderBuilder;
 import org.apache.pulsar.reactive.client.api.ReactiveMessageSenderBuilder;
 
+import org.springframework.boot.autoconfigure.pulsar.PulsarProperties.FailurePolicy;
 import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.pulsar.config.StartupFailurePolicy;
+import org.springframework.pulsar.listener.PulsarContainerProperties;
 import org.springframework.pulsar.reactive.listener.ReactivePulsarContainerProperties;
 
 /**
@@ -96,6 +99,16 @@ final class PulsarReactivePropertiesMapper {
 		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		map.from(properties::getSchemaType).to(containerProperties::setSchemaType);
 		map.from(properties::getConcurrency).to(containerProperties::setConcurrency);
+		customizeListenerStartupProperties(containerProperties);
+	}
+
+	private void customizeListenerStartupProperties(ReactivePulsarContainerProperties<?> containerProperties) {
+		PulsarProperties.Startup properties = this.properties.getListener().getStartup();
+		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
+		map.from(properties::getOnFailure)
+				.as(FailurePolicy::name)
+				.as(StartupFailurePolicy::valueOf)
+				.to(containerProperties::setStartupFailurePolicy);
 	}
 
 	void customizeMessageReaderBuilder(ReactiveMessageReaderBuilder<?> builder) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapperTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesMapperTests.java
@@ -316,4 +316,5 @@ class PulsarPropertiesMapperTests {
 		assertThat(readerContainerProperties.getStartupFailurePolicy()).isEqualTo(StartupFailurePolicy.CONTINUE);
 		assertThat(readerContainerProperties.getReaderStartTimeout()).isEqualTo(Duration.ofSeconds(25));
 	}
+
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesTests.java
@@ -38,6 +38,7 @@ import org.springframework.boot.autoconfigure.pulsar.PulsarProperties.Defaults.S
 import org.springframework.boot.autoconfigure.pulsar.PulsarProperties.Defaults.TypeMapping;
 import org.springframework.boot.autoconfigure.pulsar.PulsarProperties.Failover;
 import org.springframework.boot.autoconfigure.pulsar.PulsarProperties.Failover.BackupCluster;
+import org.springframework.boot.autoconfigure.pulsar.PulsarProperties.FailurePolicy;
 import org.springframework.boot.context.properties.bind.BindException;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
@@ -395,10 +396,14 @@ class PulsarPropertiesTests {
 			map.put("spring.pulsar.listener.schema-type", "avro");
 			map.put("spring.pulsar.listener.concurrency", "10");
 			map.put("spring.pulsar.listener.observation-enabled", "true");
+			map.put("spring.pulsar.listener.startup.on-failure", "retry");
+			map.put("spring.pulsar.listener.startup.timeout", "2m");
 			PulsarProperties.Listener properties = bindProperties(map).getListener();
 			assertThat(properties.getSchemaType()).isEqualTo(SchemaType.AVRO);
 			assertThat(properties.getConcurrency()).isEqualTo(10);
 			assertThat(properties.isObservationEnabled()).isTrue();
+			assertThat(properties.getStartup().getOnFailure()).isEqualTo(FailurePolicy.RETRY);
+			assertThat(properties.getStartup().getTimeout()).isEqualTo(Duration.ofSeconds(13));
 		}
 
 	}
@@ -414,12 +419,16 @@ class PulsarPropertiesTests {
 			map.put("spring.pulsar.reader.subscription-name", "my-subscription");
 			map.put("spring.pulsar.reader.subscription-role-prefix", "sub-role");
 			map.put("spring.pulsar.reader.read-compacted", "true");
+			map.put("spring.pulsar.reader.startup.on-failure", "continue");
+			map.put("spring.pulsar.reader.startup.timeout", "2m");
 			PulsarProperties.Reader properties = bindProperties(map).getReader();
 			assertThat(properties.getName()).isEqualTo("my-reader");
 			assertThat(properties.getTopics()).containsExactly("my-topic");
 			assertThat(properties.getSubscriptionName()).isEqualTo("my-subscription");
 			assertThat(properties.getSubscriptionRolePrefix()).isEqualTo("sub-role");
 			assertThat(properties.isReadCompacted()).isTrue();
+			assertThat(properties.getStartup().getOnFailure()).isEqualTo(FailurePolicy.CONTINUE);
+			assertThat(properties.getStartup().getTimeout()).isEqualTo(Duration.ofMinutes(2));
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarPropertiesTests.java
@@ -403,7 +403,7 @@ class PulsarPropertiesTests {
 			assertThat(properties.getConcurrency()).isEqualTo(10);
 			assertThat(properties.isObservationEnabled()).isTrue();
 			assertThat(properties.getStartup().getOnFailure()).isEqualTo(FailurePolicy.RETRY);
-			assertThat(properties.getStartup().getTimeout()).isEqualTo(Duration.ofSeconds(13));
+			assertThat(properties.getStartup().getTimeout()).isEqualTo(Duration.ofMinutes(2));
 		}
 
 	}
@@ -420,7 +420,7 @@ class PulsarPropertiesTests {
 			map.put("spring.pulsar.reader.subscription-role-prefix", "sub-role");
 			map.put("spring.pulsar.reader.read-compacted", "true");
 			map.put("spring.pulsar.reader.startup.on-failure", "continue");
-			map.put("spring.pulsar.reader.startup.timeout", "2m");
+			map.put("spring.pulsar.reader.startup.timeout", "23s");
 			PulsarProperties.Reader properties = bindProperties(map).getReader();
 			assertThat(properties.getName()).isEqualTo("my-reader");
 			assertThat(properties.getTopics()).containsExactly("my-topic");
@@ -428,7 +428,7 @@ class PulsarPropertiesTests {
 			assertThat(properties.getSubscriptionRolePrefix()).isEqualTo("sub-role");
 			assertThat(properties.isReadCompacted()).isTrue();
 			assertThat(properties.getStartup().getOnFailure()).isEqualTo(FailurePolicy.CONTINUE);
-			assertThat(properties.getStartup().getTimeout()).isEqualTo(Duration.ofMinutes(2));
+			assertThat(properties.getStartup().getTimeout()).isEqualTo(Duration.ofSeconds(23));
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactivePropertiesMapperTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/pulsar/PulsarReactivePropertiesMapperTests.java
@@ -37,6 +37,8 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.pulsar.PulsarProperties.Consumer;
 import org.springframework.boot.autoconfigure.pulsar.PulsarProperties.Consumer.Subscription;
+import org.springframework.boot.autoconfigure.pulsar.PulsarProperties.FailurePolicy;
+import org.springframework.pulsar.config.StartupFailurePolicy;
 import org.springframework.pulsar.reactive.listener.ReactivePulsarContainerProperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -123,12 +125,14 @@ class PulsarReactivePropertiesMapperTests {
 		properties.getConsumer().getSubscription().setName("my-subscription");
 		properties.getListener().setSchemaType(SchemaType.AVRO);
 		properties.getListener().setConcurrency(10);
+		properties.getListener().getStartup().setOnFailure(FailurePolicy.CONTINUE);
 		ReactivePulsarContainerProperties<Object> containerProperties = new ReactivePulsarContainerProperties<>();
 		new PulsarReactivePropertiesMapper(properties).customizeContainerProperties(containerProperties);
 		assertThat(containerProperties.getSubscriptionType()).isEqualTo(SubscriptionType.Shared);
 		assertThat(containerProperties.getSubscriptionName()).isEqualTo("my-subscription");
 		assertThat(containerProperties.getSchemaType()).isEqualTo(SchemaType.AVRO);
 		assertThat(containerProperties.getConcurrency()).isEqualTo(10);
+		assertThat(containerProperties.getStartupFailurePolicy()).isEqualTo(StartupFailurePolicy.CONTINUE);
 	}
 
 	@Test


### PR DESCRIPTION
This commit adds properties to configure the startup behavior for the Pulsar message containers  that back the `@PulsarListener`, `@ReactivePulsarListener`, and `@PulsarReader`.

This is to support the recently added [startup policy feature](https://github.com/spring-projects/spring-pulsar/commit/a518e110893772a86239a1252b27126c28286188) in Spring for Apache Pulsar.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
