### PR TITLE
Don't use ArgFile when using JavaCompiler

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractAotMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractAotMojo.java
@@ -147,7 +147,7 @@ public abstract class AbstractAotMojo extends AbstractDependencyFilterMojo {
 			JavaCompilerPluginConfiguration compilerConfiguration = new JavaCompilerPluginConfiguration(this.project);
 			List<String> options = new ArrayList<>();
 			options.add("-cp");
-			options.add(ClasspathBuilder.forURLs(classPath).build().argument());
+			options.add(ClasspathBuilder.forURLs(classPath).build().toString());
 			options.add("-d");
 			options.add(outputDirectory.toPath().toAbsolutePath().toString());
 			String releaseVersion = compilerConfiguration.getReleaseVersion();

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractRunMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractRunMojo.java
@@ -348,8 +348,7 @@ public abstract class AbstractRunMojo extends AbstractDependencyFilterMojo {
 		try {
 			Classpath classpath = ClasspathBuilder.forURLs(getClassPathUrls()).build();
 			if (getLog().isDebugEnabled()) {
-				getLog().debug("Classpath for forked process: "
-						+ classpath.elements().map(Object::toString).collect(Collectors.joining(File.separator)));
+				getLog().debug("Classpath for forked process: " + classpath);
 			}
 			args.add("-cp");
 			args.add(classpath.argument());

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/ClasspathBuilder.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/ClasspathBuilder.java
@@ -172,6 +172,11 @@ class ClasspathBuilder {
 			return this.elements.stream();
 		}
 
+		@Override
+		public String toString() {
+			return elements().map(Path::toString).collect(Collectors.joining(File.pathSeparator));
+		}
+
 	}
 
 }


### PR DESCRIPTION
Fixes build on Windows


see https://github.com/spring-projects/spring-boot/pull/44305


ArgFile should not be used when compiling sources via `JavaCompiler`.  

>[CreateProcess error=206, The filename or extension is too long]

This happens only when running a process via `ProcessBuilder` but not `JavaCompiler`. 