### PR TITLE
Consider properties on outer class in nested @DataJpaTest tests

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/orm/jpa/DataJpaTestContextBootstrapper.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/orm/jpa/DataJpaTestContextBootstrapper.java
@@ -17,8 +17,7 @@
 package org.springframework.boot.test.autoconfigure.orm.jpa;
 
 import org.springframework.boot.test.context.SpringBootTestContextBootstrapper;
-import org.springframework.core.annotation.MergedAnnotations;
-import org.springframework.core.annotation.MergedAnnotations.SearchStrategy;
+import org.springframework.test.context.TestContextAnnotationUtils;
 import org.springframework.test.context.TestContextBootstrapper;
 
 /**
@@ -30,10 +29,8 @@ class DataJpaTestContextBootstrapper extends SpringBootTestContextBootstrapper {
 
 	@Override
 	protected String[] getProperties(Class<?> testClass) {
-		return MergedAnnotations.from(testClass, SearchStrategy.INHERITED_ANNOTATIONS)
-			.get(DataJpaTest.class)
-			.getValue("properties", String[].class)
-			.orElse(null);
+		DataJpaTest dataJpaTest = TestContextAnnotationUtils.findMergedAnnotation(testClass, DataJpaTest.class);
+		return (dataJpaTest != null) ? dataJpaTest.properties() : null;
 	}
 
 }

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/jpa/DataJpaTestPropertiesIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/data/jpa/DataJpaTestPropertiesIntegrationTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.data.jpa;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.core.env.Environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the {@link DataJpaTest#properties properties} attribute of
+ * {@link DataJpaTest @DataJpaTest}.
+ *
+ * @author Bernie Schelberg
+ */
+@DataJpaTest(properties = "spring.profiles.active=test")
+class DataJpaTestPropertiesIntegrationTests {
+
+	@Autowired
+	private Environment environment;
+
+	@Test
+	void environmentWithNewProfile() {
+		assertThat(this.environment.getActiveProfiles()).containsExactly("test");
+	}
+
+	@Nested
+	class NestedTests {
+
+		@Autowired
+		private Environment innerEnvironment;
+
+		@Test
+		void propertiesFromEnclosingClassAffectNestedTests() {
+			assertThat(DataJpaTestPropertiesIntegrationTests.this.environment.getActiveProfiles())
+				.containsExactly("test");
+			assertThat(this.innerEnvironment.getActiveProfiles()).containsExactly("test");
+		}
+
+	}
+
+}


### PR DESCRIPTION
The commit https://github.com/spring-projects/spring-boot/commit/5669ea69d004705fead1a60d4aacdd0d41744e8d
omitted the DataJpaTestContextBootstrapper. This PR applies similar changes to the other commit.

Fixes #33317