### PR TITLE
Hint about Testcontainers in DataSourceBeanCreationFailureAnalyzer

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBeanCreationFailureAnalyzer.java
@@ -66,8 +66,8 @@ class DataSourceBeanCreationFailureAnalyzer extends AbstractFailureAnalyzer<Data
 		StringBuilder action = new StringBuilder();
 		action.append(String.format("Consider the following:%n"));
 		if (EmbeddedDatabaseConnection.NONE == cause.getConnection()) {
-			action.append(String
-					.format("\tIf you're using Testcontainers to set up your development datasource, consider starting the application from the test sources instead.%n"));
+			action.append(String.format(
+					"\tIf you're using Testcontainers to set up your development datasource, consider starting the application from the test sources instead.%n"));
 			action.append(String
 				.format("\tIf you want an embedded database (H2, HSQL or Derby), please put it on the classpath.%n"));
 		}


### PR DESCRIPTION
I'm a big fan of setting up the developent time datasource with Testcontainers. The problem I see people checking out and trying my examples/demos is that they are not (yet) familiar with the idea of starting the development time server from the srs/test/java.  

Similarly to which DataSourceBeanCreationFailureAnalyzer currently hints about embedded databases, I think in 2024 it should hint somehow about Testcontainers too. Probably just guiding them to seek an application class from the test sources is enough (like currently in this PR), but maybe it should mention e.g. `mvn spring-boot:test-run` 🤷‍♂️

For one of my recent demos I [added an app specific FailureAnalyzer](https://github.com/mstahv/sakila-spring-data-jpa-starter/blob/mysql/src/main/java/com/example/demo/TestcontainersNewbieAnalyzer.java), but I don't think that is a good approach.
