### PR TITLE
Build info timestamp is truncated to seconds

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/MavenBuildOutputTimestamp.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/MavenBuildOutputTimestamp.java
@@ -88,7 +88,7 @@ class MavenBuildOutputTimestamp {
 		try {
 			Instant instant = OffsetDateTime.parse(this.timestamp)
 				.withOffsetSameInstant(ZoneOffset.UTC)
-				.truncatedTo(ChronoUnit.SECONDS)
+				.truncatedTo(ChronoUnit.MILLIS)
 				.toInstant();
 			if (instant.isBefore(DATE_MIN) || instant.isAfter(DATE_MAX)) {
 				throw new IllegalArgumentException(

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/MavenBuildOutputTimestampTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/MavenBuildOutputTimestampTests.java
@@ -52,8 +52,13 @@ class MavenBuildOutputTimestampTests {
 	}
 
 	@Test
-	void shouldParseIso8601WithMilliseconds() {
-		assertThat(parse("2011-12-03T10:15:30.12345Z")).isEqualTo(Instant.parse("2011-12-03T10:15:30Z"));
+	void shouldParseIso8601WithSeconds_whenMillisecondsNotPresent() {
+		assertThat(parse("2011-12-03T10:15:30Z")).isEqualTo(Instant.parse("2011-12-03T10:15:30Z"));
+	}
+
+	@Test
+	void shouldParseIso8601WithMillisecondsPreserved_whenPresent() {
+		assertThat(parse("2024-12-19T19:59:39.040Z")).isEqualTo(Instant.parse("2024-12-19T19:59:39.040Z"));
 	}
 
 	@Test


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

This is a fix for: https://github.com/spring-projects/spring-boot/issues/43581
Build info timestamp is truncated to seconds

The fix is to update the method that converts to an Instant to cater for milliseconds too and includes test fixes and changes. I have added test that validates the current behaviour will also work as usual in addition to adding Sub Seconds.
