### PR TITLE
Document all the available Testcontainers integrations

### DIFF
--- a/buildSrc/src/main/resources/org/springframework/boot/build/antora/antora-asciidoc-attributes.properties
+++ b/buildSrc/src/main/resources/org/springframework/boot/build/antora/antora-asciidoc-attributes.properties
@@ -75,6 +75,7 @@ url-spring-data-rest-docs=https://docs.spring.io/spring-data/rest/reference/{ant
 url-spring-data-rest-site=https://spring.io/projects/spring-data-rest
 url-spring-data-rest-javadoc=https://docs.spring.io/spring-data/rest/docs/{dotxversion-spring-data-rest}/api
 url-spring-data-site=https://spring.io/projects/spring-data
+url-testcontainers-java-doc=https://java.testcontainers.org
 url-testcontainers-activemq-javadoc=https://javadoc.io/doc/org.testcontainers/activemq/{version-testcontainers-activemq}
 url-testcontainers-cassandra-javadoc=https://javadoc.io/doc/org.testcontainers/cassandra/{version-testcontainers-cassandra}
 url-testcontainers-couchbase-javadoc=https://javadoc.io/doc/org.testcontainers/couchbase/{version-testcontainers-couchbase}

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
@@ -47,6 +47,28 @@ All that is needed to do that is adding javadoc:org.springframework.boot.testcon
 
 include-code::importcontainers/MyConfiguration[]
 
+== Lifecycle of managed containers
+
+If you have used the annotations and extensions provided by Testcontainers framework, then the lifecycle of container instances is managed by the Testcontainers framework.
+Please refer to the official documentation for the information about lifecycle of the containers, when managed by the Testcontainers framework.
+
+When the containers are managed by Spring as beans, then the lifecycle is clearly defined by Spring.
+The container beans are created and started before the beans of other types are created.
+This process ensures that any beans, which rely on functionality provided by the containers, can use those functionalities.
+
+The test containers can be started multiple times.
+Like any other beans the test containers are created and started once per application context managed by the TestContext Framework.
+For details about how TestContext framework manages the underlying application contexts and beans therein, please refer to the official Spring documentation.
+
+The container beans are stopped after the destruction of beans of other types.
+This ensures that any beans depending on the functionalities provided by the containers are cleaned up first.
+
+The containers are stopped as part of the application shutdown process, managed by the TestContext framework.
+When the application context gets shutdown, the containers are shutdown as well.
+This usually happens after all tests using that specific cached application context have finished executing, but may happen earlier depending on the caching behavior configured in TestContext Framework.
+
+It is important to note that a single test container instance can be, and often is, retained across execution of tests from multiple test classes.
+
 [[testing.testcontainers.service-connections]]
 == Service Connections
 

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
@@ -24,7 +24,7 @@ In this case the lifecycle of the container instance is managed by Testcontainer
 == Using via Spring managed beans
 
 The containers provided by Testcontainers can be managed by Spring Boot as beans.
-This method is often used in combination with javadoc:org.springframework.boot.testcontainers.service.connection.ServiceConnection[format=annotation].
+This method of managing contains can be used in combination with javadoc:org.springframework.boot.testcontainers.service.connection.ServiceConnection[format=annotation].
 
 To use Testcontainer contains as Spring beans we need to create a configuration class declaring the container as bean:
 
@@ -37,7 +37,7 @@ include-code::beandeclaration/SpringTest[]
 
 == Using via importing container declaration classes
 
-A common pattern with Testcontainers is to declare the Container instances as static fields in an interface
+A common pattern with Testcontainers is to declare the Container instances as static fields in an interface.
 For example the following interface `MyInterface` declares two containers, one named `mongo` of type MongoDB and another named `neo` of type Neo4j:
 
 include-code::importcontainers/MyInterface[]
@@ -47,10 +47,13 @@ All that is needed to do that is adding javadoc:org.springframework.boot.testcon
 
 include-code::importcontainers/MyConfiguration[]
 
+TIP: Using interfaces for declaring contains helps with reuse.
+When containers are declared in an interface, this can be reused in your javadoc:org.springframework.context.annotation.Configuration[format=annotation] classes and in test classes.
+
 == Lifecycle of managed containers
 
 If you have used the annotations and extensions provided by Testcontainers, then the lifecycle of container instances is managed by the Testcontainers.
-Please refer to the official documentation for the information about lifecycle of the containers, when managed by the Testcontainers.
+Please refer to the {url-testcontainres-java-doc}[Testcontainers official documentation] for the information about lifecycle of the containers, when managed by the Testcontainers.
 
 When the containers are managed by Spring as beans, then the lifecycle is clearly defined by Spring.
 The container beans are created and started before the beans of other types are created.
