### PR TITLE
Centralize logging for health indicator failures

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/AbstractHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/AbstractHealthIndicator.java
@@ -18,12 +18,8 @@ package org.springframework.boot.actuate.health;
 
 import java.util.function.Function;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import org.springframework.boot.actuate.health.Health.Builder;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 /**
  * Base {@link HealthIndicator} implementations that encapsulates creation of
@@ -39,10 +35,6 @@ import org.springframework.util.StringUtils;
 public abstract class AbstractHealthIndicator implements HealthIndicator {
 
 	private static final String NO_MESSAGE = null;
-
-	private static final String DEFAULT_MESSAGE = "Health check failed";
-
-	private final Log logger = LogFactory.getLog(getClass());
 
 	private final Function<Exception, String> healthCheckFailedMessage;
 
@@ -84,15 +76,8 @@ public abstract class AbstractHealthIndicator implements HealthIndicator {
 		catch (Exception ex) {
 			builder.down(ex);
 		}
-		logExceptionIfPresent(builder.getException());
+		HealthLogger.logExceptionIfPresent(builder.getException());
 		return builder.build();
-	}
-
-	private void logExceptionIfPresent(Throwable throwable) {
-		if (throwable != null && this.logger.isWarnEnabled()) {
-			String message = (throwable instanceof Exception ex) ? this.healthCheckFailedMessage.apply(ex) : null;
-			this.logger.warn(StringUtils.hasText(message) ? message : DEFAULT_MESSAGE, throwable);
-		}
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Health.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/Health.java
@@ -55,6 +55,8 @@ public final class Health extends HealthComponent {
 
 	private final Map<String, Object> details;
 
+	private final Throwable exception;
+
 	/**
 	 * Create a new {@link Health} instance with the specified status and details.
 	 * @param builder the Builder to use
@@ -63,11 +65,13 @@ public final class Health extends HealthComponent {
 		Assert.notNull(builder, "Builder must not be null");
 		this.status = builder.status;
 		this.details = Collections.unmodifiableMap(builder.details);
+		this.exception = builder.exception;
 	}
 
 	Health(Status status, Map<String, Object> details) {
 		this.status = status;
 		this.details = details;
+		this.exception = null;
 	}
 
 	/**
@@ -86,6 +90,14 @@ public final class Health extends HealthComponent {
 	@JsonInclude(Include.NON_EMPTY)
 	public Map<String, Object> getDetails() {
 		return this.details;
+	}
+
+	/**
+	 * Return the exception of the health.
+	 * @return the exception (or {@code null})
+	 */
+	public Throwable getException() {
+		return this.exception;
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthEndpointSupport.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthEndpointSupport.java
@@ -169,7 +169,9 @@ abstract class HealthEndpointSupport<C, T> {
 	private T getLoggedHealth(C contributor, String name, boolean showDetails) {
 		Instant start = Instant.now();
 		try {
-			return getHealth(contributor, showDetails);
+			T health = getHealth(contributor, showDetails);
+			HealthLogger.logExceptionIfPresent(health.getException());
+			return health;
 		}
 		finally {
 			if (logger.isWarnEnabled() && this.slowIndicatorLoggingThreshold != null) {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthLogger.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthLogger.java
@@ -1,0 +1,18 @@
+package org.springframework.boot.actuate.health;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.util.StringUtils;
+
+public class HealthLogger {
+
+    private static final Log logger = LogFactory.getLog(HealthLogger.class);
+    private static final String DEFAULT_MESSAGE = "Health check failed";
+
+    public static void logExceptionIfPresent(Throwable throwable) {
+        if (throwable != null && logger.isWarnEnabled()) {
+            String message = (throwable instanceof Exception ex) ? ex.getMessage() : null;
+            logger.warn(StringUtils.hasText(message) ? message : DEFAULT_MESSAGE, throwable);
+        }
+    }
+}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthLoggerTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthLoggerTests.java
@@ -1,0 +1,36 @@
+package org.springframework.boot.actuate.health;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(OutputCaptureExtension.class)
+class HealthLoggerTests {
+
+    private static final Log logger = LogFactory.getLog(HealthLogger.class);
+
+    @Test
+    void logExceptionIfPresentShouldLogException(CapturedOutput output) {
+        Exception exception = new Exception("Test exception");
+        HealthLogger.logExceptionIfPresent(exception);
+        assertThat(output).contains("Test exception");
+    }
+
+    @Test
+    void logExceptionIfPresentShouldNotLogWhenNoException(CapturedOutput output) {
+        HealthLogger.logExceptionIfPresent(null);
+        assertThat(output).doesNotContain("Health check failed");
+    }
+
+    @Test
+    void logExceptionIfPresentShouldLogDefaultMessageWhenNoMessage(CapturedOutput output) {
+        Exception exception = new Exception();
+        HealthLogger.logExceptionIfPresent(exception);
+        assertThat(output).contains("Health check failed");
+    }
+}


### PR DESCRIPTION
Centralize logging for health indicator failures.

* Add `HealthLogger` class to centralize logging for health indicator failures.
* Remove `logExceptionIfPresent` method from `AbstractHealthIndicator` and `AbstractReactiveHealthIndicator`.
* Update `AbstractHealthIndicator` and `AbstractReactiveHealthIndicator` to use `HealthLogger.logExceptionIfPresent`.
* Add `exception` field to `Health` class and update `Builder` class to set the `exception` field.
* Add `getException` method to `Health` class to retrieve the exception.
* Update `HealthEndpointSupport` to use `HealthLogger.logExceptionIfPresent`.
* Add `HealthLoggerTests` class to test the `HealthLogger` class.

