### PR TITLE
Allow the automatic import of the spring-boot-dependencies BOM to be disabled in the Gradle plugin

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/DependencyManagementPluginAction.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/DependencyManagementPluginAction.java
@@ -21,6 +21,7 @@ import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.plugins.ExtraPropertiesExtension;
 
 /**
  * {@link Action} that is performed in response to the {@link DependencyManagementPlugin}
@@ -30,16 +31,30 @@ import org.gradle.api.Project;
  */
 final class DependencyManagementPluginAction implements PluginApplicationAction {
 
+	public static final String IMPORT_BOM_PROPERTY = "org.springframework.boot.import-bom";
+
 	@Override
 	public void execute(Project project) {
-		project.getExtensions()
-			.findByType(DependencyManagementExtension.class)
-			.imports((importsHandler) -> importsHandler.mavenBom(SpringBootPlugin.BOM_COORDINATES));
+		if (shouldImportBom(project)) {
+			project.getExtensions()
+				.findByType(DependencyManagementExtension.class)
+				.imports((importsHandler) -> importsHandler.mavenBom(SpringBootPlugin.BOM_COORDINATES));
+		}
 	}
 
 	@Override
 	public Class<? extends Plugin<Project>> getPluginClass() {
 		return DependencyManagementPlugin.class;
+	}
+
+	private boolean shouldImportBom(Project project) {
+		Object value = project.getExtensions()
+			.findByType(ExtraPropertiesExtension.class)
+			.getProperties()
+			.getOrDefault(IMPORT_BOM_PROPERTY, Boolean.TRUE);
+
+		return (value instanceof Boolean && (Boolean) value)
+				|| (value instanceof String && Boolean.parseBoolean((String) value));
 	}
 
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/DependencyManagementPluginActionIntegrationTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/DependencyManagementPluginActionIntegrationTests.java
@@ -37,15 +37,24 @@ class DependencyManagementPluginActionIntegrationTests {
 
 	@TestTemplate
 	void noDependencyManagementIsAppliedByDefault() {
-		assertThat(this.gradleBuild.build("doesNotHaveDependencyManagement")
-			.task(":doesNotHaveDependencyManagement")
+		assertThat(this.gradleBuild.build("hasNotConfiguredDependencyManagement")
+			.task(":hasNotConfiguredDependencyManagement")
 			.getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
 	}
 
 	@TestTemplate
 	void bomIsImportedWhenDependencyManagementPluginIsApplied() {
-		assertThat(this.gradleBuild.build("hasDependencyManagement", "-PapplyDependencyManagementPlugin")
-			.task(":hasDependencyManagement")
+		assertThat(this.gradleBuild.build("hasConfiguredDependencyManagement", "-PapplyDependencyManagementPlugin")
+			.task(":hasConfiguredDependencyManagement")
+			.getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+	}
+
+	@TestTemplate
+	void bomIsNotImportedWhenDependencyManagementPluginIsAppliedAndPropertyIsSetToDisableImport() {
+		assertThat(this.gradleBuild
+			.build("hasNotConfiguredDependencyManagement", "-PapplyDependencyManagementPlugin",
+					"-Porg.springframework.boot.import-bom=false")
+			.task(":hasNotConfiguredDependencyManagement")
 			.getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/DependencyManagementPluginActionIntegrationTests.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/DependencyManagementPluginActionIntegrationTests.gradle
@@ -20,17 +20,22 @@ repositories {
 	maven { url 'repository' }
 }
 
-task doesNotHaveDependencyManagement {
+def isDependencyManagementConfigured() {
+	def dependencyManagement = project.extensions.findByName('dependencyManagement')
+	return dependencyManagement != null && dependencyManagement.managedVersions
+}
+
+task hasNotConfiguredDependencyManagement {
 	doLast {
-		if (project.extensions.findByName('dependencyManagement') != null) {
-			throw new GradleException('Found dependency management extension')
+		if (isDependencyManagementConfigured()) {
+			throw new GradleException('Managed versions have been configured')
 		}
 	}
 }
 
-task hasDependencyManagement {
+task hasConfiguredDependencyManagement {
 	doLast {
-		if (!dependencyManagement.managedVersions) {
+		if (!isDependencyManagementConfigured()) {
 			throw new GradleException('No managed versions have been configured')
 		}
 	}


### PR DESCRIPTION
### Background

The org.springframework.boot plugin automatically imports the spring-boot-dependencies BOM if the io.spring.dependency-management is applied.

While this behaviour is convenient, it overrides explicit configuration done using the dependencyManagement extension, so it does not work as described [here](https://docs.spring.io/dependency-management-plugin/docs/current/reference/html/#dependency-management-configuration-bom-import-multiple):

> **4.2.1. Importing Multiple Boms**
> If you import more than one bom, the order in which the boms are imported can be important. The boms are processed in the order in which they are imported. If multiple boms provide dependency management for the same dependency, the dependency management from the last bom will be used.

I have described the issue in greater detail [here](https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/398), where I accidentally submitted an issue to the wrong project.

### Proposal

In order to disable the behaviour, I have introduced the property `org.springframework.boot.import-bom` which can be set to `false` to disabling the import. It defaults to `true` to preserve the current behaviour.

### Other ideas

I considered using SpringBootExtension instead of a property, but if the io.spring.dependency-management plugin is applied first, then there's no opportunity to configure the extension, since the dependency management configuration happens as soon as the org.springframework.boot plugin is applied. This could be worked around with `afterEvaulate`, but that would be a breaking change since the delaying of the import to `afterEvaulate` would mean that spring-boot-dependencies is always imported last (and order is important).