### PR TITLE
Pull up setDisableMBeanRegistry to ConfigurableTomcatWebServerFactory

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/ConfigurableTomcatWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/ConfigurableTomcatWebServerFactory.java
@@ -49,6 +49,13 @@ public interface ConfigurableTomcatWebServerFactory extends ConfigurableWebServe
 	void setBackgroundProcessorDelay(int delay);
 
 	/**
+	 * Set whether the factory should disable Tomcat's MBean registry prior to creating
+	 * the server.
+	 * @param disableMBeanRegistry whether to disable the MBean registry
+	 */
+	void setDisableMBeanRegistry(boolean disableMBeanRegistry);
+
+	/**
 	 * Add {@link Valve}s that should be applied to the Tomcat {@link Engine}.
 	 * @param engineValves the valves to add
 	 */

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatReactiveWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatReactiveWebServerFactory.java
@@ -262,6 +262,11 @@ public class TomcatReactiveWebServerFactory extends AbstractReactiveWebServerFac
 		this.backgroundProcessorDelay = delay;
 	}
 
+	@Override
+	public void setDisableMBeanRegistry(boolean disableMBeanRegistry) {
+		this.disableMBeanRegistry = disableMBeanRegistry;
+	}
+
 	/**
 	 * Set {@link TomcatContextCustomizer}s that should be applied to the Tomcat
 	 * {@link Context}. Calling this method will replace any existing customizers.
@@ -460,16 +465,6 @@ public class TomcatReactiveWebServerFactory extends AbstractReactiveWebServerFac
 	public void setProtocol(String protocol) {
 		Assert.hasLength(protocol, "'protocol' must not be empty");
 		this.protocol = protocol;
-	}
-
-	/**
-	 * Set whether the factory should disable Tomcat's MBean registry prior to creating
-	 * the server.
-	 * @param disableMBeanRegistry whether to disable the MBean registry
-	 * @since 2.2.0
-	 */
-	public void setDisableMBeanRegistry(boolean disableMBeanRegistry) {
-		this.disableMBeanRegistry = disableMBeanRegistry;
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
@@ -770,12 +770,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 		this.backgroundProcessorDelay = delay;
 	}
 
-	/**
-	 * Set whether the factory should disable Tomcat's MBean registry prior to creating
-	 * the server.
-	 * @param disableMBeanRegistry whether to disable the MBean registry
-	 * @since 2.2.0
-	 */
+	@Override
 	public void setDisableMBeanRegistry(boolean disableMBeanRegistry) {
 		this.disableMBeanRegistry = disableMBeanRegistry;
 	}


### PR DESCRIPTION
Since all inheritors implement `setDisableMBeanRegistry` we should put it in their interface

Fix #44070