### PR TITLE
Correct AutoConfigurationSorter for source-style nested class name

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/AutoConfigurationSorterTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/AutoConfigurationSorterTests.java
@@ -233,6 +233,14 @@ class AutoConfigurationSorterTests {
 		assertThat(actual).containsExactly(oa1, oa2, oa3, oa4, oa);
 	}
 
+	@Test
+	void byAutoConfigureAfterWithNestedClassNameInSourceStyle() {
+		// For B, replace the last $ with .
+		String srcStyleB = B.substring(0, B.lastIndexOf('$')) + '.' + B.substring(B.lastIndexOf('$') + 1);
+		List<String> actual = getInPriorityOrder(A, srcStyleB, C);
+		assertThat(actual).containsExactly(C, B, A);
+	}
+
 	private List<String> getInPriorityOrder(String... classNames) {
 		return this.sorter.getInPriorityOrder(Arrays.asList(classNames));
 	}


### PR DESCRIPTION
Since the AutoConfiguration loaded by `org.springframework.core.type.classreading.SimpleMetadataReaderFactory#getMetadataReader(java.lang.String)` supports source-style nested class names, developers can register AutoConfiguration in this way. However, if AutoConfiguration is used as an `@AutoConfigureBefore`/`@AutoConfigureAfter` reference (class reference in the value attribute), the source-style nested class name registration will fail in the sorting operation.
The failure caused by `toSort.contains(after)` in `org.springframework.boot.autoconfigure.AutoConfigurationSorter#doSortByAfterAnnotation` method, which requires the AutoConfiguration class name from `@AutoConfigureBefore`/`@AutoConfigureAfter` attribute to be the same as in `spring.factories`/`AutoConfiguration.imports`.
This PR fixes this issue by replacing source-style nested class names with class-style nested class names before sorting. For the purpose of minimal modification, this fix is not so elegant. Maybe you can rewrite some code to fit Spring Boot's design ideas.