### PR TITLE
Accept progress on numbers >2GB

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/ProgressUpdateEvent.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/ProgressUpdateEvent.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
  * An {@link UpdateEvent} that includes progress information.
  *
  * @author Phillip Webb
+ * @author Wolfgang Kronberg
  * @since 2.3.0
  */
 public abstract class ProgressUpdateEvent extends UpdateEvent {
@@ -67,12 +68,12 @@ public abstract class ProgressUpdateEvent extends UpdateEvent {
 	 */
 	public static class ProgressDetail {
 
-		private final Integer current;
+		private final Long current;
 
-		private final Integer total;
+		private final Long total;
 
 		@JsonCreator
-		public ProgressDetail(Integer current, Integer total) {
+		public ProgressDetail(Long current, Long total) {
 			this.current = current;
 			this.total = total;
 		}
@@ -81,7 +82,7 @@ public abstract class ProgressUpdateEvent extends UpdateEvent {
 		 * Return the current progress value.
 		 * @return the current progress
 		 */
-		public int getCurrent() {
+		public long getCurrent() {
 			return this.current;
 		}
 
@@ -89,7 +90,7 @@ public abstract class ProgressUpdateEvent extends UpdateEvent {
 		 * Return the total progress possible value.
 		 * @return the total progress possible
 		 */
-		public int getTotal() {
+		public long getTotal() {
 			return this.total;
 		}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ProgressUpdateEventTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ProgressUpdateEventTests.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @param <E> The event type
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author Wolfgang Kronberg
  */
 abstract class ProgressUpdateEventTests<E extends ProgressUpdateEvent> {
 
@@ -45,6 +46,13 @@ abstract class ProgressUpdateEventTests<E extends ProgressUpdateEvent> {
 	}
 
 	@Test
+	void getProgressDetailsReturnsProgressDetailsForLongNumbers() {
+		ProgressUpdateEvent event = createEvent("status", new ProgressDetail(4000000000L, 8000000000L), "progress");
+		assertThat(event.getProgressDetail().getCurrent()).isEqualTo(4000000000L);
+		assertThat(event.getProgressDetail().getTotal()).isEqualTo(8000000000L);
+	}
+
+	@Test
 	void getProgressReturnsProgress() {
 		ProgressUpdateEvent event = createEvent();
 		assertThat(event.getProgress()).isEqualTo("progress");
@@ -52,24 +60,24 @@ abstract class ProgressUpdateEventTests<E extends ProgressUpdateEvent> {
 
 	@Test
 	void progressDetailIsEmptyWhenCurrentIsNullReturnsTrue() {
-		ProgressDetail detail = new ProgressDetail(null, 2);
+		ProgressDetail detail = new ProgressDetail(null, 2L);
 		assertThat(ProgressDetail.isEmpty(detail)).isTrue();
 	}
 
 	@Test
 	void progressDetailIsEmptyWhenTotalIsNullReturnsTrue() {
-		ProgressDetail detail = new ProgressDetail(1, null);
+		ProgressDetail detail = new ProgressDetail(1L, null);
 		assertThat(ProgressDetail.isEmpty(detail)).isTrue();
 	}
 
 	@Test
 	void progressDetailIsEmptyWhenTotalAndCurrentAreNotNullReturnsFalse() {
-		ProgressDetail detail = new ProgressDetail(1, 2);
+		ProgressDetail detail = new ProgressDetail(1L, 2L);
 		assertThat(ProgressDetail.isEmpty(detail)).isFalse();
 	}
 
 	protected E createEvent() {
-		return createEvent("status", new ProgressDetail(1, 2), "progress");
+		return createEvent("status", new ProgressDetail(1L, 2L), "progress");
 	}
 
 	protected abstract E createEvent(String status, ProgressDetail progressDetail, String progress);


### PR DESCRIPTION
Docker ProgressUpdateEvent may report file sizes larger than 2GB, but int has been used as the target type on parsing the according json output. If we attempt to push an image with a total size of >2GB, this will result in a build failure (although the image will still be pushed correctly).

This Pull Request fixes that by changing the affected types from int to long.
