### PR TITLE
Remove deprecated getFiles() instead of getResolvedArtifacts()

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -128,3 +128,6 @@ eclipse.classpath.file.whenMerged {
 	jreEntry.entryAttributes['limit-modules'] = 'java.base'
 }
 
+tasks.named('compileJava') {
+	options.compilerArgs += ['-Xlint:deprecation']
+}

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -127,7 +127,3 @@ eclipse.classpath.file.whenMerged {
 	jreEntry.entryAttributes['module'] = 'true'
 	jreEntry.entryAttributes['limit-modules'] = 'java.base'
 }
-
-tasks.named('compileJava') {
-	options.compilerArgs += ['-Xlint:deprecation']
-}

--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/CheckBom.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/CheckBom.java
@@ -32,6 +32,7 @@ import org.apache.maven.artifact.versioning.VersionRange;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.tasks.TaskAction;
 
@@ -46,6 +47,7 @@ import org.springframework.boot.build.bom.bomr.version.DependencyVersion;
  * Checks the validity of a bom.
  *
  * @author Andy Wilkinson
+ * @author Wick Dynex
  */
 public abstract class CheckBom extends DefaultTask {
 
@@ -207,16 +209,32 @@ public abstract class CheckBom extends DefaultTask {
 		}
 	}
 
+//	private File resolveBom(Library library, String alignsWithBom) {
+//		String coordinates = alignsWithBom + ":" + library.getVersion().getVersion() + "@pom";
+//		Set<File> files = this.configurations.detachedConfiguration(this.dependencies.create(coordinates))
+//			.getResolvedConfiguration()
+//			.getFiles();
+//		if (files.size() != 1) {
+//			throw new IllegalStateException(
+//					"Expected a single file but '" + coordinates + "' resolved to " + files.size());
+//		}
+//		return files.iterator().next();
+//	}
+
+
 	private File resolveBom(Library library, String alignsWithBom) {
 		String coordinates = alignsWithBom + ":" + library.getVersion().getVersion() + "@pom";
-		Set<File> files = this.configurations.detachedConfiguration(this.dependencies.create(coordinates))
-			.getResolvedConfiguration()
-			.getFiles();
-		if (files.size() != 1) {
-			throw new IllegalStateException(
-					"Expected a single file but '" + coordinates + "' resolved to " + files.size());
-		}
-		return files.iterator().next();
-	}
 
+		Set<ResolvedArtifact> artifacts = this.configurations
+				.detachedConfiguration(this.dependencies.create(coordinates))
+				.getResolvedConfiguration()
+				.getResolvedArtifacts();
+
+		if (artifacts.size() != 1) {
+			throw new IllegalStateException(
+					"Expected a single file but '" + coordinates + "' resolved to " + artifacts.size());
+		}
+
+		return artifacts.iterator().next().getFile();
+	}
 }

--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/CheckBom.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/CheckBom.java
@@ -209,19 +209,6 @@ public abstract class CheckBom extends DefaultTask {
 		}
 	}
 
-//	private File resolveBom(Library library, String alignsWithBom) {
-//		String coordinates = alignsWithBom + ":" + library.getVersion().getVersion() + "@pom";
-//		Set<File> files = this.configurations.detachedConfiguration(this.dependencies.create(coordinates))
-//			.getResolvedConfiguration()
-//			.getFiles();
-//		if (files.size() != 1) {
-//			throw new IllegalStateException(
-//					"Expected a single file but '" + coordinates + "' resolved to " + files.size());
-//		}
-//		return files.iterator().next();
-//	}
-
-
 	private File resolveBom(Library library, String alignsWithBom) {
 		String coordinates = alignsWithBom + ":" + library.getVersion().getVersion() + "@pom";
 


### PR DESCRIPTION
## Description

This PR removes the usage of the deprecated `getFiles()` method in `CheckBom.class` and replaces it with the newer `getResolvedArtifacts()` method. The `getFiles()` method was deprecated due to its potential for incorrect behavior and its reliance on legacy API, while `getResolvedArtifacts()` provides a more reliable and modern approach to resolving dependencies.

### Backward compatibility

This change is fully backward-compatible and does not affect the existing functionality of the BOM resolution process. The `getResolvedArtifacts()` method is a direct replacement for `getFiles()` and provides the same functionality but with updated API usage.

---

## Related Issue
Fixed #43142

---

## Type of Change

- [X] Refactor feature
- [ ] Modify related tests
- [ ] Documentation update

---

## Checklist

- [X] I have reviewed the code for any potential issues or improvements.
- [X] I have run tests locally and they are passing.
- [X] I have followed the coding style and conventions of the project.

---

## Screenshots 

### Run Tests

<img width="1335" alt="image" src="https://github.com/user-attachments/assets/3cdcee6a-8d98-4422-aef1-c599bdd59799">


### Remove Warning

#### Before

<img width="1082" alt="image" src="https://github.com/user-attachments/assets/005dc2cb-13f9-40ba-8020-d70a22925709">

#### After

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/d87d06d6-2d33-4d07-a5f1-707e8a8194fe">


---

## Additional Notes

To display warning correctly, I modified the `build.gradle` file, and use command `./gradlew :buildSrc:compileJava --rerun-tasks -Duser.language=en` to show the warning obviously. But, I did't find the test class named `CheckBomTests`, but `BomPluginIntegrationTests` instead. I don't know whether it covers the method `resolveBom()` in `CheckBom`, so `TDD` workflow doesn't work. If there's some mistake, please leave a comment. Thanks~
