### PR TITLE
Fix typo

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
@@ -114,7 +114,7 @@ javadoc {
 		use = true
 		windowTitle = "Spring Boot Gradle Plugin ${project.version} API"
 		links "https://docs.gradle.org/$gradle.gradleVersion/javadoc/"
-		links "https://docs.oracle.com/en/java/javase/17/docs/api/"
+		links "https://docs.oracle.com/en/java/javase/17/docs/api"
 	}
 }
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/reacting.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/reacting.adoc
@@ -17,7 +17,7 @@ When Gradle's {url-gradle-docs-java-plugin}[`java` plugin] is applied to a proje
 3. Configures the `jar` task to use `plain` as the convention for its archive classifier.
 4. Creates a {apiref-gradle-plugin-boot-build-image}[`BootBuildImage`] task named `bootBuildImage` that will create a OCI image using a https://buildpacks.io[buildpack].
 5. Creates a {apiref-gradle-plugin-boot-run}[`BootRun`] task named `bootRun` that can be used to run your application using the `main` source set to find its main method and provide its runtime classpath.
-6. Creates a {apiref-gradle-plugin-boot-run}['BootRun`] task named `bootTestRun` that can be used to run your application using the `test` source set to find its main method and provide its runtime classpath.
+6. Creates a {apiref-gradle-plugin-boot-run}[`BootRun`] task named `bootTestRun` that can be used to run your application using the `test` source set to find its main method and provide its runtime classpath.
 7. Creates a configuration named `bootArchives` that contains the artifact produced by the `bootJar` task.
 8. Creates a configuration named `developmentOnly` for dependencies that are only required at development time, such as Spring Boot's Devtools, and should not be packaged in executable jars and wars.
 9. Creates a configuration named `testAndDevelopmentOnly` for dependencies that are only required at development time and when writing and running tests and that should not be packaged in executable jars and wars.


### PR DESCRIPTION
I see double slash in javadoc link and remove one. Please check and tell me if something goes wrong

> To configure your own [DataSource](https://docs.oracle.com/en/java/javase/17/docs/api//java.sql/javax/sql/DataSource.html) ...

Reference
https://docs.spring.io/spring-boot/3.4-SNAPSHOT/how-to/data-access.html
<br/>

Fix typo format `BootRun`

Reference
https://docs.spring.io/spring-boot/3.4-SNAPSHOT/gradle-plugin/reacting.html