### PR TITLE
Add Javadoc since for UndertowReactiveWebServerFactory.getAccessLogPrefix()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowReactiveWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowReactiveWebServerFactory.java
@@ -112,6 +112,11 @@ public class UndertowReactiveWebServerFactory extends AbstractReactiveWebServerF
 		this.delegate.setAccessLogPattern(accessLogPattern);
 	}
 
+	/**
+	 * Returns the access log prefix.
+	 * @return the access log prefix
+	 * @since 3.5.0
+	 */
 	public String getAccessLogPrefix() {
 		return this.delegate.getAccessLogPrefix();
 	}


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `UndertowReactiveWebServerFactory.getAccessLogPrefix()`.

See gh-44197