### PR TITLE
remove duplicated file name access and use StringBuilder to insert in WebServerPortFileWriter

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/context/WebServerPortFileWriter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/context/WebServerPortFileWriter.java
@@ -109,18 +109,17 @@ public class WebServerPortFileWriter implements ApplicationListener<WebServerIni
 			return this.file;
 		}
 		String name = this.file.getName();
-		String extension = StringUtils.getFilenameExtension(this.file.getName());
-		name = name.substring(0, name.length() - extension.length() - 1);
-		if (isUpperCase(name)) {
-			name = name + "-" + namespace.toUpperCase(Locale.ENGLISH);
-		}
-		else {
-			name = name + "-" + namespace.toLowerCase(Locale.ENGLISH);
-		}
-		if (StringUtils.hasLength(extension)) {
-			name = name + "." + extension;
-		}
-		return new File(this.file.getParentFile(), name);
+		String extension = StringUtils.getFilenameExtension(name);
+
+		StringBuilder builder = new StringBuilder(name);
+
+		String suffix = "-" + (isUpperCase(name) ? namespace.toUpperCase(Locale.ENGLISH) : namespace.toLowerCase(Locale.ENGLISH));
+		if (StringUtils.hasLength(extension))
+			builder.insert(name.lastIndexOf(extension) - 1, suffix);
+		else
+			builder.append(suffix);
+
+		return new File(this.file.getParentFile(), builder.toString());
 	}
 
 	private String getServerNamespace(ApplicationContext applicationContext) {


### PR DESCRIPTION
The File.getName() method always slice the path to get the name. so, it's not cached
It doesn't have a huge impact, but it's not efficient, so i fixed it :)

Also, the original code was truncating the extension from the filename, adding the namespace, and then putting the extension back together again, but i modified the code to be cleaner by using StringBuilder to do the insertion.

This change passed the test (WebServerPortFileWriterTests.java)

* Remove duplicated File.getName() method
* using StringBuilder to insert namespace