### PR TITLE
Display package in section Developing Your First Spring Boot Application

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/tutorial/pages/first-application/index.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/tutorial/pages/first-application/index.adoc
@@ -1,5 +1,6 @@
 [[getting-started.first-application]]
 = Developing Your First Spring Boot Application
+:chomp_package_replacement: com.example
 
 This section describes how to develop a small "`Hello World!`" web application that highlights some of Spring Boot's key features.
 You can choose between Maven or Gradle as the build system.
@@ -287,7 +288,6 @@ If you run `gradle dependencies` again, you see that there are now a number of a
 To finish our application, we need to create a single Java file.
 By default, Maven and Gradle compile sources from `src/main/java`, so you need to create that directory structure and then add a file named `src/main/java/MyApplication.java` to contain the following code:
 
-[chomp_package_replacement=com.example]
 include-code::MyApplication[]
 
 Although there is not much code here, quite a lot is going on.


### PR DESCRIPTION
Related https://github.com/spring-projects/spring-boot/issues/43964

`[chomp_package_replacement=com.example]` doesn't seem to work, we can set it on the document and the result:
![image](https://github.com/user-attachments/assets/657c9d0a-fbd5-4f5c-8c4e-b0d1def78c20)

