### PR TITLE
Add the ability to trigger a Quartz job on-demand through an Actuator endpoint

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/docs/antora/modules/api/pages/rest/actuator/quartz.adoc
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/docs/antora/modules/api/pages/rest/actuator/quartz.adoc
@@ -156,6 +156,39 @@ The following table describes the structure of the response:
 include::partial$rest/actuator/quartz/job-details/response-fields.adoc[]
 
 
+[[quartz.trigger-job]]
+== Trigger Quartz Job On Demand
+
+To trigger a particular Quartz job, make a `POST` request to `/actuator/quartz/jobs/\{groupName}/\{jobName}`, as shown in the following curl-based example:
+
+include::partial$rest/actuator/quartz/trigger-job/curl-request.adoc[]
+
+The preceding example demonstrates how to trigger a job that belongs to the `samples` group and is named `jobOne`.
+
+The response will look similar to the following:
+
+include::partial$rest/actuator/quartz/trigger-job/http-response.adoc[]
+
+
+[[quartz.trigger-job.request-structure]]
+=== Request Structure
+
+The request specifies a desired `state` associated with a particular job.
+Sending an HTTP Request with a  `"state": "running"` body indicates that the job should be run now.
+The following table describes the structure of the request:
+
+[cols="2,1,3"]
+include::partial$rest/actuator/quartz/trigger-job/request-fields.adoc[]
+
+[[quartz.trigger-job.response-structure]]
+=== Response Structure
+
+The response contains the details of a triggered job.
+The following table describes the structure of the response:
+
+[cols="2,1,3"]
+include::partial$rest/actuator/quartz/trigger-job/response-fields.adoc[]
+
 
 [[quartz.trigger]]
 == Retrieving Details of a Trigger

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/QuartzEndpointDocumentationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/documentation/QuartzEndpointDocumentationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TimeZone;
 
@@ -54,9 +55,11 @@ import org.quartz.spi.OperableTrigger;
 import org.springframework.boot.actuate.endpoint.Show;
 import org.springframework.boot.actuate.quartz.QuartzEndpoint;
 import org.springframework.boot.actuate.quartz.QuartzEndpointWebExtension;
+import org.springframework.boot.json.JsonWriter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.scheduling.quartz.DelegatingJob;
@@ -68,8 +71,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.relaxedResponseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 
@@ -383,6 +390,23 @@ class QuartzEndpointDocumentationTests extends MockMvcEndpointDocumentationTests
 			.apply(document("quartz/trigger-details-custom",
 					relaxedResponseFields(fieldWithPath("custom").description("Custom trigger specific details."))
 						.andWithPrefix("custom.", customTriggerSummary)));
+	}
+
+	@Test
+	void quartzTriggerJob() throws Exception {
+		mockJobs(jobOne);
+		String json = JsonWriter.standard().writeToString(Map.of("state", "running"));
+		assertThat(this.mvc.post()
+			.content(json)
+			.contentType(MediaType.APPLICATION_JSON)
+			.uri("/actuator/quartz/jobs/samples/jobOne"))
+			.hasStatusOk()
+			.apply(document("quartz/trigger-job", preprocessRequest(), preprocessResponse(prettyPrint()),
+					requestFields(fieldWithPath("state").description("The desired state of the job.")),
+					responseFields(fieldWithPath("group").description("Name of the group."),
+							fieldWithPath("name").description("Name of the job."),
+							fieldWithPath("className").description("Fully qualified name of the job implementation."),
+							fieldWithPath("triggerTime").description("Time the job is triggered."))));
 	}
 
 	private <T extends Trigger> void setupTriggerDetails(TriggerBuilder<T> builder, TriggerState state)

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/quartz/QuartzEndpointWebExtension.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/quartz/QuartzEndpointWebExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.boot.actuate.endpoint.SecurityContext;
 import org.springframework.boot.actuate.endpoint.Show;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.annotation.EndpointWebExtension;
 import org.springframework.boot.actuate.quartz.QuartzEndpoint.QuartzGroupsDescriptor;
