### PR TITLE
JacksonAutoConfiguration should retain modules registered in Jackson2ObjectMapperBuilderCustomizer with higher precedence rather than overwriting them

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -306,7 +306,7 @@ public class JacksonAutoConfiguration {
 			}
 
 			private void configureModules(Jackson2ObjectMapperBuilder builder) {
-				builder.modulesToInstall(this.modules.toArray(new Module[0]));
+				builder.modulesToInstall((modules) -> modules.addAll(this.modules));
 			}
 
 			private void configureLocale(Jackson2ObjectMapperBuilder builder) {


### PR DESCRIPTION
#39592