### PR TITLE
Fix wrong document

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/logging.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/logging.adoc
@@ -610,7 +610,6 @@ logging:
 ----
 
 TIP: For more advanced customizations, you can write your own class that implements the javadoc:org.springframework.boot.logging.structured.StructuredLoggingJsonMembersCustomizer[] interface and declare it using the configprop:logging.structured.json.customizer[] property.
-You can also declare implementations by listing them in a `META-INF/spring.factories` file.
 
 
 


### PR DESCRIPTION
The javadoc of `StructuredLoggingJsonMembersCustomizer` doesn't mention that, and I'm failed to reproduce it, I believe it cannot be loaded from `spring.factories`.
