### PR TITLE
Remove deprecated ZipkinSender

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
@@ -32,21 +32,16 @@ import zipkin2.reporter.HttpEndpointSuppliers;
 import zipkin2.reporter.SpanBytesEncoder;
 import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
 import zipkin2.reporter.brave.MutableSpanBytesEncoder;
-import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.tracing.ConditionalOnEnabledTracing;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * Configurations for Zipkin. Those are imported by {@link ZipkinAutoConfiguration}.
@@ -57,9 +52,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 class ZipkinConfigurations {
 
 	@Configuration(proxyBeanMethods = false)
-	@Import({
-			HttpClientSenderConfiguration.class
-	})
+	@Import({ HttpClientSenderConfiguration.class })
 	static class SenderConfiguration {
 
 	}
@@ -76,9 +69,9 @@ class ZipkinConfigurations {
 				ObjectProvider<ZipkinConnectionDetails> connectionDetailsProvider,
 				ObjectProvider<HttpEndpointSupplier.Factory> endpointSupplierFactoryProvider) {
 			ZipkinConnectionDetails connectionDetails = connectionDetailsProvider
-					.getIfAvailable(() -> new PropertiesZipkinConnectionDetails(properties));
+				.getIfAvailable(() -> new PropertiesZipkinConnectionDetails(properties));
 			HttpEndpointSupplier.Factory endpointSupplierFactory = endpointSupplierFactoryProvider
-					.getIfAvailable(HttpEndpointSuppliers::constantFactory);
+				.getIfAvailable(HttpEndpointSuppliers::constantFactory);
 			Builder httpClientBuilder = HttpClient.newBuilder().connectTimeout(properties.getConnectTimeout());
 			customizers.orderedStream().forEach((customizer) -> customizer.customize(httpClientBuilder));
 			return new ZipkinHttpClientSender(encoding, endpointSupplierFactory, connectionDetails.getSpanEndpoint(),

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
@@ -59,9 +59,6 @@ class ZipkinConfigurations {
 	@Configuration(proxyBeanMethods = false)
 	@Import({
 			HttpClientSenderConfiguration.class
-			// UrlConnectionSenderConfiguration.class,
-			// WebClientSenderConfiguration.class,
-			// RestTemplateSenderConfiguration.class,
 	})
 	static class SenderConfiguration {
 
@@ -132,98 +129,5 @@ class ZipkinConfigurations {
 		}
 
 	}
-
-	/*
-	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(URLConnectionSender.class)
-	@EnableConfigurationProperties(ZipkinProperties.class)
-	static class UrlConnectionSenderConfiguration {
-
-		@Bean
-		@ConditionalOnMissingBean(BytesMessageSender.class)
-		URLConnectionSender urlConnectionSender(ZipkinProperties properties, Encoding encoding,
-				ObjectProvider<ZipkinConnectionDetails> connectionDetailsProvider,
-				ObjectProvider<HttpEndpointSupplier.Factory> endpointSupplierFactoryProvider) {
-			ZipkinConnectionDetails connectionDetails = connectionDetailsProvider
-				.getIfAvailable(() -> new PropertiesZipkinConnectionDetails(properties));
-			HttpEndpointSupplier.Factory endpointSupplierFactory = endpointSupplierFactoryProvider
-				.getIfAvailable(HttpEndpointSuppliers::constantFactory);
-			URLConnectionSender.Builder builder = URLConnectionSender.newBuilder();
-			builder.connectTimeout((int) properties.getConnectTimeout().toMillis());
-			builder.readTimeout((int) properties.getReadTimeout().toMillis());
-			builder.endpointSupplierFactory(endpointSupplierFactory);
-			builder.endpoint(connectionDetails.getSpanEndpoint());
-			builder.encoding(encoding);
-			return builder.build();
-		}
-
-	}
-	*/
-
-	/*
-	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(RestTemplate.class)
-	@EnableConfigurationProperties(ZipkinProperties.class)
-	static class RestTemplateSenderConfiguration {
-
-		@Bean
-		@ConditionalOnMissingBean(BytesMessageSender.class)
-		@SuppressWarnings({ "deprecation", "removal" })
-		ZipkinRestTemplateSender restTemplateSender(ZipkinProperties properties, Encoding encoding,
-				ObjectProvider<ZipkinRestTemplateBuilderCustomizer> customizers,
-				ObjectProvider<ZipkinConnectionDetails> connectionDetailsProvider,
-				ObjectProvider<HttpEndpointSupplier.Factory> endpointSupplierFactoryProvider) {
-			ZipkinConnectionDetails connectionDetails = connectionDetailsProvider
-				.getIfAvailable(() -> new PropertiesZipkinConnectionDetails(properties));
-			HttpEndpointSupplier.Factory endpointSupplierFactory = endpointSupplierFactoryProvider
-				.getIfAvailable(HttpEndpointSuppliers::constantFactory);
-			RestTemplateBuilder restTemplateBuilder = new RestTemplateBuilder()
-				.setConnectTimeout(properties.getConnectTimeout())
-				.setReadTimeout(properties.getReadTimeout());
-			restTemplateBuilder = applyCustomizers(restTemplateBuilder, customizers);
-			return new ZipkinRestTemplateSender(encoding, endpointSupplierFactory, connectionDetails.getSpanEndpoint(),
-					restTemplateBuilder.build());
-		}
-
-		@SuppressWarnings({ "deprecation", "removal" })
-		private RestTemplateBuilder applyCustomizers(RestTemplateBuilder restTemplateBuilder,
-				ObjectProvider<ZipkinRestTemplateBuilderCustomizer> customizers) {
-			Iterable<ZipkinRestTemplateBuilderCustomizer> orderedCustomizers = () -> customizers.orderedStream()
-				.iterator();
-			RestTemplateBuilder currentBuilder = restTemplateBuilder;
-			for (ZipkinRestTemplateBuilderCustomizer customizer : orderedCustomizers) {
-				currentBuilder = customizer.customize(currentBuilder);
-			}
-			return currentBuilder;
-		}
-
-	}
-	*/
-
-	/*
-	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(WebClient.class)
-	@EnableConfigurationProperties(ZipkinProperties.class)
-	static class WebClientSenderConfiguration {
-
-		@Bean
-		@ConditionalOnMissingBean(BytesMessageSender.class)
-		@SuppressWarnings({ "deprecation", "removal" })
-		ZipkinWebClientSender webClientSender(ZipkinProperties properties, Encoding encoding,
-				ObjectProvider<ZipkinWebClientBuilderCustomizer> customizers,
-				ObjectProvider<ZipkinConnectionDetails> connectionDetailsProvider,
-				ObjectProvider<HttpEndpointSupplier.Factory> endpointSupplierFactoryProvider) {
-			ZipkinConnectionDetails connectionDetails = connectionDetailsProvider
-				.getIfAvailable(() -> new PropertiesZipkinConnectionDetails(properties));
-			HttpEndpointSupplier.Factory endpointSupplierFactory = endpointSupplierFactoryProvider
-				.getIfAvailable(HttpEndpointSuppliers::constantFactory);
-			WebClient.Builder builder = WebClient.builder();
-			customizers.orderedStream().forEach((customizer) -> customizer.customize(builder));
-			return new ZipkinWebClientSender(encoding, endpointSupplierFactory, connectionDetails.getSpanEndpoint(),
-					builder.build(), properties.getConnectTimeout().plus(properties.getReadTimeout()));
-		}
-
-	}
-	*/
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
@@ -54,9 +54,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 
 	@Test
 	void shouldSupplyBeans() {
-		this.contextRunner.run((context) -> {
-			assertThat(context).hasSingleBean(BytesMessageSender.class);
-		});
+		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(BytesMessageSender.class));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
@@ -16,14 +16,6 @@
 
 package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import zipkin2.reporter.BytesMessageSender;
@@ -36,10 +28,8 @@ import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.reactive.function.client.WebClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.then;


### PR DESCRIPTION
## Description

This PR have removed three `SenderConfiguration` also its `Sender`: `UrlConnectionSenderConfiguration`, `RestTemplateSenderConfiguration` and `WebClientSenderConfiguration` in file `ZipkinConfigurations`. Remove the related test cases about these `SenderConfiguration` class in file `ZipkinConfigurationsSenderConfigurationTests`.

---

## Related Issue
Fixed #42589, #43047, #43048 

---

## Type of Change

- [X] Remove feature
- [X] Remove related tests
- [ ] Add new test cases
- [ ] Documentation update

---

## Checklist

- [X] I have reviewed the code for any potential issues or improvements.
- [X] I have run tests locally and they are passing.
- [X] I have followed the coding style and conventions of the project.

---

## Screenshots 

<img width="634" alt="image" src="https://github.com/user-attachments/assets/2b79d956-f570-42ca-8f55-d3fd8310161b">

---

## Additional Notes

I does remove the other `Senders` and its `SenderConfiguration` class, and also remove the test class related to these deprecated🥰. But do I need refactor `ZipkinConfiguration` structure, and write some test case to integrate test this modified class.🤨 Also update the documents about this related Sender🤔. Please give me some advice if this PR can't be merged🥹, and I will try my best to fix it up. Looking forward to your reply❤️~