@@ -58,10 +61,18 @@ This process ensures that any beans, which rely on functionality provided by the
 
 The test containers can be started multiple times.
 Like any other beans the test containers are created and started once per application context managed by the TestContext Framework.
-For details about how TestContext framework manages the underlying application contexts and beans therein, please refer to the official Spring documentation.
+For details about how TestContext framework manages the underlying application contexts and beans therein, please refer to the {url-spring-framework-docs}[official Spring documentation].
 
 The container beans are stopped after the destruction of beans of other types.
 This ensures that any beans depending on the functionalities provided by the containers are cleaned up first.
+
+TIP: When your application beans rely on functionality of containers, prefer configuring the containers as Spring beans.
+When containers are managed as Spring beans, then Spring framework ensures that upon start the container beans are started before any beans relying on them.
+On shutdown the application beans depending on container functionalities are cleaned up first, and only then are the containers shut down.
+
+NOTE: Having containers managed by Testcontainers instead of as Spring beans provides no guarantee of order in which beans and containers will shutdown.
+It can happen that containers are shutdown before the beans relying on container functionality are cleaned up.
+This can lead to exceptions being thrown by client beans due to loss of connection for example.
 
 The containers are stopped as part of the application shutdown process, managed by the TestContext framework.
 When the application context gets shutdown, the containers are shutdown as well.

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
@@ -7,6 +7,9 @@ Testcontainers is especially useful for writing integration tests that talk to a
 
 In following sections we will describe some of the methods you can use to integrate Testcontainers with your tests.
 
+
+
+[[testing.testcontainers.via-junit-extension]]
 == Using via @Testcontainers JUnit5 extension
 
 The Testcontainers provides JUnit5 extensions, which can be used to manage containers in your tests.
@@ -21,6 +24,8 @@ In most cases, you will need to configure the application to connect to the serv
 
 In this case the lifecycle of the container instance is managed by Testcontainers, as described in official documentation.
 
+
+[[testing.testcontainers.via-spring-beans]]
 == Using via Spring managed beans
 
 The containers provided by Testcontainers can be managed by Spring Boot as beans.
@@ -35,6 +40,7 @@ then we can start the container by importing the configuration class in the test
 include-code::beandeclaration/SpringTest[]
 
 
+[[testing.testcontainers.via-declaration-classes]]
 == Using via importing container declaration classes
 
 A common pattern with Testcontainers is to declare the Container instances as static fields in an interface.
@@ -50,6 +56,8 @@ include-code::importcontainers/MyConfiguration[]
 TIP: Using interfaces for declaring contains helps with reuse.
 When containers are declared in an interface, this can be reused in your javadoc:org.springframework.context.annotation.Configuration[format=annotation] classes and in test classes.
 
+
+[[test.testcontainers.container-lifecycle]]
 == Lifecycle of managed containers
 
 If you have used the annotations and extensions provided by Testcontainers, then the lifecycle of container instances is managed by the Testcontainers.
@@ -79,6 +87,8 @@ When the application context gets shutdown, the containers are shutdown as well.
 This usually happens after all tests using that specific cached application context have finished executing, but may happen earlier depending on the caching behavior configured in TestContext Framework.
 
 It is important to note that a single test container instance can be, and often is, retained across execution of tests from multiple test classes.
+
+
 
 [[testing.testcontainers.service-connections]]
 == Service Connections

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
@@ -9,7 +9,7 @@ In following sections we will describe some of the methods you can use to integr
 
 == Using via @Testcontainers JUnit5 extension
 
-The Testcontainers framework provides JUnit5 extensions, which can be used to manage containers in your tests.
+The Testcontainers provides JUnit5 extensions, which can be used to manage containers in your tests.
 The extension is activated by applying the
 
 Testcontainers can be used in a Spring Boot test as follows:
@@ -19,11 +19,11 @@ include-code::vanilla/MyIntegrationTests[]
 This will start up a Docker container running Neo4j (if Docker is running locally) before any of the tests are run.
 In most cases, you will need to configure the application to connect to the service running in the container.
 
-In this case the lifecycle of the container instance is managed by Testcontainers framework, as described in official documentation.
+In this case the lifecycle of the container instance is managed by Testcontainers, as described in official documentation.
 
 == Using via Spring managed beans
 
-The containers provided by Testcontainers framework can be managed by Spring Boot as beans.
+The containers provided by Testcontainers can be managed by Spring Boot as beans.
 This method is often used in combination with javadoc:org.springframework.boot.testcontainers.service.connection.ServiceConnection[format=annotation].
 
 To use Testcontainer contains as Spring beans we need to create a configuration class declaring the container as bean:
