### PR TITLE
Add support for detecting AWS Advanced JDBC Wrapper to DatabaseDriver

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchDataSourceScriptDatabaseInitializerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchDataSourceScriptDatabaseInitializerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,8 +62,8 @@ class BatchDataSourceScriptDatabaseInitializerTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(value = DatabaseDriver.class, mode = Mode.EXCLUDE, names = { "CLICKHOUSE", "FIREBIRD", "INFORMIX",
-			"JTDS", "PHOENIX", "REDSHIFT", "TERADATA", "TESTCONTAINERS", "UNKNOWN" })
+	@EnumSource(value = DatabaseDriver.class, mode = Mode.EXCLUDE, names = { "AWS_JDBC_WRAPPER", "CLICKHOUSE",
+			"FIREBIRD", "INFORMIX", "JTDS", "PHOENIX", "REDSHIFT", "TERADATA", "TESTCONTAINERS", "UNKNOWN" })
 	void batchSchemaCanBeLocated(DatabaseDriver driver) throws SQLException {
 		DefaultResourceLoader resourceLoader = new DefaultResourceLoader();
 		BatchProperties properties = new BatchProperties();

--- a/spring-boot-project/spring-boot-parent/build.gradle
+++ b/spring-boot-project/spring-boot-parent/build.gradle
@@ -25,6 +25,13 @@ bom {
 			]
 		}
 	}
+	library("AWS Advanced JDBC Wrapper", "2.5.4") {
+		group("software.amazon.jdbc") {
+			modules = [
+					"aws-advanced-jdbc-wrapper"
+			]
+		}
+	}
 	library("C3P0", "0.9.5.5") {
 		group("com.mchange") {
 			modules = [

--- a/spring-boot-project/spring-boot/build.gradle
+++ b/spring-boot-project/spring-boot/build.gradle
@@ -100,6 +100,9 @@ dependencies {
 	optional("org.yaml:snakeyaml")
 	optional("org.jetbrains.kotlin:kotlin-reflect")
 	optional("org.jetbrains.kotlin:kotlin-stdlib")
+	optional("software.amazon.jdbc:aws-advanced-jdbc-wrapper") {
+		exclude(group: "commons-logging", module: "commons-logging")
+	}
 
 	testImplementation(project(":spring-boot-project:spring-boot-tools:spring-boot-test-support"))
 	testImplementation("org.springframework:spring-core-test")

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
@@ -19,6 +19,7 @@ package org.springframework.boot.jdbc;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import org.springframework.util.Assert;
@@ -216,6 +217,19 @@ public enum DatabaseDriver {
 		@Override
 		protected Collection<String> getUrlPrefixes() {
 			return Arrays.asList("ch", "clickhouse");
+		}
+
+	},
+
+	/**
+	 * AWS Advanced JDBC Wrapper.
+	 * @since 3.5.0
+	 */
+	AWS_JDBC_WRAPPER(null, "software.amazon.jdbc.Driver") {
+
+		@Override
+		protected Collection<String> getUrlPrefixes() {
+			return List.of("aws-wrapper");
 		}
 
 	};

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DatabaseDriverTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DatabaseDriverTests.java
@@ -121,6 +121,8 @@ class DatabaseDriverTests {
 		assertThat(DatabaseDriver.fromJdbcUrl("jdbc:clickhouse://localhost:3306/sample"))
 			.isEqualTo(DatabaseDriver.CLICKHOUSE);
 		assertThat(DatabaseDriver.fromJdbcUrl("jdbc:ch://localhost:3306/sample")).isEqualTo(DatabaseDriver.CLICKHOUSE);
+		assertThat(DatabaseDriver.fromJdbcUrl("jdbc:aws-wrapper:postgresql://127.0.0.1:5432/sample"))
+			.isEqualTo(DatabaseDriver.AWS_JDBC_WRAPPER);
 	}
 
 }


### PR DESCRIPTION
This commit adds entry for AWS Advanced JDBC Wrapper to `DatabaseDriver` enum.

See gh-31995

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
