### PR TITLE
Update version of Neo4j test container image

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support-docker/src/main/java/org/springframework/boot/testsupport/container/TestImage.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support-docker/src/main/java/org/springframework/boot/testsupport/container/TestImage.java
@@ -175,7 +175,7 @@ public enum TestImage {
 	/**
 	 * A container image suitable for testing Neo4j.
 	 */
-	NEO4J("neo4j", "4.4.11", () -> Neo4jContainer.class,
+	NEO4J("neo4j", "4.4.41", () -> Neo4jContainer.class,
 			(container) -> ((Neo4jContainer<?>) container).withStartupAttempts(5)
 				.withStartupTimeout(Duration.ofMinutes(10))),
 


### PR DESCRIPTION
Upgrade Neo4j test container image to `4.4.41`

The previous version failed to start on MacBook Pro M2 with the latest version of Docker Desktop installed (likely due to [this  OpenJDK issue](https://bugs.openjdk.org/browse/JDK-8287073)):

```
2025-02-27 13:04:09 Exception in thread "main" java.lang.ExceptionInInitializerError
2025-02-27 13:04:09     at org.neo4j.memory.MachineMemory$1.getTotalPhysicalMemory(MachineMemory.java:45)
2025-02-27 13:04:09     at org.neo4j.server.NeoBootstrapper.requestedMemoryExceedsAvailable(NeoBootstrapper.java:200)
2025-02-27 13:04:09     at org.neo4j.server.NeoBootstrapper.start(NeoBootstrapper.java:129)
2025-02-27 13:04:09     at org.neo4j.server.NeoBootstrapper.start(NeoBootstrapper.java:95)
2025-02-27 13:04:09     at org.neo4j.server.CommunityEntryPoint.main(CommunityEntryPoint.java:34)
2025-02-27 13:04:09 Caused by: java.lang.NullPointerException
2025-02-27 13:04:09     at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(CgroupV2Subsystem.java:81)
2025-02-27 13:04:09     at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(CgroupSubsystemFactory.java:113)
2025-02-27 13:04:09     at java.base/jdk.internal.platform.CgroupMetrics.getInstance(CgroupMetrics.java:167)
2025-02-27 13:04:09     at java.base/jdk.internal.platform.SystemMetrics.instance(SystemMetrics.java:29)
2025-02-27 13:04:09     at java.base/jdk.internal.platform.Metrics.systemMetrics(Metrics.java:58)
2025-02-27 13:04:09     at java.base/jdk.internal.platform.Container.metrics(Container.java:43)
2025-02-27 13:04:09     at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>(OperatingSystemImpl.java:182)
2025-02-27 13:04:09     at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl.getOperatingSystemMXBean(PlatformMBeanProviderImpl.java:281)
2025-02-27 13:04:09     at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl$3.nameToMBeanMap(PlatformMBeanProviderImpl.java:198)
2025-02-27 13:04:09     at java.management/sun.management.spi.PlatformMBeanProvider$PlatformComponent.getMBeans(PlatformMBeanProvider.java:195)
2025-02-27 13:04:09     at java.management/java.lang.management.ManagementFactory.getPlatformMXBean(ManagementFactory.java:686)
2025-02-27 13:04:09     at java.management/java.lang.management.ManagementFactory.getOperatingSystemMXBean(ManagementFactory.java:388)
2025-02-27 13:04:09     at org.neo4j.io.os.OsBeanUtil.<clinit>(OsBeanUtil.java:40)
2025-02-27 13:04:09     ... 5 more
2025-02-27 13:04:09 2025-02-27 11:04:09.809+0000 INFO  Neo4j Server shutdown initiated by request
2025-02-27 13:04:09 2025-02-27 11:04:09.810+0000 INFO  Stopped.
```