### PR TITLE
Restore shouldNotRegisterStructuredLoggingJsonMembersCustomizerRuntimeHints()

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/structured/StructuredLoggingJsonMembersCustomizerBeanFactoryInitializationAotProcessorTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/structured/StructuredLoggingJsonMembersCustomizerBeanFactoryInitializationAotProcessorTests.java
@@ -63,6 +63,13 @@ class StructuredLoggingJsonMembersCustomizerBeanFactoryInitializationAotProcesso
 	}
 
 	@Test
+	void shouldNotRegisterStructuredLoggingJsonMembersCustomizerRuntimeHintsWhenPropertiesAreNotSet() {
+		MockEnvironment environment = new MockEnvironment();
+		BeanFactoryInitializationAotContribution contribution = getContribution(environment);
+		assertThat(contribution).isNull();
+	}
+
+	@Test
 	void shouldNotRegisterStructuredLoggingJsonMembersCustomizerRuntimeHintsWhenCustomizerIsNotSet() {
 		MockEnvironment environment = new MockEnvironment();
 		environment.setProperty("logging.structured.json.exclude", "something");


### PR DESCRIPTION
This PR restores `shouldNotRegisterStructuredLoggingJsonMembersCustomizerRuntimeHints()` that has been removed in https://github.com/spring-projects/spring-boot/pull/44013, and renames it to reflect its intention.