### PR TITLE
Remove usage of java.home system property in native image

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/ApplicationTemp.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/system/ApplicationTemp.java
@@ -31,6 +31,7 @@ import java.util.HexFormat;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.springframework.core.NativeDetector;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -145,7 +146,10 @@ public class ApplicationTemp {
 			update(digest, home.getSource());
 			update(digest, home.getDir());
 			update(digest, System.getProperty("user.dir"));
-			update(digest, System.getProperty("java.home"));
+			if (!NativeDetector.inNativeImage()) {
+				String javaHome = System.getProperty("java.home");
+				update(digest, javaHome);
+			}
 			update(digest, System.getProperty("java.class.path"));
 			update(digest, System.getProperty("sun.java.command"));
 			update(digest, System.getProperty("sun.boot.class.path"));


### PR DESCRIPTION
Overview
---
1. Provides an explicit null check.
2. Prevents issues in native image mode.

Related Issues
---
#43050

