### PR TITLE
POSTGRESQL_USERNAME and POSTGRESQL_DATABASE are ignored when using the Bitnami PostgreSQL image with Docker Compose

### DIFF
--- a/spring-boot-project/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresJdbcDockerComposeConnectionDetailsFactoryIntegrationTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresJdbcDockerComposeConnectionDetailsFactoryIntegrationTests.java
@@ -39,8 +39,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PostgresJdbcDockerComposeConnectionDetailsFactoryIntegrationTests {
 
 	@DockerComposeTest(composeFile = "postgres-compose.yaml", image = TestImage.POSTGRESQL)
-	void runCreatesConnectionDetails(JdbcConnectionDetails connectionDetails) {
+	void runCreatesConnectionDetails(JdbcConnectionDetails connectionDetails) throws ClassNotFoundException {
 		assertConnectionDetails(connectionDetails);
+		checkDatabaseAccess(connectionDetails);
 	}
 
 	@DockerComposeTest(composeFile = "postgres-with-trust-host-auth-method-compose.yaml", image = TestImage.POSTGRESQL)
@@ -53,8 +54,10 @@ class PostgresJdbcDockerComposeConnectionDetailsFactoryIntegrationTests {
 	}
 
 	@DockerComposeTest(composeFile = "postgres-bitnami-compose.yaml", image = TestImage.BITNAMI_POSTGRESQL)
-	void runWithBitnamiImageCreatesConnectionDetails(JdbcConnectionDetails connectionDetails) {
+	void runWithBitnamiImageCreatesConnectionDetails(JdbcConnectionDetails connectionDetails)
+			throws ClassNotFoundException {
 		assertConnectionDetails(connectionDetails);
+		checkDatabaseAccess(connectionDetails);
 	}
 
 	@DockerComposeTest(composeFile = "postgres-application-name-compose.yaml", image = TestImage.POSTGRESQL)

--- a/spring-boot-project/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresR2dbcDockerComposeConnectionDetailsFactoryIntegrationTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresR2dbcDockerComposeConnectionDetailsFactoryIntegrationTests.java
@@ -43,6 +43,7 @@ class PostgresR2dbcDockerComposeConnectionDetailsFactoryIntegrationTests {
 	@DockerComposeTest(composeFile = "postgres-compose.yaml", image = TestImage.POSTGRESQL)
 	void runCreatesConnectionDetails(R2dbcConnectionDetails connectionDetails) {
 		assertConnectionDetails(connectionDetails);
+		checkDatabaseAccess(connectionDetails);
 	}
 
 	@DockerComposeTest(composeFile = "postgres-with-trust-host-auth-method-compose.yaml", image = TestImage.POSTGRESQL)
@@ -59,6 +60,7 @@ class PostgresR2dbcDockerComposeConnectionDetailsFactoryIntegrationTests {
 	@DockerComposeTest(composeFile = "postgres-bitnami-compose.yaml", image = TestImage.BITNAMI_POSTGRESQL)
 	void runWithBitnamiImageCreatesConnectionDetails(R2dbcConnectionDetails connectionDetails) {
 		assertConnectionDetails(connectionDetails);
+		checkDatabaseAccess(connectionDetails);
 	}
 
 	@DockerComposeTest(composeFile = "postgres-application-name-compose.yaml", image = TestImage.POSTGRESQL)

--- a/spring-boot-project/spring-boot-docker-compose/src/dockerTest/resources/org/springframework/boot/docker/compose/service/connection/postgres/postgres-bitnami-compose.yaml
+++ b/spring-boot-project/spring-boot-docker-compose/src/dockerTest/resources/org/springframework/boot/docker/compose/service/connection/postgres/postgres-bitnami-compose.yaml
@@ -4,6 +4,6 @@ services:
     ports:
       - '5432'
     environment:
-      - 'POSTGRESQL_USER=myuser'
-      - 'POSTGRESQL_DB=mydatabase'
+      - 'POSTGRESQL_USERNAME=myuser'
+      - 'POSTGRESQL_DATABASE=mydatabase'
       - 'POSTGRESQL_PASSWORD=secret'

--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresEnvironment.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,17 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @author Scott Frederick
  * @author Sidmar Theodoro
+ * @author He Zean
  */
 class PostgresEnvironment {
+
+	private static final String[] USERNAME_KEYS = new String[] { "POSTGRES_USER", "POSTGRES_USERNAME",
+			"POSTGRESQL_USER", "POSTGRESQL_USERNAME" };
+
+	private static final String DEFAULT_USERNAME = "postgres";
+
+	private static final String[] DATABASE_KEYS = new String[] { "POSTGRES_DB", "POSTGRES_DATABASE",
+			"POSTGRESQL_DATABASE" };
 
 	private final String username;
 
@@ -39,9 +48,18 @@ class PostgresEnvironment {
 	private final String database;
 
 	PostgresEnvironment(Map<String, String> env) {
-		this.username = env.getOrDefault("POSTGRES_USER", env.getOrDefault("POSTGRESQL_USER", "postgres"));
+		this.username = extractUsername(env);
 		this.password = extractPassword(env);
-		this.database = env.getOrDefault("POSTGRES_DB", env.getOrDefault("POSTGRESQL_DB", this.username));
+		this.database = extractDatabase(env);
+	}
+
+	private String extractUsername(Map<String, String> env) {
+		for (String key : USERNAME_KEYS) {
+			if (env.containsKey(key)) {
+				return env.get(key);
+			}
+		}
+		return DEFAULT_USERNAME;
 	}
 
 	private String extractPassword(Map<String, String> env) {
@@ -51,6 +69,15 @@ class PostgresEnvironment {
 		String password = env.getOrDefault("POSTGRES_PASSWORD", env.get("POSTGRESQL_PASSWORD"));
 		Assert.state(StringUtils.hasLength(password), "PostgreSQL password must be provided");
 		return password;
+	}
+
+	private String extractDatabase(Map<String, String> env) {
+		for (String key : DATABASE_KEYS) {
+			if (env.containsKey(key)) {
+				return env.get(key);
+			}
+		}
+		return this.username;
 	}
 
 	private boolean isUsingTrustHostAuthMethod(Map<String, String> env) {

--- a/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresEnvironmentTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/postgres/PostgresEnvironmentTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * @author Phillip Webb
  * @author Scott Frederick
  * @author Sidmar Theodoro
+ * @author He Zean
  */
 class PostgresEnvironmentTests {
 
@@ -64,6 +65,20 @@ class PostgresEnvironmentTests {
 	void getUsernameWhenHasPostgresqlUser() {
 		PostgresEnvironment environment = new PostgresEnvironment(
 				Map.of("POSTGRESQL_USER", "me", "POSTGRESQL_PASSWORD", "secret"));
+		assertThat(environment.getUsername()).isEqualTo("me");
+	}
+
+	@Test
+	void getUsernameWhenHasPostgresUsername() {
+		PostgresEnvironment environment = new PostgresEnvironment(
+				Map.of("POSTGRES_USERNAME", "me", "POSTGRESQL_PASSWORD", "secret"));
+		assertThat(environment.getUsername()).isEqualTo("me");
+	}
+
+	@Test
+	void getUsernameWhenHasPostgresqlUsername() {
+		PostgresEnvironment environment = new PostgresEnvironment(
+				Map.of("POSTGRESQL_USERNAME", "me", "POSTGRESQL_PASSWORD", "secret"));
 		assertThat(environment.getUsername()).isEqualTo("me");
 	}
 
@@ -112,6 +127,13 @@ class PostgresEnvironmentTests {
 	}
 
 	@Test
+	void getDatabaseWhenNoPostgresqlDatabaseAndPostgresqlUsername() {
+		PostgresEnvironment environment = new PostgresEnvironment(
+				Map.of("POSTGRESQL_USERNAME", "me", "POSTGRESQL_PASSWORD", "secret"));
+		assertThat(environment.getDatabase()).isEqualTo("me");
+	}
+
+	@Test
 	void getDatabaseWhenHasPostgresDb() {
 		PostgresEnvironment environment = new PostgresEnvironment(
 				Map.of("POSTGRES_DB", "db", "POSTGRES_PASSWORD", "secret"));
@@ -119,9 +141,16 @@ class PostgresEnvironmentTests {
 	}
 
 	@Test
-	void getDatabaseWhenHasPostgresqlDb() {
+	void getDatabaseWhenHasPostgresDatabase() {
 		PostgresEnvironment environment = new PostgresEnvironment(
-				Map.of("POSTGRESQL_DB", "db", "POSTGRESQL_PASSWORD", "secret"));
+				Map.of("POSTGRES_DATABASE", "db", "POSTGRESQL_PASSWORD", "secret"));
+		assertThat(environment.getDatabase()).isEqualTo("db");
+	}
+
+	@Test
+	void getDatabaseWhenHasPostgresqlDatabase() {
+		PostgresEnvironment environment = new PostgresEnvironment(
+				Map.of("POSTGRESQL_DATABASE", "db", "POSTGRESQL_PASSWORD", "secret"));
 		assertThat(environment.getDatabase()).isEqualTo("db");
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Fixes incorrect environment variable keys in [`bitnami/postgresql`](https://hub.docker.com/r/bitnami/postgresql):
  - Add `POSTGRESQL_USERNAME` as a candidate key
  - `POSTGRESQL_DB` -> `POSTGRESQL_DATABASE`