### PR TITLE
Fix Javadoc since for GsonProperties.Strictness

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/gson/GsonProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/gson/GsonProperties.java
@@ -194,7 +194,7 @@ public class GsonProperties {
 	 * {@link com.google.gson.Strictness} that was introduced in Gson 2.11. To maximize
 	 * backwards compatibility, the Gson enum is not used directly.
 	 *
-	 * @since 3.4.1
+	 * @since 3.4.2
 	 */
 	public enum Strictness {
 


### PR DESCRIPTION
This PR fixes the Javadoc `@since` tag for the `GsonProperties.Strictness`.

See gh-43442