### PR TITLE
Refactor: Use 'source' variable consistently in log formatting

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/java/SimpleFormatter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/java/SimpleFormatter.java
@@ -45,8 +45,8 @@ public class SimpleFormatter extends Formatter {
 		String message = formatMessage(record);
 		String throwable = getThrowable(record);
 		String thread = getThreadName();
-		return String.format(this.format, date, source, record.getLoggerName(), record.getLevel().getLocalizedName(),
-				message, throwable, thread, this.pid);
+		return String.format(this.format, date, source, source, record.getLevel().getLocalizedName(), message,
+				throwable, thread, this.pid);
 	}
 
 	private String getThrowable(LogRecord record) {


### PR DESCRIPTION
This PR refactors the format method of the SimpleFormatter class to replace multiple calls to record.getLoggerName() with the source variable. This change improves code readability and ensures consistent usage of the logger name throughout the formatting process.