### PR TITLE
Add support for ClickHouse JDBC driver in enum DatabaseDriver

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchDataSourceScriptDatabaseInitializerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchDataSourceScriptDatabaseInitializerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,8 +62,8 @@ class BatchDataSourceScriptDatabaseInitializerTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(value = DatabaseDriver.class, mode = Mode.EXCLUDE,
-			names = { "FIREBIRD", "INFORMIX", "JTDS", "PHOENIX", "REDSHIFT", "TERADATA", "TESTCONTAINERS", "UNKNOWN" })
+	@EnumSource(value = DatabaseDriver.class, mode = Mode.EXCLUDE, names = { "CLICKHOUSE", "FIREBIRD", "INFORMIX",
+			"JTDS", "PHOENIX", "REDSHIFT", "TERADATA", "TESTCONTAINERS", "UNKNOWN" })
 	void batchSchemaCanBeLocated(DatabaseDriver driver) throws SQLException {
 		DefaultResourceLoader resourceLoader = new DefaultResourceLoader();
 		BatchProperties properties = new BatchProperties();

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -205,6 +205,17 @@ bom {
 			site("https://github.com/FasterXML/java-classmate")
 		}
 	}
+	library("ClickHouse", "0.6.5") {
+		group("com.clickhouse") {
+			modules = [
+				"clickhouse-jdbc"
+			]
+		}
+		links {
+			site("https://clickhouse.com")
+			releaseNotes("https://github.com/ClickHouse/clickhouse-java/releases/tag/v{version}")
+		}
+	}
 	library("Commons Codec", "${commonsCodecVersion}") {
 		group("commons-codec") {
 			modules = [

--- a/spring-boot-project/spring-boot/build.gradle
+++ b/spring-boot-project/spring-boot/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	api("org.springframework:spring-context")
 
 	optional("ch.qos.logback:logback-classic")
+	optional("com.clickhouse:clickhouse-jdbc")
 	optional("com.fasterxml.jackson.core:jackson-databind")
 	optional("com.h2database:h2")
 	optional("com.google.code.gson:gson")

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
@@ -205,6 +205,17 @@ public enum DatabaseDriver {
 			return Collections.singleton("tc");
 		}
 
+	},
+
+	/**
+	 * ClickHouse.
+	 * @since 3.4.0
+	 */
+	CLICKHOUSE("ClickHouse", "com.clickhouse.jdbc.ClickHouseDriver", null, "SELECT 1") {
+		@Override
+		protected Collection<String> getUrlPrefixes() {
+			return Arrays.asList("ch", "clickhouse");
+		}
 	};
 
 	private final String productName;

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DatabaseDriverTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DatabaseDriverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,6 +84,7 @@ class DatabaseDriverTests {
 		assertThat(DatabaseDriver.fromProductName("Teradata")).isEqualTo(DatabaseDriver.TERADATA);
 		assertThat(DatabaseDriver.fromProductName("Informix Dynamic Server")).isEqualTo(DatabaseDriver.INFORMIX);
 		assertThat(DatabaseDriver.fromProductName("Apache Phoenix")).isEqualTo(DatabaseDriver.PHOENIX);
+		assertThat(DatabaseDriver.fromProductName("ClickHouse")).isEqualTo(DatabaseDriver.CLICKHOUSE);
 	}
 
 	@Test
@@ -117,6 +118,9 @@ class DatabaseDriverTests {
 		assertThat(DatabaseDriver.fromJdbcUrl("jdbc:phoenix:localhost")).isEqualTo(DatabaseDriver.PHOENIX);
 		assertThat(DatabaseDriver.fromJdbcUrl("jdbc:tc:mysql://localhost:3306/sample"))
 			.isEqualTo(DatabaseDriver.TESTCONTAINERS);
+		assertThat(DatabaseDriver.fromJdbcUrl("jdbc:clickhouse://localhost:3306/sample"))
+			.isEqualTo(DatabaseDriver.CLICKHOUSE);
+		assertThat(DatabaseDriver.fromJdbcUrl("jdbc:ch://localhost:3306/sample")).isEqualTo(DatabaseDriver.CLICKHOUSE);
 	}
 
 }


### PR DESCRIPTION
#42799

I referred to the documentation here: https://clickhouse.com/docs/en/integrations/java/jdbc-driver. The documentation mentions the latest version as **0.6.5**, but on their GitHub releases page (https://github.com/ClickHouse/clickhouse-java/releases), the latest version is **0.7.0**.

I did not use version 0.7.0 because it has a compile dependency on `clickhouse-http-client:0.7.0-SNAPSHOT` (https://mvnrepository.com/artifact/com.clickhouse/clickhouse-jdbc/0.7.0).

Additionally, I verified the driver locally with the following test:

```java
@Testcontainers(disabledWithoutDocker = true)
class ClickhouseIntegrationTests {

	@Container
	static final ClickHouseContainer clickhouse = new ClickHouseContainer("clickhouse/clickhouse-server:24-alpine")
		.withUsername("test")
		.withPassword("password");

	@Test
	void shouldConnectToClickhouse ()  {
		String jdbcUrl = clickhouse.getJdbcUrl();
		SimpleDriverDataSource dataSource = DataSourceBuilder.create()
			.type(SimpleDriverDataSource.class)
			.url(jdbcUrl)
			.username("test")
			.password("password")
			.build();
		new JdbcTemplate(dataSource).execute(DatabaseDriver.CLICKHOUSE.getValidationQuery());
	}

}
```

By the way, when I updated the version to **0.7.0,** Gradle was against this:

```
Execution failed for task ':spring-boot-project:spring-boot:compileKotlin'.
> Could not resolve all files for configuration ':spring-boot-project:spring-boot:compileClasspath'.
   > Could not find com.clickhouse:clickhouse-http-client:0.7.0-SNAPSHOT.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/com/clickhouse/clickhouse-http-client/0.7.0-SNAPSHOT/maven-metadata.xml
       - https://repo.maven.apache.org/maven2/com/clickhouse/clickhouse-http-client/0.7.0-SNAPSHOT/clickhouse-http-client-0.7.0-SNAPSHOT.pom
       - https://repo.spring.io/milestone/com/clickhouse/clickhouse-http-client/0.7.0-SNAPSHOT/maven-metadata.xml
       - https://repo.spring.io/milestone/com/clickhouse/clickhouse-http-client/0.7.0-SNAPSHOT/clickhouse-http-client-0.7.0-SNAPSHOT.pom
       - https://repo.spring.io/snapshot/com/clickhouse/clickhouse-http-client/0.7.0-SNAPSHOT/maven-metadata.xml
       - https://repo.spring.io/snapshot/com/clickhouse/clickhouse-http-client/0.7.0-SNAPSHOT/clickhouse-http-client-0.7.0-SNAPSHOT.pom
     Required by:
         project :spring-boot-project:spring-boot > com.clickhouse:clickhouse-jdbc:0.7.0

Possible solution:
 - Declare repository providing the artifact, see the documentation at https://docs.gradle.org/current/userguide/declaring_repositories.html
```         