### PR TITLE
Kafka dependency management does not include the kafka-server module

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1115,6 +1115,7 @@ bom {
 				"kafka-log4j-appender",
 				"kafka-metadata",
 				"kafka-raft",
+				"kafka-server",
 				"kafka-server-common",
 				"kafka-server-common" {
 					classifier = "test"


### PR DESCRIPTION
Apache Kafka now ships a new module, kafka-server, since the 3.7.0 release. The `3.9.0` kafka-client introduced some breaking changes that require this dependecy for the `EmbeddedKafka` support in Spring for Apache Kafka. This commit adds this dependecny for Spring Boot based Spring Kafka projects.

