### PR TITLE
Remove shouldNotRegisterStructuredLoggingJsonMembersCustomizerRuntimeHints()

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/structured/StructuredLoggingJsonMembersCustomizerBeanFactoryInitializationAotProcessorTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/structured/StructuredLoggingJsonMembersCustomizerBeanFactoryInitializationAotProcessorTests.java
@@ -63,13 +63,6 @@ class StructuredLoggingJsonMembersCustomizerBeanFactoryInitializationAotProcesso
 	}
 
 	@Test
-	void shouldNotRegisterStructuredLoggingJsonMembersCustomizerRuntimeHints() {
-		MockEnvironment environment = new MockEnvironment();
-		BeanFactoryInitializationAotContribution contribution = getContribution(environment);
-		assertThat(contribution).isNull();
-	}
-
-	@Test
 	void shouldNotRegisterStructuredLoggingJsonMembersCustomizerRuntimeHintsWhenCustomizerIsNotSet() {
 		MockEnvironment environment = new MockEnvironment();
 		environment.setProperty("logging.structured.json.exclude", "something");


### PR DESCRIPTION
It seems to be a duplicate of `shouldNotRegisterStructuredLoggingJsonMembersCustomizerRuntimeHintsWhenCustomizerIsNotSet()` practically.