### PR TITLE
Align return type of VirtualThreadsInfo.getMounted() with the type of the mounted field

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/ProcessInfo.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/ProcessInfo.java
@@ -151,7 +151,7 @@ public class ProcessInfo {
 			this.poolSize = poolSize;
 		}
 
-		public long getMounted() {
+		public int getMounted() {
 			return this.mounted;
 		}
 


### PR DESCRIPTION
This PR changes the return type for the `VirtualThreadsInfo.getMounted()` to `int` as it seems to have been `long` accidentally.