### PR TITLE
Remove unused ScopedFooConfiguration in ConditionalOnMissingBeanTests

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnMissingBeanTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionalOnMissingBeanTests.java
@@ -683,17 +683,6 @@ class ConditionalOnMissingBeanTests {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@TestAnnotation
-	static class ScopedFooConfiguration {
-
-		@Bean
-		String foo() {
-			return "foo";
-		}
-
-	}
-
-	@Configuration(proxyBeanMethods = false)
 	static class NotAutowireCandidateConfig {
 
 		@Bean(autowireCandidate = false)


### PR DESCRIPTION
This PR removes the unused `ScopedFooConfiguration` in the `ConditionalOnMissingBeanTests` that was added in 86b0c768e72a5c2d4c2488718434e5d2f1bcfb3f.