### PR TITLE
Failures in -Djarmode=tools do not consistently return a non zero exit

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-classic/src/main/java/org/springframework/boot/loader/jarmode/JarModeLauncher.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-classic/src/main/java/org/springframework/boot/loader/jarmode/JarModeLauncher.java
@@ -40,8 +40,14 @@ public final class JarModeLauncher {
 				ClassUtils.getDefaultClassLoader());
 		for (JarMode candidate : candidates) {
 			if (candidate.accepts(mode)) {
-				candidate.run(mode, args);
-				return;
+				try {
+					candidate.run(mode, args);
+					return;
+				} catch (RuntimeException e) {
+					if (!Boolean.getBoolean(DISABLE_SYSTEM_EXIT)) {
+						System.exit(1);
+					}
+				}
 			}
 		}
 		System.err.println("Unsupported jarmode '" + mode + "'");

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/launch/JarModeRunner.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/launch/JarModeRunner.java
@@ -40,8 +40,14 @@ final class JarModeRunner {
 				ClassUtils.getDefaultClassLoader());
 		for (JarMode candidate : candidates) {
 			if (candidate.accepts(mode)) {
-				candidate.run(mode, args);
-				return;
+				try {
+					candidate.run(mode, args);
+					return;
+				} catch (RuntimeException e) {
+					if (!Boolean.getBoolean(DISABLE_SYSTEM_EXIT)) {
+						System.exit(1);
+					}
+				}
 			}
 		}
 		System.err.println("Unsupported jarmode '" + mode + "'");


### PR DESCRIPTION
Hello,

we are dealing with multiple Spring boot versions in our CI. 

As we want to leverage jar extraction and CDS, we need to deal with multiple scenarios :

1. Spring Boot 3.3+ and jar non-executable : extract and CDS are OK
1. Spring Boot < 3.3 : extract (and so CDS) is not available. It correctly fails with an exit(1) and claims `Unsupported jarmode 'tools'` . See [here](https://github.com/spring-projects/spring-boot/blob/86b0c768e72a5c2d4c2488718434e5d2f1bcfb3f/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/launch/JarModeRunner.java#L49C4-L49C19)
3. Spring Boot 3.3+ and jar executable : extract fails with `XXXX.jar is not compatible; ensure jar file is valid and launch script is not enabled` **but** when ran from CLI, the exit code is `0`, although an exception is thrown.

`3.` is painful, because you need to catch the STD output to check and grep for an error. Something like this pseudo bash

```bash
java -Djarmode=tools -jar /opt/my.jar extract --destination /opt/extracted 2>&1`; if [[ $cmd =~ "Error" ]] || [[ $cmd  =~ "Unsupported" ]]; then whatever_you_want_to_do; fi
```

This PR handles `3` by moving the exception to a system exit code, which seems to be more in line with this feature which is mostly intended to run as CLI and could lead to cleaner error handling, ie

```bash
java -Djarmode=tools -jar /opt/my.jar extract --destination /opt/extracted ||  whatever_you_want_to_do
```

