### PR TITLE
Support to inherit common properties for configuring multiple beans

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationProperties.java
@@ -39,6 +39,7 @@ import org.springframework.stereotype.Indexed;
  * values are externalized.
  *
  * @author Dave Syer
+ * @author Yanming Zhou
  * @since 1.0.0
  * @see ConfigurationPropertiesScan
  * @see ConstructorBinding
@@ -68,6 +69,14 @@ public @interface ConfigurationProperties {
 	 */
 	@AliasFor("value")
 	String prefix() default "";
+
+	/**
+	 * The prefix of the properties that {@link #prefix()} will inherit, It's used for
+	 * configuring multiple beans which share common properties.
+	 * @return the prefix of the properties to inherit
+	 * @see #prefix()
+	 */
+	String inheritedPrefix() default "";
 
 	/**
 	 * Flag to indicate that when binding to this object invalid fields should be ignored.


### PR DESCRIPTION
It's used for configuring multiple beans (#15732), we could extract common or use primary properties as parent now.

Take `org.springframework.boot.autoconfigure.data.redis.RedisProperties` for example, given:
```
# primary
spring.data.redis:
  host: 127.0.0.1
  port: 6379

# additional
additional.data.redis:
  port: 6380
```
Then effective properties:
```
additional.data.redis:
  host: 127.0.0.1
  port: 6380
```
should be bound to `additionalRedisProperties`:
```java
	@Bean(autowireCandidate = false) // do not back off autoconfigured one
	@ConfigurationProperties(prefix = "additional.data.redis", inheritedPrefix = "spring.data.redis")
	RedisProperties additionalRedisProperties() {
		return new RedisProperties();
	}
```

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