@@ -37,7 +37,7 @@ include-code::beandeclaration/SpringTest[]
 
 == Using via importing container declaration classes
 
-A common pattern with Testcontainers framework is to declare the Container instances as static fields in an interface
+A common pattern with Testcontainers is to declare the Container instances as static fields in an interface
 For example the following interface `MyInterface` declares two containers, one named `mongo` of type MongoDB and another named `neo` of type Neo4j:
 
 include-code::importcontainers/MyInterface[]
@@ -49,8 +49,8 @@ include-code::importcontainers/MyConfiguration[]
 
 == Lifecycle of managed containers
 
-If you have used the annotations and extensions provided by Testcontainers framework, then the lifecycle of container instances is managed by the Testcontainers framework.
-Please refer to the official documentation for the information about lifecycle of the containers, when managed by the Testcontainers framework.
+If you have used the annotations and extensions provided by Testcontainers, then the lifecycle of container instances is managed by the Testcontainers.
+Please refer to the official documentation for the information about lifecycle of the containers, when managed by the Testcontainers.
 
 When the containers are managed by Spring as beans, then the lifecycle is clearly defined by Spring.
 The container beans are created and started before the beans of other types are created.

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
@@ -5,14 +5,47 @@ The https://www.testcontainers.org/[Testcontainers] library provides a way to ma
 It integrates with JUnit, allowing you to write a test class that can start up a container before any of the tests run.
 Testcontainers is especially useful for writing integration tests that talk to a real backend service such as MySQL, MongoDB, Cassandra and others.
 
+In following sections we will describe some of the methods you can use to integrate Testcontainers with your tests.
+
+== Using via @Testcontainers JUnit5 extension
+
+The Testcontainers framework provides JUnit5 extensions, which can be used to manage containers in your tests.
+The extension is activated by applying the
+
 Testcontainers can be used in a Spring Boot test as follows:
 
 include-code::vanilla/MyIntegrationTests[]
 
-This will start up a docker container running Neo4j (if Docker is running locally) before any of the tests are run.
+This will start up a Docker container running Neo4j (if Docker is running locally) before any of the tests are run.
 In most cases, you will need to configure the application to connect to the service running in the container.
 
+In this case the lifecycle of the container instance is managed by Testcontainers framework, as described in official documentation.
 
+== Using via Spring managed beans
+
+The containers provided by Testcontainers framework can be managed by Spring Boot as beans.
+This method is often used in combination with javadoc:org.springframework.boot.testcontainers.service.connection.ServiceConnection[format=annotation].
+
+To use Testcontainer contains as Spring beans we need to create a configuration class declaring the container as bean:
+
+include-code::beandeclaration/BeanDeclarationConfig[]
+
+then we can start the container by importing the configuration class in the test class:
+
+include-code::beandeclaration/SpringTest[]
+
+
+== Using via importing container declaration classes
+
+A common pattern with Testcontainers framework is to declare the Container instances as static fields in an interface
+For example the following interface `MyInterface` declares two containers, one named `mongo` of type MongoDB and another named `neo` of type Neo4j:
+
+include-code::importcontainers/MyInterface[]
+
+When you have containers declared in this way, then you can have these containers managed by Spring Boot as beans.
+All that is needed to do that is adding javadoc:org.springframework.boot.testcontainers.context.ImportTestcontainers[format=annotation] to your configuration class as in:
+
+include-code::importcontainers/MyConfiguration[]
 
 [[testing.testcontainers.service-connections]]
 == Service Connections

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
@@ -13,7 +13,7 @@ In following sections we will describe some of the methods you can use to integr
 == Using via @Testcontainers JUnit5 extension
 
 The Testcontainers provides JUnit5 extensions, which can be used to manage containers in your tests.
-The extension is activated by applying the
+The extension is activated by applying the `@Testcontainers` annotation from Testcontainers to your test class.
 
 Testcontainers can be used in a Spring Boot test as follows:
 

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/testcontainers/beandeclaration/BeanDeclarationConfig.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/testcontainers/beandeclaration/BeanDeclarationConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docs.testing.testcontainers.beandeclaration;
+
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration(proxyBeanMethods = false)
+class BeanDeclarationConfig {
+
+	@ServiceConnection
+	@Bean
+	MongoDBContainer container() {
+		return new MongoDBContainer(DockerImageName.parse("mongo:latest"));
+	}
+}

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/testcontainers/beandeclaration/BeanDeclarationConfig.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/testcontainers/beandeclaration/BeanDeclarationConfig.java
@@ -31,4 +31,5 @@ class BeanDeclarationConfig {
 	MongoDBContainer container() {
 		return new MongoDBContainer(DockerImageName.parse("mongo:latest"));
 	}
+
 }

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/testcontainers/beandeclaration/SpringTest.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/testcontainers/beandeclaration/SpringTest.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Import;
 
 @SpringBootTest
 @Import(BeanDeclarationConfig.class)
