### PR TITLE
Add a configuration property to customize the Tomcat connector's max parameter count

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -73,6 +73,7 @@ import org.springframework.util.unit.DataSize;
  * @author Florian Storz
  * @author Michael Weidmann
  * @author Lasse Wulff
+ * @author Yanming Zhou
  * @since 1.0.0
  */
 @ConfigurationProperties(prefix = "server", ignoreUnknownFields = true)
@@ -513,13 +514,11 @@ public class ServerProperties {
 		 */
 		private DataSize maxHttpResponseHeaderSize = DataSize.ofKilobytes(8);
 
-		public DataSize getMaxHttpFormPostSize() {
-			return this.maxHttpFormPostSize;
-		}
-
-		public void setMaxHttpFormPostSize(DataSize maxHttpFormPostSize) {
-			this.maxHttpFormPostSize = maxHttpFormPostSize;
-		}
+		/**
+		 * Maximum number of parameters (GET plus POST) that will be automatically parsed
+		 * by the container. A value of less than 0 means no limit.
+		 */
+		private int maxParameterCount = 10000;
 
 		public Accesslog getAccesslog() {
 			return this.accesslog;
@@ -667,6 +666,22 @@ public class ServerProperties {
 
 		public void setMaxHttpResponseHeaderSize(DataSize maxHttpResponseHeaderSize) {
 			this.maxHttpResponseHeaderSize = maxHttpResponseHeaderSize;
+		}
+
+		public DataSize getMaxHttpFormPostSize() {
+			return this.maxHttpFormPostSize;
+		}
+
+		public void setMaxHttpFormPostSize(DataSize maxHttpFormPostSize) {
+			this.maxHttpFormPostSize = maxHttpFormPostSize;
+		}
+
+		public int getMaxParameterCount() {
+			return this.maxParameterCount;
+		}
+
+		public void setMaxParameterCount(int maxParameterCount) {
+			this.maxParameterCount = maxParameterCount;
 		}
 
 		/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
@@ -62,6 +62,7 @@ import org.springframework.util.unit.DataSize;
  * @author Parviz Rozikov
  * @author Florian Storz
  * @author Michael Weidmann
+ * @author Yanming Zhou
  * @since 2.0.0
  */
 public class TomcatWebServerFactoryCustomizer
@@ -119,6 +120,8 @@ public class TomcatWebServerFactoryCustomizer
 			.asInt(DataSize::toBytes)
 			.when((maxHttpFormPostSize) -> maxHttpFormPostSize != 0)
 			.to((maxHttpFormPostSize) -> customizeMaxHttpFormPostSize(factory, maxHttpFormPostSize));
+		map.from(properties::getMaxParameterCount)
+			.to((maxParameterCount) -> customizeMaxParameterCount(factory, maxParameterCount));
 		map.from(properties::getAccesslog)
 			.when(ServerProperties.Tomcat.Accesslog::isEnabled)
 			.to((enabled) -> customizeAccessLog(factory));
@@ -290,6 +293,10 @@ public class TomcatWebServerFactoryCustomizer
 
 	private void customizeMaxHttpFormPostSize(ConfigurableTomcatWebServerFactory factory, int maxHttpFormPostSize) {
 		factory.addConnectorCustomizers((connector) -> connector.setMaxPostSize(maxHttpFormPostSize));
+	}
+
+	private void customizeMaxParameterCount(ConfigurableTomcatWebServerFactory factory, int maxParameterCount) {
+		factory.addConnectorCustomizers((connector) -> connector.setMaxParameterCount(maxParameterCount));
 	}
 
 	private void customizeAccessLog(ConfigurableTomcatWebServerFactory factory) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -69,6 +69,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Chris Bono
  * @author Parviz Rozikov
  * @author Lasse Wulff
+ * @author Yanming Zhou
  */
 @DirtiesUrlFactories
 class ServerPropertiesTests {
@@ -199,7 +200,7 @@ class ServerPropertiesTests {
 	}
 
 	@Test
-	void testCustomizeUriEncoding() {
+	void testCustomizeTomcatUriEncoding() {
 		bind("server.tomcat.uri-encoding", "US-ASCII");
 		assertThat(this.properties.getTomcat().getUriEncoding()).isEqualTo(StandardCharsets.US_ASCII);
 	}
@@ -235,15 +236,21 @@ class ServerPropertiesTests {
 	}
 
 	@Test
-	void customizeMaxKeepAliveRequests() {
+	void testCustomizeTomcatMaxKeepAliveRequests() {
 		bind("server.tomcat.max-keep-alive-requests", "200");
 		assertThat(this.properties.getTomcat().getMaxKeepAliveRequests()).isEqualTo(200);
 	}
 
 	@Test
-	void customizeMaxKeepAliveRequestsWithInfinite() {
+	void testCustomizeTomcatMaxKeepAliveRequestsWithInfinite() {
 		bind("server.tomcat.max-keep-alive-requests", "-1");
 		assertThat(this.properties.getTomcat().getMaxKeepAliveRequests()).isEqualTo(-1);
+	}
+
+	@Test
+	void testCustomizeTomcatMaxParameterCount() {
+		bind("server.tomcat.max-parameter-count", "100");
+		assertThat(this.properties.getTomcat().getMaxParameterCount()).isEqualTo(100);
 	}
 
 	@Test
@@ -377,6 +384,12 @@ class ServerPropertiesTests {
 	void tomcatMaxHttpPostSizeMatchesConnectorDefault() {
 		assertThat(this.properties.getTomcat().getMaxHttpFormPostSize().toBytes())
 			.isEqualTo(getDefaultConnector().getMaxPostSize());
+	}
+
+	@Test
+	void tomcatMaxParameterCountMatchesConnectorDefault() {
+		assertThat(this.properties.getTomcat().getMaxParameterCount())
+			.isEqualTo(getDefaultConnector().getMaxParameterCount());
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizerTests.java
@@ -59,6 +59,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Victor Mandujano
  * @author Parviz Rozikov
  * @author Moritz Halbritter
+ * @author Yanming Zhou
  */
 class TomcatWebServerFactoryCustomizerTests {
 
@@ -192,6 +193,13 @@ class TomcatWebServerFactoryCustomizerTests {
 				((AbstractHttp11Protocol<?>) server.getTomcat().getConnector().getProtocolHandler())
 					.getMaxHttpRequestHeaderSize())
 			.isEqualTo(DataSize.ofMegabytes(10).toBytes()));
+	}
+
+	@Test
+	void customMaxParameterCount() {
+		bind("server.tomcat.max-parameter-count=100");
+		customizeAndRunServer(
+				(server) -> assertThat(server.getTomcat().getConnector().getMaxParameterCount()).isEqualTo(100));
 	}
 
 	@Test


### PR DESCRIPTION
Closes GH-43275
