### PR TITLE
Add Javadoc since for PrometheusScrapeEndpoint(PrometheusRegistry, Properties)

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusScrapeEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/export/prometheus/PrometheusScrapeEndpoint.java
@@ -69,6 +69,7 @@ public class PrometheusScrapeEndpoint {
 	 * @param prometheusRegistry the Prometheus registry to use
 	 * @param exporterProperties the properties used to configure Prometheus'
 	 * {@link ExpositionFormats}
+	 * @since 3.3.1
 	 */
 	public PrometheusScrapeEndpoint(PrometheusRegistry prometheusRegistry, Properties exporterProperties) {
 		this.prometheusRegistry = prometheusRegistry;


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `PrometheusScrapeEndpoint(PrometheusRegistry, Properties)`.

See gh-40904