### PR TITLE
Logback configuration that relies on inner-classes does not work in a native image

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringBootJoranConfigurator.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringBootJoranConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -231,12 +231,12 @@ class SpringBootJoranConfigurator extends JoranConfigurator {
 			return modelClasses;
 		}
 
-		private Set<String> reflectionTypes(Model model) {
+		private Set<Class<?>> reflectionTypes(Model model) {
 			return reflectionTypes(model, () -> null);
 		}
 
-		private Set<String> reflectionTypes(Model model, Supplier<Object> parent) {
-			Set<String> reflectionTypes = new HashSet<>();
+		private Set<Class<?>> reflectionTypes(Model model, Supplier<Object> parent) {
+			Set<Class<?>> reflectionTypes = new HashSet<>();
 			Class<?> componentType = determineType(model, parent);
 			if (componentType != null) {
 				processComponent(componentType, reflectionTypes);
@@ -306,15 +306,15 @@ class SpringBootJoranConfigurator extends JoranConfigurator {
 			}
 		}
 
-		private void processComponent(Class<?> componentType, Set<String> reflectionTypes) {
+		private void processComponent(Class<?> componentType, Set<Class<?>> reflectionTypes) {
 			BeanDescription beanDescription = this.modelInterpretationContext.getBeanDescriptionCache()
 				.getBeanDescription(componentType);
 			reflectionTypes.addAll(parameterTypesNames(beanDescription.getPropertyNameToAdder().values()));
 			reflectionTypes.addAll(parameterTypesNames(beanDescription.getPropertyNameToSetter().values()));
-			reflectionTypes.add(componentType.getCanonicalName());
+			reflectionTypes.add(componentType);
 		}
 
-		private Collection<String> parameterTypesNames(Collection<Method> methods) {
+		private Collection<Class<?>> parameterTypesNames(Collection<Method> methods) {
 			return methods.stream()
 				.filter((method) -> !method.getDeclaringClass().equals(ContextAware.class)
 						&& !method.getDeclaringClass().equals(ContextAwareBase.class))
@@ -322,7 +322,6 @@ class SpringBootJoranConfigurator extends JoranConfigurator {
 				.flatMap(Stream::of)
 				.filter((type) -> !type.isPrimitive() && !type.equals(String.class))
 				.map((type) -> type.isArray() ? type.getComponentType() : type)
-				.map(Class::getName)
 				.toList();
 		}
 

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackConfigurationAotContributionTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackConfigurationAotContributionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ import org.springframework.aot.hint.JavaSerializationHint;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.SerializationHints;
+import org.springframework.aot.hint.TypeHint;
 import org.springframework.aot.hint.TypeReference;
 import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
 import org.springframework.aot.test.generate.TestGenerationContext;
@@ -149,15 +150,18 @@ class LogbackConfigurationAotContributionTests {
 		Model model = new Model();
 		model.getSubModels().add(component);
 		TestGenerationContext generationContext = applyContribution(model);
+		RuntimeHints runtimeHints = generationContext.getRuntimeHints();
 		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(SizeAndTimeBasedRollingPolicy.class))
-			.accepts(generationContext.getRuntimeHints());
+			.accepts(runtimeHints);
 		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(FileAppender.class))
-			.accepts(generationContext.getRuntimeHints());
-		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(FileSize.class))
-			.accepts(generationContext.getRuntimeHints());
+			.accepts(runtimeHints);
+		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(FileSize.class)).accepts(runtimeHints);
 		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(
 				TimeBasedFileNamingAndTriggeringPolicy.class))
-			.accepts(generationContext.getRuntimeHints());
+			.accepts(runtimeHints);
+		assertThat(runtimeHints).satisfies(hasValidTypeName(SizeAndTimeBasedRollingPolicy.class));
+		assertThat(runtimeHints).satisfies(hasValidTypeName(FileSize.class));
+		assertThat(runtimeHints).satisfies(hasValidTypeName(FileAppender.class));
 	}
 
 	@Test
@@ -167,12 +171,14 @@ class LogbackConfigurationAotContributionTests {
 		Model model = new Model();
 		model.getSubModels().add(implicit);
 		TestGenerationContext generationContext = applyContribution(model);
+		RuntimeHints runtimeHints = generationContext.getRuntimeHints();
 		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(PatternLayoutEncoder.class))
-			.accepts(generationContext.getRuntimeHints());
-		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(Layout.class))
-			.accepts(generationContext.getRuntimeHints());
-		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(Charset.class))
-			.accepts(generationContext.getRuntimeHints());
+			.accepts(runtimeHints);
+		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(Layout.class)).accepts(runtimeHints);
+		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(Charset.class)).accepts(runtimeHints);
+		assertThat(runtimeHints).satisfies(hasValidTypeName(PatternLayoutEncoder.class));
+		assertThat(runtimeHints).satisfies(hasValidTypeName(Layout.class));
+		assertThat(runtimeHints).satisfies(hasValidTypeName(Charset.class));
 	}
 
 	@Test
@@ -186,6 +192,8 @@ class LogbackConfigurationAotContributionTests {
 		TestGenerationContext generationContext = applyContribution(model);
 		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(SizeAndTimeBasedRollingPolicy.class))
 			.accepts(generationContext.getRuntimeHints());
