### PR TITLE
Add spring.application.name to StartupInfoLogger

### DIFF
--- a/spring-boot-project/spring-boot-docs/build.gradle
+++ b/spring-boot-project/spring-boot-docs/build.gradle
@@ -301,7 +301,7 @@ task runLoggingFormatExample(type: org.springframework.boot.build.docs.Applicati
 	mainClass = "org.springframework.boot.docs.features.logexample.MyApplication"
 	args = ["--spring.main.banner-mode=off", "--server.port=0", "--spring.application.name=myapp"]
 	output = file("$buildDir/example-output/logging-format.txt")
-	expectedLogging = "Started MyApplication in "
+	expectedLogging = "Started MyApplication \"myapp\" in "
 	normalizeTomcatPort()
 }
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
@@ -64,6 +64,7 @@ class StartupInfoLogger {
 		StringBuilder message = new StringBuilder();
 		message.append("Starting");
 		appendAotMode(message);
+		appendApplicationClassName(message);
 		appendApplicationName(message);
 		appendApplicationVersion(message);
 		appendJavaVersion(message);
@@ -84,6 +85,7 @@ class StartupInfoLogger {
 	private CharSequence getStartedMessage(Startup startup) {
 		StringBuilder message = new StringBuilder();
 		message.append(startup.action());
+		appendApplicationClassName(message);
 		appendApplicationName(message);
 		message.append(" in ");
 		message.append(startup.timeTakenToStarted().toMillis() / 1000.0);
@@ -101,6 +103,10 @@ class StartupInfoLogger {
 	}
 
 	private void appendApplicationName(StringBuilder message) {
+		append(message, "\"", "\"", () -> this.environment.getProperty("spring.application.name"));
+	}
+
+	private void appendApplicationClassName(StringBuilder message) {
 		append(message, "",
 				() -> (this.sourceClass != null) ? ClassUtils.getShortName(this.sourceClass) : "application");
 	}
@@ -137,10 +143,15 @@ class StartupInfoLogger {
 	}
 
 	private void append(StringBuilder message, String prefix, Callable<Object> call) {
-		append(message, prefix, call, "");
+		append(message, prefix, "", call);
 	}
 
-	private void append(StringBuilder message, String prefix, Callable<Object> call, String defaultValue) {
+	private void append(StringBuilder message, String prefix, String suffix, Callable<Object> call) {
+		append(message, prefix, suffix, call, "");
+	}
+
+	private void append(StringBuilder message, String prefix, String suffix, Callable<Object> call,
+			String defaultValue) {
 		Object result = callIfPossible(call);
 		String value = (result != null) ? result.toString() : null;
 		if (!StringUtils.hasLength(value)) {
@@ -150,6 +161,7 @@ class StartupInfoLogger {
 			message.append((!message.isEmpty()) ? " " : "");
 			message.append(prefix);
 			message.append(value);
+			message.append(suffix);
 		}
 	}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/StartupInfoLoggerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/StartupInfoLoggerTests.java
@@ -47,6 +47,7 @@ class StartupInfoLoggerTests {
 		this.environment = new MockEnvironment();
 		this.environment.setProperty("spring.application.version", "1.2.3");
 		this.environment.setProperty("spring.application.pid", "42");
+		this.environment.setProperty("spring.application.name", "spring-boot");
 	}
 
 	@Test
@@ -54,10 +55,10 @@ class StartupInfoLoggerTests {
 		given(this.log.isInfoEnabled()).willReturn(true);
 		new StartupInfoLogger(getClass(), this.environment).logStarting(this.log);
 		then(this.log).should()
-			.info(assertArg(
-					(message) -> assertThat(message.toString()).contains("Starting " + getClass().getSimpleName()
-							+ " v1.2.3 using Java " + System.getProperty("java.version") + " with PID 42 (started by "
-							+ System.getProperty("user.name") + " in " + System.getProperty("user.dir") + ")")));
+			.info(assertArg((message) -> assertThat(message.toString())
+				.contains("Starting " + getClass().getSimpleName() + " \"spring-boot\"" + " v1.2.3 using Java "
+						+ System.getProperty("java.version") + " with PID 42 (started by "
+						+ System.getProperty("user.name") + " in " + System.getProperty("user.dir") + ")")));
 	}
 
 	@Test
@@ -66,10 +67,10 @@ class StartupInfoLoggerTests {
 		given(this.log.isInfoEnabled()).willReturn(true);
 		new StartupInfoLogger(getClass(), this.environment).logStarting(this.log);
 		then(this.log).should()
-			.info(assertArg(
-					(message) -> assertThat(message.toString()).contains("Starting " + getClass().getSimpleName()
-							+ " using Java " + System.getProperty("java.version") + " with PID 42 (started by "
-							+ System.getProperty("user.name") + " in " + System.getProperty("user.dir") + ")")));
+			.info(assertArg((message) -> assertThat(message.toString())
+				.contains("Starting " + getClass().getSimpleName() + " \"spring-boot\"" + " using Java "
+						+ System.getProperty("java.version") + " with PID 42 (started by "
+						+ System.getProperty("user.name") + " in " + System.getProperty("user.dir") + ")")));
 	}
 
 	@Test
@@ -78,9 +79,21 @@ class StartupInfoLoggerTests {
 		given(this.log.isInfoEnabled()).willReturn(true);
 		new StartupInfoLogger(getClass(), this.environment).logStarting(this.log);
 		then(this.log).should()
+			.info(assertArg((message) -> assertThat(message.toString())
+				.contains("Starting " + getClass().getSimpleName() + " \"spring-boot\"" + " v1.2.3 using Java "
+						+ System.getProperty("java.version") + " (started by " + System.getProperty("user.name")
+						+ " in " + System.getProperty("user.dir") + ")")));
+	}
+
+	@Test
+	void startingFormatWhenApplicationNameIsNotAvailable() {
+		this.environment.setProperty("spring.application.name", "");
+		given(this.log.isInfoEnabled()).willReturn(true);
+		new StartupInfoLogger(getClass(), this.environment).logStarting(this.log);
+		then(this.log).should()
 			.info(assertArg(
 					(message) -> assertThat(message.toString()).contains("Starting " + getClass().getSimpleName()
-							+ " v1.2.3 using Java " + System.getProperty("java.version") + " (started by "
+							+ " v1.2.3 using Java " + System.getProperty("java.version") + " with PID 42 (started by "
 							+ System.getProperty("user.name") + " in " + System.getProperty("user.dir") + ")")));
 	}
 
@@ -92,10 +105,9 @@ class StartupInfoLoggerTests {
 			new StartupInfoLogger(getClass(), this.environment).logStarting(this.log);
 			then(this.log).should()
 				.info(assertArg((message) -> assertThat(message.toString())
-					.contains("Starting AOT-processed " + getClass().getSimpleName() + " v1.2.3 using Java "
-							+ System.getProperty("java.version") + " with PID 42 (started by "
+					.contains("Starting AOT-processed " + getClass().getSimpleName() + " \"spring-boot\""
+							+ " v1.2.3 using Java " + System.getProperty("java.version") + " with PID 42 (started by "
 							+ System.getProperty("user.name") + " in " + System.getProperty("user.dir") + ")")));
-
 		}
 		finally {
 			System.clearProperty("spring.aot.enabled");
@@ -108,7 +120,7 @@ class StartupInfoLoggerTests {
 		new StartupInfoLogger(getClass(), this.environment).logStarted(this.log, new TestStartup(1345L, "Started"));
 		then(this.log).should()
 			.info(assertArg((message) -> assertThat(message.toString()).matches("Started " + getClass().getSimpleName()
-					+ " in \\d+\\.\\d{1,3} seconds \\(process running for 1.345\\)")));
+					+ " \"spring-boot\"" + " in \\d+\\.\\d{1,3} seconds \\(process running for 1.345\\)")));
 	}
 
 	@Test
@@ -116,8 +128,8 @@ class StartupInfoLoggerTests {
 		given(this.log.isInfoEnabled()).willReturn(true);
 		new StartupInfoLogger(getClass(), this.environment).logStarted(this.log, new TestStartup(null, "Started"));
 		then(this.log).should()
-			.info(assertArg((message) -> assertThat(message.toString())
-				.matches("Started " + getClass().getSimpleName() + " in \\d+\\.\\d{1,3} seconds")));
+			.info(assertArg((message) -> assertThat(message.toString()).matches(
+					"Started " + getClass().getSimpleName() + " \"spring-boot\"" + " in \\d+\\.\\d{1,3} seconds")));
 	}
 
 	@Test
@@ -125,8 +137,8 @@ class StartupInfoLoggerTests {
 		given(this.log.isInfoEnabled()).willReturn(true);
 		new StartupInfoLogger(getClass(), this.environment).logStarted(this.log, new TestStartup(null, "Restored"));
 		then(this.log).should()
-			.info(assertArg((message) -> assertThat(message.toString())
-				.matches("Restored " + getClass().getSimpleName() + " in \\d+\\.\\d{1,3} seconds")));
+			.info(assertArg((message) -> assertThat(message.toString()).matches(
+					"Restored " + getClass().getSimpleName() + " \"spring-boot\"" + " in \\d+\\.\\d{1,3} seconds")));
 	}
 
 	static class TestStartup extends Startup {


### PR DESCRIPTION
> Starting StartupInfoLoggerTests "spring-boot" v1.2.3 using Java 17.0.12 (started by dmytronosan in /Users/dmytronosan/IdeaProjects/spring-boot/spring-boot-project/spring-boot)

> Starting AOT-processed StartupInfoLoggerTests "spring-boot" v1.2.3 using Java 17.0.12 with PID 42 (started by dmytronosan in /Users/dmytronosan/IdeaProjects/spring-boot/spring-boot-project/spring-boot)

> Starting StartupInfoLoggerTests "spring-boot" v1.2.3 using Java 17.0.12 with PID 42 (started by dmytronosan in /Users/dmytronosan/IdeaProjects/spring-boot/spring-boot-project/spring-boot)

> Restored StartupInfoLoggerTests "spring-boot" in 0.0 seconds

> Started StartupInfoLoggerTests "spring-boot" in 0.0 seconds (process running for 1.345)

**spring.application.name** is not present

> Starting StartupInfoLoggerTests v1.2.3 using Java 17.0.12 with PID 42 (started by dmytronosan in /Users/dmytronosan/IdeaProjects/spring-boot/spring-boot-project/spring-boot)




gh-42330
