### PR TITLE
Documentation still has references to 'layertools'

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -862,7 +862,7 @@ bom {
 		}
 		links {
 			releaseNotes("https://github.com/jakartaee/jaxb-api/releases/tag/{version}")
-			javadoc(version -> "https://jakarta.ee/specifications/xml-binding/%s.%s/apidocs"
+			javadoc(version -> "https://jakarta.ee/specifications/xml-binding/%s.%s/apidocs/jakarta.xml.bind"
 				.formatted(version.major(), version.minor()), "jakarta.xml.bind")
 		}
 	}

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/container-images/dockerfiles.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/container-images/dockerfiles.adoc
@@ -6,7 +6,7 @@ When you create a jar containing the layers index file, the `spring-boot-jarmode
 With this jar on the classpath, you can launch your application in a special mode which allows the bootstrap code to run something entirely different from your application, for example, something that extracts the layers.
 
 CAUTION: The `tools` mode can not be used with a xref:how-to:deployment/installing.adoc[fully executable Spring Boot archive] that includes a launch script.
-Disable launch script configuration when building a jar file that is intended to be used with `layertools`.
+Disable launch script configuration when building a jar file that is intended to be used with `extract` tools mode command.
 
 Here’s how you can launch your jar with a `tools` jar mode:
 


### PR DESCRIPTION
Change `layertools` to `tools`
Closes https://github.com/spring-projects/spring-boot/issues/43565

<br>

Fix `@XmlRootElement` javadoc links

Reference
https://docs.spring.io/spring-boot/how-to/spring-mvc.html#howto.spring-mvc.write-xml-rest-service
