### PR TITLE
Fix Javadoc link for Hikari

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -562,7 +562,7 @@ bom {
 		}
 		links {
 			site("https://github.com/brettwooldridge/HikariCP")
-			javadoc("https://javadoc.io/doc/com.zaxxer/HikariCP/{version}", "com.zaxxer.hikari")
+			javadoc("https://javadoc.io/doc/com.zaxxer/HikariCP/{version}/com.zaxxer.hikari", "com.zaxxer.hikari")
 		}
 	}
 	library("HSQLDB", "2.7.3") {


### PR DESCRIPTION
When I click [HikariDataSource](https://javadoc.io/doc/com.zaxxer/HikariCP/5.1.0/com/zaxxer/hikari/HikariDataSource.html), a `Hikari` javadoc page should be opened in a new tab instead `module-summary`

![image](https://github.com/user-attachments/assets/7c0912e1-bbdc-4648-888e-170234ccb75e)


Reference:

https://docs.spring.io/spring-boot/3.4-SNAPSHOT/how-to/data-access.html#howto.data-access.configure-custom-datasource