### PR TITLE
Fix assert null checks with dynamic error messages

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/http/client/ReflectiveComponentsClientHttpRequestFactoryBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/http/client/ReflectiveComponentsClientHttpRequestFactoryBuilder.java
@@ -44,12 +44,12 @@ final class ReflectiveComponentsClientHttpRequestFactoryBuilder<T extends Client
 	private final Supplier<T> requestFactorySupplier;
 
 	ReflectiveComponentsClientHttpRequestFactoryBuilder(Supplier<T> requestFactorySupplier) {
-		Assert.notNull(requestFactorySupplier, "'requestFactorySupplier' must not be null");
+		Assert.notNull(requestFactorySupplier, () -> String.format("'%s' must not be null", "requestFactorySupplier"));
 		this.requestFactorySupplier = requestFactorySupplier;
 	}
 
 	ReflectiveComponentsClientHttpRequestFactoryBuilder(Class<T> requestFactoryType) {
-		Assert.notNull(requestFactoryType, "'requestFactoryType' must not be null");
+		Assert.notNull(requestFactoryType, () -> String.format("'%s' must not be null", "requestFactoryType"));
 		this.requestFactorySupplier = () -> createRequestFactory(requestFactoryType);
 	}
 


### PR DESCRIPTION
This pull request introduces improvements to the assert error message format in the constructors of ReflectiveComponentsClientHttpRequestFactoryBuilder. By using dynamic error messages, it becomes easier to modify and improve the messages in the future.