### PR TITLE
Warn that some Quartz database schema scripts must be modified before use

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/io/quartz.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/io/quartz.adoc
@@ -35,6 +35,9 @@ WARNING: By default, the database is detected and initialized by using the stand
 These scripts drop existing tables, deleting all triggers on every restart.
 It is also possible to provide a custom script by setting the configprop:spring.quartz.jdbc.schema[] property.
 
+WARNING: SQL Server and Azure SQL databases may not use this mechanism because the script requires the specification of the database name directly.
+Make a copy of the script and edit it, before using configprop:spring.quartz.jdbc.schema[] to direct Spring to use it.
+
 To have Quartz use a javadoc:javax.sql.DataSource[] other than the application's main javadoc:javax.sql.DataSource[], declare a javadoc:javax.sql.DataSource[] bean, annotating its javadoc:org.springframework.context.annotation.Bean[format=annotation] method with javadoc:org.springframework.boot.autoconfigure.quartz.QuartzDataSource[format=annotation].
 Doing so ensures that the Quartz-specific javadoc:javax.sql.DataSource[] is used by both the javadoc:org.springframework.scheduling.quartz.SchedulerFactoryBean[] and for schema initialization.
 Similarly, to have Quartz use a javadoc:org.springframework.transaction.TransactionManager[] other than the application's main javadoc:org.springframework.transaction.TransactionManager[] declare a javadoc:org.springframework.transaction.TransactionManager[] bean, annotating its javadoc:org.springframework.context.annotation.Bean[format=annotation] method with javadoc:org.springframework.boot.autoconfigure.quartz.QuartzTransactionManager[format=annotation].


### PR DESCRIPTION
https://github.com/quartznet/quartznet/blob/b9574e915496487e9f031174a61efc2ba572433d/database/tables/tables_sqlServer.sql shows that the SQL Server script requires replacing `enter_db_name_here` manually, so we need to make a copy of the script in our project for it to work.

If this modification is not satisfactory, feel free to edit it; my goal is simply to inform the next person using SQL Server that there is no easy way of using this property.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
