### PR TITLE
Deprecate ConditionOutcome.inverse()

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionOutcome.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionOutcome.java
@@ -153,7 +153,10 @@ public class ConditionOutcome {
 	 * @param outcome the outcome to inverse
 	 * @return the inverse of the condition outcome
 	 * @since 1.3.0
+	 * @deprecated since 3.5.0 for removal in 3.6.0 in favor of
+	 * {@link #ConditionOutcome(boolean, ConditionMessage)}
 	 */
+	@Deprecated(since = "3.5.0", forRemoval = true)
 	public static ConditionOutcome inverse(ConditionOutcome outcome) {
 		return new ConditionOutcome(!outcome.isMatch(), outcome.getConditionMessage());
 	}


### PR DESCRIPTION
1. It's not used anywhere.
2. The condition message is not applicable for reusing if match is reversed in practice.
3. The method is not doing much, we should call the constructor directly since it is public.
4. It's better to define it as instance method if it indeed required.
