### PR TITLE
Fix description of management.metrics.graphql.autotime.enabled

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1938,7 +1938,7 @@
     },
     {
       "name": "management.metrics.graphql.autotime.enabled",
-      "description": "Whether to automatically time web client requests.",
+      "description": "Whether to automatically time GraphQL requests.",
       "defaultValue": true,
       "deprecation": {
         "level": "error",


### PR DESCRIPTION
This PR fixes the description of the `management.metrics.graphql.autotime.enabled`.

Closes gh-43901