### PR TITLE
Refactor: Extract qualifier constant in EntityManagerFactory configuration

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/dataaccess/usemultipleentitymanagers/MyAdditionalEntityManagerFactoryConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/dataaccess/usemultipleentitymanagers/MyAdditionalEntityManagerFactoryConfiguration.java
@@ -31,19 +31,21 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 @Configuration(proxyBeanMethods = false)
 public class MyAdditionalEntityManagerFactoryConfiguration {
 
-	@Qualifier("second")
+	private static final String SECOND = "second";
+
+	@Qualifier(SECOND)
 	@Bean(defaultCandidate = false)
 	@ConfigurationProperties("app.jpa")
 	public JpaProperties secondJpaProperties() {
 		return new JpaProperties();
 	}
 
-	@Qualifier("second")
+	@Qualifier(SECOND)
 	@Bean(defaultCandidate = false)
-	public LocalContainerEntityManagerFactoryBean secondEntityManagerFactory(@Qualifier("second") DataSource dataSource,
-			@Qualifier("second") JpaProperties jpaProperties) {
+	public LocalContainerEntityManagerFactoryBean secondEntityManagerFactory(@Qualifier(SECOND) DataSource dataSource,
+			@Qualifier(SECOND) JpaProperties jpaProperties) {
 		EntityManagerFactoryBuilder builder = createEntityManagerFactoryBuilder(jpaProperties);
-		return builder.dataSource(dataSource).packages(Order.class).persistenceUnit("second").build();
+		return builder.dataSource(dataSource).packages(Order.class).persistenceUnit(SECOND).build();
 	}
 
 	private EntityManagerFactoryBuilder createEntityManagerFactoryBuilder(JpaProperties jpaProperties) {


### PR DESCRIPTION
## Overview
This PR introduces a simple refactoring to improve code maintainability in
the `MyAdditionalEntityManagerFactoryConfiguration` class by extracting a
commonly used string literal to a constant.

## Changes
- Added private static final constant `SECOND = "second"`
- Updated all qualifier references to use the constant
- Updated persistenceUnit parameter to use the constant

## Motivation
The string literal "second" was used multiple times in the configuration
class. Extracting it to a constant:
- Reduces the risk of typos
- Makes future changes easier (single point of modification)
- Improves code maintainability
- Follows DRY principle

## Type of Change
- [x] Code refactoring (non-breaking change)
- [x] Documentation update

## Checklist
- [x] Code follows project's style guidelines
- [x] All tests pass successfully
- [x] Commit message follows guidelines
- [x] DCO sign-off included
- [x] No functional changes introduced
- [x] Documentation updated if needed