### PR TITLE
Links to logback javadoc are incorrect

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1241,7 +1241,7 @@ bom {
 		}
 		links {
 			site("https://logback.qos.ch")
-			javadoc("https://logback.qos.ch/apidocs", "ch.qos.logback")
+			javadoc("https://logback.qos.ch/apidocs/ch.qos.logback.core", "ch.qos.logback")
 		}
 	}
 	library("Lombok", "1.18.36") {


### PR DESCRIPTION
[ConsoleAppender](https://logback.qos.ch/apidocs/ch/qos/logback/core/ConsoleAppender.html) goes to page 404

Reference
https://docs.spring.io/spring-boot/how-to/logging.html