### PR TITLE
Tighten rules around profile naming

### DIFF
--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootContextLoaderTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootContextLoaderTests.java
@@ -127,11 +127,6 @@ class SpringBootContextLoaderTests {
 		assertThat(getActiveProfiles(MultipleActiveProfiles.class)).containsExactly("profile1", "profile2");
 	}
 
-	@Test
-	void activeProfileWithComma() {
-		assertThat(getActiveProfiles(ActiveProfileWithComma.class)).containsExactly("profile1,2");
-	}
-
 	@Test // gh-28776
 	void testPropertyValuesShouldTakePrecedenceWhenInlinedPropertiesPresent() {
 		TestContext context = new ExposedTestContextManager(SimpleConfig.class).getExposedTestContext();
@@ -311,12 +306,6 @@ class SpringBootContextLoaderTests {
 	@SpringBootTest(classes = Config.class)
 	@ActiveProfiles({ "profile1", "profile2" })
 	static class MultipleActiveProfiles {
-
-	}
-
-	@SpringBootTest(classes = Config.class)
-	@ActiveProfiles({ "profile1,2" })
-	static class ActiveProfileWithComma {
 
 	}
 

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootContextLoaderTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootContextLoaderTests.java
@@ -60,6 +60,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * @author Stephane Nicoll
  * @author Scott Frederick
  * @author Madhura Bhave
+ * @author Sijun Yang
  */
 class SpringBootContextLoaderTests {
 
@@ -310,7 +311,7 @@ class SpringBootContextLoaderTests {
 	}
 
 	@SpringBootTest(properties = { "key=myValue" }, classes = Config.class)
-	@ActiveProfiles({ "profile1,2" })
+	@ActiveProfiles({ "profile1" })
 	static class ActiveProfileWithInlinedProperties {
 
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/StandardConfigDataLocationResolver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/StandardConfigDataLocationResolver.java
@@ -166,18 +166,24 @@ public class StandardConfigDataLocationResolver
 	}
 
 	private void validateProfiles(Profiles profiles) {
-		Pattern validProfilePattern = Pattern.compile("^[a-zA-Z0-9_\\-]+$");
-		Assert.notNull(profiles, "Profiles must not be null");
 		for (String profile : profiles) {
-			Assert.notNull(profile, "Profile must not be null");
-			Assert.hasText(profile, "Profile must not be empty");
-			Assert.state(!profile.startsWith("-") && !profile.startsWith("_"),
-					() -> String.format("Invalid profile '%s': must not start with '-' or '_'", profile));
-			Assert.state(!profile.endsWith("-") && !profile.endsWith("_"),
-					() -> String.format("Invalid profile '%s': must not end with '-' or '_'", profile));
-			Assert.state(validProfilePattern.matcher(profile).matches(), () -> String
-				.format("Invalid profile '%s': must only contain alphanumeric characters, '-', or '_'", profile));
+			validateProfile(profile);
 		}
+	}
+
+	private void validateProfile(String profile) {
+		Assert.notNull(profile, "Profile must not be null");
+		Assert.hasText(profile, "Profile must not be empty");
+		Assert.state(!profile.startsWith("-") && !profile.startsWith("_"),
+				() -> String.format("Invalid profile '%s': must not start with '-' or '_'", profile));
+		Assert.state(!profile.endsWith("-") && !profile.endsWith("_"),
+				() -> String.format("Invalid profile '%s': must not end with '-' or '_'", profile));
+		profile.codePoints().forEach((codePoint) -> {
+			if (codePoint == '-' || codePoint == '_' || Character.isLetterOrDigit(codePoint)) {
+				return;
+			}
+			throw new IllegalStateException(String.format("Invalid profile '%s': must contain only letters or digits or '-' or '_'", profile));
+		});
 	}
 
 	private String getResourceLocation(ConfigDataLocationResolverContext context,

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/StandardConfigDataLocationResolver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/StandardConfigDataLocationResolver.java
@@ -54,6 +54,7 @@ import org.springframework.util.StringUtils;
  * @author Madhura Bhave
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author Sijun Yang
  * @since 2.4.0
  */
 public class StandardConfigDataLocationResolver
@@ -154,6 +155,7 @@ public class StandardConfigDataLocationResolver
 	private Set<StandardConfigDataReference> getProfileSpecificReferences(ConfigDataLocationResolverContext context,
 			ConfigDataLocation[] configDataLocations, Profiles profiles) {
 		Set<StandardConfigDataReference> references = new LinkedHashSet<>();
+		validateProfiles(profiles);
 		for (String profile : profiles) {
 			for (ConfigDataLocation configDataLocation : configDataLocations) {
 				String resourceLocation = getResourceLocation(context, configDataLocation);
@@ -161,6 +163,21 @@ public class StandardConfigDataLocationResolver
 			}
 		}
 		return references;
+	}
+
+	private void validateProfiles(Profiles profiles) {
+		Pattern validProfilePattern = Pattern.compile("^[a-zA-Z0-9_\\-]+$");
+		Assert.notNull(profiles, "Profiles must not be null");
+		for (String profile : profiles) {
+			Assert.notNull(profile, "Profile must not be null");
+			Assert.hasText(profile, "Profile must not be empty");
+			Assert.state(!profile.startsWith("-") && !profile.startsWith("_"),
+					() -> String.format("Invalid profile '%s': must not start with '-' or '_'", profile));
+			Assert.state(!profile.endsWith("-") && !profile.endsWith("_"),
+					() -> String.format("Invalid profile '%s': must not end with '-' or '_'", profile));
+			Assert.state(validProfilePattern.matcher(profile).matches(), () -> String
+				.format("Invalid profile '%s': must only contain alphanumeric characters, '-', or '_'", profile));
+		}
 	}
 
 	private String getResourceLocation(ConfigDataLocationResolverContext context,

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/StandardConfigDataLocationResolver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/config/StandardConfigDataLocationResolver.java
@@ -172,8 +172,7 @@ public class StandardConfigDataLocationResolver
 	}
 
 	private void validateProfile(String profile) {
-		Assert.notNull(profile, "Profile must not be null");
-		Assert.hasText(profile, "Profile must not be empty");
+		Assert.hasText(profile, "Profile must contain text");
 		Assert.state(!profile.startsWith("-") && !profile.startsWith("_"),
 				() -> String.format("Invalid profile '%s': must not start with '-' or '_'", profile));
 		Assert.state(!profile.endsWith("-") && !profile.endsWith("_"),

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
@@ -165,6 +165,7 @@ import static org.mockito.Mockito.spy;
  * @author Moritz Halbritter
  * @author Tadaya Tsuyukubo
  * @author Yanming Zhou
+ * @author Sijun Yang
  */
 @ExtendWith(OutputCaptureExtension.class)
 class SpringApplicationTests {
@@ -252,13 +253,13 @@ class SpringApplicationTests {
 	@Test
 	void logsActiveProfilesWithoutProfileAndMultipleDefaults(CapturedOutput output) {
 		MockEnvironment environment = new MockEnvironment();
-		environment.setDefaultProfiles("p0,p1", "default");
+		environment.setDefaultProfiles("p0", "default");
 		SpringApplication application = new SpringApplication(ExampleConfig.class);
 		application.setWebApplicationType(WebApplicationType.NONE);
 		application.setEnvironment(environment);
 		this.context = application.run();
 		assertThat(output)
-			.contains("No active profile set, falling back to 2 default profiles: \"p0,p1\", \"default\"");
+			.contains("No active profile set, falling back to 2 default profiles: \"p0\", \"default\"");
 	}
 
 	@Test
@@ -273,9 +274,9 @@ class SpringApplicationTests {
 	void logsActiveProfilesWithMultipleProfiles(CapturedOutput output) {
 		SpringApplication application = new SpringApplication(ExampleConfig.class);
 		application.setWebApplicationType(WebApplicationType.NONE);
-		application.setAdditionalProfiles("p1,p2", "p3");
+		application.setAdditionalProfiles("p1", "p2");
 		application.run();
-		assertThat(output).contains("The following 2 profiles are active: \"p1,p2\", \"p3\"");
+		assertThat(output).contains("The following 2 profiles are active: \"p1\", \"p2\"");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLocationResolverTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLocationResolverTests.java
@@ -294,6 +294,75 @@ class StandardConfigDataLocationResolverTests {
 		assertThatNoException().isThrownBy(() -> this.resolver.resolve(this.context, location));
 	}
 
+	@Test
+	void resolveProfileSpecificWhenProfileIsValidShouldNotThrowException() {
+		ConfigDataLocation location = ConfigDataLocation.of("classpath:/configdata/properties/");
+		this.environment.setActiveProfiles("dev-test_123");
+		Profiles profiles = new Profiles(this.environment, this.environmentBinder, Collections.emptyList());
+		assertThatNoException()
+			.isThrownBy(() -> this.resolver.resolveProfileSpecific(this.context, location, profiles));
+	}
+
+	@Test
+	void resolveProfileSpecificWithAdditionalValidProfilesShouldNotThrowException() {
+		ConfigDataLocation location = ConfigDataLocation.of("classpath:/configdata/properties/");
+		this.environment.setActiveProfiles("dev-test");
+		Profiles profiles = new Profiles(this.environment, this.environmentBinder, List.of("prod-test", "stage-test"));
+		assertThatNoException()
+			.isThrownBy(() -> this.resolver.resolveProfileSpecific(this.context, location, profiles));
+	}
+
+	@Test
+	void resolveProfileSpecificWhenProfileStartsWithSymbolThrowsException() {
+		ConfigDataLocation location = ConfigDataLocation.of("classpath:/configdata/properties/");
+		this.environment.setActiveProfiles("-dev");
+		Profiles profiles = new Profiles(this.environment, this.environmentBinder, Collections.emptyList());
+		assertThatIllegalStateException()
+			.isThrownBy(() -> this.resolver.resolveProfileSpecific(this.context, location, profiles))
+			.withMessageStartingWith("Invalid profile '-dev': must not start with '-' or '_'");
+	}
+
+	@Test
+	void resolveProfileSpecificWhenProfileStartsWithUnderscoreThrowsException() {
+		ConfigDataLocation location = ConfigDataLocation.of("classpath:/configdata/properties/");
+		this.environment.setActiveProfiles("_dev");
+		Profiles profiles = new Profiles(this.environment, this.environmentBinder, Collections.emptyList());
+		assertThatIllegalStateException()
+			.isThrownBy(() -> this.resolver.resolveProfileSpecific(this.context, location, profiles))
+			.withMessageStartingWith("Invalid profile '_dev': must not start with '-' or '_'");
+	}
+
+	@Test
+	void resolveProfileSpecificWhenProfileEndsWithSymbolThrowsException() {
+		ConfigDataLocation location = ConfigDataLocation.of("classpath:/configdata/properties/");
+		this.environment.setActiveProfiles("dev-");
+		Profiles profiles = new Profiles(this.environment, this.environmentBinder, Collections.emptyList());
+		assertThatIllegalStateException()
+			.isThrownBy(() -> this.resolver.resolveProfileSpecific(this.context, location, profiles))
+			.withMessageStartingWith("Invalid profile 'dev-': must not end with '-' or '_'");
+	}
+
+	@Test
+	void resolveProfileSpecificWhenProfileEndsWithUnderscoreThrowsException() {
+		ConfigDataLocation location = ConfigDataLocation.of("classpath:/configdata/properties/");
+		this.environment.setActiveProfiles("dev_");
+		Profiles profiles = new Profiles(this.environment, this.environmentBinder, Collections.emptyList());
+		assertThatIllegalStateException()
+			.isThrownBy(() -> this.resolver.resolveProfileSpecific(this.context, location, profiles))
+			.withMessageStartingWith("Invalid profile 'dev_': must not end with '-' or '_'");
+	}
+
+	@Test
+	void resolveProfileSpecificWhenProfileContainsInvalidCharactersThrowsException() {
+		ConfigDataLocation location = ConfigDataLocation.of("classpath:/configdata/properties/");
+		this.environment.setActiveProfiles("dev*test");
+		Profiles profiles = new Profiles(this.environment, this.environmentBinder, Collections.emptyList());
+		assertThatIllegalStateException()
+			.isThrownBy(() -> this.resolver.resolveProfileSpecific(this.context, location, profiles))
+			.withMessageStartingWith(
+					"Invalid profile 'dev*test': must only contain alphanumeric characters, '-', or '_'");
+	}
+
 	private String filePath(String... components) {
 		return "file [" + String.join(File.separator, components) + "]";
 	}

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLocationResolverTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLocationResolverTests.java
@@ -360,7 +360,7 @@ class StandardConfigDataLocationResolverTests {
 		assertThatIllegalStateException()
 			.isThrownBy(() -> this.resolver.resolveProfileSpecific(this.context, location, profiles))
 			.withMessageStartingWith(
-					"Invalid profile 'dev*test': must only contain alphanumeric characters, '-', or '_'");
+					"Invalid profile 'dev*test': must contain only letters or digits or '-' or '_'");
 	}
 
 	private String filePath(String... components) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLocationResolverTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLocationResolverTests.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.mock;
  * @author Madhura Bhave
  * @author Phillip Webb
  * @author Moritz Halbritter
+ * @author Sijun Yang
  */
 class StandardConfigDataLocationResolverTests {
 
@@ -254,8 +255,8 @@ class StandardConfigDataLocationResolverTests {
 	@Test
 	void resolveProfileSpecificReturnsProfileSpecificFiles() {
 		ConfigDataLocation location = ConfigDataLocation.of("classpath:/configdata/properties/");
-		Profiles profiles = mock(Profiles.class);
-		given(profiles.iterator()).willReturn(Collections.singletonList("dev").iterator());
+		this.environment.setActiveProfiles("dev");
+		Profiles profiles = new Profiles(this.environment, this.environmentBinder, Collections.emptyList());
 		List<StandardConfigDataResource> locations = this.resolver.resolveProfileSpecific(this.context, location,
 				profiles);
 		assertThat(locations).hasSize(1);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLocationResolverTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/config/StandardConfigDataLocationResolverTests.java
@@ -304,6 +304,15 @@ class StandardConfigDataLocationResolverTests {
 	}
 
 	@Test
+	void resolveProfileSpecificWithNonAsciiCharactersShouldNotThrowException() {
+		ConfigDataLocation location = ConfigDataLocation.of("classpath:/configdata/properties/");
+		this.environment.setActiveProfiles("dev-테스트_123");
+		Profiles profiles = new Profiles(this.environment, this.environmentBinder, Collections.emptyList());
+		assertThatNoException()
+				.isThrownBy(() -> this.resolver.resolveProfileSpecific(this.context, location, profiles));
+	}
+
+	@Test
 	void resolveProfileSpecificWithAdditionalValidProfilesShouldNotThrowException() {
 		ConfigDataLocation location = ConfigDataLocation.of("classpath:/configdata/properties/");
 		this.environment.setActiveProfiles("dev-test");


### PR DESCRIPTION
I added the `validateProfiles()` method to enforce stricter rules for Spring profile names. 

Currently, only alphanumeric characters, hyphens (`-`), and underscores (`_`) are allowed. Please let me know if additional characters should be permitted - I'll update accordingly.

I've verified validation works in `application.properties` and `@ActiveProfiles`. 

While `@Profile` doesn't perform validation, this seems acceptable since invalid profiles will fail during activation. Perhaps we could explore adding warnings as a potential enhancement in the future.

Note: this change may break applications using non-conforming profile names.

Fixes gh-34062