### PR TITLE
Update HttpWebServiceMessageSenderBuilder  javadoc

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/webservices/client/HttpWebServiceMessageSenderBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/webservices/client/HttpWebServiceMessageSenderBuilder.java
@@ -48,7 +48,7 @@ public class HttpWebServiceMessageSenderBuilder {
 	/**
 	 * Set the connection timeout.
 	 * @param connectTimeout the connection timeout
-	 * @return a new builder instance
+	 * @return the current builder instance
 	 */
 	public HttpWebServiceMessageSenderBuilder setConnectTimeout(Duration connectTimeout) {
 		this.connectTimeout = connectTimeout;
@@ -58,7 +58,7 @@ public class HttpWebServiceMessageSenderBuilder {
 	/**
 	 * Set the read timeout.
 	 * @param readTimeout the read timeout
-	 * @return a new builder instance
+	 * @return the current builder instance
 	 */
 	public HttpWebServiceMessageSenderBuilder setReadTimeout(Duration readTimeout) {
 		this.readTimeout = readTimeout;
@@ -68,7 +68,7 @@ public class HttpWebServiceMessageSenderBuilder {
 	/**
 	 * Set an {@link SslBundle} that will be used to configure a secure connection.
 	 * @param sslBundle the SSL bundle
-	 * @return a new builder instance
+	 * @return the current builder instance
 	 */
 	public HttpWebServiceMessageSenderBuilder sslBundle(SslBundle sslBundle) {
 		this.sslBundle = sslBundle;
@@ -79,7 +79,7 @@ public class HttpWebServiceMessageSenderBuilder {
 	 * Set the {@code Supplier} of {@link ClientHttpRequestFactory} that should be called
 	 * to create the HTTP-based {@link WebServiceMessageSender}.
 	 * @param requestFactorySupplier the supplier for the request factory
-	 * @return a new builder instance
+	 * @return the current builder instance
 	 */
 	public HttpWebServiceMessageSenderBuilder requestFactory(
 			Supplier<ClientHttpRequestFactory> requestFactorySupplier) {
@@ -93,7 +93,7 @@ public class HttpWebServiceMessageSenderBuilder {
 	 * {@link ClientHttpRequestFactory} that should be called to create the HTTP-based
 	 * {@link WebServiceMessageSender}.
 	 * @param requestFactoryFunction the function for the request factory
-	 * @return a new builder instance
+	 * @return the current builder instance
 	 * @since 3.0.0
 	 */
 	public HttpWebServiceMessageSenderBuilder requestFactory(


### PR DESCRIPTION
### Description

This PR try to update the javadoc from file `HttpWebServiceMessageSenderBuilder.java`. In this file's javadoc, it's methods says can `@return a new builder instance`, but actually `@return the current builder instance`. Therefore, I fixed the doc bug.


### Related Issue

Fixes #42858  

### Additional Notes

If there's anything else I can help with, plz comment.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
