### PR TITLE
Provide a configuration property for configuring Jetty's max form keys

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -1149,6 +1149,11 @@ public class ServerProperties {
 		private DataSize maxHttpFormPostSize = DataSize.ofBytes(200000);
 
 		/**
+		 * Maximum size of the form keys.
+		 */
+		private int maxFormKeys = 1000;
+
+		/**
 		 * Time that the connection can be idle before it is closed.
 		 */
 		private Duration connectionIdleTimeout;
@@ -1178,6 +1183,14 @@ public class ServerProperties {
 
 		public void setMaxHttpFormPostSize(DataSize maxHttpFormPostSize) {
 			this.maxHttpFormPostSize = maxHttpFormPostSize;
+		}
+
+		public int getMaxFormKeys() {
+			return maxFormKeys;
+		}
+
+		public void setMaxFormKeys(int maxFormKeys) {
+			this.maxFormKeys = maxFormKeys;
 		}
 
 		public Duration getConnectionIdleTimeout() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -1149,7 +1149,7 @@ public class ServerProperties {
 		private DataSize maxHttpFormPostSize = DataSize.ofBytes(200000);
 
 		/**
-		 * Maximum size of the form keys.
+		 * Maximum number of form keys.
 		 */
 		private int maxFormKeys = 1000;
 
@@ -1186,7 +1186,7 @@ public class ServerProperties {
 		}
 
 		public int getMaxFormKeys() {
-			return maxFormKeys;
+			return this.maxFormKeys;
 		}
 
 		public void setMaxFormKeys(int maxFormKeys) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.web.embedded;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.server.AbstractConnector;
@@ -93,7 +94,11 @@ public class JettyWebServerFactoryCustomizer
 		map.from(properties::getMaxHttpFormPostSize)
 			.asInt(DataSize::toBytes)
 			.when(this::isPositive)
-			.to((maxHttpFormPostSize) -> customizeMaxHttpFormPostSize(factory, maxHttpFormPostSize));
+			.to((maxHttpFormPostSize) -> customizeServletContextHandler(factory, contextHandler -> contextHandler.setMaxFormContentSize(maxHttpFormPostSize)));
+		map.from(properties::getMaxFormKeys)
+				.when(this::isPositive)
+				.to((maxFormKeys) -> customizeServletContextHandler(factory, contextHandler -> contextHandler.setMaxFormKeys(maxFormKeys)));
+
 		map.from(properties::getConnectionIdleTimeout).to((idleTimeout) -> customizeIdleTimeout(factory, idleTimeout));
 		map.from(properties::getAccesslog)
 			.when(ServerProperties.Jetty.Accesslog::isEnabled)
@@ -122,7 +127,7 @@ public class JettyWebServerFactoryCustomizer
 		});
 	}
 
-	private void customizeMaxHttpFormPostSize(ConfigurableJettyWebServerFactory factory, int maxHttpFormPostSize) {
+	private void customizeServletContextHandler(ConfigurableJettyWebServerFactory factory, Consumer<ServletContextHandler> customFunc) {
 		factory.addServerCustomizers(new JettyServerCustomizer() {
 
 			@Override
@@ -138,7 +143,7 @@ public class JettyWebServerFactoryCustomizer
 
 			private void setHandlerMaxHttpFormPostSize(Handler handler) {
 				if (handler instanceof ServletContextHandler contextHandler) {
-					contextHandler.setMaxFormContentSize(maxHttpFormPostSize);
+					customFunc.accept(contextHandler);
 				}
 				else if (handler instanceof Handler.Wrapper wrapper) {
 					setHandlerMaxHttpFormPostSize(wrapper.getHandler());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizer.java
@@ -132,24 +132,24 @@ public class JettyWebServerFactoryCustomizer
 
 			@Override
 			public void customize(Server server) {
-				setHandlerMaxHttpFormPostSize(server.getHandlers());
+				acceptCustomizeServletContextHandler(server.getHandlers());
 			}
 
-			private void setHandlerMaxHttpFormPostSize(List<Handler> handlers) {
+			private void acceptCustomizeServletContextHandler(List<Handler> handlers) {
 				for (Handler handler : handlers) {
-					setHandlerMaxHttpFormPostSize(handler);
+					acceptCustomizeServletContextHandler(handler);
 				}
 			}
 
-			private void setHandlerMaxHttpFormPostSize(Handler handler) {
+			private void acceptCustomizeServletContextHandler(Handler handler) {
 				if (handler instanceof ServletContextHandler contextHandler) {
 					customFunc.accept(contextHandler);
 				}
 				else if (handler instanceof Handler.Wrapper wrapper) {
-					setHandlerMaxHttpFormPostSize(wrapper.getHandler());
+					acceptCustomizeServletContextHandler(wrapper.getHandler());
 				}
 				else if (handler instanceof Handler.Collection collection) {
-					setHandlerMaxHttpFormPostSize(collection.getHandlers());
+					acceptCustomizeServletContextHandler(collection.getHandlers());
 				}
 			}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -466,6 +466,15 @@ class ServerPropertiesTests {
 	}
 
 	@Test
+	void jettyMaxFormKeysMatchesDefault() {
+		JettyServletWebServerFactory jettyFactory = new JettyServletWebServerFactory(0);
+		JettyWebServer jetty = (JettyWebServer) jettyFactory.getWebServer();
+		Server server = jetty.getServer();
+		assertThat(this.properties.getJetty().getMaxFormKeys())
+				.isEqualTo(((ServletContextHandler) server.getHandler()).getMaxFormKeys());
+	}
+
+	@Test
 	void undertowMaxHttpPostSizeMatchesDefault() {
 		assertThat(this.properties.getUndertow().getMaxHttpPostSize().toBytes())
 			.isEqualTo(UndertowOptions.DEFAULT_MAX_ENTITY_SIZE);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/JettyWebServerFactoryCustomizerTests.java
@@ -26,6 +26,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.function.Function;
 
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.server.AbstractConnector;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.CustomRequestLog;
@@ -322,6 +323,23 @@ class JettyWebServerFactoryCustomizerTests {
 		JettyWebServer server = customizeAndGetServer();
 		List<Long> timeouts = connectorsIdleTimeouts(server);
 		assertThat(timeouts).containsOnly(60000L);
+	}
+
+	@Test
+	void customMaxFormKeys() {
+		bind("server.jetty.max-form-keys=2048");
+		JettyWebServer server = customizeAndGetServer();
+		List<Integer> maxFormKeys = getMaxFormKeys(server);
+		assertThat(maxFormKeys).containsOnly(2048);
+	}
+
+	private List<Integer> getMaxFormKeys(JettyWebServer server) {
+		server.start();
+		server.stop();
+		return server.getServer().getHandlers().stream()
+				.filter(handler -> handler instanceof ServletContextHandler)
+				.map(handler -> ((ServletContextHandler) handler).getMaxFormKeys())
+				.toList();
 	}
 
 	private List<Long> connectorsIdleTimeouts(JettyWebServer server) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

I encountered an issue in the project related to form submissions, where the number of keys exceeded Jetty's default limit of 1000. I found that there's no way to configure this parameter in the Spring Boot configuration file. 

Although I achieved my goal by setting `org.eclipse.jetty.server.Request.maxFormKeys`, it doesn't feel like an ideal solution. 
May I submit a PR to add this configuration option?