### PR TITLE
Allow specifying a different management access log prefix

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementServerProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementServerProperties.java
@@ -57,6 +57,8 @@ public class ManagementServerProperties {
 	@NestedConfigurationProperty
 	private Ssl ssl;
 
+	private final Accesslog accesslog = new Accesslog();
+
 	/**
 	 * Returns the management port or {@code null} if the
 	 * {@link ServerProperties#getPort() server port} should be used.
@@ -115,6 +117,28 @@ public class ManagementServerProperties {
 			}
 		}
 		return candidate;
+	}
+
+	public Accesslog getAccesslog() {
+		return this.accesslog;
+	}
+
+	public static class Accesslog {
+
+		/**
+		 * Enable management access logs prefix customization
+		 * management.server.accesslog.prefix.
+		 */
+		private String prefix = "management_";
+
+		public String getPrefix() {
+			return this.prefix;
+		}
+
+		public void setPrefix(String prefix) {
+			this.prefix = prefix;
+		}
+
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementServerPropertiesTests.java
@@ -68,4 +68,10 @@ class ManagementServerPropertiesTests {
 		assertThat(properties.getBasePath()).isEmpty();
 	}
 
+	@Test
+	void accessLogsArePrefixedByDefault() {
+		ManagementServerProperties properties = new ManagementServerProperties();
+		assertThat(properties.getAccesslog().getPrefix()).isEqualTo("management_");
+	}
+
 }


### PR DESCRIPTION
Hi,

This a WIP in order to try to tackle GH-14948, GH-24170 for example.
It's today very common to handle logs in stdout, regarding k8s and such 'cloud' platforms., ie

```yml
server:
 tomcat:
    accesslog:
      enabled: true
      directory: /dev
      prefix: stdout
      suffix:
 ```

It's also reassuring (for SEC) to make actuator available on another port. Wrong properties can easily leak and bad things may happen.

This is just a draft to see if this could be an answer in order to have the ability to disable the access logs prefix while using actuator on an other port. Most companies that put logs in stdout can easily filter logs with tools like [Splunk](https://www.splunk.com), so putting all those logs in the same output is not a problem at all.

The idea is to add a property to disable access logs prefix for actuator. Default is `true` to keep BC

`management.server.accesslog-prefix=false`

Is this the good direction?

Thanks