### PR TITLE
Fix link to proxyBeanMethods in @AutoConfiguration javadoc

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfiguration.java
@@ -35,8 +35,8 @@ import org.springframework.core.annotation.AliasFor;
  * Indicates that a class provides configuration that can be automatically applied by
  * Spring Boot. Auto-configuration classes are regular
  * {@link Configuration @Configuration} with the exception that
- * {@literal Configuration#proxyBeanMethods() proxyBeanMethods} is always {@code false}.
- * They are located using {@link ImportCandidates}.
+ * {@link Configuration#proxyBeanMethods() proxyBeanMethods} is always {@code false}. They
+ * are located using {@link ImportCandidates}.
  * <p>
  * Generally auto-configuration classes are marked as {@link Conditional @Conditional}
  * (most often using {@link ConditionalOnClass @ConditionalOnClass} and


### PR DESCRIPTION
Based on how the `@AutoConfiguration` Javadoc is [currently rendered](https://javadoc.io/doc/org.springframework.boot/spring-boot-autoconfigure/latest/org/springframework/boot/autoconfigure/AutoConfiguration.html), I have the impression that the `@literal` should have been an `@link`.

![image](https://github.com/user-attachments/assets/92c699d3-81c0-4af4-b10a-38a9f331e547)


If that isn't the case, feel free to close this PR 🙂 