### PR TITLE
Downgraded Maven Javadoc Plugin to v3.8.0 from v3.10.0

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1264,7 +1264,7 @@ bom {
 			]
 		}
 	}
-	library("Maven Javadoc Plugin", "3.10.0") {
+	library("Maven Javadoc Plugin", "3.8.0") {
 		group("org.apache.maven.plugins") {
 			plugins = [
 				"maven-javadoc-plugin"


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Downgraded Maven Javadoc Plugin to v3.8.0 from v3.10.0 as per 
- issue reported #42401
- MJAVADOC-812 https://issues.apache.org/jira/browse/MJAVADOC-812

Revert of commit https://github.com/spring-projects/spring-boot/commit/53554278bcb3ba43f11d9829e9277a711d4e01f6