### PR TITLE
Fix default StringHttpMessageConverter

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/HttpMessageConverters.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/HttpMessageConverters.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.support.AllEncompassingFormHttpMessageConverter;
 import org.springframework.http.converter.xml.AbstractXmlHttpMessageConverter;
 import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
@@ -121,14 +122,24 @@ public class HttpMessageConverters implements Iterable<HttpMessageConverter<?>> 
 		List<HttpMessageConverter<?>> processing = new ArrayList<>(converters);
 		for (HttpMessageConverter<?> defaultConverter : defaultConverters) {
 			Iterator<HttpMessageConverter<?>> iterator = processing.iterator();
+			boolean skipDefault = false;
 			while (iterator.hasNext()) {
 				HttpMessageConverter<?> candidate = iterator.next();
 				if (isReplacement(defaultConverter, candidate)) {
 					combined.add(candidate);
 					iterator.remove();
+
+					if (defaultConverter instanceof StringHttpMessageConverter
+							&& defaultConverter.getSupportedMediaTypes().equals(candidate.getSupportedMediaTypes())) {
+						skipDefault = true;
+					}
 				}
 			}
-			combined.add(defaultConverter);
+
+			if (!skipDefault) {
+				combined.add(defaultConverter);
+			}
+
 			if (defaultConverter instanceof AllEncompassingFormHttpMessageConverter allEncompassingConverter) {
 				configurePartConverters(allEncompassingConverter, converters);
 			}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/http/HttpMessageConvertersTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/http/HttpMessageConvertersTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.autoconfigure.http;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -163,4 +164,19 @@ class HttpMessageConvertersTests {
 		return null;
 	}
 
+	@Test
+	void replaceDefaultStringHttpConverter() {
+		StringHttpMessageConverter converter = new StringHttpMessageConverter(StandardCharsets.UTF_8);
+		HttpMessageConverters converters = new HttpMessageConverters(converter);
+		assertThat(converters.getConverters()).contains(converter);
+		List<StringHttpMessageConverter> httpConverters = new ArrayList<>();
+		for (HttpMessageConverter<?> candidate : converters) {
+			if (candidate instanceof StringHttpMessageConverter) {
+				httpConverters.add((StringHttpMessageConverter) candidate);
+			}
+		}
+
+		assertThat(httpConverters).hasSize(1);
+		assertThat(httpConverters.get(0)).isEqualTo(converter);
+	}
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a252b2af-dd05-4913-8555-d62caf510a0d)
https://docs.spring.io/spring-boot/appendix/application-properties/index.html#application-properties.server.server.servlet.encoding.charset

Since the default value of `server.servlet.encoding.charset` is UTF-8, StringHttpMessageConverter with UTF-8 encoding is automatically created by the code below.

https://github.com/spring-projects/spring-boot/blob/c1a733130873c712f162d98fac812dde4a9de05a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/HttpMessageConvertersAutoConfiguration.java#L79-L86

Therefore, HttpMessageConverters has two StringHttpMessageConverter as shown below.
![image](https://github.com/user-attachments/assets/d8fc9d6e-cf3f-4fc1-aa35-64da89496346)

So, StringHttpMessageConverter with ISO-8859-1 encoding is not used.
(Especially because the default value of `server.servlet.encoding.charset` is UTF-8)

Even if the developer sets ISO-8859-1 encoding according to the servlet default specification, There are two StringHttpMessageConverter using ISO-8859-1 encoding as shown below.
```properties
server.servlet.encoding.charset=ISO-8859-1
```
![image](https://github.com/user-attachments/assets/a1071902-2dad-4c36-b226-58ae29876394)
So, if there is an additional StringHttpMessageConverter, I would like to change it to not add the default StringHttpMessageConverter.