### PR TITLE
Add statsd graceful shutdown support

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdMetricsExportAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/statsd/StatsdMetricsExportAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.boot.actuate.autoconfigure.metrics.export.statsd;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.statsd.StatsdConfig;
 import io.micrometer.statsd.StatsdMeterRegistry;
+import jakarta.annotation.PreDestroy;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
@@ -59,4 +60,8 @@ public class StatsdMetricsExportAutoConfiguration {
 		return new StatsdMeterRegistry(statsdConfig, clock);
 	}
 
+	@PreDestroy
+	public void destroy(StatsdMeterRegistry statsdMeterRegistry) {
+		statsdMeterRegistry.close();
+	}
 }


### PR DESCRIPTION
I have encountered an issue in my Spring Batch job where, intermittently, the error "Singleton bean creation not allowed while the singletons of this factory are in destruction" occurs with the StatsdMeterRegistry bean.

This issue seems to arise when the application unexpectedly receives a SIGTERM signal (such as when a node goes down in a cloud environment) and begins the shutdown process, some background tasks in the StatsdMeterRegistry are not properly terminated before the bean destruction phase. As a result, there appears to be an attempt to access the StatsdMeterRegistry after the ApplicationContext has already started to shut down.

To address this, I believe it would be beneficial to gracefully shut down the StatsdMeterRegistry before the bean is destroyed. A possible solution could be to modify the StatsdMetricsExportAutoConfiguration to ensure that StatsdMeterRegistry.close() is called during the shutdown phase, as shown below:

```java
    @PreDestroy
    public void destroy(StatsdMeterRegistry statsdMeterRegistry) {
        statsdMeterRegistry.close();
    }
```

This would help to properly terminate any ongoing background tasks and prevent the issue from occurring during application shutdown.

Thank you for considering this PR. I look forward to your feedback!
