### PR TITLE
Remove NoSuchMethodError guard for Context.setCreateUploadTargets()

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
@@ -253,7 +253,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 		context.setParentClassLoader(parentClassLoader);
 		resetDefaultLocaleMapping(context);
 		addLocaleMappings(context);
-		ignoringNoSuchMethodError(() -> context.setCreateUploadTargets(true));
+		context.setCreateUploadTargets(true);
 		configureTldPatterns(context);
 		WebappLoader loader = new WebappLoader();
 		loader.setLoaderInstance(new TomcatEmbeddedWebappClassLoader(parentClassLoader));


### PR DESCRIPTION
This PR removes the `NoSuchMethodError` guard for the `Context.setCreateUploadTargets()` as [it's on the minimum required version (10.1.25) for Tomcat](https://github.com/apache/tomcat/blob/10.1.25/java/org/apache/catalina/Context.java#L1754).

See https://docs.spring.io/spring-boot/3.3/system-requirements.html#getting-started.system-requirements.servlet-containers