### PR TITLE
Change RestTemplateBuilder redirections at HttpComponentsClientHttpRequestFactory to FOLLOW_WHEN_POSSIBLE

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/CheckLinks.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/CheckLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.build.bom;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -31,9 +30,8 @@ import org.gradle.internal.impldep.org.apache.http.client.config.CookieSpecs;
 
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.NoOpResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -57,7 +55,7 @@ public abstract class CheckLinks extends DefaultTask {
 		CloseableHttpClient httpClient = HttpClients.custom().setDefaultRequestConfig(config).build();
 		HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
 		RestTemplate restTemplate = new RestTemplate(requestFactory);
-		restTemplate.setErrorHandler(new IgnoringErrorHandler());
+		restTemplate.setErrorHandler(new NoOpResponseErrorHandler());
 		for (Library library : this.bom.getLibraries()) {
 			library.getLinks().forEach((name, links) -> links.forEach((link) -> {
 				URI uri;
@@ -72,14 +70,6 @@ public abstract class CheckLinks extends DefaultTask {
 				}
 			}));
 		}
-	}
-
-	static class IgnoringErrorHandler extends DefaultResponseErrorHandler {
-
-		@Override
-		public void handleError(ClientHttpResponse response) throws IOException {
-		}
-
 	}
 
 }

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/TestRestTemplate.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/TestRestTemplate.java
@@ -157,9 +157,8 @@ public class TestRestTemplate {
 		Assert.notNull(builder, "Builder must not be null");
 		if (httpClientOptions != null) {
 			ClientHttpRequestFactory requestFactory = builder.buildRequestFactory();
+			builder = builder.redirects(Redirects.FOLLOW_WHEN_POSSIBLE);
 			if (requestFactory instanceof HttpComponentsClientHttpRequestFactory) {
-				builder = builder.redirects(HttpClientOption.ENABLE_REDIRECTS.isPresent(httpClientOptions)
-						? Redirects.FOLLOW : Redirects.DONT_FOLLOW);
 				builder = builder.requestFactoryBuilder(
 						(settings) -> new CustomHttpComponentsClientHttpRequestFactory(httpClientOptions, settings));
 			}

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/intTest/java/org/springframework/boot/context/embedded/EmbeddedServerContainerInvocationContextProvider.java
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/src/intTest/java/org/springframework/boot/context/embedded/EmbeddedServerContainerInvocationContextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,12 +44,10 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import org.junit.platform.commons.util.ReflectionUtils;
 
 import org.springframework.boot.testsupport.BuildOutput;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.util.FileSystemUtils;
 import org.springframework.util.StringUtils;
-import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.NoOpResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriTemplateHandler;
 
@@ -188,23 +186,7 @@ class EmbeddedServerContainerInvocationContextProvider
 			RestTemplate rest = new RestTemplate(new HttpComponentsClientHttpRequestFactory(HttpClients.custom()
 				.setRetryStrategy(new DefaultHttpRequestRetryStrategy(10, TimeValue.of(1, TimeUnit.SECONDS)))
 				.build()));
-			rest.setErrorHandler(new ResponseErrorHandler() {
-
-				@Override
-				public boolean hasError(ClientHttpResponse response) throws IOException {
-					return false;
-				}
-
-				@Override
-				@SuppressWarnings("removal")
-				public void handleError(ClientHttpResponse response) throws IOException {
-				}
-
-				@Override
-				public void handleError(URI url, HttpMethod method, ClientHttpResponse response) throws IOException {
-				}
-
-			});
+			rest.setErrorHandler(new NoOpResponseErrorHandler());
 			rest.setUriTemplateHandler(new UriTemplateHandler() {
 
 				@Override


### PR DESCRIPTION
Our main problem is that `RestTemplate` has a default redirect status of `FOLLOW_WHEN_POSSIBLE`. When we build `RestTemplateBuilder` and want to use Apache HttpComponents as a basis, for some reason we check `httpClientOptions` for `HttpClientOption.ENABLE_REDIRECTS`, otherwise we set it to false, which is wrong.

The solution to this problem I saw was to set `builder.redirects(Redirects.FOLLOW_WHEN_POSSIBLE);` the default `if (httpClientOptions != null)`.

Closes: #43431 