### PR TITLE
Remove prohibited undertow upgrade restriction as it no longer applies

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -2468,10 +2468,6 @@ bom {
 		}
 	}
 	library("Undertow", "2.3.17.Final") {
-		prohibit {
-			versionRange "[2.3.18.Final]"
-			because "requires new framework patch due to regression (https://issues.redhat.com/browse/UNDERTOW-2512)"
-		}
 		group("io.undertow") {
 			modules = [
 				"undertow-core",


### PR DESCRIPTION
Removing the restriction from upgrading undertow.

See gh-43169
