### PR TITLE
Update descriptions of properties that no longer require Flyway Teams

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration.java
@@ -306,7 +306,6 @@ public class FlywayAutoConfiguration {
 			map.from(properties::getLoggers).to((loggers) -> configuration.loggers(loggers));
 			map.from(properties::getCommunityDbSupportEnabled)
 				.to((communityDbSupportEnabled) -> configuration.communityDBSupportEnabled(communityDbSupportEnabled));
-			// Flyway Teams properties
 			map.from(properties.getBatch()).to((batch) -> configuration.batch(batch));
 			map.from(properties.getDryRunOutput()).to((dryRunOutput) -> configuration.dryRunOutput(dryRunOutput));
 			map.from(properties.getErrorOverrides())

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayProperties.java
@@ -275,7 +275,7 @@ public class FlywayProperties {
 	private String[] loggers = { "slf4j" };
 
 	/**
-	 * Whether to batch SQL statements when executing them. Requires Flyway Teams.
+	 * Whether to batch SQL statements when executing them.
 	 */
 	private Boolean batch;
 
@@ -292,12 +292,12 @@ public class FlywayProperties {
 	private String[] errorOverrides;
 
 	/**
-	 * Whether to stream SQL migrations when executing them. Requires Flyway Teams.
+	 * Whether to stream SQL migrations when executing them.
 	 */
 	private Boolean stream;
 
 	/**
-	 * Properties to pass to the JDBC driver. Requires Flyway Teams.
+	 * Properties to pass to the JDBC driver.
 	 */
 	private Map<String, String> jdbcProperties = new HashMap<>();
 
@@ -308,25 +308,23 @@ public class FlywayProperties {
 
 	/**
 	 * Whether Flyway should output a table with the results of queries when executing
-	 * migrations. Requires Flyway Teams.
+	 * migrations.
 	 */
 	private Boolean outputQueryResults;
 
 	/**
 	 * Whether Flyway should skip executing the contents of the migrations and only update
-	 * the schema history table. Requires Flyway teams.
+	 * the schema history table.
 	 */
 	private Boolean skipExecutingMigrations;
 
 	/**
 	 * List of patterns that identify migrations to ignore when performing validation.
-	 * Requires Flyway Teams.
 	 */
 	private List<String> ignoreMigrationPatterns;
 
 	/**
-	 * Whether to attempt to automatically detect SQL migration file encoding. Requires
-	 * Flyway Teams.
+	 * Whether to attempt to automatically detect SQL migration file encoding.
 	 */
 	private Boolean detectEncoding;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/flyway/FlywayAutoConfigurationTests.java
@@ -33,6 +33,7 @@ import org.flywaydb.core.api.callback.Context;
 import org.flywaydb.core.api.callback.Event;
 import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.flywaydb.core.api.migration.JavaMigration;
+import org.flywaydb.core.api.pattern.ValidatePattern;
 import org.flywaydb.core.internal.license.FlywayEditionUpgradeRequiredException;
 import org.flywaydb.database.oracle.OracleConfigurationExtension;
 import org.flywaydb.database.postgresql.PostgreSQLConfigurationExtension;
@@ -914,6 +915,22 @@ class FlywayAutoConfigurationTests {
 		new FlywayAutoConfigurationRuntimeHints().registerHints(runtimeHints, getClass().getClassLoader());
 		assertThat(RuntimeHintsPredicates.resource().forResource("db/migration/")).accepts(runtimeHints);
 		assertThat(RuntimeHintsPredicates.resource().forResource("db/migration/V1__init.sql")).accepts(runtimeHints);
+	}
+
+	@Test
+	void detectEncodingCorrectlyMapped() {
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+			.withPropertyValues("spring.flyway.detect-encoding=true")
+			.run((context) -> assertThat(context.getBean(Flyway.class).getConfiguration().isDetectEncoding())
+				.isEqualTo(true));
+	}
+
+	@Test
+	void ignoreMigrationPatternsCorrectlyMapped() {
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+			.withPropertyValues("spring.flyway.ignore-migration-patterns=*:missing")
+			.run((context) -> assertThat(context.getBean(Flyway.class).getConfiguration().getIgnoreMigrationPatterns())
+				.containsExactly(ValidatePattern.fromPattern("*:missing")));
 	}
 
 	private ContextConsumer<AssertableApplicationContext> validateFlywayTeamsPropertyOnly(String propertyName) {


### PR DESCRIPTION
Since flyway v10 most of teams features are available for community too (see [here](https://documentation.red-gate.com/fd/flyway-namespace-277578913.html)). I checked the documentation and removed obsoleted hints in java documentation.