### PR TITLE
WebServerPortFileWriter fails when using a portfile without extension

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/context/WebServerPortFileWriter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/context/WebServerPortFileWriter.java
@@ -110,7 +110,8 @@ public class WebServerPortFileWriter implements ApplicationListener<WebServerIni
 		}
 		String filename = this.file.getName();
 		String extension = StringUtils.getFilenameExtension(filename);
-		String filenameWithoutExtension = filename.substring(0, filename.length() - extension.length() - 1);
+		String filenameWithoutExtension = (extension != null)
+				? filename.substring(0, filename.length() - extension.length() - 1) : filename;
 		String suffix = (!isUpperCase(filename)) ? namespace.toLowerCase(Locale.ENGLISH)
 				: namespace.toUpperCase(Locale.ENGLISH);
 		return new File(this.file.getParentFile(),

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/context/WebServerPortFileWriterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/context/WebServerPortFileWriterTests.java
@@ -110,6 +110,15 @@ class WebServerPortFileWriterTests {
 		assertThat(collectFileNames(file.getParentFile())).contains(managementFile);
 	}
 
+	@Test
+	void getPortFileWhenPortFileNameDoesNotHaveExtension() {
+		File file = new File(this.tempDir, "portfile");
+		WebServerPortFileWriter listener = new WebServerPortFileWriter(file);
+		WebServerApplicationContext applicationContext = mock(WebServerApplicationContext.class);
+		given(applicationContext.getServerNamespace()).willReturn("management");
+		assertThat(listener.getPortFile(applicationContext).getName()).isEqualTo("portfile-management");
+	}
+
 	private WebServerInitializedEvent mockEvent(String namespace, int port) {
 		WebServer webServer = mock(WebServer.class);
 		given(webServer.getPort()).willReturn(port);


### PR DESCRIPTION
This PR fixes `WebServerPortFileWriter.getPortFile()` with namespace and file without extension.