### PR TITLE
Upgrade Elasticsearch Client to version 8.17.2

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-autoconfigure/build.gradle
@@ -97,7 +97,7 @@ dependencies {
 			classifier = 'jakarta'
 		}
 	}
-	optional("org.elasticsearch.client:elasticsearch-rest-client") {
+	optional("org.elasticsearch.client:elasticsearch-rest-client:8.17.2") {
 		exclude group: "commons-logging", module: "commons-logging"
 	}
 	optional("org.elasticsearch.client:elasticsearch-rest-client-sniffer") {


### PR DESCRIPTION
This pull request upgrades the Elasticsearch client to version 8.17.2 in the build.gradle file, replacing the existing version. This upgrade is necessary to stay current with the latest version of Elasticsearch and its associated fixes and improvements.