### PR TITLE
Use Hikari rather than Commons DBCP in DataSource configuration examples

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyAdditionalDataSourceConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyAdditionalDataSourceConfiguration.java
@@ -30,7 +30,7 @@ public class MyAdditionalDataSourceConfiguration {
 	@Qualifier("second")
 	@Bean(defaultCandidate = false)
 	@ConfigurationProperties("app.datasource")
-	public BasicDataSource secondDataSource() {
+	public HikariDataSource secondDataSource() {
 		return DataSourceBuilder.create().type(HikariDataSource.class).build();
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyAdditionalDataSourceConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyAdditionalDataSourceConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.docs.howto.dataaccess.configuretwodatasources;
 
-import org.apache.commons.dbcp2.BasicDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -31,7 +31,7 @@ public class MyAdditionalDataSourceConfiguration {
 	@Bean(defaultCandidate = false)
 	@ConfigurationProperties("app.datasource")
 	public BasicDataSource secondDataSource() {
-		return DataSourceBuilder.create().type(BasicDataSource.class).build();
+		return DataSourceBuilder.create().type(HikariDataSource.class).build();
 	}
 
 }

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteAdditionalDataSourceConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteAdditionalDataSourceConfiguration.java
@@ -36,7 +36,7 @@ public class MyCompleteAdditionalDataSourceConfiguration {
 
 	@Qualifier("second")
 	@Bean(defaultCandidate = false)
-	@ConfigurationProperties("app.datasource.configuration")
+	@ConfigurationProperties("app.datasource.hikari")
 	public HikariDataSource secondDataSource(
 			@Qualifier("secondDataSourceProperties") DataSourceProperties secondDataSourceProperties) {
 		return secondDataSourceProperties.initializeDataSourceBuilder().type(HikariDataSource.class).build();

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteAdditionalDataSourceConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteAdditionalDataSourceConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.docs.howto.dataaccess.configuretwodatasources;
 
-import org.apache.commons.dbcp2.BasicDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
@@ -39,7 +39,7 @@ public class MyCompleteAdditionalDataSourceConfiguration {
 	@ConfigurationProperties("app.datasource.configuration")
 	public BasicDataSource secondDataSource(
 			@Qualifier("secondDataSourceProperties") DataSourceProperties secondDataSourceProperties) {
-		return secondDataSourceProperties.initializeDataSourceBuilder().type(BasicDataSource.class).build();
+		return secondDataSourceProperties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
 	}
 
 }

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteAdditionalDataSourceConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteAdditionalDataSourceConfiguration.java
@@ -37,7 +37,7 @@ public class MyCompleteAdditionalDataSourceConfiguration {
 	@Qualifier("second")
 	@Bean(defaultCandidate = false)
 	@ConfigurationProperties("app.datasource.configuration")
-	public BasicDataSource secondDataSource(
+	public HikariDataSource secondDataSource(
 			@Qualifier("secondDataSourceProperties") DataSourceProperties secondDataSourceProperties) {
 		return secondDataSourceProperties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
 	}

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MyConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MyConfiguration.java
@@ -36,7 +36,7 @@ public class MyConfiguration {
 
 	@Bean
 	@ConfigurationProperties("app.datasource.second")
-	public BasicDataSource secondDataSource() {
+	public HikariDataSource secondDataSource() {
 		return DataSourceBuilder.create().type(HikariDataSource.class).build();
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MyConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MyConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.docs.howto.testing.slicetests;
 
-import org.apache.commons.dbcp2.BasicDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
@@ -37,7 +37,7 @@ public class MyConfiguration {
 	@Bean
 	@ConfigurationProperties("app.datasource.second")
 	public BasicDataSource secondDataSource() {
-		return DataSourceBuilder.create().type(BasicDataSource.class).build();
+		return DataSourceBuilder.create().type(HikariDataSource.class).build();
 	}
 
 }

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MyDatasourceConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MyDatasourceConfiguration.java
@@ -28,7 +28,7 @@ public class MyDatasourceConfiguration {
 
 	@Bean
 	@ConfigurationProperties("app.datasource.second")
-	public BasicDataSource secondDataSource() {
+	public HikariDataSource secondDataSource() {
 		return DataSourceBuilder.create().type(HikariDataSource.class).build();
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MyDatasourceConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/testing/slicetests/MyDatasourceConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.docs.howto.testing.slicetests;
 
-import org.apache.commons.dbcp2.BasicDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
@@ -29,7 +29,7 @@ public class MyDatasourceConfiguration {
 	@Bean
 	@ConfigurationProperties("app.datasource.second")
 	public BasicDataSource secondDataSource() {
-		return DataSourceBuilder.create().type(BasicDataSource.class).build();
+		return DataSourceBuilder.create().type(HikariDataSource.class).build();
 	}
 
 }

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyAdditionalDataSourceConfiguration.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyAdditionalDataSourceConfiguration.kt
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.docs.howto.dataaccess.configuretwodatasources
 
-import org.apache.commons.dbcp2.BasicDataSource
+import com.zaxxer.hikari.HikariDataSource
 
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -30,8 +30,8 @@ class MyAdditionalDataSourceConfiguration {
 	@Qualifier("second")
 	@Bean(defaultCandidate = false)
 	@ConfigurationProperties("app.datasource")
-	fun secondDataSource(): BasicDataSource {
-		return DataSourceBuilder.create().type(BasicDataSource::class.java).build()
+	fun secondDataSource(): HikariDataSource? {
+		return DataSourceBuilder.create().type(HikariDataSource::class.java).build()
 	}
 
 }

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteAdditionalDataSourceConfiguration.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteAdditionalDataSourceConfiguration.kt
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.docs.howto.dataaccess.configuretwodatasources
 
-import org.apache.commons.dbcp2.BasicDataSource
+import com.zaxxer.hikari.HikariDataSource
 
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties
@@ -36,9 +36,9 @@ class MyCompleteAdditionalDataSourceConfiguration {
 
 	@Qualifier("second")
 	@Bean(defaultCandidate = false)
-	@ConfigurationProperties("app.datasource.configuration")
-	fun secondDataSource(secondDataSourceProperties: DataSourceProperties): BasicDataSource {
-		return secondDataSourceProperties.initializeDataSourceBuilder().type(BasicDataSource::class.java).build()
+	@ConfigurationProperties("app.datasource.hikari")
+	fun secondDataSource(secondDataSourceProperties: DataSourceProperties): HikariDataSource? {
+		return secondDataSourceProperties.initializeDataSourceBuilder().type(HikariDataSource::class.java).build()
 	}
 
 }

--- a/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteDataSourcesConfigurationTests.java
+++ b/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteDataSourcesConfigurationTests.java
@@ -20,6 +20,7 @@ import java.sql.SQLException;
 
 import javax.sql.DataSource;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteDataSourcesConfigurationTests.java
+++ b/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteDataSourcesConfigurationTests.java
@@ -34,8 +34,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link MyCompleteAdditionalDataSourceConfiguration}.
  *
  * @author Stephane Nicoll
+ * @author Raja Kolli
  */
-@SpringBootTest
+@SpringBootTest(properties = { "app.datasource.url=jdbc:h2:mem:bar;DB_CLOSE_DELAY=-1",
+		"app.datasource.hikari.maximum-pool-size=42" })
 @Import(MyCompleteAdditionalDataSourceConfiguration.class)
 class MyCompleteDataSourcesConfigurationTests {
 
@@ -55,7 +57,11 @@ class MyCompleteDataSourcesConfigurationTests {
 		assertThat(this.context.getBean("dataSource")).isSameAs(this.dataSource);
 		assertThat(this.dataSource.getConnection().getMetaData().getURL()).startsWith("jdbc:h2:mem:");
 		assertThat(this.context.getBean("secondDataSource")).isSameAs(this.secondDataSource);
-		assertThat(this.secondDataSource.getConnection().getMetaData().getURL()).startsWith("jdbc:h2:mem:");
+		assertThat(this.secondDataSource).extracting((dataSource) -> ((HikariDataSource) dataSource).getJdbcUrl())
+			.isEqualTo("jdbc:h2:mem:bar;DB_CLOSE_DELAY=-1");
+		assertThat(this.secondDataSource)
+			.extracting((dataSource) -> ((HikariDataSource) dataSource).getMaximumPoolSize())
+			.isEqualTo(42);
 	}
 
 }

--- a/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyDataSourcesConfigurationTests.java
+++ b/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyDataSourcesConfigurationTests.java
@@ -20,7 +20,6 @@ import java.sql.SQLException;
 
 import javax.sql.DataSource;
 
-import com.zaxxer.hikari.HikariDataSource;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Stephane Nicoll
  */
-@SpringBootTest(properties = { "app.datasource.url=jdbc:h2:mem:bar;DB_CLOSE_DELAY=-1" })
+@SpringBootTest(properties = { "app.datasource.jdbcUrl=jdbc:h2:mem:bar;DB_CLOSE_DELAY=-1" })
 @Import(MyAdditionalDataSourceConfiguration.class)
 class MyDataSourcesConfigurationTests {
 

--- a/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyDataSourcesConfigurationTests.java
+++ b/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyDataSourcesConfigurationTests.java
@@ -20,7 +20,7 @@ import java.sql.SQLException;
 
 import javax.sql.DataSource;
 
-import org.apache.commons.dbcp2.BasicDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,9 +56,9 @@ class MyDataSourcesConfigurationTests {
 		assertThat(this.context.getBean("dataSource")).isSameAs(this.dataSource);
 		assertThat(this.dataSource.getConnection().getMetaData().getURL()).startsWith("jdbc:h2:mem:");
 		assertThat(this.context.getBean("secondDataSource")).isSameAs(this.secondDataSource);
-		assertThat(this.secondDataSource).extracting((dataSource) -> ((BasicDataSource) dataSource).getUrl())
+		assertThat(this.secondDataSource).extracting((dataSource) -> ((HikariDataSource) dataSource).getUrl())
 			.isEqualTo("jdbc:h2:mem:bar;DB_CLOSE_DELAY=-1");
-		assertThat(this.secondDataSource).extracting((dataSource) -> ((BasicDataSource) dataSource).getMaxTotal())
+		assertThat(this.secondDataSource).extracting((dataSource) -> ((HikariDataSource) dataSource).getMaxTotal())
 			.isEqualTo(42);
 	}
 

--- a/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyDataSourcesConfigurationTests.java
+++ b/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyDataSourcesConfigurationTests.java
@@ -32,13 +32,12 @@ import org.springframework.context.annotation.Import;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link MyCompleteAdditionalDataSourceConfiguration}.
+ * Tests for {@link MyAdditionalDataSourceConfiguration}.
  *
  * @author Stephane Nicoll
  */
-@SpringBootTest(properties = { "app.datasource.url=jdbc:h2:mem:bar;DB_CLOSE_DELAY=-1",
-		"app.datasource.hikari.maximum-pool-size=42" })
-@Import(MyCompleteAdditionalDataSourceConfiguration.class)
+@SpringBootTest(properties = { "app.datasource.url=jdbc:h2:mem:bar;DB_CLOSE_DELAY=-1" })
+@Import(MyAdditionalDataSourceConfiguration.class)
 class MyDataSourcesConfigurationTests {
 
 	@Autowired
@@ -57,11 +56,7 @@ class MyDataSourcesConfigurationTests {
 		assertThat(this.context.getBean("dataSource")).isSameAs(this.dataSource);
 		assertThat(this.dataSource.getConnection().getMetaData().getURL()).startsWith("jdbc:h2:mem:");
 		assertThat(this.context.getBean("secondDataSource")).isSameAs(this.secondDataSource);
-		assertThat(this.secondDataSource).extracting((dataSource) -> ((HikariDataSource) dataSource).getJdbcUrl())
-			.isEqualTo("jdbc:h2:mem:bar;DB_CLOSE_DELAY=-1");
-		assertThat(this.secondDataSource)
-			.extracting((dataSource) -> ((HikariDataSource) dataSource).getMaximumPoolSize())
-			.isEqualTo(42);
+		assertThat(this.secondDataSource.getConnection().getMetaData().getURL()).startsWith("jdbc:h2:mem:");
 	}
 
 }

--- a/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyDataSourcesConfigurationTests.java
+++ b/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyDataSourcesConfigurationTests.java
@@ -32,12 +32,13 @@ import org.springframework.context.annotation.Import;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link MyAdditionalDataSourceConfiguration}.
+ * Tests for {@link MyCompleteAdditionalDataSourceConfiguration}.
  *
  * @author Stephane Nicoll
  */
-@SpringBootTest(properties = { "app.datasource.url=jdbc:h2:mem:bar;DB_CLOSE_DELAY=-1", "app.datasource.max-total=42" })
-@Import(MyAdditionalDataSourceConfiguration.class)
+@SpringBootTest(properties = { "app.datasource.url=jdbc:h2:mem:bar;DB_CLOSE_DELAY=-1",
+		"app.datasource.hikari.maximum-pool-size=42" })
+@Import(MyCompleteAdditionalDataSourceConfiguration.class)
 class MyDataSourcesConfigurationTests {
 
 	@Autowired

--- a/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyDataSourcesConfigurationTests.java
+++ b/spring-boot-project/spring-boot-docs/src/test/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyDataSourcesConfigurationTests.java
@@ -56,9 +56,10 @@ class MyDataSourcesConfigurationTests {
 		assertThat(this.context.getBean("dataSource")).isSameAs(this.dataSource);
 		assertThat(this.dataSource.getConnection().getMetaData().getURL()).startsWith("jdbc:h2:mem:");
 		assertThat(this.context.getBean("secondDataSource")).isSameAs(this.secondDataSource);
-		assertThat(this.secondDataSource).extracting((dataSource) -> ((HikariDataSource) dataSource).getUrl())
+		assertThat(this.secondDataSource).extracting((dataSource) -> ((HikariDataSource) dataSource).getJdbcUrl())
 			.isEqualTo("jdbc:h2:mem:bar;DB_CLOSE_DELAY=-1");
-		assertThat(this.secondDataSource).extracting((dataSource) -> ((HikariDataSource) dataSource).getMaxTotal())
+		assertThat(this.secondDataSource)
+			.extracting((dataSource) -> ((HikariDataSource) dataSource).getMaximumPoolSize())
 			.isEqualTo(42);
 	}
 


### PR DESCRIPTION
From spring boot 2.x, the default DataSource library that comes with starter is Hikari, documentation is using commons-dbcp. To avoid confusion updating documentation to use `HikariDataSource`