### PR TITLE
Refactor: Reuse existing variable for logger name in SimpleFormatter

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/java/SimpleFormatter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/java/SimpleFormatter.java
@@ -45,7 +45,7 @@ public class SimpleFormatter extends Formatter {
 		String message = formatMessage(record);
 		String throwable = getThrowable(record);
 		String thread = getThreadName();
-		return String.format(this.format, date, source, record.getLoggerName(), record.getLevel().getLocalizedName(),
+		return String.format(this.format, date, source, source, record.getLevel().getLocalizedName(),
 				message, throwable, thread, this.pid);
 	}
 


### PR DESCRIPTION
In the format method of SimpleFormatter, I noticed that the source variable and record.getLoggerName() are used interchangeably, even though they represent the exact same value. Since the result of getLoggerName() is already stored in the source variable, it makes sense to reuse it rather than calling the method again. This change simplifies the code, avoids redundancy, and makes it more consistent and easier to read.






