### PR TITLE
Prevent redis pool to initialize in unit test

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationJedisTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisAutoConfigurationJedisTests.java
@@ -152,14 +152,14 @@ class RedisAutoConfigurationJedisTests {
 	@Test
 	void testRedisConfigurationWithPool() {
 		this.contextRunner
-			.withPropertyValues("spring.data.redis.host:foo", "spring.data.redis.jedis.pool.min-idle:1",
+			.withPropertyValues("spring.data.redis.host:foo", "spring.data.redis.jedis.pool.min-idle:0",
 					"spring.data.redis.jedis.pool.max-idle:4", "spring.data.redis.jedis.pool.max-active:16",
 					"spring.data.redis.jedis.pool.max-wait:2000",
 					"spring.data.redis.jedis.pool.time-between-eviction-runs:30000")
 			.run((context) -> {
 				JedisConnectionFactory cf = context.getBean(JedisConnectionFactory.class);
 				assertThat(cf.getHostName()).isEqualTo("foo");
-				assertThat(cf.getPoolConfig().getMinIdle()).isOne();
+				assertThat(cf.getPoolConfig().getMinIdle()).isZero();
 				assertThat(cf.getPoolConfig().getMaxIdle()).isEqualTo(4);
 				assertThat(cf.getPoolConfig().getMaxTotal()).isEqualTo(16);
 				assertThat(cf.getPoolConfig().getMaxWaitDuration()).isEqualTo(Duration.ofSeconds(2));


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

As https://github.com/spring-projects/spring-boot/commit/52d419a26aaebc290317c990b61c96532f60fc80 bumps spring-data bom to `2024.1.2-SNAPSHOT`, an unconditional [preparePool](https://github.com/apache/commons-pool/blob/e5c44f5184a55a58fef4a1efec8124d162a348bd/src/main/java/org/apache/commons/pool2/impl/GenericObjectPool.java#L978-L983) invocation is added to the start lifecycle of JedisConnectionFactory (see: https://github.com/spring-projects/spring-data-redis/commit/2bcdd36a368d68e5ecffc204294c890556017079). That is, with `min-idle` set to 1, the pool will attempt to create a socket over the dummy domain `foo`, failing the bean creation.

Related to:
- https://github.com/spring-projects/spring-boot/actions/runs/12710459852/job/35433379770?pr=43771#step:3:4925
- https://github.com/spring-projects/spring-boot/actions/runs/12716605691/job/35451295161?pr=43773#step:3:4735