### PR TITLE
Add support for ALLOW_EMPTY_PASSWORD when using bitnami/postgresql with Docker Compose

### DIFF
--- a/spring-boot-project/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresJdbcDockerComposeConnectionDetailsFactoryIntegrationTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresJdbcDockerComposeConnectionDetailsFactoryIntegrationTests.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Andy Wilkinson
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author He Zean
  */
 class PostgresJdbcDockerComposeConnectionDetailsFactoryIntegrationTests {
 
@@ -57,6 +58,16 @@ class PostgresJdbcDockerComposeConnectionDetailsFactoryIntegrationTests {
 	void runWithBitnamiImageCreatesConnectionDetails(JdbcConnectionDetails connectionDetails)
 			throws ClassNotFoundException {
 		assertConnectionDetails(connectionDetails);
+		checkDatabaseAccess(connectionDetails);
+	}
+
+	@DockerComposeTest(composeFile = "postgres-bitnami-empty-password-compose.yaml",
+			image = TestImage.BITNAMI_POSTGRESQL)
+	void runWithBitnamiImageCreatesConnectionDetailsWithAllowEmptyPassword(JdbcConnectionDetails connectionDetails)
+			throws ClassNotFoundException {
+		assertThat(connectionDetails.getUsername()).isEqualTo("myuser");
+		assertThat(connectionDetails.getPassword()).isEmpty();
+		assertThat(connectionDetails.getJdbcUrl()).startsWith("jdbc:postgresql://").endsWith("/mydatabase");
 		checkDatabaseAccess(connectionDetails);
 	}
 

--- a/spring-boot-project/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresR2dbcDockerComposeConnectionDetailsFactoryIntegrationTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresR2dbcDockerComposeConnectionDetailsFactoryIntegrationTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Andy Wilkinson
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author He Zean
  */
 class PostgresR2dbcDockerComposeConnectionDetailsFactoryIntegrationTests {
 
@@ -60,6 +61,17 @@ class PostgresR2dbcDockerComposeConnectionDetailsFactoryIntegrationTests {
 	@DockerComposeTest(composeFile = "postgres-bitnami-compose.yaml", image = TestImage.BITNAMI_POSTGRESQL)
 	void runWithBitnamiImageCreatesConnectionDetails(R2dbcConnectionDetails connectionDetails) {
 		assertConnectionDetails(connectionDetails);
+		checkDatabaseAccess(connectionDetails);
+	}
+
+	@DockerComposeTest(composeFile = "postgres-bitnami-empty-password-compose.yaml",
+			image = TestImage.BITNAMI_POSTGRESQL)
+	void runWithBitnamiImageCreatesConnectionDetailsWithAllowEmptyPassword(R2dbcConnectionDetails connectionDetails) {
+		ConnectionFactoryOptions connectionFactoryOptions = connectionDetails.getConnectionFactoryOptions();
+		assertThat(connectionFactoryOptions.getRequiredValue(ConnectionFactoryOptions.USER)).isEqualTo("myuser");
+		assertThat(connectionFactoryOptions.getValue(ConnectionFactoryOptions.PASSWORD)).isNull();
+		assertThat(connectionFactoryOptions.getRequiredValue(ConnectionFactoryOptions.DATABASE))
+			.isEqualTo("mydatabase");
 		checkDatabaseAccess(connectionDetails);
 	}
 

--- a/spring-boot-project/spring-boot-docker-compose/src/dockerTest/resources/org/springframework/boot/docker/compose/service/connection/postgres/postgres-bitnami-empty-password-compose.yaml
+++ b/spring-boot-project/spring-boot-docker-compose/src/dockerTest/resources/org/springframework/boot/docker/compose/service/connection/postgres/postgres-bitnami-empty-password-compose.yaml
@@ -1,0 +1,9 @@
+services:
+  database:
+    image: '{imageName}'
+    ports:
+      - '5432'
+    environment:
+      - 'POSTGRESQL_USERNAME=myuser'
+      - 'POSTGRESQL_DATABASE=mydatabase'
+      - 'ALLOW_EMPTY_PASSWORD=yes'

--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresEnvironment.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresEnvironment.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.docker.compose.service.connection.postgres;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -67,8 +68,9 @@ class PostgresEnvironment {
 			return null;
 		}
 		String password = env.getOrDefault("POSTGRES_PASSWORD", env.get("POSTGRESQL_PASSWORD"));
-		Assert.state(StringUtils.hasLength(password), "PostgreSQL password must be provided");
-		return password;
+		boolean allowEmpty = env.containsKey("ALLOW_EMPTY_PASSWORD");
+		Assert.state(allowEmpty || StringUtils.hasLength(password), "PostgreSQL password must be provided");
+		return Objects.requireNonNullElse(password, "");
 	}
 
 	private boolean isUsingTrustHostAuthMethod(Map<String, String> env) {

--- a/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresEnvironmentTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresEnvironmentTests.java
@@ -94,6 +94,12 @@ class PostgresEnvironmentTests {
 	}
 
 	@Test
+	void getPasswordWhenHasNoPasswordAndAllowEmptyPassword() {
+		PostgresEnvironment environment = new PostgresEnvironment(Map.of("ALLOW_EMPTY_PASSWORD", "yes"));
+		assertThat(environment.getPassword()).isEmpty();
+	}
+
+	@Test
 	void getDatabaseWhenNoPostgresDbOrPostgresUser() {
 		PostgresEnvironment environment = new PostgresEnvironment(Map.of("POSTGRES_PASSWORD", "secret"));
 		assertThat(environment.getDatabase()).isEqualTo("postgres");


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Adds support for `ALLOW_EMPTY_PASSWORD` in [`bitnami/postgresql`](https://hub.docker.com/r/bitnami/postgresql).