### PR TITLE
Auto-configure VirtualThreadMetrics

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	optional("io.lettuce:lettuce-core")
 	optional("io.micrometer:micrometer-observation")
 	optional("io.micrometer:micrometer-jakarta9")
+	optional("io.micrometer:micrometer-java21")
 	optional("io.micrometer:micrometer-tracing")
 	optional("io.micrometer:micrometer-tracing-bridge-brave")
 	optional("io.micrometer:micrometer-tracing-bridge-otel")

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics;
 
+import java.io.Closeable;
+
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmCompilationMetrics;
@@ -25,12 +27,21 @@ import io.micrometer.core.instrument.binder.jvm.JvmInfoMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.FactoryBean;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ImportRuntimeHints;
+import org.springframework.util.ClassUtils;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for JVM metrics.
@@ -43,6 +54,8 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnClass(MeterRegistry.class)
 @ConditionalOnBean(MeterRegistry.class)
 public class JvmMetricsAutoConfiguration {
+
+	private static final String VIRTUAL_THREAD_METRICS_CLASS = "io.micrometer.java21.instrument.binder.jdk.VirtualThreadMetrics";
 
 	@Bean
 	@ConditionalOnMissingBean
@@ -84,6 +97,64 @@ public class JvmMetricsAutoConfiguration {
 	@ConditionalOnMissingBean
 	public JvmCompilationMetrics jvmCompilationMetrics() {
 		return new JvmCompilationMetrics();
+	}
+
+	@Bean
+	@ConditionalOnClass(name = VIRTUAL_THREAD_METRICS_CLASS)
+	@ConditionalOnMissingBean(type = VIRTUAL_THREAD_METRICS_CLASS)
+	@ImportRuntimeHints(VirtualThreadMetricsRuntimeHintsRegistrar.class)
+	VirtualThreadMetricsFactoryBean virtualThreadMetrics() {
+		return new VirtualThreadMetricsFactoryBean();
+	}
+
+	static final class VirtualThreadMetricsFactoryBean
+			implements FactoryBean<Object>, BeanClassLoaderAware, DisposableBean {
+
+		private ClassLoader classLoader;
+
+		private Class<?> instanceType;
+
+		private Object instance;
+
+		@Override
+		public void setBeanClassLoader(ClassLoader classLoader) {
+			this.classLoader = classLoader;
+		}
+
+		@Override
+		public Object getObject() {
+			if (this.instance == null) {
+				this.instance = BeanUtils.instantiateClass(getObjectType());
+			}
+			return this.instance;
+		}
+
+		@Override
+		public Class<?> getObjectType() {
+			if (this.instanceType == null) {
+				this.instanceType = ClassUtils.resolveClassName(VIRTUAL_THREAD_METRICS_CLASS, this.classLoader);
+			}
+			return this.instanceType;
+		}
+
+		@Override
+		public void destroy() throws Exception {
+			if (this.instance instanceof Closeable closeable) {
+				closeable.close();
+			}
+		}
+
+	}
+
+	static final class VirtualThreadMetricsRuntimeHintsRegistrar implements RuntimeHintsRegistrar {
+
+		@Override
+		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+			hints.reflection()
+				.registerTypeIfPresent(classLoader, VIRTUAL_THREAD_METRICS_CLASS,
+						MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS);
+		}
+
 	}
 
 }


### PR DESCRIPTION
See gh-43122

I also verified these changes with a native image.

`JDK`
```
openjdk version "23.0.1" 2024-10-15
OpenJDK Runtime Environment Liberica-NIK-24.1.1-1 (build 23.0.1+13)
OpenJDK 64-Bit Server VM Liberica-NIK-24.1.1-1 (build 23.0.1+13, mixed mode, sharing)
```
---
`pom.xml`

