### PR TITLE
Document how to use structured logging with custom log configuration

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/logging.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/logging.adoc
@@ -450,6 +450,34 @@ Spring Boot supports structured logging and has support for the following JSON f
 
 To enable structured logging, set the property configprop:logging.structured.format.console[] (for console output) or configprop:logging.structured.format.file[] (for file output) to the id of the format you want to use.
 
+If you are using xref:#features.logging.custom-log-configuration[Custom Log Configuration], update your configuration to respect `CONSOLE_LOG_STRUCTURED_FORMAT` and `FILE_LOG_STRUCTURED_FORMAT` system properties.
+Take `CONSOLE_LOG_STRUCTURED_FORMAT` for example:
+[tabs]
+======
+Logback::
++
+[source,xml]
+----
+<!-- replace your encoder with StructuredLogEncoder -->
+<encoder class="org.springframework.boot.logging.logback.StructuredLogEncoder">
+	<format>${CONSOLE_LOG_STRUCTURED_FORMAT}</format>
+	<charset>${CONSOLE_LOG_CHARSET}</charset>
+</encoder>
+----
+Log4j2::
++
+[source,xml]
+----
+<!-- replace your PatternLayout with StructuredLogLayout -->
+<StructuredLogLayout format="${sys:CONSOLE_LOG_STRUCTURED_FORMAT}" charset="${sys:CONSOLE_LOG_CHARSET}"/>
+----
+======
+You can refer to default configurations in `spring-boot.jar` for fine-grained control:
+
+* {code-spring-boot}/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/structured-console-appender.xml[Logback Structured Console Appender]
+* {code-spring-boot}/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/structured-file-appender.xml[Logback Structured File Appender]
+* {code-spring-boot}/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/log4j2/log4j2.xml[Log4j2 Console Appender]
+* {code-spring-boot}/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/log4j2/log4j2-file.xml[Log4j2 Console and File Appender]
 
 
 [[features.logging.structured.ecs]]


### PR DESCRIPTION
I try to enable structured logging by configuring
```yaml
logging:
  structured.format.console: ecs
  structured.format.file: ecs
```
It doesn't works because there is `log4j2.xml` in classpath, I think it's worthy to add warning to document.