### PR TITLE
Reject binding non-uniform property key as map key

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/external-config.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/external-config.adoc
@@ -912,7 +912,7 @@ TIP: We recommend that, when possible, properties are stored in lower-case kebab
 ==== Binding Maps
 
 When binding to `Map` properties you may need to use a special bracket notation so that the original `key` value is preserved.
-If the key is not surrounded by `[]`, any characters that are not alpha-numeric, `-` or `.` are removed.
+A binding failure occurs if the key contains any characters that are not alpha-numeric, `-` or `.` but not surrounded by `[]`.
 
 For example, consider binding the following properties to a `Map<String,String>`:
 
@@ -927,8 +927,8 @@ my:
 
 NOTE: For YAML files, the brackets need to be surrounded by quotes for the keys to be parsed properly.
 
-The properties above will bind to a `Map` with `/key1`, `/key2` and `key3` as the keys in the map.
-The slash has been removed from `key3` because it was not surrounded by square brackets.
+The properties above is failed to bind to a `Map` with `/key1`, `/key2` and `/key3` as the keys in the map,
+because `/key3` was not surrounded by square brackets.
 
 When binding to scalar values, keys with `.` in them do not need to be surrounded by `[]`.
 Scalar values include enums and all types in the `java.lang` package except for `Object`.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
@@ -31,6 +31,7 @@ import org.springframework.boot.context.properties.source.ConfigurationPropertyS
 import org.springframework.boot.context.properties.source.IterableConfigurationPropertySource;
 import org.springframework.core.CollectionFactory;
 import org.springframework.core.ResolvableType;
+import org.springframework.core.env.PropertySource;
 
 /**
  * {@link AggregateBinder} for Maps.
@@ -173,8 +174,15 @@ class MapBinder extends AggregateBinder<Map<Object, Object>> {
 						String key = sourceName.substring(index + 1);
 						if (!key.equals(name.getLastElement(Form.ORIGINAL))
 								&& !key.equalsIgnoreCase(name.getLastElement(Form.UNIFORM))) {
-							throw new IllegalArgumentException("Please rewrite key '" + key + "' to '[" + key
-									+ "]' and surround it with quotes if YAML is using");
+							boolean forYaml = false;
+							if (source.getUnderlyingSource() instanceof PropertySource<?> ps) {
+								String propertySourceName = ps.getName();
+								forYaml = propertySourceName.contains(".yaml") || propertySourceName.contains(".yml");
+							}
+							String validKey = (forYaml ? "\"[" : "[") + key + (forYaml ? "]\"" : "]");
+							throw new IllegalArgumentException(
+									"Please rewrite key '" + key + "' to '" + validKey + "'");
+
 						}
 					}
 					Bindable<?> valueBindable = getValueBindable(name);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
@@ -37,6 +37,7 @@ import org.springframework.core.ResolvableType;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Yanming Zhou
  */
 class MapBinder extends AggregateBinder<Map<Object, Object>> {
 
@@ -166,6 +167,16 @@ class MapBinder extends AggregateBinder<Map<Object, Object>> {
 		void bindEntries(ConfigurationPropertySource source, Map<Object, Object> map) {
 			if (source instanceof IterableConfigurationPropertySource iterableSource) {
 				for (ConfigurationPropertyName name : iterableSource) {
+					if (name.isLastElementNonUniform()) {
+						String sourceName = name.getSource();
+						int index = sourceName.lastIndexOf('.');
+						String key = sourceName.substring(index + 1);
+						if (!key.equals(name.getLastElement(Form.ORIGINAL))
+								&& !key.equalsIgnoreCase(name.getLastElement(Form.UNIFORM))) {
+							throw new IllegalArgumentException("Please rewrite key '" + key + "' to '[" + key
+									+ "]' and surround it with quotes if YAML is using");
+						}
+					}
 					Bindable<?> valueBindable = getValueBindable(name);
 					ConfigurationPropertyName entryName = getEntryName(source, name);
 					Object key = getContext().getConverter().convert(getKeyName(entryName), this.keyType);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -46,6 +46,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Yanming Zhou
  * @since 2.0.0
  * @see #of(CharSequence)
  * @see ConfigurationPropertySource
@@ -119,6 +120,23 @@ public final class ConfigurationPropertyName implements Comparable<Configuration
 	 */
 	public boolean isNumericIndex(int elementIndex) {
 		return this.elements.getType(elementIndex) == ElementType.NUMERICALLY_INDEXED;
+	}
+
+	/**
+	 * Return whether the last element is non-uniform.
+	 * @return whether the last element is non-uniform
+	 */
+	public boolean isLastElementNonUniform() {
+		int size = getNumberOfElements();
+		return size != 0 && this.elements.getType(size - 1) == ElementType.NON_UNIFORM;
+	}
+
+	/**
+	 * Return the source.
+	 * @return the source
+	 */
+	public String getSource() {
+		return this.elements.source.toString();
 	}
 
 	/**


### PR DESCRIPTION
Given:
```yaml
my:
  map:
    "/key": "value"
```
---
Before this commit:
It's equivalent to
```yaml
my:
  map:
    "[key]": "value" # "[/key]" is expected
```
Such counter-intuitive behavior will confuse developers, there are several reported issues, incomplete list: GH-41099 GH-29582 GH-24548

---
After this commit:
```
***************************
APPLICATION FAILED TO START
***************************

Description:

Failed to bind properties under 'my.map' to java.util.Map<java.lang.String, java.lang.String>:

    Reason: java.lang.IllegalArgumentException: Please rewrite key '/key' to '[/key]' and surround it with quotes if YAML is using

Action:

Update your application's configuration

```
---

See GH-42802

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
