### PR TITLE
Avoid calling `Task.getProject()` from a task action at execution time

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/cli/HomebrewFormula.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/cli/HomebrewFormula.java
@@ -47,21 +47,24 @@ import org.springframework.boot.build.properties.BuildType;
  * A {@link Task} for creating a Homebrew formula manifest.
  *
  * @author Andy Wilkinson
+ * @author Yanming Zhou
  */
 public abstract class HomebrewFormula extends DefaultTask {
 
 	private static final Logger logger = LoggerFactory.getLogger(HomebrewFormula.class);
 
+	private final Project project;
+
 	private final FileSystemOperations fileSystemOperations;
 
 	@Inject
 	public HomebrewFormula(FileSystemOperations fileSystemOperations) {
+		this.project = getProject();
 		this.fileSystemOperations = fileSystemOperations;
-		Project project = getProject();
 		MapProperty<String, Object> properties = getProperties();
 		properties.put("hash", getArchive().map((archive) -> sha256(archive.getAsFile())));
-		getProperties().put("repo", ArtifactRelease.forProject(project).getDownloadRepo());
-		getProperties().put("version", project.getVersion().toString());
+		getProperties().put("repo", ArtifactRelease.forProject(this.project).getDownloadRepo());
+		getProperties().put("version", this.project.getVersion().toString());
 	}
 
 	private String sha256(File file) {
@@ -90,7 +93,7 @@ public abstract class HomebrewFormula extends DefaultTask {
 
 	@TaskAction
 	void createFormula() {
-		BuildType buildType = BuildProperties.get(getProject()).buildType();
+		BuildType buildType = BuildProperties.get(this.project).buildType();
 		if (buildType != BuildType.OPEN_SOURCE) {
 			logger.debug("Skipping Homebrew formula for non open source build type");
 			return;

--- a/buildSrc/src/main/java/org/springframework/boot/build/mavenplugin/MavenPluginPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/mavenplugin/MavenPluginPlugin.java
@@ -106,6 +106,7 @@ import org.springframework.util.Assert;
  *
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Yanming Zhou
  */
 public class MavenPluginPlugin implements Plugin<Project> {
 
@@ -334,7 +335,13 @@ public class MavenPluginPlugin implements Plugin<Project> {
 
 	public abstract static class FormatHelpMojoSource extends DefaultTask {
 
+		private final Project project;
+
 		private Task generator;
+
+		public FormatHelpMojoSource() {
+			this.project = getProject();
+		}
 
 		void setGenerator(Task generator) {
 			this.generator = generator;
@@ -350,7 +357,7 @@ public class MavenPluginPlugin implements Plugin<Project> {
 		void syncAndFormat() {
 			FileFormatter formatter = new FileFormatter();
 			for (File output : this.generator.getOutputs().getFiles()) {
-				formatter.formatFiles(getProject().fileTree(output), StandardCharsets.UTF_8)
+				formatter.formatFiles(this.project.fileTree(output), StandardCharsets.UTF_8)
 					.forEach((edit) -> save(output, edit));
 			}
 		}

--- a/spring-boot-project/spring-boot-tools/spring-boot-antlib/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-antlib/build.gradle
@@ -32,6 +32,7 @@ task syncIntegrationTestSources(type: Sync) {
 }
 
 processResources {
+	def project = owner.project
 	eachFile {
 		filter { it.replace('${spring-boot.version}', project.version) }
 	}


### PR DESCRIPTION
Fix
```
> Task :spring-boot-project:spring-boot-tools:spring-boot-maven-plugin:formatHelpMojoSource
Invocation of Task.project at execution time has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.10.2/userguide/upgrading_version_7.html#task_project
```