### PR TITLE
X-Registry-Auth header sent to Docker Engine API contains field "authHeader"

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/JsonEncodedDockerRegistryAuthentication.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/JsonEncodedDockerRegistryAuthentication.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.boot.buildpack.platform.json.SharedObjectMapper;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * {@link DockerRegistryAuthentication} that uses a Base64 encoded auth header value based
  * on the JSON created from the instance.

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/JsonEncodedDockerRegistryAuthentication.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/JsonEncodedDockerRegistryAuthentication.java
@@ -18,11 +18,10 @@ package org.springframework.boot.buildpack.platform.docker.configuration;
 
 import java.util.Base64;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import org.springframework.boot.buildpack.platform.json.SharedObjectMapper;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
  * {@link DockerRegistryAuthentication} that uses a Base64 encoded auth header value based

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/JsonEncodedDockerRegistryAuthentication.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/JsonEncodedDockerRegistryAuthentication.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import org.springframework.boot.buildpack.platform.json.SharedObjectMapper;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 /**
  * {@link DockerRegistryAuthentication} that uses a Base64 encoded auth header value based
  * on the JSON created from the instance.
@@ -30,6 +31,7 @@ import org.springframework.boot.buildpack.platform.json.SharedObjectMapper;
  */
 class JsonEncodedDockerRegistryAuthentication implements DockerRegistryAuthentication {
 
+	@JsonIgnore
 	private String authHeader;
 
 	@Override


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
## Overview of Changes
1. Add annotation `@JsonIgnore` on variable `authHeader` to avoid auto-serialization.
2. Import package `com.fasterxml.jackson.annotation.JsonIgnore` to make annotation valid.
3. run command `./gradlew checkstyleMain` and `./gradlew format` to fix style error.

## Related Issues
Fixed #42905 

## Type of Change
- [X] Fix bug

## Impact
Now when class `DockerRegistryUserAuthentication` and `DockerRegistryTokenAuthentication` use method `createAuthHeader()` would't add `"authHeader" : null` field.

## Test
I've already test the class `DockerRegistryUserAuthentication` and `DockerRegistryTokenAuthentication` method `getAuthHeader()`, but only write rough test code not create a new branch to test. Do I need create a new branch?

## Effect of Test
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/df5995b8-8ecf-47fd-a96a-bc33699826ad">
Use decode tools to display the original string.

### Expected Result:

```
{
  "username" : "Ben",
  "password" : "123455",
  "serveraddress" : "docker@example.com",
  "email" : "https://docker.example.com"
}
```
it works as expected.

## Note
If anything I did worked not as expected, plz contact with me. Finally, looking forward to your reply.