### PR TITLE
Polish formatting of log configuration file

### DIFF
--- a/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/log4j2/log4j2-file.xml
+++ b/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/log4j2/log4j2-file.xml
@@ -34,22 +34,22 @@
 				<ThresholdFilter level="${sys:FILE_LOG_THRESHOLD:-TRACE}"/>
 			</Filters>
 			<Policies>
-				<SizeBasedTriggeringPolicy size="10 MB" />
+				<SizeBasedTriggeringPolicy size="10 MB"/>
 			</Policies>
 		</RollingFile>
 	</Appenders>
 	<Loggers>
-		<Logger name="org.apache.catalina.startup.DigesterFactory" level="error" />
-		<Logger name="org.apache.catalina.util.LifecycleBase" level="error" />
-		<Logger name="org.apache.coyote.http11.Http11NioProtocol" level="warn" />
-		<Logger name="org.apache.sshd.common.util.SecurityUtils" level="warn"/>
-		<Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="warn" />
-		<Logger name="org.eclipse.jetty.util.component.AbstractLifeCycle" level="error" />
-		<Logger name="org.hibernate.validator.internal.util.Version" level="warn" />
-		<Logger name="org.springframework.boot.actuate.endpoint.jmx" level="warn"/>
-		<Root level="info">
-			<AppenderRef ref="Console" />
-			<AppenderRef ref="File" />
+		<Logger name="org.apache.catalina.startup.DigesterFactory" level="ERROR"/>
+		<Logger name="org.apache.catalina.util.LifecycleBase" level="ERROR"/>
+		<Logger name="org.apache.coyote.http11.Http11NioProtocol" level="WARN"/>
+		<Logger name="org.apache.sshd.common.util.SecurityUtils" level="WARN"/>
+		<Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="WARN"/>
+		<Logger name="org.eclipse.jetty.util.component.AbstractLifeCycle" level="ERROR"/>
+		<Logger name="org.hibernate.validator.internal.util.Version" level="WARN"/>
+		<Logger name="org.springframework.boot.actuate.endpoint.jmx" level="WARN"/>
+		<Root level="INFO">
+			<AppenderRef ref="Console"/>
+			<AppenderRef ref="File"/>
 		</Root>
 	</Loggers>
 </Configuration>

--- a/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/log4j2/log4j2.xml
+++ b/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/log4j2/log4j2.xml
@@ -17,22 +17,22 @@
 					<PatternLayout pattern="${sys:CONSOLE_LOG_PATTERN}" charset="${sys:CONSOLE_LOG_CHARSET}"/>
 				</DefaultArbiter>
 			</Select>
-			<filters>
+			<Filters>
 				<ThresholdFilter level="${sys:CONSOLE_LOG_THRESHOLD:-TRACE}"/>
-			</filters>
+			</Filters>
 		</Console>
 	</Appenders>
 	<Loggers>
-		<Logger name="org.apache.catalina.startup.DigesterFactory" level="error" />
-		<Logger name="org.apache.catalina.util.LifecycleBase" level="error" />
-		<Logger name="org.apache.coyote.http11.Http11NioProtocol" level="warn" />
-		<Logger name="org.apache.sshd.common.util.SecurityUtils" level="warn"/>
-		<Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="warn" />
-		<Logger name="org.eclipse.jetty.util.component.AbstractLifeCycle" level="error" />
-		<Logger name="org.hibernate.validator.internal.util.Version" level="warn" />
-		<Logger name="org.springframework.boot.actuate.endpoint.jmx" level="warn"/>
-		<Root level="info">
-			<AppenderRef ref="Console" />
+		<Logger name="org.apache.catalina.startup.DigesterFactory" level="ERROR"/>
+		<Logger name="org.apache.catalina.util.LifecycleBase" level="ERROR"/>
+		<Logger name="org.apache.coyote.http11.Http11NioProtocol" level="WARN"/>
+		<Logger name="org.apache.sshd.common.util.SecurityUtils" level="WARN"/>
+		<Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="WARN"/>
+		<Logger name="org.eclipse.jetty.util.component.AbstractLifeCycle" level="ERROR"/>
+		<Logger name="org.hibernate.validator.internal.util.Version" level="WARN"/>
+		<Logger name="org.springframework.boot.actuate.endpoint.jmx" level="WARN"/>
+		<Root level="INFO">
+			<AppenderRef ref="Console"/>
 		</Root>
 	</Loggers>
 </Configuration>

--- a/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/base.xml
+++ b/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/base.xml
@@ -5,12 +5,12 @@ Base logback configuration provided for compatibility with Spring Boot 1.1
 -->
 
 <included>
-	<include resource="org/springframework/boot/logging/logback/defaults.xml" />
+	<include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 	<property name="LOG_FILE" value="${LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}}/spring.log}"/>
-	<include resource="org/springframework/boot/logging/logback/console-appender.xml" />
-	<include resource="org/springframework/boot/logging/logback/file-appender.xml" />
+	<include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+	<include resource="org/springframework/boot/logging/logback/file-appender.xml"/>
 	<root level="INFO">
-		<appender-ref ref="CONSOLE" />
-		<appender-ref ref="FILE" />
+		<appender-ref ref="CONSOLE"/>
+		<appender-ref ref="FILE"/>
 	</root>
 </included>

--- a/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/defaults.xml
+++ b/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/logback/defaults.xml
@@ -5,12 +5,12 @@ Default logback configuration provided for import
 -->
 
 <included>
