### PR TITLE
Use builder-jammy-java-tiny when using Buildpacks

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/native-image/developing-your-first-application.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/native-image/developing-your-first-application.adoc
@@ -33,7 +33,7 @@ This means you can just type a single command and quickly get a sensible image i
 The resulting image doesn't contain a JVM, instead the native image is compiled statically.
 This leads to smaller images.
 
-NOTE: The CNB builder used for the images is `paketobuildpacks/builder-jammy-tiny:latest`.
+NOTE: The CNB builder used for the images is `paketobuildpacks/builder-jammy-java-tiny:latest`.
 It has small footprint and reduced attack surface, but you can also use `paketobuildpacks/builder-jammy-base:latest` or `paketobuildpacks/builder-jammy-full:latest` to have more tools available in the image if required.
 
 

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/native-image/advanced-topics.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/native-image/advanced-topics.adoc
@@ -66,7 +66,7 @@ Assuming an AOT processed Spring Boot executable jar built as `myproject-0.0.1-S
 
 [source,shell]
 ----
-$ pack build --builder paketobuildpacks/builder-jammy-tiny \
+$ pack build --builder paketobuildpacks/builder-jammy-java-tiny \
     --path target/myproject-0.0.1-SNAPSHOT.jar \
     --env 'BP_NATIVE_IMAGE=true' \
     my-application:0.0.1-SNAPSHOT

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildRequest.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildRequest.java
@@ -46,11 +46,13 @@ import org.springframework.util.Assert;
  */
 public class BuildRequest {
 
-	static final String DEFAULT_BUILDER_IMAGE_NAME = "paketobuildpacks/builder-jammy-tiny";
+	static final String DEFAULT_BUILDER_IMAGE_NAME = "paketobuildpacks/builder-jammy-java-tiny";
 
 	static final String DEFAULT_BUILDER_IMAGE_REF = DEFAULT_BUILDER_IMAGE_NAME + ":latest";
 
 	static final List<ImageReference> KNOWN_TRUSTED_BUILDERS = List.of(
+			ImageReference.of("paketobuildpacks/builder-noble-java-tiny"),
+			ImageReference.of("paketobuildpacks/builder-jammy-java-tiny"),
 			ImageReference.of("paketobuildpacks/builder-jammy-tiny"),
 			ImageReference.of("paketobuildpacks/builder-jammy-base"),
 			ImageReference.of("paketobuildpacks/builder-jammy-full"),

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/packaging-oci-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/packaging-oci-image.adoc
@@ -119,12 +119,12 @@ The following table summarizes the available properties and their default values
 | `builder`
 | `--builder`
 | Name of the builder image to use.
-| `paketobuildpacks/builder-jammy-tiny:latest`
+| `paketobuildpacks/builder-jammy-java-tiny:latest`
 
 | `trustBuilder`
 | `--trustBuilder`
 | Whether to treat the builder as https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/concepts/trusted_builders/#what-is-a-trusted-builder[trusted].
-| `true` if the builder is one of `paketobuildpacks/builder-jammy-tiny`, `paketobuildpacks/builder-jammy-base`, `paketobuildpacks/builder-jammy-full`, `paketobuildpacks/builder-jammy-buildpackless-tiny`, `paketobuildpacks/builder-jammy-buildpackless-base`, `paketobuildpacks/builder-jammy-buildpackless-full`, `gcr.io/buildpacks/builder`, `heroku/builder`; `false` otherwise.
+| `true` if the builder is one of `paketobuildpacks/builder-jammy-java-tiny`, `paketobuildpacks/builder-noble-java-tiny`, `paketobuildpacks/builder-jammy-tiny`, `paketobuildpacks/builder-jammy-base`, `paketobuildpacks/builder-jammy-full`, `paketobuildpacks/builder-jammy-buildpackless-tiny`, `paketobuildpacks/builder-jammy-buildpackless-base`, `paketobuildpacks/builder-jammy-buildpackless-full`, `gcr.io/buildpacks/builder`, `heroku/builder`; `false` otherwise.
 
 | `imagePlatform`
 | `--imagePlatform`
@@ -251,7 +251,7 @@ NOTE: The plugin detects the target Java compatibility of the project using the 
 When using the default Paketo builder and buildpacks, the plugin instructs the buildpacks to install the same Java version.
 You can override this behavior as shown in the xref:packaging-oci-image.adoc#build-image.examples.builder-configuration[builder configuration] examples.
 
-NOTE: The default builder `paketobuildpacks/builder-jammy-tiny:latest` does not include a shell.
+NOTE: The default builder `paketobuildpacks/builder-jammy-java-tiny:latest` does not include a shell.
 Applications that require a shell to run a start script, as might be the case when the {url-gradle-docs-application-plugin}[`application` plugin] has been applied to generate a distribution zip archive, should override the `builder` configuration to use one that includes a shell, such as `paketobuildpacks/builder-jammy-base:latest` or `paketobuildpacks/builder-jammy-full:latest`.
 
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageTests.java
@@ -174,7 +174,7 @@ class BootBuildImageTests {
 	@Test
 	void whenNoBuilderIsConfiguredThenRequestHasDefaultBuilder() {
 		BuildRequest request = this.buildImage.createRequest();
-		assertThat(request.getBuilder().getName()).isEqualTo("paketobuildpacks/builder-jammy-tiny");
+		assertThat(request.getBuilder().getName()).isEqualTo("paketobuildpacks/builder-jammy-java-tiny");
 		assertThat(request.isTrustBuilder()).isTrue();
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/pages/build-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/pages/build-image.adoc
@@ -135,12 +135,12 @@ The following table summarizes the available parameters and their default values
 | `builder` +
 (`spring-boot.build-image.builder`)
 | Name of the builder image to use.
-| `paketobuildpacks/builder-jammy-tiny:latest`
+| `paketobuildpacks/builder-jammy-java-tiny:latest`
 
 | `trustBuilder` +
 (`spring-boot.build-image.trustBuilder`)
 | Whether to treat the builder as https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/concepts/trusted_builders/#what-is-a-trusted-builder[trusted].
-| `true` if the builder is one of `paketobuildpacks/builder-jammy-tiny`, `paketobuildpacks/builder-jammy-base`, `paketobuildpacks/builder-jammy-full`, `paketobuildpacks/builder-jammy-buildpackless-tiny`, `paketobuildpacks/builder-jammy-buildpackless-base`, `paketobuildpacks/builder-jammy-buildpackless-full`, `gcr.io/buildpacks/builder`, `heroku/builder`; `false` otherwise.
+| `true` if the builder is one of `paketobuildpacks/builder-jammy-java-tiny`, `paketobuildpacks/builder-noble-java-tiny`, `paketobuildpacks/builder-jammy-tiny`, `paketobuildpacks/builder-jammy-base`, `paketobuildpacks/builder-jammy-full`, `paketobuildpacks/builder-jammy-buildpackless-tiny`, `paketobuildpacks/builder-jammy-buildpackless-base`, `paketobuildpacks/builder-jammy-buildpackless-full`, `gcr.io/buildpacks/builder`, `heroku/builder`; `false` otherwise.
 
 | `imagePlatform` +
 (`spring-boot.build-image.imagePlatform`)

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ImageTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ImageTests.java
@@ -70,7 +70,7 @@ class ImageTests {
 	void getBuildRequestWhenNoCustomizationsUsesDefaults() {
 		BuildRequest request = new Image().getBuildRequest(createArtifact(), mockApplicationContent());
 		assertThat(request.getName()).hasToString("docker.io/library/my-app:0.0.1-SNAPSHOT");
-		assertThat(request.getBuilder().toString()).contains("paketobuildpacks/builder-jammy-tiny");
+		assertThat(request.getBuilder().toString()).contains("paketobuildpacks/builder-jammy-java-tiny");
 		assertThat(request.isTrustBuilder()).isTrue();
 		assertThat(request.getRunImage()).isNull();
 		assertThat(request.getEnv()).isEmpty();
@@ -108,7 +108,7 @@ class ImageTests {
 		Image image = new Image();
 		image.trustBuilder = false;
 		BuildRequest request = image.getBuildRequest(createArtifact(), mockApplicationContent());
-		assertThat(request.getBuilder().toString()).contains("paketobuildpacks/builder-jammy-tiny");
+		assertThat(request.getBuilder().toString()).contains("paketobuildpacks/builder-jammy-java-tiny");
 		assertThat(request.isTrustBuilder()).isFalse();
 	}
 


### PR DESCRIPTION
* with dual arch builder-jammy-java-tiny
* update documentation and trusted builders too

