### PR TITLE
Ensure DefaultErrorAttributes adds JSON serialization safe errors

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/error/ErrorWrapper.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/error/ErrorWrapper.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.error;
+
+import jakarta.annotation.Nullable;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.util.Assert;
+
+/**
+ * A wrapper class for error objects that implements {@link MessageSourceResolvable}.
+ * This class extends {@link DefaultMessageSourceResolvable} and delegates the
+ * message resolution to the wrapped error object.
+ *
+ * @author Yongjun Hong
+ * @since 3.5.0
+ */
+public class ErrorWrapper extends DefaultMessageSourceResolvable {
+
+	private final Object error;
+
+	/**
+	 * Create a new {@code ErrorWrapper} instance with the specified error.
+	 *
+	 * @param error the error object to wrap (must not be {@code null})
+	 */
+	public ErrorWrapper(Object error) {
+		this(error, null, null, null);
+	}
+
+	/**
+	 * Create a new {@code ErrorWrapper} instance with the specified error, codes,
+	 * arguments, and default message.
+	 *
+	 * @param error the error object to wrap (must not be {@code null})
+	 * @param codes the codes to be used for message resolution
+	 * @param arguments the arguments to be used for message resolution
+	 * @param defaultMessage the default message to be used if no message is found
+	 */
+	public ErrorWrapper(Object error, @Nullable String[] codes, @Nullable Object[] arguments, @Nullable String defaultMessage) {
+		super(codes, arguments, defaultMessage);
+		Assert.notNull(error, "Error must not be null");
+		this.error = error;
+	}
+
+	/**
+	 * Return the codes to be used for message resolution.
+	 *
+	 * @return the codes to be used for message resolution
+	 */
+	@Override
+	public String[] getCodes() {
+		return ((MessageSourceResolvable) this.error).getCodes();
+	}
+
+	/**
+	 * Return the arguments to be used for message resolution.
+	 *
+	 * @return the arguments to be used for message resolution
+	 */
+	@Override
+	public Object[] getArguments() {
+		return ((MessageSourceResolvable) this.error).getArguments();
+	}
+
+	/**
+	 * Return the default message to be used if no message is found.
+	 *
+	 * @return the default message to be used if no message is found
+	 */
+	@Override
+	public String getDefaultMessage() {
+		return ((MessageSourceResolvable) this.error).getDefaultMessage();
+	}
+
+}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributes.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/error/DefaultErrorAttributes.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.springframework.boot.web.error.ErrorWrapper;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
 import org.springframework.boot.web.error.ErrorAttributeOptions.Include;
 import org.springframework.core.annotation.MergedAnnotation;
@@ -32,7 +33,6 @@ import org.springframework.core.annotation.MergedAnnotations.SearchStrategy;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.ObjectError;
 import org.springframework.validation.method.MethodValidationResult;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.reactive.function.server.ServerRequest;
@@ -48,8 +48,8 @@ import org.springframework.web.server.ServerWebExchange;
  * <li>error - The error reason</li>
  * <li>exception - The class name of the root exception (if configured)</li>
  * <li>message - The exception message (if configured)</li>
- * <li>errors - Any {@link ObjectError}s from a {@link BindingResult} or
- * {@link MethodValidationResult} exception (if configured)</li>
+ * <li>errors - Any validation errors wrapped in {@link ErrorWrapper}, derived from a
+ * {@link BindingResult} or {@link MethodValidationResult} exception (if configured)</li>
  * <li>trace - The exception stack trace (if configured)</li>
  * <li>path - The URL path when the exception was raised</li>
  * <li>requestId - Unique ID associated with the current request</li>
@@ -61,6 +61,7 @@ import org.springframework.web.server.ServerWebExchange;
  * @author Scott Frederick
  * @author Moritz Halbritter
  * @author Yanming Zhou
+ * @author Yongjun Hong
  * @since 2.0.0
  * @see ErrorAttributes
  */
@@ -141,10 +142,9 @@ public class DefaultErrorAttributes implements ErrorAttributes {
 
 	private void addMessageAndErrorsFromMethodValidationResult(Map<String, Object> errorAttributes,
 			MethodValidationResult result) {
-		List<ObjectError> errors = result.getAllErrors()
+		List<ErrorWrapper> errors = result.getAllErrors()
 			.stream()
-			.filter(ObjectError.class::isInstance)
-			.map(ObjectError.class::cast)
+			.map(ErrorWrapper::new)
 			.toList();
 		errorAttributes.put("message",
 				"Validation failed for method='" + result.getMethod() + "'. Error count: " + errors.size());


### PR DESCRIPTION
resolved #42013 

- Added `ErrorWrapper` to enable `DefaultErrorAttributes` to handle errors related to `MethodValidationResult`.