@@ -77,6 +78,18 @@ public class QuartzEndpointWebExtension {
 		boolean showUnsanitized = this.showValues.isShown(securityContext, this.roles);
 		return handle(jobsOrTriggers, () -> this.delegate.quartzJob(group, name, showUnsanitized),
 				() -> this.delegate.quartzTrigger(group, name, showUnsanitized));
+	}
+
+	@WriteOperation
+	public WebEndpointResponse<Object> triggerQuartzJob(@Selector String jobs, @Selector String group,
+			@Selector String name, String state) throws SchedulerException {
+		if (!"jobs".equals(jobs)) {
+			return new WebEndpointResponse<>(WebEndpointResponse.STATUS_BAD_REQUEST);
+		}
+		if (!"running".equals(state)) {
+			return new WebEndpointResponse<>(WebEndpointResponse.STATUS_BAD_REQUEST);
+		}
+		return handleNull(this.delegate.triggerQuartzJob(group, name));
 	}
 
 	private <T> WebEndpointResponse<T> handle(String jobsOrTriggers, ResponseSupplier<T> jobAction,

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/quartz/QuartzEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/quartz/QuartzEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ import org.springframework.boot.actuate.quartz.QuartzEndpoint.QuartzDescriptor;
 import org.springframework.boot.actuate.quartz.QuartzEndpoint.QuartzJobDetailsDescriptor;
 import org.springframework.boot.actuate.quartz.QuartzEndpoint.QuartzJobGroupSummaryDescriptor;
 import org.springframework.boot.actuate.quartz.QuartzEndpoint.QuartzJobSummaryDescriptor;
+import org.springframework.boot.actuate.quartz.QuartzEndpoint.QuartzJobTriggerDescriptor;
 import org.springframework.boot.actuate.quartz.QuartzEndpoint.QuartzTriggerGroupSummaryDescriptor;
 import org.springframework.scheduling.quartz.DelegatingJob;
 import org.springframework.util.LinkedMultiValueMap;
@@ -73,9 +74,12 @@ import org.springframework.util.MultiValueMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 
 /**
  * Tests for {@link QuartzEndpoint}.
@@ -753,6 +757,31 @@ class QuartzEndpointTests {
 		QuartzJobDetailsDescriptor jobDetails = this.endpoint.quartzJob("samples", "hello", false);
 		assertThat(jobDetails.getData()).containsOnly(entry("user", "******"), entry("password", "******"),
 				entry("url", "******"));
+	}
+
+	@Test
+	void quartzJobShouldBeTriggered() throws SchedulerException {
+		JobDetail job = JobBuilder.newJob(Job.class)
+			.withIdentity("hello", "samples")
+			.withDescription("A sample job")
+			.storeDurably()
+			.requestRecovery(false)
+			.build();
+		mockJobs(job);
+		QuartzJobTriggerDescriptor quartzJobTriggerDescriptor = this.endpoint.triggerQuartzJob("samples", "hello");
+		assertThat(quartzJobTriggerDescriptor).isNotNull();
+		assertThat(quartzJobTriggerDescriptor.getName()).isEqualTo("hello");
+		assertThat(quartzJobTriggerDescriptor.getGroup()).isEqualTo("samples");
+		assertThat(quartzJobTriggerDescriptor.getClassName()).isEqualTo("org.quartz.Job");
+		assertThat(quartzJobTriggerDescriptor.getTriggerTime()).isCloseTo(Instant.now(), within(5, ChronoUnit.SECONDS));
+		then(this.scheduler).should().triggerJob(new JobKey("hello", "samples"));
+	}
+
+	@Test
+	void quartzJobShouldNotBeTriggeredJobDoesNotExist() throws SchedulerException {
+		QuartzJobTriggerDescriptor quartzJobTriggerDescriptor = this.endpoint.triggerQuartzJob("samples", "hello");
+		assertThat(quartzJobTriggerDescriptor).isNull();
+		then(this.scheduler).should(never()).triggerJob(any());
 	}
 
 	private void mockJobs(JobDetail... jobs) throws SchedulerException {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/quartz/QuartzEndpointWebIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/quartz/QuartzEndpointWebIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import net.minidev.json.JSONArray;
@@ -42,10 +43,12 @@ import org.quartz.TriggerBuilder;
 import org.quartz.TriggerKey;
 import org.quartz.impl.matchers.GroupMatcher;
 
+import org.springframework.boot.actuate.endpoint.ApiVersion;
 import org.springframework.boot.actuate.endpoint.Show;
 import org.springframework.boot.actuate.endpoint.web.test.WebEndpointTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
 import org.springframework.scheduling.quartz.DelegatingJob;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.util.LinkedMultiValueMap;
@@ -61,6 +64,10 @@ import static org.mockito.Mockito.mock;
  * @author Stephane Nicoll
  */
 class QuartzEndpointWebIntegrationTests {
+
+	private static final String V2_JSON = ApiVersion.V2.getProducedMimeType().toString();
+
+	private static final String V3_JSON = ApiVersion.V3.getProducedMimeType().toString();
 
 	private static final JobDetail jobOne = JobBuilder.newJob(Job.class)
 		.withIdentity("jobOne", "samples")
@@ -247,6 +254,92 @@ class QuartzEndpointWebIntegrationTests {
 	@WebEndpointTest
 	void quartzTriggerDetailWithUnknownKey(WebTestClient client) {
 		client.get().uri("/actuator/quartz/triggers/tests/does-not-exist").exchange().expectStatus().isNotFound();
+	}
+
+	@WebEndpointTest
+	void quartzTriggerJob(WebTestClient client) {
+		client.post()
+			.uri("/actuator/quartz/jobs/samples/jobOne")
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.bodyValue(Map.of("state", "running"))
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody()
+			.jsonPath("group")
+			.isEqualTo("samples")
+			.jsonPath("name")
+			.isEqualTo("jobOne")
+			.jsonPath("className")
+			.isEqualTo("org.quartz.Job")
+			.jsonPath("triggerTime")
+			.isNotEmpty();
+	}
+
+	@WebEndpointTest
+	void quartzTriggerJobV2(WebTestClient client) {
+		client.post()
+			.uri("/actuator/quartz/jobs/samples/jobOne")
+			.contentType(MediaType.parseMediaType(V2_JSON))
+			.accept(MediaType.APPLICATION_JSON)
+			.bodyValue(Map.of("state", "running"))
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody()
+			.jsonPath("group")
+			.isEqualTo("samples")
+			.jsonPath("name")
+			.isEqualTo("jobOne")
+			.jsonPath("className")
+			.isEqualTo("org.quartz.Job")
+			.jsonPath("triggerTime")
+			.isNotEmpty();
+	}
+
+	@WebEndpointTest
+	void quartzTriggerJobV3(WebTestClient client) {
+		client.post()
+			.uri("/actuator/quartz/jobs/samples/jobOne")
+			.contentType(MediaType.parseMediaType(V3_JSON))
+			.accept(MediaType.APPLICATION_JSON)
+			.bodyValue(Map.of("state", "running"))
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody()
+			.jsonPath("group")
+			.isEqualTo("samples")
+			.jsonPath("name")
+			.isEqualTo("jobOne")
+			.jsonPath("className")
+			.isEqualTo("org.quartz.Job")
+			.jsonPath("triggerTime")
+			.isNotEmpty();
+	}
+
+	@WebEndpointTest
+	void quartzTriggerJobWithUnknownJobKey(WebTestClient client) {
+		client.post()
+			.uri("/actuator/quartz/jobs/samples/does-not-exist")
+			.contentType(MediaType.APPLICATION_JSON)
+			.bodyValue(Map.of("state", "running"))
+			.exchange()
+			.expectStatus()
+			.isNotFound();
+	}
+
+	@WebEndpointTest
+	void quartzTriggerJobWithUnknownState(WebTestClient client) {
+		client.post()
+			.uri("/actuator/quartz/jobs/samples/jobOne")
+			.contentType(MediaType.parseMediaType(V3_JSON))
+			.accept(MediaType.APPLICATION_JSON)
+			.bodyValue(Map.of("state", "unknown"))
+			.exchange()
+			.expectStatus()
+			.isBadRequest();
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-quartz/src/main/java/smoketest/quartz/SampleQuartzApplication.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-quartz/src/main/java/smoketest/quartz/SampleQuartzApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,15 @@ public class SampleQuartzApplication {
 		return JobBuilder.newJob(SampleJob.class)
 			.withIdentity("anotherJob", "samples")
 			.usingJobData("name", "Everyone")
+			.storeDurably()
+			.build();
+	}
+
+	@Bean
+	public JobDetail onDemandJobDetail() {
+		return JobBuilder.newJob(SampleJob.class)
+			.withIdentity("onDemandJob", "samples")
+			.usingJobData("name", "On Demand Job")
 			.storeDurably()
 			.build();
 	}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-quartz/src/test/java/smoketest/quartz/SampleQuartzApplicationWebTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-quartz/src/test/java/smoketest/quartz/SampleQuartzApplicationWebTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,29 @@
 
 package smoketest.quartz;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.InstanceOfAssertFactory;
 import org.assertj.core.api.MapAssert;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.within;
 
 /**
  * Web tests for {@link SampleQuartzApplication}.
@@ -39,6 +46,7 @@ import static org.assertj.core.api.Assertions.entry;
  * @author Stephane Nicoll
  */
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ExtendWith(OutputCaptureExtension.class)
 class SampleQuartzApplicationWebTests {
 
 	@Autowired
@@ -89,6 +97,20 @@ class SampleQuartzApplicationWebTests {
 		ResponseEntity<String> response = this.restTemplate
 			.getForEntity("/actuator/quartz/triggers/samples/does-not-exist", String.class);
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	void quartzJobTriggeredManually(CapturedOutput output) {
+		ResponseEntity<Map<String, Object>> result = asMapEntity(this.restTemplate.postForEntity(
+				"/actuator/quartz/jobs/samples/onDemandJob", new HttpEntity<>(Map.of("state", "running")), Map.class));
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		Map<String, Object> content = result.getBody();
+		assertThat(content).contains(entry("group", "samples"), entry("name", "onDemandJob"),
+				entry("className", SampleJob.class.getName()));
+		assertThat(content).extractingByKey("triggerTime", InstanceOfAssertFactories.STRING)
+			.satisfies((triggerTime) -> assertThat(Instant.parse(triggerTime)).isCloseTo(Instant.now(),
+					within(10, ChronoUnit.SECONDS)));
+		assertThat(output).contains("Hello On Demand Job");
 	}
 
 	private Map<String, Object> getContent(String path) {


### PR DESCRIPTION
Before this commit, triggering a Quartz job on demand was not possible. This commit introduces a new `@WriteOperation` endpoint at `/actuator/quartz/jobs/{groupName}/{jobName}/trigger`, allowing a job to be triggered by specifying the `{jobName}`, `{groupName}`, and an optional `JobDataMap`.

See gh-42530

```bash

$ curl 'http://localhost:8080/actuator/quartz/jobs/samples/jobOne/trigger' -i -X POST \
    -H 'Content-Type: application/json' \
    -d '{"jobData":{"key":"value","keyN":"valueN"}}'
    
```

```http

HTTP/1.1 200 OK
Content-Type: application/vnd.spring-boot.actuator.v3+json
Content-Length: 166

{
  "group" : "samples",
  "name" : "jobOne",
  "className" : "org.springframework.scheduling.quartz.DelegatingJob",
  "triggerTime" : "2024-11-10T09:44:05.425233Z"
}

```