### PR TITLE
Add tests to ensure private constructor is not used for value object binding

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/DefaultBindConstructorProviderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/DefaultBindConstructorProviderTests.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Yanming Zhou
  */
 class DefaultBindConstructorProviderTests {
 
@@ -90,6 +91,12 @@ class DefaultBindConstructorProviderTests {
 		assertThatIllegalStateException()
 			.isThrownBy(() -> this.provider.getBindConstructor(TwoConstructorsWithBothConstructorBinding.class, false))
 			.withMessageContaining("has more than one @ConstructorBinding");
+	}
+
+	@Test
+	void getBindConstructorWhenIsTypeWithPrivateConstructorReturnsNull() {
+		Constructor<?> constructor = this.provider.getBindConstructor(TypeWithPrivateConstructor.class, false);
+		assertThat(constructor).isNull();
 	}
 
 	@Test
@@ -220,6 +227,13 @@ class DefaultBindConstructorProviderTests {
 
 		@ConstructorBinding
 		TwoConstructorsWithBothConstructorBinding(String name, int age) {
+		}
+
+	}
+
+	static final class TypeWithPrivateConstructor {
+
+		private TypeWithPrivateConstructor(Environment environment) {
 		}
 
 	}


### PR DESCRIPTION
Sometimes we want to duplicate `@ConfigurationProperties` bean with different prefix, we should use the primary configuration properties as default of additional configuration properties instead of re-configuring them all, then we could inject that primary bean and copy its values as default via constructor, there are two ways to force constructor used for injection instead of binding, annotating it with `@Autowired` or marking it as `private`, and the former one is already covered by tests, this commit add test for latter one.