### PR TITLE
Refactor Remove redundant null check for sorter

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/annotation/Configurations.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/annotation/Configurations.java
@@ -92,7 +92,7 @@ public abstract class Configurations {
 		Assert.notNull(classes, "Classes must not be null");
 		sorter = (sorter != null) ? sorter : UnaryOperator.identity();
 		Collection<Class<?>> sorted = sorter.apply(classes);
-		this.sorter = (sorter != null) ? sorter : UnaryOperator.identity();
+		this.sorter = sorter;
 		this.classes = Collections.unmodifiableSet(new LinkedHashSet<>(sorted));
 		this.beanNameGenerator = beanNameGenerator;
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
I think the second Null check on the classifier field assignment is redundant because its value has already been processed in the previous part of the method. Therefore, I modified it by specifying the sorter that has already been processed.