### PR TITLE
Allow customization of the banner printer used by SpringBootApplication

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DefaultSpringApplicationBannerPrinter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/DefaultSpringApplicationBannerPrinter.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.boot.Banner.Mode;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+/**
+ * Class used by {@link SpringApplication} to print the application banner.
+ *
+ * @author Phillip Webb
+ */
+class DefaultSpringApplicationBannerPrinter implements SpringApplicationBannerPrinter {
+
+	private static final Log logger = LogFactory.getLog(DefaultSpringApplicationBannerPrinter.class);
+
+	private static final Banner DEFAULT_BANNER = new SpringBootBanner();
+
+	private final ResourceLoader resourceLoader;
+
+	private final Banner fallbackBanner;
+
+	DefaultSpringApplicationBannerPrinter(ResourceLoader resourceLoader, Banner fallbackBanner) {
+		this.resourceLoader = resourceLoader;
+		this.fallbackBanner = fallbackBanner;
+	}
+
+	@Override
+	public Banner print(Environment environment, Class<?> sourceClass, Mode bannerMode) {
+		switch (bannerMode) {
+			case CONSOLE -> {
+				return print(environment, sourceClass, System.out);
+			}
+			case LOG -> {
+				return print(environment, sourceClass, logger);
+			}
+		}
+		return new PrintedBanner(getBanner(environment), sourceClass);
+	}
+
+	private Banner print(Environment environment, Class<?> sourceClass, Log logger) {
+		Banner banner = getBanner(environment);
+		try {
+			logger.info(createStringFromBanner(banner, environment, sourceClass));
+		}
+		catch (UnsupportedEncodingException ex) {
+			logger.warn("Failed to create String for banner", ex);
+		}
+		return new PrintedBanner(banner, sourceClass);
+	}
+
+	private Banner print(Environment environment, Class<?> sourceClass, PrintStream out) {
+		Banner banner = getBanner(environment);
+		banner.printBanner(environment, sourceClass, out);
+		return new PrintedBanner(banner, sourceClass);
+	}
+
+	private Banner getBanner(Environment environment) {
+		Banner textBanner = getTextBanner(environment);
+		if (textBanner != null) {
+			return textBanner;
+		}
+		if (this.fallbackBanner != null) {
+			return this.fallbackBanner;
+		}
+		return DEFAULT_BANNER;
+	}
+
+	private Banner getTextBanner(Environment environment) {
+		String location = environment.getProperty(BANNER_LOCATION_PROPERTY, DEFAULT_BANNER_LOCATION);
+		Resource resource = this.resourceLoader.getResource(location);
+		try {
+			if (resource.exists() && !resource.getURL().toExternalForm().contains("liquibase-core")) {
+				return new ResourceBanner(resource);
+			}
+		}
+		catch (IOException ex) {
+			// Ignore
+		}
+		return null;
+	}
+
+	private String createStringFromBanner(Banner banner, Environment environment, Class<?> mainApplicationClass)
+			throws UnsupportedEncodingException {
+		String charset = environment.getProperty("spring.banner.charset", StandardCharsets.UTF_8.name());
+		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+		try (PrintStream out = new PrintStream(byteArrayOutputStream, false, charset)) {
+			banner.printBanner(environment, mainApplicationClass, out);
+		}
+		return byteArrayOutputStream.toString(charset);
+	}
+
+	/**
+	 * Decorator that allows a {@link Banner} to be printed again without needing to
+	 * specify the source class.
+	 */
+	private static class PrintedBanner implements Banner {
+
+		private final Banner banner;
+
+		private final Class<?> sourceClass;
+
+		PrintedBanner(Banner banner, Class<?> sourceClass) {
+			this.banner = banner;
+			this.sourceClass = sourceClass;
+		}
+
+		@Override
+		public void printBanner(Environment environment, Class<?> sourceClass, PrintStream out) {
+			sourceClass = (sourceClass != null) ? sourceClass : this.sourceClass;
+			this.banner.printBanner(environment, sourceClass, out);
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -563,7 +563,8 @@ public class SpringApplication {
 		ResourceLoader resourceLoader = (this.resourceLoader != null) ? this.resourceLoader
 				: new DefaultResourceLoader(null);
 
-		SpringApplicationBannerPrinter bannerPrinter = Objects.requireNonNullElseGet(this.bannerPrinter, () -> new DefaultSpringApplicationBannerPrinter(resourceLoader, this.banner));
+		SpringApplicationBannerPrinter bannerPrinter = Objects.requireNonNullElseGet(this.bannerPrinter,
+				() -> new DefaultSpringApplicationBannerPrinter(resourceLoader, this.banner));
 		return bannerPrinter.print(environment, this.mainApplicationClass, this.properties.getBannerMode(environment));
 	}
 
@@ -1038,9 +1039,8 @@ public class SpringApplication {
 	}
 
 	/**
-	 * Sets the {@link SpringApplicationBannerPrinter} used to print the banner. Defaults to
-	 * {@link SpringApplicationBannerPrinter}.
-	 *
+	 * Sets the {@link SpringApplicationBannerPrinter} used to print the banner. Defaults
+	 * to {@link SpringApplicationBannerPrinter}.
 	 * @param bannerPrinter the printer used to print the banner
 	 */
 	public void setBannerPrinter(SpringApplicationBannerPrinter bannerPrinter) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -180,6 +180,7 @@ import org.springframework.util.function.ThrowingSupplier;
  * @author Tadaya Tsuyukubo
  * @author Lasse Wulff
  * @author Yanming Zhou
+ * @author Junhyung Park
  * @since 1.0.0
  * @see #run(Class, String[])
  * @see #run(Class[], String[])
@@ -214,6 +215,8 @@ public class SpringApplication {
 	private boolean addConversionService = true;
 
 	private Banner banner;
+
+	private SpringApplicationBannerPrinter bannerPrinter;
 
 	private ResourceLoader resourceLoader;
 
@@ -559,11 +562,9 @@ public class SpringApplication {
 		}
 		ResourceLoader resourceLoader = (this.resourceLoader != null) ? this.resourceLoader
 				: new DefaultResourceLoader(null);
-		SpringApplicationBannerPrinter bannerPrinter = new SpringApplicationBannerPrinter(resourceLoader, this.banner);
-		if (this.properties.getBannerMode(environment) == Mode.LOG) {
-			return bannerPrinter.print(environment, this.mainApplicationClass, logger);
-		}
-		return bannerPrinter.print(environment, this.mainApplicationClass, System.out);
+
+		SpringApplicationBannerPrinter bannerPrinter = Objects.requireNonNullElseGet(this.bannerPrinter, () -> new DefaultSpringApplicationBannerPrinter(resourceLoader, this.banner));
+		return bannerPrinter.print(environment, this.mainApplicationClass, this.properties.getBannerMode(environment));
 	}
 
 	/**
@@ -1034,6 +1035,16 @@ public class SpringApplication {
 	 */
 	public void setBannerMode(Banner.Mode bannerMode) {
 		this.properties.setBannerMode(bannerMode);
+	}
+
+	/**
+	 * Sets the {@link SpringApplicationBannerPrinter} used to print the banner. Defaults to
+	 * {@link SpringApplicationBannerPrinter}.
+	 *
+	 * @param bannerPrinter the printer used to print the banner
+	 */
+	public void setBannerPrinter(SpringApplicationBannerPrinter bannerPrinter) {
+		this.bannerPrinter = bannerPrinter;
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplicationBannerPrinter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplicationBannerPrinter.java
@@ -20,6 +20,13 @@ import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.core.env.Environment;
 
+/**
+ * Interface class used to print the application banner.
+ *
+ * @author Phillip Webb
+ * @author Junhyung Park
+ * @since 3.4.0
+ */
 public interface SpringApplicationBannerPrinter {
 
 	String BANNER_LOCATION_PROPERTY = "spring.banner.location";

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplicationBannerPrinter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplicationBannerPrinter.java
@@ -16,118 +16,19 @@
 
 package org.springframework.boot;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.logging.Log;
-
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.core.env.Environment;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 
-/**
- * Class used by {@link SpringApplication} to print the application banner.
- *
- * @author Phillip Webb
- */
-class SpringApplicationBannerPrinter {
+public interface SpringApplicationBannerPrinter {
 
-	static final String BANNER_LOCATION_PROPERTY = "spring.banner.location";
+	String BANNER_LOCATION_PROPERTY = "spring.banner.location";
 
-	static final String DEFAULT_BANNER_LOCATION = "banner.txt";
+	String DEFAULT_BANNER_LOCATION = "banner.txt";
 
-	private static final Banner DEFAULT_BANNER = new SpringBootBanner();
+	Banner print(Environment environment, Class<?> sourceClass, Banner.Mode bannerMode);
 
-	private final ResourceLoader resourceLoader;
-
-	private final Banner fallbackBanner;
-
-	SpringApplicationBannerPrinter(ResourceLoader resourceLoader, Banner fallbackBanner) {
-		this.resourceLoader = resourceLoader;
-		this.fallbackBanner = fallbackBanner;
-	}
-
-	Banner print(Environment environment, Class<?> sourceClass, Log logger) {
-		Banner banner = getBanner(environment);
-		try {
-			logger.info(createStringFromBanner(banner, environment, sourceClass));
-		}
-		catch (UnsupportedEncodingException ex) {
-			logger.warn("Failed to create String for banner", ex);
-		}
-		return new PrintedBanner(banner, sourceClass);
-	}
-
-	Banner print(Environment environment, Class<?> sourceClass, PrintStream out) {
-		Banner banner = getBanner(environment);
-		banner.printBanner(environment, sourceClass, out);
-		return new PrintedBanner(banner, sourceClass);
-	}
-
-	private Banner getBanner(Environment environment) {
-		Banner textBanner = getTextBanner(environment);
-		if (textBanner != null) {
-			return textBanner;
-		}
-		if (this.fallbackBanner != null) {
-			return this.fallbackBanner;
-		}
-		return DEFAULT_BANNER;
-	}
-
-	private Banner getTextBanner(Environment environment) {
-		String location = environment.getProperty(BANNER_LOCATION_PROPERTY, DEFAULT_BANNER_LOCATION);
-		Resource resource = this.resourceLoader.getResource(location);
-		try {
-			if (resource.exists() && !resource.getURL().toExternalForm().contains("liquibase-core")) {
-				return new ResourceBanner(resource);
-			}
-		}
-		catch (IOException ex) {
-			// Ignore
-		}
-		return null;
-	}
-
-	private String createStringFromBanner(Banner banner, Environment environment, Class<?> mainApplicationClass)
-			throws UnsupportedEncodingException {
-		String charset = environment.getProperty("spring.banner.charset", StandardCharsets.UTF_8.name());
-		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-		try (PrintStream out = new PrintStream(byteArrayOutputStream, false, charset)) {
-			banner.printBanner(environment, mainApplicationClass, out);
-		}
-		return byteArrayOutputStream.toString(charset);
-	}
-
-	/**
-	 * Decorator that allows a {@link Banner} to be printed again without needing to
-	 * specify the source class.
-	 */
-	private static class PrintedBanner implements Banner {
-
-		private final Banner banner;
-
-		private final Class<?> sourceClass;
-
-		PrintedBanner(Banner banner, Class<?> sourceClass) {
-			this.banner = banner;
-			this.sourceClass = sourceClass;
-		}
-
-		@Override
-		public void printBanner(Environment environment, Class<?> sourceClass, PrintStream out) {
-			sourceClass = (sourceClass != null) ? sourceClass : this.sourceClass;
-			this.banner.printBanner(environment, sourceClass, out);
-		}
-
-	}
-
-	static class SpringApplicationBannerPrinterRuntimeHints implements RuntimeHintsRegistrar {
+	class SpringApplicationBannerPrinterRuntimeHints implements RuntimeHintsRegistrar {
 
 		@Override
 		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplicationBannerPrinter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplicationBannerPrinter.java
@@ -33,7 +33,7 @@ public interface SpringApplicationBannerPrinter {
 
 	String DEFAULT_BANNER_LOCATION = "banner.txt";
 
-	Banner print(Environment environment, Class<?> sourceClass, Banner.Mode bannerMode);
+	Banner print(Environment environment, Class<?> sourceClass, Banner.Mode mode, Banner banner);
 
 	class SpringApplicationBannerPrinterRuntimeHints implements RuntimeHintsRegistrar {
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/builder/SpringApplicationBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/builder/SpringApplicationBuilder.java
@@ -34,6 +34,7 @@ import org.springframework.boot.Banner;
 import org.springframework.boot.BootstrapRegistry;
 import org.springframework.boot.BootstrapRegistryInitializer;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.SpringApplicationBannerPrinter;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.context.ApplicationContext;
@@ -334,6 +335,11 @@ public class SpringApplicationBuilder {
 
 	public SpringApplicationBuilder bannerMode(Banner.Mode bannerMode) {
 		this.application.setBannerMode(bannerMode);
+		return this;
+	}
+
+	public SpringApplicationBuilder bannerPrinter(SpringApplicationBannerPrinter bannerPrinter) {
+		this.application.setBannerPrinter(bannerPrinter);
 		return this;
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/DefaultSpringApplicationBannerPrinterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/DefaultSpringApplicationBannerPrinterTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.Banner.Mode;
+import org.springframework.boot.testsupport.system.CapturedOutput;
+import org.springframework.boot.testsupport.system.OutputCaptureExtension;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DefaultSpringApplicationBannerPrinter}.
+ *
+ * @author Moritz Halbritter
+ * @author Junhyung Park
+ */
+@ExtendWith(OutputCaptureExtension.class)
+class DefaultSpringApplicationBannerPrinterTests {
+
+	@Test
+	void shouldUseUtf8(CapturedOutput capturedOutput) {
+		ResourceLoader resourceLoader = new GenericApplicationContext();
+		Resource resource = resourceLoader.getResource("classpath:/banner-utf8.txt");
+		SpringApplicationBannerPrinter printer = new DefaultSpringApplicationBannerPrinter(resourceLoader,
+				new ResourceBanner(resource));
+		printer.print(new MockEnvironment(), DefaultSpringApplicationBannerPrinterTests.class, Mode.LOG);
+		assertThat(capturedOutput).containsIgnoringNewLines("\uD83D\uDE0D Spring Boot! \uD83D\uDE0D");
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/DefaultSpringApplicationBannerPrinterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/DefaultSpringApplicationBannerPrinterTests.java
@@ -42,9 +42,9 @@ class DefaultSpringApplicationBannerPrinterTests {
 	void shouldUseUtf8(CapturedOutput capturedOutput) {
 		ResourceLoader resourceLoader = new GenericApplicationContext();
 		Resource resource = resourceLoader.getResource("classpath:/banner-utf8.txt");
-		SpringApplicationBannerPrinter printer = new DefaultSpringApplicationBannerPrinter(resourceLoader,
+		SpringApplicationBannerPrinter printer = new DefaultSpringApplicationBannerPrinter();
+		printer.print(new MockEnvironment(), DefaultSpringApplicationBannerPrinterTests.class, Mode.LOG,
 				new ResourceBanner(resource));
-		printer.print(new MockEnvironment(), DefaultSpringApplicationBannerPrinterTests.class, Mode.LOG);
 		assertThat(capturedOutput).containsIgnoringNewLines("\uD83D\uDE0D Spring Boot! \uD83D\uDE0D");
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationBannerPrinterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationBannerPrinterTests.java
@@ -89,6 +89,7 @@ public class SpringApplicationBannerPrinterTests {
 			banner.printBanner(environment, sourceClass, System.out);
 			return banner;
 		}
+
 	}
 
 	static class DummyBanner implements Banner {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationBannerPrinterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationBannerPrinterTests.java
@@ -77,6 +77,7 @@ public class SpringApplicationBannerPrinterTests {
 	private SpringApplication createSpringApplicationWithBannerModeLog() {
 		SpringApplication application = new SpringApplication(Config.class);
 		application.setBannerMode(Mode.LOG);
+		application.setBanner(new DummyBanner());
 		application.setWebApplicationType(WebApplicationType.NONE);
 		return application;
 	}
@@ -84,8 +85,10 @@ public class SpringApplicationBannerPrinterTests {
 	static class CustomSpringApplicationBannerPrinter implements SpringApplicationBannerPrinter {
 
 		@Override
-		public Banner print(Environment environment, Class<?> sourceClass, Mode bannerMode) {
-			Banner banner = new DummyBanner();
+		public Banner print(Environment environment, Class<?> sourceClass, Mode bannerMode, Banner banner) {
+			if (banner == null) {
+				return null;
+			}
 			banner.printBanner(environment, sourceClass, System.out);
 			return banner;
 		}


### PR DESCRIPTION
Hello! I’ve made changes to allow the customization of the banner printer.

The `Banner` class was originally intended for printing a banner programmatically, but I needed a way to customize it more flexibly.
Here is the code before my contribution:
```kotlin
class MyBanner(private val plugin: Plugin) : Banner {
    override fun printBanner(environment: Environment?, sourceClass: Class<*>?, out: PrintStream?) {
        with(plugin.logger) {
            info("██╗  ██╗██╗████████╗")
            info("██║ ██╔╝██║╚══██╔══╝")
            info("█████╔╝ ██║   ██║   ")
            info("██╔═██╗ ██║   ██║   ")
            info("██║  ██╗██║   ██║   ")
            info("╚═╝  ╚═╝╚═╝   ╚═╝   ")
        }
    }
}
```
So, I changed the printer to be changeable. Now I can create a banner more programmatically!
```kotlin
class MyBanner(private val plugin: Plugin) : Banner {
    override fun printBanner(environment: Environment?, sourceClass: Class<*>?, printStream: PrintStream) {
        with(printStream) {
            println("██╗  ██╗██╗████████╗")
            println("██║ ██╔╝██║╚══██╔══╝")
            println("█████╔╝ ██║   ██║   ")
            println("██╔═██╗ ██║   ██║   ")
            println("██║  ██╗██║   ██║   ")
            println("╚═╝  ╚═╝╚═╝   ╚═╝   ")
        }
    }
}
```
```kotlin
class MyBannerPrinter(private val plugin: Plugin) : SpringApplicationBannerPrinter {
    override fun print(environment: Environment?, sourceClass: Class<*>?, bannerMode: Banner.Mode): Banner {
        return when (bannerMode) {
            Banner.Mode.CONSOLE -> print(environment, sourceClass, System.out)
            Banner.Mode.LOG -> print(environment, sourceClass, plugin.logger)
            else -> PrintedBanner(getBanner(environment), sourceClass)
        }
    }
}
```
I tried to follow the existing code style, but if any parts need to be revised, I would appreciate it if you could make corrections.
Thank you!