### PR TITLE
Fix JUnit javadoc links

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1089,7 +1089,8 @@ bom {
 		}
 		links {
 			site("https://junit.org/junit5")
-			javadoc("https://junit.org/junit5/docs/{version}/api", "org.junit.jupiter.api", "org.junit.platform")
+			javadoc("junit-platform-engine", version -> "https://junit.org/junit5/docs/%s/api/org.junit.platform.engine".formatted(version), "org.junit.platform")
+			javadoc("junit-jupiter-api", version -> "https://junit.org/junit5/docs/%s/api/org.junit.jupiter.api".formatted(version), "org.junit.jupiter.api")
 			docs("https://junit.org/junit5/docs/{version}/user-guide")
 			releaseNotes("https://junit.org/junit5/docs/{version}/release-notes")
 		}


### PR DESCRIPTION
JUnit javadoc links go to page 404

<br/>

>The native image also includes the JUnit [TestEngine](https://junit.org/junit5/docs/5.11.3/api/org/junit/platform/engine/TestEngine.html) configured with a list of the discovered tests.

Reference
https://docs.spring.io/spring-boot/3.4-SNAPSHOT/how-to/native-image/testing-native-applications.html

<br/>

>...is a JUnit [Extension](https://junit.org/junit5/docs/5.11.3/api/org/junit/jupiter/api/extension/Extension.html) that you can use to capture...

Reference
https://docs.spring.io/spring-boot/3.4-SNAPSHOT/reference/testing/test-utilities.html

<br/>

>...method of the helper in your [@BeforeEach](https://junit.org/junit5/docs/5.11.3/api/org/junit/jupiter/api/BeforeEach.html) method if you do not use...

Reference
https://docs.spring.io/spring-boot/3.4-SNAPSHOT/reference/testing/spring-boot-applications.html

