### PR TITLE
Logback config XML format detection: if the URL ends with .xml, it should also be considered as XML format.

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -295,7 +295,7 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 
 	private void configureByResourceUrl(LoggingInitializationContext initializationContext, LoggerContext loggerContext,
 			URL url) throws JoranException {
-		if (url.getPath().endsWith(".xml")) {
+		if (url.getPath().endsWith(".xml") || url.toString().endsWith(".xml")) {
 			JoranConfigurator configurator = new SpringBootJoranConfigurator(initializationContext);
 			configurator.setContext(loggerContext);
 			configurator.doConfigure(url);


### PR DESCRIPTION
Logback config XML format detection: if the URL ends with .xml, it should also be considered as XML format.

Some URLs' path referring to XML files do not end with ".xml".

for example,
`http://${spring.cloud.nacos.config.server-addr}/nacos/v1/cs/configs?group=DEFAULT_GROUP&dataId=logback.xml`
refers to my logback configuration, but its path ("/nacos/v1/cs/configs") doesn't end with ".xml", so it cannot be loaded correctly.
