### PR TITLE
Polish ClassPath

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/ClassPath.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/ClassPath.java
@@ -79,6 +79,11 @@ final class ClassPath {
 		return this.path;
 	}
 
+	@Override
+	public String toString() {
+		return this.path;
+	}
+
 	private Path createArgFile() throws IOException {
 		Path argFile = Files.createTempFile("spring-boot-", ".argfile");
 		argFile.toFile().deleteOnExit();
@@ -121,9 +126,8 @@ final class ClassPath {
 	 * @return a new {@link ClassPath} instance
 	 */
 	static ClassPath of(UnaryOperator<String> getSystemProperty, List<URL> urls) {
-		boolean preferrArgFile = urls.size() > 1 && isWindows(getSystemProperty);
-		return new ClassPath(preferrArgFile,
-				urls.stream().map(ClassPath::toPathString).collect(JOIN_BY_PATH_SEPARATOR));
+		boolean preferArgFile = urls.size() > 1 && isWindows(getSystemProperty);
+		return new ClassPath(preferArgFile, urls.stream().map(ClassPath::toPathString).collect(JOIN_BY_PATH_SEPARATOR));
 	}
 
 	private static boolean isWindows(UnaryOperator<String> getSystemProperty) {

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ClassPathTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ClassPathTests.java
@@ -85,6 +85,14 @@ class ClassPathTests {
 		assertThat(classPath.args(true)).containsExactly("-cp", path1 + File.pathSeparator + path2);
 	}
 
+	@Test
+	void toStringShouldReturnClassPath(@TempDir Path temp) throws Exception {
+		Path path1 = temp.resolve("test1.jar");
+		Path path2 = temp.resolve("test2.jar");
+		ClassPath classPath = ClassPath.of(onLinux(), List.of(path1.toUri().toURL(), path2.toUri().toURL()));
+		assertThat(classPath.toString()).isEqualTo(path1 + File.pathSeparator + path2);
+	}
+
 	private UnaryOperator<String> onWindows() {
 		return Map.of("os.name", "windows")::get;
 	}


### PR DESCRIPTION
Introduced `toString` to fix the following:

```java


	private void addClasspath(List<String> args) throws MojoExecutionException {
		try {
			ClassPath classpath = ClassPath.of(getClassPathUrls());
			if (getLog().isDebugEnabled()) {
				getLog().debug("Classpath for forked process: " + classpath);
			}
			args.addAll(classpath.args(true));
		}
		catch (Exception ex) {
			throw new MojoExecutionException("Could not build classpath", ex);
		}
	}
```		