### PR TITLE
Fix links to Servlet and JPA javadoc

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -763,7 +763,7 @@ bom {
 		links {
 			site(version -> "https://jakarta.ee/specifications/persistence/%s.%s"
 				.formatted(version.major(), version.minor()))
-			javadoc(version -> "https://jakarta.ee/specifications/persistence/%s.%s/apidocs"
+			javadoc(version -> "https://jakarta.ee/specifications/persistence/%s.%s/apidocs/jakarta.persistence"
 				.formatted(version.major(), version.minor()), "jakarta.persistence")
 			releaseNotes(version -> "https://github.com/jakartaee/persistence/releases/tag/%s.%s-%s-RELEASE"
 				.formatted(version.major(), version.minor(), version))
@@ -782,7 +782,7 @@ bom {
 		links {
 			site(version -> "https://jakarta.ee/specifications/servlet/%s.%s"
 				.formatted(version.major(), version.minor()))
-			javadoc(version -> "https://jakarta.ee/specifications/servlet/%s.%s/apidocs"
+			javadoc(version -> "https://jakarta.ee/specifications/servlet/%s.%s/apidocs/jakarta.servlet"
 				.formatted(version.major(), version.minor()), "jakarta.servlet")
 		}
 	}


### PR DESCRIPTION
Reference javadoc links go to 404 page

>Any [Servlet](https://jakarta.ee/specifications/servlet/6.0/apidocs/jakarta/servlet/Servlet.html), [Filter](https://jakarta.ee/specifications/servlet/6.0/apidocs/jakarta/servlet/Filter.html)...

Reference
https://docs.spring.io/spring-boot/reference/web/servlet.html#web.servlet.embedded-container.servlets-filters-listeners.beans

<br/>

>...To get started, create some repository interfaces to handle your [@Entity](https://jakarta.ee/specifications/persistence/3.1/apidocs/jakarta/persistence/Entity.html) objects.

Reference
https://docs.spring.io/spring-boot/how-to/data-access.html#howto.data-access.spring-data-repositories