### PR TITLE
build-info doesn't support seconds since the epoch from project.build.outputTimestamp

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/BuildInfoIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/BuildInfoIntegrationTests.java
@@ -84,6 +84,16 @@ class BuildInfoIntegrationTests {
 	}
 
 	@TestTemplate
+	void generatedBuildInfoReproducibleEpochSeconds(MavenBuild mavenBuild) {
+		mavenBuild.project("build-info-reproducible-epochseconds")
+			.execute(buildInfo((buildInfo) -> assertThat(buildInfo).hasBuildGroup("org.springframework.boot.maven.it")
+				.hasBuildArtifact("build-reproducible-epochseconds")
+				.hasBuildName("Generate build info with build time from project.build.outputTimestamp")
+				.hasBuildVersion("0.0.1.BUILD-SNAPSHOT")
+				.hasBuildTime("1976-01-09T12:00:00Z")));
+	}
+
+	@TestTemplate
 	void buildInfoPropertiesAreGeneratedToCustomOutputLocation(MavenBuild mavenBuild) {
 		mavenBuild.project("build-info-custom-file")
 			.execute(buildInfo("target/build.info",

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-info-reproducible-epochseconds/pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-info-reproducible-epochseconds/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.boot.maven.it</groupId>
+	<artifactId>build-reproducible-epochseconds</artifactId>
+	<version>0.0.1.BUILD-SNAPSHOT</version>
+	<name>Generate build info with build time from project.build.outputTimestamp</name>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>@java.version@</maven.compiler.source>
+		<maven.compiler.target>@java.version@</maven.compiler.target>
+		<!-- Epoch seconds should be support bey build-info plugin too -->
+		<project.build.outputTimestamp>190036800</project.build.outputTimestamp>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>build-info</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-info-reproducible-epochseconds/src/main/java/org/test/SampleApplication.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/intTest/projects/build-info-reproducible-epochseconds/src/main/java/org/test/SampleApplication.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.test;
+
+public class SampleApplication {
+
+	public static void main(String[] args) {
+	}
+
+}

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildInfoMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildInfoMojo.java
@@ -154,7 +154,7 @@ public class BuildInfoMojo extends AbstractMojo {
 		if ("off".equalsIgnoreCase(this.time)) {
 			return null;
 		}
-		return Instant.parse(this.time);
+		return new MavenBuildOutputTimestamp(this.time).toInstant();
 	}
 
 }


### PR DESCRIPTION
Use MavenBuildOutputTimestamp inside BuildInfoMojo to create Instant from project.build.outputTimestamp where the value of this property is in just epoch seconds.

#42871 