### PR TITLE
Fix typo in "committed" in ProcessInfo

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/ProcessInfo.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/ProcessInfo.java
@@ -126,7 +126,7 @@ public class ProcessInfo {
 				return this.memoryUsage.getUsed();
 			}
 
-			public long getCommited() {
+			public long getCommitted() {
 				return this.memoryUsage.getCommitted();
 			}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/info/ProcessInfoTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/info/ProcessInfoTests.java
@@ -45,12 +45,12 @@ class ProcessInfoTests {
 		MemoryUsageInfo heapUsageInfo = processInfo.getMemory().getHeap();
 		MemoryUsageInfo nonHeapUsageInfo = processInfo.getMemory().getNonHeap();
 		assertThat(heapUsageInfo.getInit()).isPositive().isLessThanOrEqualTo(heapUsageInfo.getMax());
-		assertThat(heapUsageInfo.getUsed()).isPositive().isLessThanOrEqualTo(heapUsageInfo.getCommited());
-		assertThat(heapUsageInfo.getCommited()).isPositive().isLessThanOrEqualTo(heapUsageInfo.getMax());
+		assertThat(heapUsageInfo.getUsed()).isPositive().isLessThanOrEqualTo(heapUsageInfo.getCommitted());
+		assertThat(heapUsageInfo.getCommitted()).isPositive().isLessThanOrEqualTo(heapUsageInfo.getMax());
 		assertThat(heapUsageInfo.getMax()).isPositive();
 		assertThat(nonHeapUsageInfo.getInit()).isPositive();
-		assertThat(nonHeapUsageInfo.getUsed()).isPositive().isLessThanOrEqualTo(heapUsageInfo.getCommited());
-		assertThat(nonHeapUsageInfo.getCommited()).isPositive();
+		assertThat(nonHeapUsageInfo.getUsed()).isPositive().isLessThanOrEqualTo(heapUsageInfo.getCommitted());
+		assertThat(nonHeapUsageInfo.getCommitted()).isPositive();
 		assertThat(nonHeapUsageInfo.getMax()).isEqualTo(-1);
 	}
 


### PR DESCRIPTION
This PR fixes typo in "committed" in the `ProcessInfo`.

See gh-41262