### PR TITLE
Make ReactiveUserDetailsServiceAutoConfiguration conditional on reactive web app

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/reactive/ReactiveUserDetailsServiceAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/reactive/ReactiveUserDetailsServiceAutoConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.boot.autoconfigure.rsocket.RSocketMessagingAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -55,6 +56,7 @@ import org.springframework.util.StringUtils;
  * {@link ReactiveAuthenticationManagerResolver}.
  *
  * @author Madhura Bhave
+ * @author Lasse Wulff
  * @since 2.0.0
  */
 @AutoConfiguration(before = ReactiveSecurityAutoConfiguration.class, after = RSocketMessagingAutoConfiguration.class)
@@ -65,6 +67,7 @@ import org.springframework.util.StringUtils;
 		type = { "org.springframework.security.oauth2.jwt.ReactiveJwtDecoder" })
 @Conditional({ ReactiveUserDetailsServiceAutoConfiguration.RSocketEnabledOrReactiveWebApplication.class,
 		ReactiveUserDetailsServiceAutoConfiguration.MissingAlternativeOrUserPropertiesConfigured.class })
+@ConditionalOnWebApplication(type = Type.REACTIVE)
 @EnableConfigurationProperties(SecurityProperties.class)
 public class ReactiveUserDetailsServiceAutoConfiguration {
 


### PR DESCRIPTION
The UserDetailsServiceAutoConfiguration is only to be active in a reactive web application

I tried to align my tests to this commit https://github.com/spring-projects/spring-boot/commit/ff9fde0ef4a116bf13f0c5860414b0b2798fbdda
But I am not sure, if that is now entirely correct.
If you have remarks, please hit me up :)

See gh-43345
