### PR TITLE
Refactor/Make ZipkinHttpClientSender the default BytesMessageSender 

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
@@ -52,6 +52,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  *
  * @author Moritz Halbritter
  * @author Stefan Bratanov
+ * @author Wick Dynex
  */
 class ZipkinConfigurations {
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurations.java
@@ -56,33 +56,55 @@ import org.springframework.web.reactive.function.client.WebClient;
 class ZipkinConfigurations {
 
 	@Configuration(proxyBeanMethods = false)
-	@Import({ UrlConnectionSenderConfiguration.class, WebClientSenderConfiguration.class,
-			RestTemplateSenderConfiguration.class, HttpClientSenderConfiguration.class })
+	@Import({ HttpClientSenderConfiguration.class, WebClientSenderConfiguration.class,
+			RestTemplateSenderConfiguration.class, UrlConnectionSenderConfiguration.class })
 	static class SenderConfiguration {
 
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(URLConnectionSender.class)
+	@ConditionalOnClass(HttpClient.class)
 	@EnableConfigurationProperties(ZipkinProperties.class)
-	static class UrlConnectionSenderConfiguration {
+	static class HttpClientSenderConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(BytesMessageSender.class)
-		URLConnectionSender urlConnectionSender(ZipkinProperties properties, Encoding encoding,
+		ZipkinHttpClientSender httpClientSender(ZipkinProperties properties, Encoding encoding,
+				ObjectProvider<ZipkinHttpClientBuilderCustomizer> customizers,
 				ObjectProvider<ZipkinConnectionDetails> connectionDetailsProvider,
 				ObjectProvider<HttpEndpointSupplier.Factory> endpointSupplierFactoryProvider) {
 			ZipkinConnectionDetails connectionDetails = connectionDetailsProvider
 				.getIfAvailable(() -> new PropertiesZipkinConnectionDetails(properties));
 			HttpEndpointSupplier.Factory endpointSupplierFactory = endpointSupplierFactoryProvider
 				.getIfAvailable(HttpEndpointSuppliers::constantFactory);
-			URLConnectionSender.Builder builder = URLConnectionSender.newBuilder();
-			builder.connectTimeout((int) properties.getConnectTimeout().toMillis());
-			builder.readTimeout((int) properties.getReadTimeout().toMillis());
-			builder.endpointSupplierFactory(endpointSupplierFactory);
-			builder.endpoint(connectionDetails.getSpanEndpoint());
-			builder.encoding(encoding);
-			return builder.build();
+			Builder httpClientBuilder = HttpClient.newBuilder().connectTimeout(properties.getConnectTimeout());
+			customizers.orderedStream().forEach((customizer) -> customizer.customize(httpClientBuilder));
+			return new ZipkinHttpClientSender(encoding, endpointSupplierFactory, connectionDetails.getSpanEndpoint(),
+					httpClientBuilder.build(), properties.getReadTimeout());
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(WebClient.class)
+	@EnableConfigurationProperties(ZipkinProperties.class)
+	static class WebClientSenderConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean(BytesMessageSender.class)
+		@SuppressWarnings({ "deprecation", "removal" })
+		ZipkinWebClientSender webClientSender(ZipkinProperties properties, Encoding encoding,
+				ObjectProvider<ZipkinWebClientBuilderCustomizer> customizers,
+				ObjectProvider<ZipkinConnectionDetails> connectionDetailsProvider,
+				ObjectProvider<HttpEndpointSupplier.Factory> endpointSupplierFactoryProvider) {
+			ZipkinConnectionDetails connectionDetails = connectionDetailsProvider
+				.getIfAvailable(() -> new PropertiesZipkinConnectionDetails(properties));
+			HttpEndpointSupplier.Factory endpointSupplierFactory = endpointSupplierFactoryProvider
+				.getIfAvailable(HttpEndpointSuppliers::constantFactory);
+			WebClient.Builder builder = WebClient.builder();
+			customizers.orderedStream().forEach((customizer) -> customizer.customize(builder));
+			return new ZipkinWebClientSender(encoding, endpointSupplierFactory, connectionDetails.getSpanEndpoint(),
+					builder.build(), properties.getConnectTimeout().plus(properties.getReadTimeout()));
 		}
 
 	}
@@ -126,48 +148,26 @@ class ZipkinConfigurations {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(WebClient.class)
+	@ConditionalOnClass(URLConnectionSender.class)
 	@EnableConfigurationProperties(ZipkinProperties.class)
-	static class WebClientSenderConfiguration {
+	static class UrlConnectionSenderConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(BytesMessageSender.class)
-		@SuppressWarnings({ "deprecation", "removal" })
-		ZipkinWebClientSender webClientSender(ZipkinProperties properties, Encoding encoding,
-				ObjectProvider<ZipkinWebClientBuilderCustomizer> customizers,
+		URLConnectionSender urlConnectionSender(ZipkinProperties properties, Encoding encoding,
 				ObjectProvider<ZipkinConnectionDetails> connectionDetailsProvider,
 				ObjectProvider<HttpEndpointSupplier.Factory> endpointSupplierFactoryProvider) {
 			ZipkinConnectionDetails connectionDetails = connectionDetailsProvider
 				.getIfAvailable(() -> new PropertiesZipkinConnectionDetails(properties));
 			HttpEndpointSupplier.Factory endpointSupplierFactory = endpointSupplierFactoryProvider
 				.getIfAvailable(HttpEndpointSuppliers::constantFactory);
-			WebClient.Builder builder = WebClient.builder();
-			customizers.orderedStream().forEach((customizer) -> customizer.customize(builder));
-			return new ZipkinWebClientSender(encoding, endpointSupplierFactory, connectionDetails.getSpanEndpoint(),
-					builder.build(), properties.getConnectTimeout().plus(properties.getReadTimeout()));
-		}
-
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(HttpClient.class)
-	@EnableConfigurationProperties(ZipkinProperties.class)
-	static class HttpClientSenderConfiguration {
-
-		@Bean
-		@ConditionalOnMissingBean(BytesMessageSender.class)
-		ZipkinHttpClientSender httpClientSender(ZipkinProperties properties, Encoding encoding,
-				ObjectProvider<ZipkinHttpClientBuilderCustomizer> customizers,
-				ObjectProvider<ZipkinConnectionDetails> connectionDetailsProvider,
-				ObjectProvider<HttpEndpointSupplier.Factory> endpointSupplierFactoryProvider) {
-			ZipkinConnectionDetails connectionDetails = connectionDetailsProvider
-				.getIfAvailable(() -> new PropertiesZipkinConnectionDetails(properties));
-			HttpEndpointSupplier.Factory endpointSupplierFactory = endpointSupplierFactoryProvider
-				.getIfAvailable(HttpEndpointSuppliers::constantFactory);
-			Builder httpClientBuilder = HttpClient.newBuilder().connectTimeout(properties.getConnectTimeout());
-			customizers.orderedStream().forEach((customizer) -> customizer.customize(httpClientBuilder));
-			return new ZipkinHttpClientSender(encoding, endpointSupplierFactory, connectionDetails.getSpanEndpoint(),
-					httpClientBuilder.build(), properties.getReadTimeout());
+			URLConnectionSender.Builder builder = URLConnectionSender.newBuilder();
+			builder.connectTimeout((int) properties.getConnectTimeout().toMillis());
+			builder.readTimeout((int) properties.getReadTimeout().toMillis());
+			builder.endpointSupplierFactory(endpointSupplierFactory);
+			builder.endpoint(connectionDetails.getSpanEndpoint());
+			builder.encoding(encoding);
+			return builder.build();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
@@ -131,9 +131,9 @@ class ZipkinConfigurationsSenderConfigurationTests {
 	@Test
 	void willUseRestTemplateInNonWebApplicationIfSenderAndWebClientAreNotAvailable() {
 		this.contextRunner.withUserConfiguration(RestTemplateConfiguration.class)
-			.withClassLoader(new FilteredClassLoader(URLConnectionSender.class, WebClient.class))
+			.withClassLoader(new FilteredClassLoader(HttpClient.class, WebClient.class))
 			.run((context) -> {
-				assertThat(context).doesNotHaveBean(URLConnectionSender.class);
+				assertThat(context).doesNotHaveBean(HttpClient.class);
 				assertThat(context).hasSingleBean(BytesMessageSender.class);
 				assertThat(context).hasSingleBean(ZipkinRestTemplateSender.class);
 			});
@@ -202,27 +202,31 @@ class ZipkinConfigurationsSenderConfigurationTests {
 		}
 	}
 
+	// passed
 	@Test
 	void shouldUseCustomHttpEndpointSupplierFactory() {
 		this.contextRunner.withUserConfiguration(CustomHttpEndpointSupplierFactoryConfiguration.class)
+				.withClassLoader(new FilteredClassLoader(HttpClient.class, WebClient.class, RestTemplate.class))
 			.run((context) -> assertThat(context.getBean(URLConnectionSender.class))
 				.extracting("delegate.endpointSupplier")
 				.isInstanceOf(CustomHttpEndpointSupplier.class));
 	}
 
+	// passed
 	@Test
 	void shouldUseCustomHttpEndpointSupplierFactoryWhenReactive() {
 		this.reactiveContextRunner.withUserConfiguration(WebClientConfiguration.class)
-			.withClassLoader(new FilteredClassLoader(URLConnectionSender.class))
+			.withClassLoader(new FilteredClassLoader(HttpClient.class))
 			.withUserConfiguration(CustomHttpEndpointSupplierFactoryConfiguration.class)
 			.run((context) -> assertThat(context.getBean(ZipkinWebClientSender.class)).extracting("endpointSupplier")
 				.isInstanceOf(CustomHttpEndpointSupplier.class));
 	}
 
+	// passed
 	@Test
 	void shouldUseCustomHttpEndpointSupplierFactoryWhenRestTemplate() {
 		this.contextRunner.withUserConfiguration(RestTemplateConfiguration.class)
-			.withClassLoader(new FilteredClassLoader(URLConnectionSender.class, WebClient.class))
+			.withClassLoader(new FilteredClassLoader(HttpClient.class, WebClient.class))
 			.withUserConfiguration(CustomHttpEndpointSupplierFactoryConfiguration.class)
 			.run((context) -> assertThat(context.getBean(ZipkinRestTemplateSender.class)).extracting("endpointSupplier")
 				.isInstanceOf(CustomHttpEndpointSupplier.class));

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
@@ -77,7 +77,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 	@Test
 	void shouldUseUrlSenderIfHttpSenderIsNotAvailable() {
 		this.contextRunner.withUserConfiguration(UrlConnectionSenderConfiguration.class)
-			.withClassLoader(new FilteredClassLoader("java.net.http.HttpClient", "org.springframework.web.client",
+			.withClassLoader(new FilteredClassLoader("zipkin2.reporter.http.HttpClientSender", "org.springframework.web.client",
 					"org.springframework.web.reactive.function.client"))
 			.run((context) -> {
 				assertThat(context).doesNotHaveBean(ZipkinHttpClientSender.class);
@@ -87,7 +87,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 	}
 
 	@Test
-	void shouldPreferWebClientSenderIfWebApplicationIsReactiveAndUrlSenderIsNotAvailable() {
+	void shouldPreferWebClientSenderIfWebApplicationIsReactiveAndHttpClientSenderIsNotAvailable() {
 		this.reactiveContextRunner.withUserConfiguration(RestTemplateConfiguration.class, WebClientConfiguration.class)
 			.withClassLoader(new FilteredClassLoader("zipkin2.reporter.urlconnection"))
 			.run((context) -> {
@@ -100,11 +100,11 @@ class ZipkinConfigurationsSenderConfigurationTests {
 	}
 
 	@Test
-	void shouldPreferWebClientSenderIfWebApplicationIsServletAndUrlSenderIsNotAvailable() {
+	void shouldPreferWebClientSenderIfWebApplicationIsServletAndHttpClientSenderIsNotAvailable() {
 		this.servletContextRunner.withUserConfiguration(RestTemplateConfiguration.class, WebClientConfiguration.class)
-			.withClassLoader(new FilteredClassLoader("zipkin2.reporter.urlconnection"))
+			.withClassLoader(new FilteredClassLoader("zipkin2.reporter.http.HttpClientSender"))
 			.run((context) -> {
-				assertThat(context).doesNotHaveBean(URLConnectionSender.class);
+				assertThat(context).doesNotHaveBean(ZipkinHttpClientSender.class);
 				assertThat(context).hasSingleBean(BytesMessageSender.class);
 				assertThat(context).hasSingleBean(ZipkinWebClientSender.class);
 			});

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.actuate.autoconfigure.tracing.zipkin;
 
 import java.io.IOException;
+import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -40,6 +41,7 @@ import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -79,8 +81,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 	@Test
 	void shouldUseUrlSenderIfHttpSenderIsNotAvailable() {
 		this.contextRunner.withUserConfiguration(UrlConnectionSenderConfiguration.class)
-			.withClassLoader(new FilteredClassLoader("java.net.http.HttpClient", "org.springframework.web.client",
-					"org.springframework.web.reactive.function.client"))
+			.withClassLoader(new FilteredClassLoader(HttpClient.class, WebClient.class, RestTemplate.class))
 			.run((context) -> {
 				assertThat(context).doesNotHaveBean(ZipkinHttpClientSender.class);
 				assertThat(context).hasSingleBean(BytesMessageSender.class);
@@ -92,7 +93,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 	@Test
 	void shouldPreferWebClientSenderIfWebApplicationIsReactiveAndHttpClientSenderIsNotAvailable() {
 		this.reactiveContextRunner.withUserConfiguration(RestTemplateConfiguration.class, WebClientConfiguration.class)
-			.withClassLoader(new FilteredClassLoader("java.net.http.HttpClient"))
+			.withClassLoader(new FilteredClassLoader(HttpClient.class))
 			.run((context) -> {
 				assertThat(context).doesNotHaveBean(ZipkinHttpClientSender.class);
 				assertThat(context).hasSingleBean(BytesMessageSender.class);
@@ -106,7 +107,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 	@Test
 	void shouldPreferWebClientSenderIfWebApplicationIsServletAndHttpClientSenderIsNotAvailable() {
 		this.servletContextRunner.withUserConfiguration(RestTemplateConfiguration.class, WebClientConfiguration.class)
-			.withClassLoader(new FilteredClassLoader("java.net.http.HttpClient"))
+			.withClassLoader(new FilteredClassLoader(HttpClient.class))
 			.run((context) -> {
 				assertThat(context).doesNotHaveBean(ZipkinHttpClientSender.class);
 				assertThat(context).hasSingleBean(BytesMessageSender.class);
@@ -118,7 +119,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 	@Test
 	void shouldPreferWebClientInNonWebApplicationAndHttpClientSenderIsNotAvailable() {
 		this.contextRunner.withUserConfiguration(RestTemplateConfiguration.class, WebClientConfiguration.class)
-			.withClassLoader(new FilteredClassLoader("java.net.http.HttpClient"))
+			.withClassLoader(new FilteredClassLoader(HttpClient.class))
 			.run((context) -> {
 				assertThat(context).doesNotHaveBean(ZipkinHttpClientSender.class);
 				assertThat(context).hasSingleBean(BytesMessageSender.class);
@@ -142,7 +143,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 	@Test
 	void willUseRestTemplateInServletWebApplicationIfHttpClientSenderAndWebClientNotAvailable() {
 		this.servletContextRunner.withUserConfiguration(RestTemplateConfiguration.class)
-			.withClassLoader(new FilteredClassLoader("java.net.http.HttpClient", "org.springframework.web.reactive.function.client"))
+			.withClassLoader(new FilteredClassLoader(HttpClient.class, WebClient.class))
 			.run((context) -> {
 				assertThat(context).doesNotHaveBean(ZipkinHttpClientSender.class);
 				assertThat(context).hasSingleBean(BytesMessageSender.class);
@@ -154,7 +155,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 	@Test
 	void willUseRestTemplateInReactiveWebApplicationIfHttpClientSenderAndWebClientAreNotAvailable() {
 		this.reactiveContextRunner.withUserConfiguration(RestTemplateConfiguration.class)
-			.withClassLoader(new FilteredClassLoader("java.net.http.HttpClient", "org.springframework.web.reactive.function.client"))
+			.withClassLoader(new FilteredClassLoader(HttpClient.class, WebClient.class))
 			.run((context) -> {
 				assertThat(context).doesNotHaveBean(ZipkinHttpClientSender.class);
 				assertThat(context).hasSingleBean(BytesMessageSender.class);
@@ -189,7 +190,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 			this.reactiveContextRunner
 				.withPropertyValues("management.zipkin.tracing.endpoint=" + mockWebServer.url("/"))
 				.withUserConfiguration(RestTemplateConfiguration.class)
-				.withClassLoader(new FilteredClassLoader("java.net.http.HttpClient", "org.springframework.web.reactive.function.client"))
+				.withClassLoader(new FilteredClassLoader(HttpClient.class, WebClient.class))
 				.run((context) -> {
 					assertThat(context).hasSingleBean(ZipkinRestTemplateSender.class);
 					ZipkinRestTemplateSender sender = context.getBean(ZipkinRestTemplateSender.class);

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
@@ -52,6 +52,7 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link SenderConfiguration}.
  *
  * @author Moritz Halbritter
+ * @author Wick Dynex
  */
 @SuppressWarnings({ "deprecation", "removal" })
 class ZipkinConfigurationsSenderConfigurationTests {
@@ -65,7 +66,6 @@ class ZipkinConfigurationsSenderConfigurationTests {
 	private final WebApplicationContextRunner servletContextRunner = new WebApplicationContextRunner()
 		.withConfiguration(AutoConfigurations.of(DefaultEncodingConfiguration.class, SenderConfiguration.class));
 
-	// passed
 	@Test
 	void shouldSupplyDefaultHttpClientSenderBeans() {
 		this.contextRunner.run((context) -> {
@@ -77,7 +77,6 @@ class ZipkinConfigurationsSenderConfigurationTests {
 		});
 	}
 
-	// passed
 	@Test
 	void shouldUseUrlSenderIfHttpSenderIsNotAvailable() {
 		this.contextRunner.withUserConfiguration(UrlConnectionSenderConfiguration.class)
@@ -89,7 +88,6 @@ class ZipkinConfigurationsSenderConfigurationTests {
 			});
 	}
 
-	// passed
 	@Test
 	void shouldPreferWebClientSenderIfWebApplicationIsReactiveAndHttpClientSenderIsNotAvailable() {
 		this.reactiveContextRunner.withUserConfiguration(RestTemplateConfiguration.class, WebClientConfiguration.class)
@@ -103,7 +101,6 @@ class ZipkinConfigurationsSenderConfigurationTests {
 			});
 	}
 
-	// passed
 	@Test
 	void shouldPreferWebClientSenderIfWebApplicationIsServletAndHttpClientSenderIsNotAvailable() {
 		this.servletContextRunner.withUserConfiguration(RestTemplateConfiguration.class, WebClientConfiguration.class)
@@ -115,7 +112,6 @@ class ZipkinConfigurationsSenderConfigurationTests {
 			});
 	}
 
-	// passed
 	@Test
 	void shouldPreferWebClientInNonWebApplicationAndHttpClientSenderIsNotAvailable() {
 		this.contextRunner.withUserConfiguration(RestTemplateConfiguration.class, WebClientConfiguration.class)
@@ -127,7 +123,6 @@ class ZipkinConfigurationsSenderConfigurationTests {
 			});
 	}
 
-	// passed
 	@Test
 	void willUseRestTemplateInNonWebApplicationIfSenderAndWebClientAreNotAvailable() {
 		this.contextRunner.withUserConfiguration(RestTemplateConfiguration.class)
@@ -139,7 +134,6 @@ class ZipkinConfigurationsSenderConfigurationTests {
 			});
 	}
 
-	// passed
 	@Test
 	void willUseRestTemplateInServletWebApplicationIfHttpClientSenderAndWebClientNotAvailable() {
 		this.servletContextRunner.withUserConfiguration(RestTemplateConfiguration.class)
@@ -151,7 +145,6 @@ class ZipkinConfigurationsSenderConfigurationTests {
 			});
 	}
 
-	// passed
 	@Test
 	void willUseRestTemplateInReactiveWebApplicationIfHttpClientSenderAndWebClientAreNotAvailable() {
 		this.reactiveContextRunner.withUserConfiguration(RestTemplateConfiguration.class)
@@ -163,7 +156,6 @@ class ZipkinConfigurationsSenderConfigurationTests {
 			});
 	}
 
-	// passed
 	@Test
 	void shouldNotUseWebClientSenderIfNoBuilderIsAvailable() {
 		this.reactiveContextRunner.run((context) -> {
@@ -173,7 +165,6 @@ class ZipkinConfigurationsSenderConfigurationTests {
 		});
 	}
 
-	// passed
 	@Test
 	void shouldBackOffOnCustomBeans() {
 		this.contextRunner.withUserConfiguration(CustomConfiguration.class).run((context) -> {
@@ -182,7 +173,6 @@ class ZipkinConfigurationsSenderConfigurationTests {
 		});
 	}
 
-	// passed
 	@Test
 	void shouldApplyZipkinRestTemplateBuilderCustomizers() throws IOException {
 		try (MockWebServer mockWebServer = new MockWebServer()) {
@@ -202,17 +192,15 @@ class ZipkinConfigurationsSenderConfigurationTests {
 		}
 	}
 
-	// passed
 	@Test
 	void shouldUseCustomHttpEndpointSupplierFactory() {
 		this.contextRunner.withUserConfiguration(CustomHttpEndpointSupplierFactoryConfiguration.class)
-				.withClassLoader(new FilteredClassLoader(HttpClient.class, WebClient.class, RestTemplate.class))
+			.withClassLoader(new FilteredClassLoader(HttpClient.class, WebClient.class, RestTemplate.class))
 			.run((context) -> assertThat(context.getBean(URLConnectionSender.class))
 				.extracting("delegate.endpointSupplier")
 				.isInstanceOf(CustomHttpEndpointSupplier.class));
 	}
 
-	// passed
 	@Test
 	void shouldUseCustomHttpEndpointSupplierFactoryWhenReactive() {
 		this.reactiveContextRunner.withUserConfiguration(WebClientConfiguration.class)
@@ -222,7 +210,6 @@ class ZipkinConfigurationsSenderConfigurationTests {
 				.isInstanceOf(CustomHttpEndpointSupplier.class));
 	}
 
-	// passed
 	@Test
 	void shouldUseCustomHttpEndpointSupplierFactoryWhenRestTemplate() {
 		this.contextRunner.withUserConfiguration(RestTemplateConfiguration.class)

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/zipkin/ZipkinConfigurationsSenderConfigurationTests.java
@@ -63,6 +63,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 	private final WebApplicationContextRunner servletContextRunner = new WebApplicationContextRunner()
 		.withConfiguration(AutoConfigurations.of(DefaultEncodingConfiguration.class, SenderConfiguration.class));
 
+	// passed
 	@Test
 	void shouldSupplyDefaultHttpClientSenderBeans() {
 		this.contextRunner.run((context) -> {
@@ -74,10 +75,11 @@ class ZipkinConfigurationsSenderConfigurationTests {
 		});
 	}
 
+	// passed
 	@Test
 	void shouldUseUrlSenderIfHttpSenderIsNotAvailable() {
 		this.contextRunner.withUserConfiguration(UrlConnectionSenderConfiguration.class)
-			.withClassLoader(new FilteredClassLoader("zipkin2.reporter.http.HttpClientSender", "org.springframework.web.client",
+			.withClassLoader(new FilteredClassLoader("java.net.http.HttpClient", "org.springframework.web.client",
 					"org.springframework.web.reactive.function.client"))
 			.run((context) -> {
 				assertThat(context).doesNotHaveBean(ZipkinHttpClientSender.class);
@@ -86,12 +88,13 @@ class ZipkinConfigurationsSenderConfigurationTests {
 			});
 	}
 
+	// passed
 	@Test
 	void shouldPreferWebClientSenderIfWebApplicationIsReactiveAndHttpClientSenderIsNotAvailable() {
 		this.reactiveContextRunner.withUserConfiguration(RestTemplateConfiguration.class, WebClientConfiguration.class)
-			.withClassLoader(new FilteredClassLoader("zipkin2.reporter.urlconnection"))
+			.withClassLoader(new FilteredClassLoader("java.net.http.HttpClient"))
 			.run((context) -> {
-				assertThat(context).doesNotHaveBean(URLConnectionSender.class);
+				assertThat(context).doesNotHaveBean(ZipkinHttpClientSender.class);
 				assertThat(context).hasSingleBean(BytesMessageSender.class);
 				assertThat(context).hasSingleBean(ZipkinWebClientSender.class);
 				then(context.getBean(ZipkinWebClientBuilderCustomizer.class)).should()
@@ -99,10 +102,11 @@ class ZipkinConfigurationsSenderConfigurationTests {
 			});
 	}
 
+	// passed
 	@Test
 	void shouldPreferWebClientSenderIfWebApplicationIsServletAndHttpClientSenderIsNotAvailable() {
 		this.servletContextRunner.withUserConfiguration(RestTemplateConfiguration.class, WebClientConfiguration.class)
-			.withClassLoader(new FilteredClassLoader("zipkin2.reporter.http.HttpClientSender"))
+			.withClassLoader(new FilteredClassLoader("java.net.http.HttpClient"))
 			.run((context) -> {
 				assertThat(context).doesNotHaveBean(ZipkinHttpClientSender.class);
 				assertThat(context).hasSingleBean(BytesMessageSender.class);
@@ -110,19 +114,21 @@ class ZipkinConfigurationsSenderConfigurationTests {
 			});
 	}
 
+	// passed
 	@Test
-	void shouldPreferWebClientInNonWebApplicationAndUrlConnectionSenderIsNotAvailable() {
+	void shouldPreferWebClientInNonWebApplicationAndHttpClientSenderIsNotAvailable() {
 		this.contextRunner.withUserConfiguration(RestTemplateConfiguration.class, WebClientConfiguration.class)
-			.withClassLoader(new FilteredClassLoader("zipkin2.reporter.urlconnection"))
+			.withClassLoader(new FilteredClassLoader("java.net.http.HttpClient"))
 			.run((context) -> {
-				assertThat(context).doesNotHaveBean(URLConnectionSender.class);
+				assertThat(context).doesNotHaveBean(ZipkinHttpClientSender.class);
 				assertThat(context).hasSingleBean(BytesMessageSender.class);
 				assertThat(context).hasSingleBean(ZipkinWebClientSender.class);
 			});
 	}
 
+	// passed
 	@Test
-	void willUseRestTemplateInNonWebApplicationIfUrlConnectionSenderAndWebClientAreNotAvailable() {
+	void willUseRestTemplateInNonWebApplicationIfSenderAndWebClientAreNotAvailable() {
 		this.contextRunner.withUserConfiguration(RestTemplateConfiguration.class)
 			.withClassLoader(new FilteredClassLoader(URLConnectionSender.class, WebClient.class))
 			.run((context) -> {
@@ -132,37 +138,41 @@ class ZipkinConfigurationsSenderConfigurationTests {
 			});
 	}
 
+	// passed
 	@Test
-	void willUseRestTemplateInServletWebApplicationIfUrlConnectionSenderAndWebClientNotAvailable() {
+	void willUseRestTemplateInServletWebApplicationIfHttpClientSenderAndWebClientNotAvailable() {
 		this.servletContextRunner.withUserConfiguration(RestTemplateConfiguration.class)
-			.withClassLoader(new FilteredClassLoader(URLConnectionSender.class, WebClient.class))
+			.withClassLoader(new FilteredClassLoader("java.net.http.HttpClient", "org.springframework.web.reactive.function.client"))
 			.run((context) -> {
-				assertThat(context).doesNotHaveBean(URLConnectionSender.class);
+				assertThat(context).doesNotHaveBean(ZipkinHttpClientSender.class);
 				assertThat(context).hasSingleBean(BytesMessageSender.class);
 				assertThat(context).hasSingleBean(ZipkinRestTemplateSender.class);
 			});
 	}
 
+	// passed
 	@Test
-	void willUseRestTemplateInReactiveWebApplicationIfUrlConnectionSenderAndWebClientAreNotAvailable() {
+	void willUseRestTemplateInReactiveWebApplicationIfHttpClientSenderAndWebClientAreNotAvailable() {
 		this.reactiveContextRunner.withUserConfiguration(RestTemplateConfiguration.class)
-			.withClassLoader(new FilteredClassLoader(URLConnectionSender.class, WebClient.class))
+			.withClassLoader(new FilteredClassLoader("java.net.http.HttpClient", "org.springframework.web.reactive.function.client"))
 			.run((context) -> {
-				assertThat(context).doesNotHaveBean(URLConnectionSender.class);
+				assertThat(context).doesNotHaveBean(ZipkinHttpClientSender.class);
 				assertThat(context).hasSingleBean(BytesMessageSender.class);
 				assertThat(context).hasSingleBean(ZipkinRestTemplateSender.class);
 			});
 	}
 
+	// passed
 	@Test
 	void shouldNotUseWebClientSenderIfNoBuilderIsAvailable() {
 		this.reactiveContextRunner.run((context) -> {
 			assertThat(context).doesNotHaveBean(ZipkinWebClientSender.class);
 			assertThat(context).hasSingleBean(BytesMessageSender.class);
-			assertThat(context).hasSingleBean(URLConnectionSender.class);
+			assertThat(context).hasSingleBean(ZipkinHttpClientSender.class);
 		});
 	}
 
+	// passed
 	@Test
 	void shouldBackOffOnCustomBeans() {
 		this.contextRunner.withUserConfiguration(CustomConfiguration.class).run((context) -> {
@@ -171,6 +181,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 		});
 	}
 
+	// passed
 	@Test
 	void shouldApplyZipkinRestTemplateBuilderCustomizers() throws IOException {
 		try (MockWebServer mockWebServer = new MockWebServer()) {
@@ -178,7 +189,7 @@ class ZipkinConfigurationsSenderConfigurationTests {
 			this.reactiveContextRunner
 				.withPropertyValues("management.zipkin.tracing.endpoint=" + mockWebServer.url("/"))
 				.withUserConfiguration(RestTemplateConfiguration.class)
-				.withClassLoader(new FilteredClassLoader(URLConnectionSender.class, WebClient.class))
+				.withClassLoader(new FilteredClassLoader("java.net.http.HttpClient", "org.springframework.web.reactive.function.client"))
 				.run((context) -> {
 					assertThat(context).hasSingleBean(ZipkinRestTemplateSender.class);
 					ZipkinRestTemplateSender sender = context.getBean(ZipkinRestTemplateSender.class);


### PR DESCRIPTION
## Description

This PR switch the `@Import` order, and switch the order of `HttpClientSenderConfiguration.class` and `UrlConnectionSenderConfiguration.class`, also adjust the declaration order in file `ZipkinConfigurations.java`And in order to pass the `ZipkinConfigurationsSenderConfigurationTests.java`, I try to adapt the filter order and `test method` name.

---

## Related Issue
Fixed #42589

---

## Type of Change

- [X] Refactor feature
- [X] Modify related tests
- [ ] Documentation update

---

## Checklist

- [X] I have reviewed the code for any potential issues or improvements.
- [X] I have run tests locally and they are passing.
- [X] I have followed the coding style and conventions of the project.

---

## Screenshots 

<img width="715" alt="image" src="https://github.com/user-attachments/assets/46ab0a9e-8c72-4def-9cac-82ea55be4e7a">

---

## Additional Notes

I switch the `@Import` order to make `ZipkinHttpClientSender` to be the default `BytesMessageSender` implement🥳, also adapt test file `ZipkinConfigurationsSenderConfigurationTests` to be passed which is mentioned in https://github.com/spring-projects/spring-boot/issues/42589#issuecomment-2459005378. And if this PR is ready to merge, could u plz assign https://github.com/spring-projects/spring-boot/issues/43047, https://github.com/spring-projects/spring-boot/issues/43048 to me🥺, I'll be glad to do so. If there's anything need to be done, plz comment🥰.
