### PR TITLE
Register beans as RootBeanDefinition instead of GenericBeanDefinition if feasible

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/webservices/WebServicesAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/webservices/WebServicesAutoConfiguration.java
@@ -124,7 +124,7 @@ public class WebServicesAutoConfiguration {
 				Function<Resource, T> beanSupplier, BeanDefinitionRegistry registry) {
 			for (Resource resource : getResources(location, pattern)) {
 				BeanDefinition beanDefinition = BeanDefinitionBuilder
-					.genericBeanDefinition(type, () -> beanSupplier.apply(resource))
+					.rootBeanDefinition(type, () -> beanSupplier.apply(resource))
 					.getBeanDefinition();
 				registry.registerBeanDefinition(StringUtils.stripFilenameExtension(resource.getFilename()),
 						beanDefinition);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/SharedMetadataReaderFactoryContextInitializerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/SharedMetadataReaderFactoryContextInitializerTests.java
@@ -70,10 +70,10 @@ class SharedMetadataReaderFactoryContextInitializerTests {
 		BeanDefinitionRegistry registry = (BeanDefinitionRegistry) context.getBeanFactory();
 		ConfigurationClassPostProcessor configurationAnnotationPostProcessor = mock(
 				ConfigurationClassPostProcessor.class);
-		BeanDefinition beanDefinition = BeanDefinitionBuilder
-			.genericBeanDefinition(ConfigurationClassPostProcessor.class)
+		AbstractBeanDefinition beanDefinition = BeanDefinitionBuilder
+			.rootBeanDefinition(ConfigurationClassPostProcessor.class)
 			.getBeanDefinition();
-		((AbstractBeanDefinition) beanDefinition).setInstanceSupplier(() -> configurationAnnotationPostProcessor);
+		beanDefinition.setInstanceSupplier(() -> configurationAnnotationPostProcessor);
 		registry.registerBeanDefinition(AnnotationConfigUtils.CONFIGURATION_ANNOTATION_PROCESSOR_BEAN_NAME,
 				beanDefinition);
 		CachingMetadataReaderFactoryPostProcessor postProcessor = new CachingMetadataReaderFactoryPostProcessor(

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/RestDocumentationContextProviderRegistrar.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/restdocs/RestDocumentationContextProviderRegistrar.java
@@ -39,7 +39,7 @@ class RestDocumentationContextProviderRegistrar implements ImportBeanDefinitionR
 		Map<String, Object> annotationAttributes = importingClassMetadata
 			.getAnnotationAttributes(AutoConfigureRestDocs.class.getName());
 		BeanDefinitionBuilder definitionBuilder = BeanDefinitionBuilder
-			.genericBeanDefinition(ManualRestDocumentation.class);
+			.rootBeanDefinition(ManualRestDocumentation.class);
 		String outputDir = (String) annotationAttributes.get("outputDir");
 		if (StringUtils.hasText(outputDir)) {
 			definitionBuilder.addConstructorArgValue(outputDir);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/BoundConfigurationProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/BoundConfigurationProperties.java
@@ -79,7 +79,7 @@ public class BoundConfigurationProperties {
 	static void register(BeanDefinitionRegistry registry) {
 		Assert.notNull(registry, "Registry must not be null");
 		if (!registry.containsBeanDefinition(BEAN_NAME)) {
-			BeanDefinition definition = BeanDefinitionBuilder.genericBeanDefinition(BoundConfigurationProperties.class)
+			BeanDefinition definition = BeanDefinitionBuilder.rootBeanDefinition(BoundConfigurationProperties.class)
 				.getBeanDefinition();
 			definition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 			registry.registerBeanDefinition(BEAN_NAME, definition);


### PR DESCRIPTION
Align with ConfigurationPropertiesBinder and ConfigurationPropertiesBindingPostProcessor