### PR TITLE
Fix typos in actuator docs for "when_authorized"

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/endpoints.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/endpoints.adoc
@@ -550,7 +550,7 @@ The information exposed by the `health` endpoint depends on the configprop:manag
 | `never`
 | Details are never shown.
 
-| `when-authorized`
+| `when_authorized`
 | Details are shown only to authorized users.
   Authorized roles can be configured by using `management.endpoint.health.roles`.
 
@@ -851,7 +851,7 @@ management:
     health:
       group:
         custom:
-          show-details: "when-authorized"
+          show-details: "when_authorized"
           roles: "admin"
           status:
             order: "fatal,up"


### PR DESCRIPTION
This PR fixes two typos in documentation of actuator health endpoints:
"Spring Boot > Reference > Production-ready Features > Endpoints"

https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.health

Wrong: `when-authorized`
Correct: `when_authorized`

