### PR TITLE
Improve logging for HikariCheckpointRestoreLifecycle

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/HikariCheckpointRestoreLifecycle.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/HikariCheckpointRestoreLifecycle.java
@@ -115,7 +115,7 @@ public class HikariCheckpointRestoreLifecycle implements Lifecycle {
 	private void closeConnections(Duration shutdownTimeout) {
 		logger.info("Evicting Hikari connections");
 		this.dataSource.getHikariPoolMXBean().softEvictConnections();
-		logger.debug("Waiting for Hikari connections to be closed");
+		logger.debug(LogMessage.format("Waiting %s for Hikari connections to be closed", shutdownTimeout));
 		CompletableFuture<Void> allConnectionsClosed = CompletableFuture.runAsync(this::waitForConnectionsToClose);
 		try {
 			allConnectionsClosed.get(shutdownTimeout.toMillis(), TimeUnit.MILLISECONDS);

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/HikariCheckpointRestoreLifecycle.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/HikariCheckpointRestoreLifecycle.java
@@ -109,6 +109,11 @@ public class HikariCheckpointRestoreLifecycle implements Lifecycle {
 			logger.info("Suspending Hikari pool");
 			this.dataSource.getHikariPoolMXBean().suspendPool();
 		}
+		else {
+			logger.warn(this.dataSource + " is not configured to allow pool suspension. "
+					+ "This will cause problems when the application is checkpointed. "
+					+ "Please configure allow-pool-suspension to fix this!");
+		}
 		closeConnections(Duration.ofMillis(this.dataSource.getConnectionTimeout() + 250));
 	}
 


### PR DESCRIPTION
Adressing #42906, open to change it to an exception instead of the warning message as it won't work as expected without `allow-pool-suspension=true`.