### PR TITLE
Document that StructuredLoggingJsonMembersCustomizer implementations may optionally take constructor parameters

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/structured/StructuredLoggingJsonMembersCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/structured/StructuredLoggingJsonMembersCustomizer.java
@@ -25,6 +25,15 @@ import org.springframework.boot.json.JsonWriter.Members;
  * <p>
  * An implementation may be provided using the {@code logging.structured.json.customizer}
  * property.
+ * <p>
+ * {@code StructuredLoggingJsonMembersCustomizer} implementations may optionally take the
+ * following constructor parameters:
+ * <ul>
+ * <li>{@link org.springframework.core.env.Environment} - The Spring
+ * {@code Environment}.</li>
+ * <li>{@link ch.qos.logback.classic.pattern.ThrowableProxyConverter} - The Logback
+ * {@code ThrowableProxyConverter} (available only if Logback is using).</li>
+ * </ul>
  *
  * @param <T> the type being written
  * @author Phillip Webb


### PR DESCRIPTION
Similar to https://github.com/spring-projects/spring-boot/blob/f9aedf5a43e0b7d3282833c89d1a3c6611f7963c/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/env/EnvironmentPostProcessor.java#L37-L46