### PR TITLE
FileWatcher used for SSL reload does not support symlinks

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/FileWatcher.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/FileWatcher.java
@@ -86,12 +86,23 @@ class FileWatcher implements Closeable {
 					this.thread = new WatcherThread();
 					this.thread.start();
 				}
-				this.thread.register(new Registration(paths, action));
+				this.thread.register(new Registration(resolveSymlinks(paths), action));
 			}
 			catch (IOException ex) {
 				throw new UncheckedIOException("Failed to register paths for watching: " + paths, ex);
 			}
 		}
+	}
+
+	private Set<Path> resolveSymlinks(Set<Path> paths) throws IOException {
+		Set<Path> result = new HashSet<>();
+		for (Path path : paths) {
+			result.add(path);
+			if (Files.isSymbolicLink(path)) {
+				result.add(Files.readSymbolicLink(path));
+			}
+		}
+		return result;
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/FileWatcher.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/FileWatcher.java
@@ -97,10 +97,7 @@ class FileWatcher implements Closeable {
 	private Set<Path> resolveSymlinks(Set<Path> paths) throws IOException {
 		Set<Path> result = new HashSet<>();
 		for (Path path : paths) {
-			result.add(path);
-			if (Files.isSymbolicLink(path)) {
-				result.add(Files.readSymbolicLink(path));
-			}
+			result.add(Files.isSymbolicLink(path) ? Files.readSymbolicLink(path) : path);
 		}
 		return result;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ssl/FileWatcherTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ssl/FileWatcherTests.java
@@ -95,6 +95,18 @@ class FileWatcherTests {
 	}
 
 	@Test
+	void shouldFollowSymlink(@TempDir Path tempDir) throws Exception {
+		Path realFile = tempDir.resolve("realFile.txt");
+		Path symLink = tempDir.resolve("symlink.txt");
+		Files.createFile(realFile);
+		Files.createSymbolicLink(symLink, realFile);
+		WaitingCallback callback = new WaitingCallback();
+		this.fileWatcher.watch(Set.of(symLink), callback);
+		Files.writeString(realFile, "Some content");
+		callback.expectChanges();
+	}
+
+	@Test
 	void shouldIgnoreNotWatchedFiles(@TempDir Path tempDir) throws Exception {
 		Path watchedFile = tempDir.resolve("watched.txt");
 		Path notWatchedFile = tempDir.resolve("not-watched.txt");


### PR DESCRIPTION
This allows using symlinks for SSL certificate hot reloading.

In my company we have services on k8s with SSL certificates stored on a mounted volumes. Since they are symlinks, we cannot use hot-reloading, because the content is changed in the file under the symlink, not the symlink itself. This change make `FileWatcher` watch not only the symlink, but also the file it resolves to.