### PR TITLE
StandardStackTracePrinter prints root first if configured otherwise

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/structured/StructuredLoggingJsonProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/structured/StructuredLoggingJsonProperties.java
@@ -120,7 +120,7 @@ record StructuredLoggingJsonProperties(Set<String> include, Set<String> exclude,
 		}
 
 		private StandardStackTracePrinter createStandardPrinter() {
-			StandardStackTracePrinter printer = (root() != Root.FIRST) ? StandardStackTracePrinter.rootFirst()
+			StandardStackTracePrinter printer = (root() == Root.FIRST) ? StandardStackTracePrinter.rootFirst()
 					: StandardStackTracePrinter.rootLast();
 			PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 			printer = map.from(this::maxLength).to(printer, StandardStackTracePrinter::withMaximumLength);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/structured/StructuredLoggingJsonPropertiesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/structured/StructuredLoggingJsonPropertiesTests.java
@@ -184,7 +184,6 @@ class StructuredLoggingJsonPropertiesTests {
 			StackTracePrinter printer = properties.createPrinter();
 			String actual = TestException.withoutLineNumbers(printer.printStackTraceToString(exception));
 			assertThat(actual).isEqualTo("RuntimeExceptionroot!	at org.springfr...");
-
 		}
 
 		@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/structured/StructuredLoggingJsonPropertiesTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/structured/StructuredLoggingJsonPropertiesTests.java
@@ -152,12 +152,11 @@ class StructuredLoggingJsonPropertiesTests {
 				.withLineSeparator("\n");
 			String actual = TestException.withoutLineNumbers(printer.printStackTraceToString(exception));
 			assertThat(actual).isEqualToNormalizingNewlines("""
-					java.lang.RuntimeException: exception
-						at org.springframework.boot.logging.TestException.actualCreateException(TestException.java:NN)
-						at org.springframework.boot.logging.TestException.createException(TestException.java:NN)
-						... 2 filtered
-						Suppressed: java.lang.RuntimeException: supressed
-							at o...""");
+					java.lang.RuntimeException: root
+						at org.springframework.boot.logging.TestException.createTestException(TestException.java:NN)
+						at org.springframework.boot.logging.TestException$CreatorThread.run(TestException.java:NN)
+					Wrapped by: java.lang.RuntimeException: cause
+						at org.springframework.boot.log...""");
 		}
 
 		@Test
@@ -184,7 +183,7 @@ class StructuredLoggingJsonPropertiesTests {
 					true, null);
 			StackTracePrinter printer = properties.createPrinter();
 			String actual = TestException.withoutLineNumbers(printer.printStackTraceToString(exception));
-			assertThat(actual).isEqualTo("RuntimeExceptionexception!	at org.spr...");
+			assertThat(actual).isEqualTo("RuntimeExceptionroot!	at org.springfr...");
 
 		}
 


### PR DESCRIPTION
Makes the StandardStackTracePrinter root option respect the `logging.structured.json.stacktrace.root` property value

I'm assuming based on the documentation that `last` should be the default value, which this respects

```
 Use `last` to print the root item last (same as Java) or `first` to print the root item first.
```