```xml

<plugin>
    <groupId>org.graalvm.buildtools</groupId>
    <artifactId>native-maven-plugin</artifactId>
    <configuration>
        <buildArgs>
            <buildArg>--enable-monitoring=jfr</buildArg>
        </buildArgs>
    </configuration>
</plugin>
<plugin>
<groupId>org.springframework.boot</groupId>
<artifactId>spring-boot-maven-plugin</artifactId>
<configuration>
    <image>
        <env>
            <BP_NATIVE_IMAGE_BUILD_ARGUMENTS>--enable-monitoring=jfr</BP_NATIVE_IMAGE_BUILD_ARGUMENTS>
        </env>
    </image>
</configuration>
</plugin>

```

---

Both `$ mvn -Pnative native:compile` and `$ mvn -Pnative spring-boot:build-image` work fine.


```
2025-01-16T13:14:07.947Z  INFO 1 --- [gh-43122] [           main] task.gh43122.Gh43122Application          : Starting AOT-processed Gh43122Application using Java 23.0.1 with PID 1 (/workspace/task.gh43122.Gh43122Application started by cnb in /workspace)
2025-01-16T13:14:07.947Z  INFO 1 --- [gh-43122] [           main] task.gh43122.Gh43122Application          : No active profile set, falling back to 1 default profile: "default"
2025-01-16T13:14:07.959Z  INFO 1 --- [gh-43122] [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port 8080 (http)
2025-01-16T13:14:07.960Z  INFO 1 --- [gh-43122] [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2025-01-16T13:14:07.961Z  INFO 1 --- [gh-43122] [           main] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/10.1.34]
2025-01-16T13:14:07.971Z  INFO 1 --- [gh-43122] [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
2025-01-16T13:14:07.971Z  INFO 1 --- [gh-43122] [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 24 ms
2025-01-16T13:14:08.025Z  WARN 1 --- [gh-43122] [           main] i.m.c.i.binder.jvm.JvmGcMetrics          : GC notifications will not be available because no GarbageCollectorMXBean of the JVM provides any. GCs=[young generation scavenger, complete scavenger]
2025-01-16T13:14:08.029Z  INFO 1 --- [gh-43122] [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 15 endpoints beneath base path '/actuator'
[warn][jfr,setting] @Deprecated JFR events, and leak profiling are not yet supported.
[warn][jfr,setting] @Deprecated JFR events, and leak profiling are not yet supported.
2025-01-16T13:14:08.090Z  INFO 1 --- [gh-43122] [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port 8080 (http) with context path '/'
2025-01-16T13:14:08.091Z  INFO 1 --- [gh-43122] [           main] task.gh43122.Gh43122Application          : Started Gh43122Application in 0.16 seconds (process running for 0.17)

```


```http
GET http://localhost:8080/actuator/metrics

```

```json
{
  "names": [
    "application.ready.time",
    "application.started.time",
    "disk.free",
    "disk.total",
    "executor.active",
    "executor.completed",
    "executor.pool.core",
    "executor.pool.max",
    "executor.pool.size",
    "executor.queue.remaining",
    "executor.queued",
    "http.server.requests.active",
    "jvm.classes.loaded",
    "jvm.classes.unloaded",
    "jvm.gc.overhead",
    "jvm.info",
    "jvm.memory.committed",
    "jvm.memory.max",
    "jvm.memory.used",
    "jvm.threads.daemon",
    "jvm.threads.live",
    "jvm.threads.peak",
    "jvm.threads.started",
    "jvm.threads.states",
    "jvm.threads.virtual.pinned",
    "jvm.threads.virtual.submit.failed",
    "logback.events",
    "process.cpu.usage",
    "process.files.max",
    "process.files.open",
    "process.start.time",
    "process.uptime",
    "ssl.chains",
    "system.cpu.count",
    "system.cpu.usage",
    "system.load.average.1m",
    "tomcat.sessions.active.current",
    "tomcat.sessions.active.max",
    "tomcat.sessions.alive.max",
    "tomcat.sessions.created",
    "tomcat.sessions.expired",
    "tomcat.sessions.rejected"
  ]
}
```




