### PR TITLE
Register Logback OnErrorConsoleStatusListener when using custom Logback file

### DIFF
--- a/spring-boot-project/spring-boot/src/test/resources/logback-include-status-listener.xml
+++ b/spring-boot-project/spring-boot/src/test/resources/logback-include-status-listener.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
+	<include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>[%p] - %m%n</pattern>
+		</encoder>
+	</appender>
+	<root level="INFO">
+		<appender-ref ref="CONSOLE"/>
+	</root>
+</configuration>

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-structured-logging/src/main/resources/application.properties
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-structured-logging/src/main/resources/application.properties
@@ -10,3 +10,7 @@ logging.structured.format.console=smoketest.structuredlogging.CustomStructuredLo
 #---
 spring.config.activate.on-profile=on-error
 logging.structured.json.customizer=smoketest.structuredlogging.DuplicateJsonMembersCustomizer
+#---
+logging.config=classpath:custom-logback.xml
+spring.config.activate.on-profile=on-error-custom-logback-file
+logging.structured.json.customizer=smoketest.structuredlogging.DuplicateJsonMembersCustomizer

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-structured-logging/src/main/resources/custom-logback.xml
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-structured-logging/src/main/resources/custom-logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder class="org.springframework.boot.logging.logback.StructuredLogEncoder">
+			<format>ecs</format>
+			<charset>UTF-8</charset>
+		</encoder>
+	</appender>
+	<root level="INFO">
+		<appender-ref ref="STDOUT"/>
+	</root>
+</configuration>

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-structured-logging/src/test/java/smoketest/structuredlogging/SampleStructuredLoggingApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-structured-logging/src/test/java/smoketest/structuredlogging/SampleStructuredLoggingApplicationTests.java
@@ -71,4 +71,11 @@ class SampleStructuredLoggingApplicationTests {
 		assertThat(output).contains("The name 'test' has already been written");
 	}
 
+	@Test
+	void shouldCaptureCustomizerErrorWhenUsingCustomLogbackFile(CapturedOutput output) {
+		SampleStructuredLoggingApplication
+			.main(new String[] { "--spring.profiles.active=on-error-custom-logback-file" });
+		assertThat(output).contains("The name 'test' has already been written");
+	}
+
 }


### PR DESCRIPTION
Prior to this commit, `OnErrorConsoleStatusListener` was not registered for a custom Logback configuration file.

This commit registers `OnErrorConsoleStatusListener` when the Logback configuration is loaded from a custom Logback file that does not include any `StatusListener`.

See gh-43822


It has also been tested with a native image.


A different approach is to register `OnErrorConsoleStatusListener`  right after `reportConfigurationErrorsIfNecessary`. 
https://github.com/spring-projects/spring-boot/compare/main...nosan:spring-boot:43822-1

