### PR TITLE
Add Date and UUID deserialization support in nullSafeValue method

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonObjectDeserializer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonObjectDeserializer.java
@@ -19,6 +19,8 @@ package org.springframework.boot.jackson;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Date;
+import java.util.UUID;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.ObjectCodec;
@@ -114,6 +116,12 @@ public abstract class JsonObjectDeserializer<T> extends com.fasterxml.jackson.da
 		}
 		if (type == BigInteger.class) {
 			return (D) jsonNode.bigIntegerValue();
+		}
+		if (type == Date.class) {
+			return (D) new Date(jsonNode.longValue());
+		}
+		if (type == UUID.class) {
+			return (D) UUID.fromString(jsonNode.textValue());
 		}
 		throw new IllegalArgumentException("Unsupported value type " + type.getName());
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonObjectDeserializerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jackson/JsonObjectDeserializerTests.java
@@ -19,6 +19,8 @@ package org.springframework.boot.jackson;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Date;
+import java.util.UUID;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.ObjectCodec;
@@ -142,6 +144,27 @@ class JsonObjectDeserializerTests {
 		given(node.bigIntegerValue()).willReturn(BigInteger.TEN);
 		BigInteger value = this.testDeserializer.testNullSafeValue(node, BigInteger.class);
 		assertThat(value).isEqualTo(BigInteger.TEN);
+	}
+
+
+	@Test
+	void nullSafeValueWhenClassIsDateShouldReturnDate() {
+		JsonNode node = mock(JsonNode.class);
+		long timestamp = 1629976800000L;
+		given(node.longValue()).willReturn(timestamp);
+		Date expectedDate = new Date(timestamp);
+		Date value = this.testDeserializer.testNullSafeValue(node, Date.class);
+		assertThat(value).isEqualTo(expectedDate);
+	}
+
+	@Test
+	void nullSafeValueWhenClassIsUUIDShouldReturnUUID() {
+		JsonNode node = mock(JsonNode.class);
+		String uuidString = "123e4567-e89b-12d3-a456-426614174000";
+		UUID expectedUUID = UUID.fromString(uuidString);
+		given(node.textValue()).willReturn(uuidString);
+		UUID value = this.testDeserializer.testNullSafeValue(node, UUID.class);
+		assertThat(value).isEqualTo(expectedUUID);
 	}
 
 	@Test


### PR DESCRIPTION
This pull request introduces enhancements to the JsonObjectDeserializer class to support the deserialization of Date and UUID types.

Changes Made:

Added Support for Date:

Implemented logic to handle Date objects by converting a long timestamp from the JSON node to a Date instance.
java

```java
if (type == Date.class) {
    return (D) new Date(jsonNode.longValue());
}
```
Added Support for UUID:

Added functionality to convert a string representation of a UUID from the JSON node into a UUID instance.
java
```java
if (type == UUID.class) {
    return (D) UUID.fromString(jsonNode.textValue());
}
```
New Unit Tests:

Implemented two unit tests to validate the new functionalities:
nullSafeValueWhenClassIsDateShouldReturnDate: Confirms that a JsonNode containing a timestamp correctly deserializes into a Date.
nullSafeValueWhenClassIsUUIDShouldReturnUUID: Validates that a JsonNode containing a UUID string deserializes into a UUID.
Benefits: These enhancements simplify the deserialization process by allowing the JsonObjectDeserializer to directly handle Date and UUID types, improving the usability of the class in applications that require these types.