+		assertThat(generationContext.getRuntimeHints())
+			.satisfies(hasValidTypeName(SizeAndTimeBasedRollingPolicy.class));
 	}
 
 	@Test
@@ -196,10 +204,12 @@ class LogbackConfigurationAotContributionTests {
 		component.setClassName(Outer.class.getName());
 		component.getSubModels().add(implementation);
 		TestGenerationContext generationContext = applyContribution(component);
-		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(Outer.class))
-			.accepts(generationContext.getRuntimeHints());
+		RuntimeHints runtimeHints = generationContext.getRuntimeHints();
+		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(Outer.class)).accepts(runtimeHints);
 		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(Implementation.class))
-			.accepts(generationContext.getRuntimeHints());
+			.accepts(runtimeHints);
+		assertThat(runtimeHints).satisfies(hasValidTypeName(Outer.class));
+		assertThat(runtimeHints).satisfies(hasValidTypeName(Implementation.class));
 	}
 
 	@Test
@@ -210,10 +220,16 @@ class LogbackConfigurationAotContributionTests {
 		component.setClassName(OuterWithDefaultClass.class.getName());
 		component.getSubModels().add(contract);
 		TestGenerationContext generationContext = applyContribution(component);
+		RuntimeHints runtimeHints = generationContext.getRuntimeHints();
 		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(OuterWithDefaultClass.class))
-			.accepts(generationContext.getRuntimeHints());
+			.accepts(runtimeHints);
 		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(Implementation.class))
-			.accepts(generationContext.getRuntimeHints());
+			.accepts(runtimeHints);
+		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(BaseImplementation.Details.class))
+			.accepts(runtimeHints);
+		assertThat(runtimeHints).satisfies(hasValidTypeName(OuterWithDefaultClass.class));
+		assertThat(runtimeHints).satisfies(hasValidTypeName(Implementation.class));
+		assertThat(runtimeHints).satisfies(hasValidTypeName(BaseImplementation.Details.class));
 	}
 
 	@Test
@@ -221,8 +237,11 @@ class LogbackConfigurationAotContributionTests {
 		ComponentModel component = new ComponentModel();
 		component.setClassName(ArrayParameters.class.getName());
 		TestGenerationContext generationContext = applyContribution(component);
+		RuntimeHints runtimeHints = generationContext.getRuntimeHints();
 		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(InetSocketAddress.class))
-			.accepts(generationContext.getRuntimeHints());
+			.accepts(runtimeHints);
+		assertThat(runtimeHints).satisfies(hasValidTypeName(InetSocketAddress.class));
+		assertThat(runtimeHints).satisfies(hasValidTypeName(ArrayParameters.class));
 	}
 
 	@Test
@@ -231,10 +250,12 @@ class LogbackConfigurationAotContributionTests {
 		component.setClassName("${VARIABLE_CLASS_NAME}");
 		TestGenerationContext generationContext = applyContribution(component,
 				(context) -> context.putProperty("VARIABLE_CLASS_NAME", Outer.class.getName()));
-		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(Outer.class))
-			.accepts(generationContext.getRuntimeHints());
+		RuntimeHints runtimeHints = generationContext.getRuntimeHints();
+		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(Outer.class)).accepts(runtimeHints);
 		assertThat(invokePublicConstructorsAndInspectAndInvokePublicMethodsOf(Implementation.class))
-			.accepts(generationContext.getRuntimeHints());
+			.accepts(runtimeHints);
+		assertThat(runtimeHints).satisfies(hasValidTypeName(Outer.class));
+		assertThat(runtimeHints).satisfies(hasValidTypeName(Implementation.class));
 	}
 
 	private Predicate<RuntimeHints> invokePublicConstructorsOf(String name) {
@@ -248,6 +269,12 @@ class LogbackConfigurationAotContributionTests {
 			.onType(TypeReference.of(type))
 			.withMemberCategories(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS, MemberCategory.INTROSPECT_PUBLIC_METHODS,
 					MemberCategory.INVOKE_PUBLIC_METHODS);
+	}
+
+	private Consumer<RuntimeHints> hasValidTypeName(Class<?> type) {
+		return (runtimeHints) -> assertThat(runtimeHints.reflection().getTypeHint(type)).extracting(TypeHint::getType)
+			.extracting(TypeReference::getName)
+			.isEqualTo(type.getName());
 	}
 
 	private Properties load(InputStreamSource source) {
@@ -323,7 +350,21 @@ class LogbackConfigurationAotContributionTests {
 
 	}
 
-	public static class Implementation implements Contract {
+	public static class BaseImplementation implements Contract {
+
+		private Details details;
+
+		public void setDetails(Details details) {
+			this.details = details;
+		}
+
+		public static final class Details {
+
+		}
+
+	}
+
+	public static class Implementation extends BaseImplementation {
 
 	}
 


### PR DESCRIPTION
Before this commit, the generated name for the inner class had the wrong format `<package>.<parent>.<child>` (canonical name). GraalVM expects **$** to separate the parent from the inner class.

This commit updates `SpringBootJoranConfigurator` to generate an appropriate format for a class name. Specifically, an inner class should be separated by a dollar sign, not a dot.

See gh-44016