-	<conversionRule conversionWord="applicationName" class="org.springframework.boot.logging.logback.ApplicationNameConverter" />
-	<conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
-	<conversionRule conversionWord="correlationId" class="org.springframework.boot.logging.logback.CorrelationIdConverter" />
-	<conversionRule conversionWord="esb" class="org.springframework.boot.logging.logback.EnclosedInSquareBracketsConverter" />
-	<conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
-	<conversionRule conversionWord="wEx" class="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
+	<conversionRule conversionWord="applicationName" class="org.springframework.boot.logging.logback.ApplicationNameConverter"/>
+	<conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter"/>
+	<conversionRule conversionWord="correlationId" class="org.springframework.boot.logging.logback.CorrelationIdConverter"/>
+	<conversionRule conversionWord="esb" class="org.springframework.boot.logging.logback.EnclosedInSquareBracketsConverter"/>
+	<conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter"/>
+	<conversionRule conversionWord="wEx" class="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter"/>
 
 	<property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd'T'HH:mm:ss.SSSXXX}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}){} %clr(${PID:-}){magenta} %clr(--- %esb(){APPLICATION_NAME}%esb{APPLICATION_GROUP}[%15.15t] ${LOG_CORRELATION_PATTERN:-}){faint}%clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
 	<property name="CONSOLE_LOG_CHARSET" value="${CONSOLE_LOG_CHARSET:-${file.encoding:-UTF-8}}"/>

--- a/spring-boot-project/spring-boot/src/test/resources/logback-broken.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/logback-broken.xml
@@ -6,6 +6,6 @@
 		</encoder>
 	</appender>
 	<root level="INFO">
-		<appender-ref ref="CONSOLE" />
+		<appender-ref ref="CONSOLE"/>
 	</root>
 </configuration>

--- a/spring-boot-project/spring-boot/src/test/resources/logback-include-defaults.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/logback-include-defaults.xml
@@ -7,6 +7,6 @@
 		</encoder>
 	</appender>
 	<root level="INFO">
-		<appender-ref ref="CONSOLE" />
+		<appender-ref ref="CONSOLE"/>
 	</root>
 </configuration>

--- a/spring-boot-project/spring-boot/src/test/resources/logback-janino.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/logback-janino.xml
@@ -13,6 +13,6 @@
 		</filter>
 	</appender>
 	<root level="INFO">
-		<appender-ref ref="CONSOLE" />
+		<appender-ref ref="CONSOLE"/>
 	</root>
 </configuration>

--- a/spring-boot-project/spring-boot/src/test/resources/logback-nondefault.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/logback-nondefault.xml
@@ -6,6 +6,6 @@
 		</encoder>
 	</appender>
 	<root level="INFO">
-		<appender-ref ref="CONSOLE" />
+		<appender-ref ref="CONSOLE"/>
 	</root>
 </configuration>

--- a/spring-boot-project/spring-boot/src/test/resources/logback-springprofile-in-root.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/logback-springprofile-in-root.xml
@@ -7,7 +7,7 @@
 	</appender>
 	<root level="INFO">
 		<springProfile name="profile">
-			<appender-ref ref="CONSOLE" />
+			<appender-ref ref="CONSOLE"/>
 		</springProfile>
 	</root>
 </configuration>

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/dockerTest/resources/logback.xml
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/src/dockerTest/resources/logback.xml
@@ -5,6 +5,6 @@
 		</encoder>
 	</appender>
 	<root level="INFO">
-		<appender-ref ref="STDOUT" />
+		<appender-ref ref="STDOUT"/>
 	</root>
 </configuration>

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator-log4j2/src/main/resources/log4j2.xml
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator-log4j2/src/main/resources/log4j2.xml
@@ -10,9 +10,9 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="org.hibernate.validator.internal.util.Version" level="warn" />
-        <Logger name="org.apache.coyote.http11.Http11NioProtocol" level="warn" />
-        <Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="warn" />
+        <Logger name="org.hibernate.validator.internal.util.Version" level="warn"/>
+        <Logger name="org.apache.coyote.http11.Http11NioProtocol" level="warn"/>
+        <Logger name="org.apache.tomcat.util.net.NioSelectorPool" level="warn"/>
 
         <Root level="info">
             <AppenderRef ref="Console"/>

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/main/resources/logback.xml
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-	<include resource="org/springframework/boot/logging/logback/base.xml" />
+	<include resource="org/springframework/boot/logging/logback/base.xml"/>
 	<root level="INFO">
-		<appender-ref ref="CONSOLE" />
+		<appender-ref ref="CONSOLE"/>
 	</root>
 </configuration>

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-logback/src/main/resources/logback-spring.xml
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-logback/src/main/resources/logback-spring.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-	<include resource="org/springframework/boot/logging/logback/base.xml" />
-	<logger name="smoketest.logback" level="DEBUG" />
+	<include resource="org/springframework/boot/logging/logback/base.xml"/>
+	<logger name="smoketest.logback" level="DEBUG"/>
 	<springProfile name="staging">
-		<logger name="smoketest.logback" level="TRACE" />
+		<logger name="smoketest.logback" level="TRACE"/>
 	</springProfile>
 </configuration>


### PR DESCRIPTION
1. Remove space before `/>` to keep consistency.
2. Capitalize `filters` for Log4j2.
3. Uppercase log level to keep consistency.