### PR TITLE
spring-boot-maven-plugin sets imagePlatform even if it's empty

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/Image.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/Image.java
@@ -257,7 +257,7 @@ public class Image {
 		if (StringUtils.hasText(this.runImage)) {
 			request = request.withRunImage(ImageReference.of(this.runImage));
 		}
-		if (this.env != null && !this.env.isEmpty()) {
+		if (!CollectionUtils.isEmpty(this.env)) {
 			request = request.withEnv(this.env);
 		}
 		if (this.cleanCache != null) {
@@ -295,10 +295,10 @@ public class Image {
 		if (StringUtils.hasText(this.applicationDirectory)) {
 			request = request.withApplicationDirectory(this.applicationDirectory);
 		}
-		if (this.securityOptions != null) {
+		if (!CollectionUtils.isEmpty(this.securityOptions)) {
 			request = request.withSecurityOptions(this.securityOptions);
 		}
-		if (this.imagePlatform != null) {
+		if (StringUtils.hasText(this.imagePlatform)) {
 			request = request.withImagePlatform(this.imagePlatform);
 		}
 		return request;


### PR DESCRIPTION
A Docker image cannot be built with the spring-boot-maven-plugin:3.4.0 if Docker API version is less than 1.41. In particular, a Spring Boot project builds are failing in Bitbucket pipelines when no 'imagePlatform' option configured for the project with the following error
```
Docker API version must be at least 1.41 to support the 'imagePlatform' option, but current API version is 1.24
```

Using an empty `<imagePlatform/>` tag in the `pom.xml` doesn't help as Maven, most probably, assigns an empty string to the corresp. Java property.

The proposed fix is to check the config property for both null and empty string values.