### PR TITLE
Servlet-based UserDetailsServiceAutoConfiguration is active in a reactive app

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/UserDetailsServiceAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/UserDetailsServiceAutoConfiguration.java
@@ -31,6 +31,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration.MissingAlternativeOrUserPropertiesConfigured;
 import org.springframework.context.annotation.Bean;
@@ -53,6 +55,7 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Rob Winch
  * @author Madhura Bhave
+ * @author Lasse Wulff
  * @since 2.0.0
  */
 @AutoConfiguration
@@ -61,6 +64,7 @@ import org.springframework.util.StringUtils;
 @ConditionalOnBean(ObjectPostProcessor.class)
 @ConditionalOnMissingBean(value = { AuthenticationManager.class, AuthenticationProvider.class, UserDetailsService.class,
 		AuthenticationManagerResolver.class }, type = "org.springframework.security.oauth2.jwt.JwtDecoder")
+@ConditionalOnWebApplication(type = Type.SERVLET)
 public class UserDetailsServiceAutoConfiguration {
 
 	private static final String NOOP_PASSWORD_PREFIX = "{noop}";

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/servlet/UserDetailsServiceAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/servlet/UserDetailsServiceAutoConfigurationTests.java
@@ -26,7 +26,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.FilteredClassLoader;
-import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.annotation.Bean;
@@ -56,11 +56,12 @@ import static org.mockito.Mockito.mock;
  *
  * @author Madhura Bhave
  * @author HaiTao Zhang
+ * @author Lasse Wulff
  */
 @ExtendWith(OutputCaptureExtension.class)
 class UserDetailsServiceAutoConfigurationTests {
 
-	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+	private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
 		.withUserConfiguration(TestSecurityConfiguration.class)
 		.withConfiguration(AutoConfigurations.of(UserDetailsServiceAutoConfiguration.class));
 
@@ -192,7 +193,7 @@ class UserDetailsServiceAutoConfigurationTests {
 			.run(((context) -> assertThat(context).hasSingleBean(InMemoryUserDetailsManager.class)));
 	}
 
-	private Function<ApplicationContextRunner, ApplicationContextRunner> noOtherFormsOfAuthenticationOnTheClasspath() {
+	private Function<WebApplicationContextRunner, WebApplicationContextRunner> noOtherFormsOfAuthenticationOnTheClasspath() {
 		return (contextRunner) -> contextRunner
 			.withClassLoader(new FilteredClassLoader(ClientRegistrationRepository.class, OpaqueTokenIntrospector.class,
 					RelyingPartyRegistrationRepository.class));


### PR DESCRIPTION
The UserDetailsServiceAutoConfiguration is only to be active in a servlet based web application

See gh-43326