### PR TITLE
Docker Compose support for ClickHouse does not allow an empty password when ALLOW_EMPTY_PASSWORD=yes

### DIFF
--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/clickhouse/ClickHouseEnvironment.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/clickhouse/ClickHouseEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ class ClickHouseEnvironment {
 	}
 
 	private String extractPassword(Map<String, String> env) {
-		boolean allowEmpty = Boolean.parseBoolean(env.getOrDefault("ALLOW_EMPTY_PASSWORD", Boolean.FALSE.toString()));
+		boolean allowEmpty = env.containsKey("ALLOW_EMPTY_PASSWORD");
 		String password = env.get("CLICKHOUSE_PASSWORD");
 		Assert.state(StringUtils.hasLength(password) || allowEmpty, "No ClickHouse password found");
 		return (password != null) ? password : "";

--- a/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/clickhouse/ClickHouseEnvironmentTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/clickhouse/ClickHouseEnvironmentTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,10 +50,9 @@ class ClickHouseEnvironmentTests {
 	}
 
 	@Test
-	void getPasswordWhenHasNoPasswordAndAllowEmptyPasswordIsFalse() {
-		assertThatIllegalStateException()
-			.isThrownBy(() -> new ClickHouseEnvironment(Map.of("ALLOW_EMPTY_PASSWORD", "false")))
-			.withMessage("No ClickHouse password found");
+	void getPasswordWhenHasNoPasswordAndAllowEmptyPasswordIsYes() {
+		ClickHouseEnvironment environment = new ClickHouseEnvironment(Map.of("ALLOW_EMPTY_PASSWORD", "yes"));
+		assertThat(environment.getPassword()).isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Adds `yes` as a positive value for `ALLOW_EMPTY_PASSWORD` in [bitnami/clickhouse](https://hub.docker.com/r/bitnami/clickhouse).