### PR TITLE
Adapt Javadoc reference of JooqExceptionTranslator to use ExceptionTranslatorExecuteListener

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/data-access.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/how-to/pages/data-access.adoc
@@ -403,4 +403,4 @@ include-code::ElasticsearchEntityManagerFactoryDependsOnPostProcessor[]
 If you need to use jOOQ with multiple data sources, you should create your own javadoc:org.jooq.DSLContext[] for each one.
 See {code-spring-boot-autoconfigure-src}/jooq/JooqAutoConfiguration.java[`JooqAutoConfiguration`] for more details.
 
-TIP: In particular, javadoc:org.springframework.boot.autoconfigure.jooq.JooqExceptionTranslator[] and javadoc:org.springframework.boot.autoconfigure.jooq.SpringTransactionProvider[] can be reused to provide similar features to what the auto-configuration does with a single javadoc:javax.sql.DataSource[].
+TIP: In particular, javadoc:org.springframework.boot.autoconfigure.jooq.ExceptionTranslatorExecuteListener[] and javadoc:org.springframework.boot.autoconfigure.jooq.SpringTransactionProvider[] can be reused to provide similar features to what the auto-configuration does with a single javadoc:javax.sql.DataSource[].


### PR DESCRIPTION
`JooqExceptionTranslator` will be removed in 3.5.0 and this PR update the reference javadoc link

Reference
https://docs.spring.io/spring-boot/3.5-SNAPSHOT/how-to/data-access.html#howto.data-access.configure-jooq-with-multiple-datasources