### PR TITLE
feat: spring-boot.build-image.* should not be read-only

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildImageMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildImageMojo.java
@@ -107,7 +107,7 @@ public abstract class BuildImageMojo extends AbstractPackagerMojo {
 	 * property.
 	 * @since 2.3.0
 	 */
-	@Parameter(property = "spring-boot.build-image.imageName", readonly = true)
+	@Parameter(property = "spring-boot.build-image.imageName")
 	String imageName;
 
 	/**
@@ -115,14 +115,14 @@ public abstract class BuildImageMojo extends AbstractPackagerMojo {
 	 * property.
 	 * @since 2.3.0
 	 */
-	@Parameter(property = "spring-boot.build-image.builder", readonly = true)
+	@Parameter(property = "spring-boot.build-image.builder")
 	String imageBuilder;
 
 	/**
 	 * Alias for {@link Image#trustBuilder} to support configuration through command-line
 	 * property.
 	 */
-	@Parameter(property = "spring-boot.build-image.trustBuilder", readonly = true)
+	@Parameter(property = "spring-boot.build-image.trustBuilder")
 	Boolean trustBuilder;
 
 	/**
@@ -130,7 +130,7 @@ public abstract class BuildImageMojo extends AbstractPackagerMojo {
 	 * property.
 	 * @since 2.3.1
 	 */
-	@Parameter(property = "spring-boot.build-image.runImage", readonly = true)
+	@Parameter(property = "spring-boot.build-image.runImage")
 	String runImage;
 
 	/**
@@ -138,21 +138,21 @@ public abstract class BuildImageMojo extends AbstractPackagerMojo {
 	 * property.
 	 * @since 2.4.0
 	 */
-	@Parameter(property = "spring-boot.build-image.cleanCache", readonly = true)
+	@Parameter(property = "spring-boot.build-image.cleanCache")
 	Boolean cleanCache;
 
 	/**
 	 * Alias for {@link Image#pullPolicy} to support configuration through command-line
 	 * property.
 	 */
-	@Parameter(property = "spring-boot.build-image.pullPolicy", readonly = true)
+	@Parameter(property = "spring-boot.build-image.pullPolicy")
 	PullPolicy pullPolicy;
 
 	/**
 	 * Alias for {@link Image#publish} to support configuration through command-line
 	 * property.
 	 */
-	@Parameter(property = "spring-boot.build-image.publish", readonly = true)
+	@Parameter(property = "spring-boot.build-image.publish")
 	Boolean publish;
 
 	/**
@@ -160,7 +160,7 @@ public abstract class BuildImageMojo extends AbstractPackagerMojo {
 	 * property.
 	 * @since 2.6.0
 	 */
-	@Parameter(property = "spring-boot.build-image.network", readonly = true)
+	@Parameter(property = "spring-boot.build-image.network")
 	String network;
 
 	/**
@@ -168,7 +168,7 @@ public abstract class BuildImageMojo extends AbstractPackagerMojo {
 	 * property.
 	 * @since 3.1.0
 	 */
-	@Parameter(property = "spring-boot.build-image.createdDate", readonly = true)
+	@Parameter(property = "spring-boot.build-image.createdDate")
 	String createdDate;
 
 	/**
@@ -176,7 +176,7 @@ public abstract class BuildImageMojo extends AbstractPackagerMojo {
 	 * command-line property.
 	 * @since 3.1.0
 	 */
-	@Parameter(property = "spring-boot.build-image.applicationDirectory", readonly = true)
+	@Parameter(property = "spring-boot.build-image.applicationDirectory")
 	String applicationDirectory;
 
 	/**
@@ -184,7 +184,7 @@ public abstract class BuildImageMojo extends AbstractPackagerMojo {
 	 * property.
 	 * @since 3.4.0
 	 */
-	@Parameter(property = "spring-boot.build-image.imagePlatform", readonly = true)
+	@Parameter(property = "spring-boot.build-image.imagePlatform")
 	String imagePlatform;
 
 	/**


### PR DESCRIPTION
Hi!

With Spring Boot 3.4+, it's now possible to build a docker image from an `amd64` host for an `arm64` platform. It works and it's awesome!

But while setting the parameter in the pom, or by command line, ie `mvn clean -Pnative spring-boot:build-image -Dspring-boot.build-image.imagePlatform=linux/arm64`, maven warns :

`Parameter 'imagePlatform' (user property 'spring-boot.build-image.imagePlatform') is read-only, must not be used in configuration`

IMO, the readonly flag should be removed here