### PR TITLE
Add application name support to StartupInfoLogger

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
@@ -101,8 +101,8 @@ class StartupInfoLogger {
 	}
 
 	private void appendApplicationName(StringBuilder message) {
-		append(message, "",
-				() -> (this.sourceClass != null) ? ClassUtils.getShortName(this.sourceClass) : "application");
+		append(message, "", () -> this.environment.getProperty("spring.application.name",
+				this.sourceClass != null ? ClassUtils.getShortName(this.sourceClass) : "application"));
 	}
 
 	private void appendVersion(StringBuilder message, Class<?> source) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/StartupInfoLoggerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/StartupInfoLoggerTests.java
@@ -103,6 +103,19 @@ class StartupInfoLoggerTests {
 	}
 
 	@Test
+	void startingFormatWhenApplicationNameIsAvailable() {
+		String applicationName = "test-application";
+		this.environment.setProperty("spring.application.name", applicationName);
+		given(this.log.isInfoEnabled()).willReturn(true);
+		new StartupInfoLogger(getClass(), this.environment).logStarting(this.log);
+		then(this.log).should()
+				.info(assertArg(
+						(message) -> assertThat(message.toString()).contains("Starting " + applicationName
+								+ " v1.2.3 using Java " + System.getProperty("java.version") + " with PID 42 (started by "
+								+ System.getProperty("user.name") + " in " + System.getProperty("user.dir") + ")")));
+	}
+
+	@Test
 	void startedFormat() {
 		given(this.log.isInfoEnabled()).willReturn(true);
 		new StartupInfoLogger(getClass(), this.environment).logStarted(this.log, new TestStartup(1345L, "Started"));
@@ -118,6 +131,17 @@ class StartupInfoLoggerTests {
 		then(this.log).should()
 			.info(assertArg((message) -> assertThat(message.toString())
 				.matches("Started " + getClass().getSimpleName() + " in \\d+\\.\\d{1,3} seconds")));
+	}
+
+	@Test
+	void startedFormatWhenApplicationNameIsAvailable() {
+		String applicationName = "test-application";
+		this.environment.setProperty("spring.application.name", applicationName);
+		given(this.log.isInfoEnabled()).willReturn(true);
+		new StartupInfoLogger(getClass(), this.environment).logStarted(this.log, new TestStartup(1345L, "Started"));
+		then(this.log).should()
+				.info(assertArg((message) -> assertThat(message.toString()).matches("Started " + applicationName
+						+ " in \\d+\\.\\d{1,3} seconds \\(process running for 1.345\\)")));
 	}
 
 	@Test


### PR DESCRIPTION
`spring.application.name` does not work with StartupInfoLogger.
Only mainApplicationClass name is logged. below is an example.

```yml
spring:
  application:
    name: HelloApp
```
```java
@SpringBootApplication
public class MyApplication {
  public static void main(String[] args) {
   // something
  }
}
```

### Expected
```log
[INFO ][](StartupInfoLogger.java:53) Starting HelloApp using Java 17.0.6 with PID ...
```

### Actual
```log
[INFO ][](StartupInfoLogger.java:53) Starting MyApplication using Java 17.0.6 with PID ...
```