-public class SpringTest {
+class SpringTest {
 
 	@Autowired
 	private MongoDBContainer mongo;
@@ -34,4 +34,5 @@ public class SpringTest {
 	void doTest() {
 		System.out.println("Mongo db is running: " + this.mongo.isRunning());
 	}
+
 }

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/testcontainers/beandeclaration/SpringTest.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/testcontainers/beandeclaration/SpringTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docs.testing.testcontainers.beandeclaration;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MongoDBContainer;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@SpringBootTest
+@Import(BeanDeclarationConfig.class)
+public class SpringTest {
+
+	@Autowired
+	private MongoDBContainer mongo;
+
+	@Test
+	void doTest() {
+		System.out.println("Mongo db is running: " + this.mongo.isRunning());
+	}
+}

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/testcontainers/importcontainers/MyConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/testcontainers/importcontainers/MyConfiguration.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docs.testing.testcontainers.importcontainers;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.context.ImportTestcontainers;
+
+@TestConfiguration(proxyBeanMethods = false)
+@ImportTestcontainers(MyInterface.class)
+class MyConfiguration {
+}

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/testcontainers/importcontainers/MyConfiguration.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/testcontainers/importcontainers/MyConfiguration.java
@@ -22,4 +22,5 @@ import org.springframework.boot.testcontainers.context.ImportTestcontainers;
 @TestConfiguration(proxyBeanMethods = false)
 @ImportTestcontainers(MyInterface.class)
 class MyConfiguration {
+
 }

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/testcontainers/importcontainers/MyInterface.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/testcontainers/importcontainers/MyInterface.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docs.testing.testcontainers.importcontainers;
+
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+
+interface MyInterface {
+
+	@Container
+	@ServiceConnection
+	MongoDBContainer mongoContainer = new MongoDBContainer("mongo:5.0");
+
+	@Container
+	@ServiceConnection
+	Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:5");
+
+}

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/testing/testcontainers/beandeclaration/BeanDeclarationConfig.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/testing/testcontainers/beandeclaration/BeanDeclarationConfig.kt
@@ -1,0 +1,17 @@
+package org.springframework.boot.docs.testing.testcontainers.beandeclaration
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.context.annotation.Bean
+import org.testcontainers.containers.MongoDBContainer
+import org.testcontainers.utility.DockerImageName
+
+
+@TestConfiguration(proxyBeanMethods = false)
+internal class BeanDeclarationConfig {
+	@ServiceConnection
+	@Bean
+	fun container(): MongoDBContainer {
+		return MongoDBContainer(DockerImageName.parse("mongo:latest"))
+	}
+}

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/testing/testcontainers/beandeclaration/SpringTest.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/testing/testcontainers/beandeclaration/SpringTest.kt
@@ -1,0 +1,19 @@
+package org.springframework.boot.docs.testing.testcontainers.beandeclaration
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.testcontainers.containers.MongoDBContainer
+
+@SpringBootTest
+@Import(BeanDeclarationConfig::class)
+class SpringTest {
+	@Autowired
+	private val mongo: MongoDBContainer? = null
+
+	@Test
+	fun doTest() {
+		println("Mongo db is running: " + mongo!!.isRunning)
+	}
+}

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -82,6 +82,7 @@
 	<suppress files="spring-boot-configuration-processor[\\/]src[\\/]test[\\/]java[\\/]org[\\/]springframework[\\/]boot[\\/]configurationsample[\\/]" checks="SpringDeprecatedCheck"/>
 	<suppress files="ImportTestcontainersTests\.java" checks="InterfaceIsType" />
 	<suppress files="MyContainers\.java" checks="InterfaceIsType" />
+	<suppress files="MyInterface\.java" checks="InterfaceIsType" />
 	<suppress files="SpringBootBanner\.java" checks="SpringLeadingWhitespace" />
 	<suppress files="LoadTimeWeaverAwareConsumerContainers\.java" checks="InterfaceIsType" />
 </suppressions>


### PR DESCRIPTION
In this PR I have documented the ways in which containers provided by Testcontainers framework can be incorporated into the test tests managed by Spring's TestContext Framework.

In addition to describing how to use the containers, information on lifecycle of containers during tests has been added. 