### PR TITLE
Remove deprecated micrometer.observations.annotations.enabled

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAspectsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAspectsAutoConfiguration.java
@@ -68,11 +68,6 @@ public class MetricsAspectsAutoConfiguration {
 			super(ConfigurationPhase.PARSE_CONFIGURATION);
 		}
 
-		@ConditionalOnBooleanProperty("micrometer.observations.annotations.enabled")
-		static class MicrometerObservationsEnabledCondition {
-
-		}
-
 		@ConditionalOnBooleanProperty("management.observations.annotations.enabled")
 		static class ManagementObservationsEnabledCondition {
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/MicrometerTracingAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/MicrometerTracingAutoConfiguration.java
@@ -158,11 +158,6 @@ public class MicrometerTracingAutoConfiguration {
 			super(ConfigurationPhase.PARSE_CONFIGURATION);
 		}
 
-		@ConditionalOnBooleanProperty("micrometer.observations.annotations.enabled")
-		static class MicrometerObservationsEnabledCondition {
-
-		}
-
 		@ConditionalOnBooleanProperty("management.observations.annotations.enabled")
 		static class ManagementObservationsEnabledCondition {
 

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -2247,14 +2247,6 @@
       "name": "management.zipkin.tracing.export.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether auto-configuration of tracing is enabled to export Zipkin traces."
-    },
-    {
-      "name": "micrometer.observations.annotations.enabled",
-      "type": "java.lang.Boolean",
-      "deprecation": {
-        "level": "error",
-        "replacement": "management.observations.annotations.enabled"
-      }
     }
   ],
   "hints": [

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAspectsAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/MetricsAspectsAutoConfigurationTests.java
@@ -55,17 +55,6 @@ class MetricsAspectsAutoConfigurationTests {
 	}
 
 	@Test
-	void shouldConfigureAspectsWithLegacyProperty() {
-		new ApplicationContextRunner().with(MetricsRun.simple())
-			.withConfiguration(AutoConfigurations.of(MetricsAspectsAutoConfiguration.class))
-			.withPropertyValues("micrometer.observations.annotations.enabled=true")
-			.run((context) -> {
-				assertThat(context).hasSingleBean(CountedAspect.class);
-				assertThat(context).hasSingleBean(TimedAspect.class);
-			});
-	}
-
-	@Test
 	void shouldConfigureAspects() {
 		this.contextRunner.run((context) -> {
 			assertThat(context).hasSingleBean(CountedAspect.class);

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/MicrometerTracingAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/tracing/MicrometerTracingAutoConfigurationTests.java
@@ -146,18 +146,6 @@ class MicrometerTracingAutoConfigurationTests {
 	}
 
 	@Test
-	void shouldSupplyAspectBeansIfLegacyPropertyIsEnabled() {
-		new ApplicationContextRunner().withPropertyValues("micrometer.observations.annotations.enabled=true")
-			.withConfiguration(AutoConfigurations.of(MicrometerTracingAutoConfiguration.class))
-			.withUserConfiguration(TracerConfiguration.class, PropagatorConfiguration.class)
-			.run((context) -> {
-				assertThat(context).hasSingleBean(DefaultNewSpanParser.class);
-				assertThat(context).hasSingleBean(ImperativeMethodInvocationProcessor.class);
-				assertThat(context).hasSingleBean(SpanAspect.class);
-			});
-	}
-
-	@Test
 	void shouldNotSupplyBeansIfAspectjIsMissing() {
 		this.contextRunner.withUserConfiguration(TracerConfiguration.class)
 			.withClassLoader(new FilteredClassLoader(Advice.class))


### PR DESCRIPTION
This PR removes the `micrometer.observations.annotations.enabled` property that has been deprecated since Spring Boot 3.2.3 in #39600.