### PR TITLE
Add support for auto-configuring SimpleMessageListenerContainer

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/AbstractJmsListenerContainerFactoryConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/AbstractJmsListenerContainerFactoryConfigurer.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jms;
+
+import io.micrometer.observation.ObservationRegistry;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.ExceptionListener;
+
+import org.springframework.boot.autoconfigure.jms.JmsProperties.Listener.Session;
+import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.jms.config.AbstractJmsListenerContainerFactory;
+import org.springframework.jms.support.converter.MessageConverter;
+import org.springframework.jms.support.destination.DestinationResolver;
+import org.springframework.util.Assert;
+
+/**
+ * Configures {@link AbstractJmsListenerContainerFactory} with sensible defaults.
+ *
+ * @param <T> the connection factory type.
+ * @author Vedran Pavic
+ * @since 3.5.0
+ */
+public abstract class AbstractJmsListenerContainerFactoryConfigurer<T extends AbstractJmsListenerContainerFactory<?>> {
+
+	private DestinationResolver destinationResolver;
+
+	private MessageConverter messageConverter;
+
+	private ExceptionListener exceptionListener;
+
+	private ObservationRegistry observationRegistry;
+
+	private JmsProperties jmsProperties;
+
+	/**
+	 * Set the {@link DestinationResolver} to use or {@code null} if no destination
+	 * resolver should be associated with the factory by default.
+	 * @param destinationResolver the {@link DestinationResolver}
+	 */
+	void setDestinationResolver(DestinationResolver destinationResolver) {
+		this.destinationResolver = destinationResolver;
+	}
+
+	/**
+	 * Set the {@link MessageConverter} to use or {@code null} if the out-of-the-box
+	 * converter should be used.
+	 * @param messageConverter the {@link MessageConverter}
+	 */
+	void setMessageConverter(MessageConverter messageConverter) {
+		this.messageConverter = messageConverter;
+	}
+
+	/**
+	 * Set the {@link ExceptionListener} to use or {@code null} if no exception listener
+	 * should be associated by default.
+	 * @param exceptionListener the {@link ExceptionListener}
+	 */
+	void setExceptionListener(ExceptionListener exceptionListener) {
+		this.exceptionListener = exceptionListener;
+	}
+
+	/**
+	 * Set the {@link ObservationRegistry} to use.
+	 * @param observationRegistry the {@link ObservationRegistry}
+	 */
+	void setObservationRegistry(ObservationRegistry observationRegistry) {
+		this.observationRegistry = observationRegistry;
+	}
+
+	/**
+	 * Set the {@link JmsProperties} to use.
+	 * @param jmsProperties the {@link JmsProperties}
+	 */
+	void setJmsProperties(JmsProperties jmsProperties) {
+		this.jmsProperties = jmsProperties;
+	}
+
+	/**
+	 * Configure the specified jms listener container factory. The factory can be further
+	 * tuned and default settings can be overridden.
+	 * @param factory the {@link AbstractJmsListenerContainerFactory} instance to
+	 * configure
+	 * @param connectionFactory the {@link ConnectionFactory} to use
+	 */
+	public void configure(T factory, ConnectionFactory connectionFactory) {
+		Assert.notNull(factory, "'factory' must not be null");
+		Assert.notNull(connectionFactory, "'connectionFactory' must not be null");
+		JmsProperties.Listener listenerProperties = this.jmsProperties.getListener();
+		Session sessionProperties = listenerProperties.getSession();
+		factory.setConnectionFactory(connectionFactory);
+		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
+		map.from(this.jmsProperties::isPubSubDomain).to(factory::setPubSubDomain);
+		map.from(this.jmsProperties::isSubscriptionDurable).to(factory::setSubscriptionDurable);
+		map.from(this.jmsProperties::getClientId).to(factory::setClientId);
+		map.from(this.destinationResolver).to(factory::setDestinationResolver);
+		map.from(this.messageConverter).to(factory::setMessageConverter);
+		map.from(this.exceptionListener).to(factory::setExceptionListener);
+		map.from(sessionProperties.getAcknowledgeMode()::getMode).to(factory::setSessionAcknowledgeMode);
+		map.from(this.observationRegistry).to(factory::setObservationRegistry);
+		map.from(sessionProperties::getTransacted).to(factory::setSessionTransacted);
+		map.from(listenerProperties::isAutoStartup).to(factory::setAutoStartup);
+		configure(factory, connectionFactory, this.jmsProperties);
+	}
+
+	/**
+	 * Configures the given {@code factory} using the given {@code connectionFactory} and
+	 * {@code jmsProperties}.
+	 * @param factory the {@link AbstractJmsListenerContainerFactory} instance to
+	 * configure
+	 * @param connectionFactory the {@link ConnectionFactory} to use
+	 * @param jmsProperties the {@link JmsProperties} to use
+	 */
+	protected abstract void configure(T factory, ConnectionFactory connectionFactory, JmsProperties jmsProperties);
+
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/JmsProperties.java
@@ -164,36 +164,53 @@ public class JmsProperties {
 	public static class Listener {
 
 		/**
+		 * Listener container type.
+		 */
+		private ContainerType containerType = ContainerType.DEFAULT;
+
+		/**
 		 * Start the container automatically on startup.
 		 */
 		private boolean autoStartup = true;
 
 		/**
 		 * Minimum number of concurrent consumers. When max-concurrency is not specified
-		 * the minimum will also be used as the maximum.
+		 * the minimum will also be used as the maximum. Applies only to container type
+		 * `default`.
 		 */
 		private Integer minConcurrency;
 
 		/**
-		 * Maximum number of concurrent consumers.
+		 * Maximum number of concurrent consumers. Applies only to container type
+		 * `default`.
 		 */
 		private Integer maxConcurrency;
 
 		/**
 		 * Timeout to use for receive calls. Use -1 for a no-wait receive or 0 for no
 		 * timeout at all. The latter is only feasible if not running within a transaction
-		 * manager and is generally discouraged since it prevents clean shutdown.
+		 * manager and is generally discouraged since it prevents clean shutdown. Applies
+		 * only to container type `default`.
 		 */
 		private Duration receiveTimeout = Duration.ofSeconds(1);
 
 		/**
 		 * Maximum number of messages to process in one task. By default, unlimited unless
 		 * a SchedulingTaskExecutor is configured on the listener (10 messages), as it
-		 * indicates a preference for short-lived tasks.
+		 * indicates a preference for short-lived tasks. Applies only to container type
+		 * `default`.
 		 */
 		private Integer maxMessagesPerTask;
 
 		private final Session session = new Session();
+
+		public ContainerType getContainerType() {
+			return this.containerType;
+		}
+
+		public void setContainerType(ContainerType containerType) {
+			this.containerType = containerType;
+		}
 
 		public boolean isAutoStartup() {
 			return this.autoStartup;
@@ -442,6 +459,20 @@ public class JmsProperties {
 			}
 
 		}
+
+	}
+
+	public enum ContainerType {
+
+		/**
+		 * Use DefaultMessageListenerContainer.
+		 */
+		DEFAULT,
+
+		/**
+		 * Use SimpleMessageListenerContainer.
+		 */
+		SIMPLE
 
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/SimpleJmsListenerContainerFactoryConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/SimpleJmsListenerContainerFactoryConfigurer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.jms;
+
+import jakarta.jms.ConnectionFactory;
+
+import org.springframework.jms.config.SimpleJmsListenerContainerFactory;
+
+/**
+ * Configures {@link SimpleJmsListenerContainerFactory} with sensible defaults.
+ *
+ * @author Vedran Pavic
+ * @since 3.5.0
+ */
+public final class SimpleJmsListenerContainerFactoryConfigurer
+		extends AbstractJmsListenerContainerFactoryConfigurer<SimpleJmsListenerContainerFactory> {
+
+	@Override
+	protected void configure(SimpleJmsListenerContainerFactory factory, ConnectionFactory connectionFactory,
+			JmsProperties jmsProperties) {
+	}
+
+}


### PR DESCRIPTION
This commit introduces a new `spring.jms.listener.container-type` configuration property which can be used to auto-configure JMS listener support backend by `SimpleMessageListenerContainer` instead of `DefaultMessageListenerContainer`.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
