### PR TITLE
Samples for metadata annotation processers have invalid fold attribute

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/appendix/configurationmetadata/annotationprocessor/automaticmetadatageneration/MyServerProperties.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/appendix/configurationmetadata/annotationprocessor/automaticmetadatageneration/MyServerProperties.java
@@ -60,6 +60,6 @@ public class MyServerProperties {
 	public void setPort(int port) {
 		this.port = port;
 	}
-	// fold:off
+	// @fold:off
 
 }

--- a/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/appendix/configurationmetadata/annotationprocessor/automaticmetadatageneration/nestedproperties/MyServerProperties.java
+++ b/spring-boot-project/spring-boot-docs/src/main/java/org/springframework/boot/docs/appendix/configurationmetadata/annotationprocessor/automaticmetadatageneration/nestedproperties/MyServerProperties.java
@@ -65,7 +65,7 @@ public class MyServerProperties {
 		public void setPort(int port) {
 			this.port = port;
 		}
-		// @fold:off // getters/setters ...
+		// @fold:off
 
 	}
 


### PR DESCRIPTION
When I expand snippet code

![image](https://github.com/user-attachments/assets/067f0cb6-1426-4cf9-848f-d671e4eedf8f)



Reference:

https://docs.spring.io/spring-boot/3.4-SNAPSHOT/specification/configuration-metadata/annotation-processor.html