### PR TITLE
Consistently use constants for annotations in ConfigurationMetadataAnnotationProcessor

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessor.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessor.java
@@ -67,7 +67,7 @@ import org.springframework.boot.configurationprocessor.metadata.ItemMetadata;
 		ConfigurationMetadataAnnotationProcessor.REST_CONTROLLER_ENDPOINT_ANNOTATION,
 		ConfigurationMetadataAnnotationProcessor.SERVLET_ENDPOINT_ANNOTATION,
 		ConfigurationMetadataAnnotationProcessor.WEB_ENDPOINT_ANNOTATION,
-		"org.springframework.context.annotation.Configuration" })
+		ConfigurationMetadataAnnotationProcessor.CONFIGURATION_ANNOTATION })
 public class ConfigurationMetadataAnnotationProcessor extends AbstractProcessor {
 
 	static final String ADDITIONAL_METADATA_LOCATIONS_OPTION = "org.springframework.boot.configurationprocessor.additionalMetadataLocations";
@@ -101,6 +101,8 @@ public class ConfigurationMetadataAnnotationProcessor extends AbstractProcessor 
 	static final String NAME_ANNOTATION = "org.springframework.boot.context.properties.bind.Name";
 
 	static final String AUTO_CONFIGURATION_ANNOTATION = "org.springframework.boot.autoconfigure.AutoConfiguration";
+
+	static final String CONFIGURATION_ANNOTATION = "org.springframework.context.annotation.Configuration";
 
 	private static final Set<String> SUPPORTED_OPTIONS = Set.of(ADDITIONAL_METADATA_LOCATIONS_OPTION);
 


### PR DESCRIPTION
This PR refactors the ConfigurationMetadataAnnotationProcessor class by replacing hardcoded values with constants. 

- All hardcoded values have been replaced with named constants.
- No functional behavior has been altered.