### PR TITLE
bump logback to latest 1.5.15 to fix CVE-2024-12801 + CVE-2024-12798

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1233,7 +1233,7 @@ bom {
 			releaseNotes("https://github.com/apache/logging-log4j2/releases/tag/rel%2F{version}")
 		}
 	}
-	library("Logback", "1.5.12") {
+	library("Logback", "1.5.15") {
 		group("ch.qos.logback") {
 			modules = [
 				"logback-classic",


### PR DESCRIPTION
fixes CVE-2024-12801 + CVE-2024-12798, see https://logback.qos.ch/news.html#1.5.13

see also https://logback.qos.ch/news.html#1.5.15


While I have read
> Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use.

the fix in logback was released 17 days ago, so I am not sure at which schedule this semi-automated process is triggered. This PR should bring this to attention.
