### PR TITLE
refactor: remove unused  method from ValidationErrors

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/validation/ValidationErrors.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/validation/ValidationErrors.java
@@ -114,10 +114,6 @@ public class ValidationErrors implements Iterable<ObjectError> {
 		return this.boundProperties;
 	}
 
-	public boolean hasErrors() {
-		return !this.errors.isEmpty();
-	}
-
 	/**
 	 * Return the list of all validation errors.
 	 * @return the errors


### PR DESCRIPTION

It appears that the hasErrors method is not referenced anywhere in the codebase. Removing it helps to simplify the class and improve code maintainability.