### PR TITLE
Add configuration properties for JdbcTemplate's ignoreWarnings, skipResultsProcess, skipUndeclaredResults, and resultsMapCaseInsensitive

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/JdbcProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/JdbcProperties.java
@@ -27,6 +27,7 @@ import org.springframework.boot.convert.DurationUnit;
  *
  * @author Kazuki Shimizu
  * @author Stephane Nicoll
+ * @author Yanming Zhou
  * @since 2.0.0
  */
 @ConfigurationProperties("spring.jdbc")
@@ -61,6 +62,33 @@ public class JdbcProperties {
 		@DurationUnit(ChronoUnit.SECONDS)
 		private Duration queryTimeout;
 
+		/**
+		 * If this variable is {@code false}, we will throw exceptions on SQL warnings.
+		 */
+		private boolean ignoreWarnings = true;
+
+		/**
+		 * If this variable is set to true, then all results checking will be bypassed for
+		 * any callable statement processing. This can be used to avoid a bug in some
+		 * older Oracle JDBC drivers like 10.1.0.2.
+		 */
+		private boolean skipResultsProcessing;
+
+		/**
+		 * If this variable is set to true then all results from a stored procedure call
+		 * that don't have a corresponding SqlOutParameter declaration will be bypassed.
+		 * All other results processing will be take place unless the variable
+		 * {@code skipResultsProcessing} is set to {@code true}.
+		 */
+		private boolean skipUndeclaredResults;
+
+		/**
+		 * If this variable is set to true then execution of a CallableStatement will
+		 * return the results in a Map that uses case-insensitive names for the
+		 * parameters.
+		 */
+		private boolean resultsMapCaseInsensitive;
+
 		public int getFetchSize() {
 			return this.fetchSize;
 		}
@@ -83,6 +111,38 @@ public class JdbcProperties {
 
 		public void setQueryTimeout(Duration queryTimeout) {
 			this.queryTimeout = queryTimeout;
+		}
+
+		public boolean isIgnoreWarnings() {
+			return this.ignoreWarnings;
+		}
+
+		public void setIgnoreWarnings(boolean ignoreWarnings) {
+			this.ignoreWarnings = ignoreWarnings;
+		}
+
+		public boolean isSkipResultsProcessing() {
+			return this.skipResultsProcessing;
+		}
+
+		public void setSkipResultsProcessing(boolean skipResultsProcessing) {
+			this.skipResultsProcessing = skipResultsProcessing;
+		}
+
+		public boolean isSkipUndeclaredResults() {
+			return this.skipUndeclaredResults;
+		}
+
+		public void setSkipUndeclaredResults(boolean skipUndeclaredResults) {
+			this.skipUndeclaredResults = skipUndeclaredResults;
+		}
+
+		public boolean isResultsMapCaseInsensitive() {
+			return this.resultsMapCaseInsensitive;
+		}
+
+		public void setResultsMapCaseInsensitive(boolean resultsMapCaseInsensitive) {
+			this.resultsMapCaseInsensitive = resultsMapCaseInsensitive;
 		}
 
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.jdbc.support.SQLExceptionTranslator;
  * Configuration for {@link JdbcTemplateConfiguration}.
  *
  * @author Stephane Nicoll
+ * @author Yanming Zhou
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnMissingBean(JdbcOperations.class)
@@ -47,6 +48,10 @@ class JdbcTemplateConfiguration {
 		if (template.getQueryTimeout() != null) {
 			jdbcTemplate.setQueryTimeout((int) template.getQueryTimeout().getSeconds());
 		}
+		jdbcTemplate.setIgnoreWarnings(template.isIgnoreWarnings());
+		jdbcTemplate.setSkipResultsProcessing(template.isSkipResultsProcessing());
+		jdbcTemplate.setSkipUndeclaredResults(template.isSkipUndeclaredResults());
+		jdbcTemplate.setResultsMapCaseInsensitive(template.isResultsMapCaseInsensitive());
 		sqlExceptionTranslator.ifUnique(jdbcTemplate::setExceptionTranslator);
 		return jdbcTemplate;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jdbc/JdbcTemplateAutoConfigurationTests.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.mock;
  * @author Stephane Nicoll
  * @author Kazuki Shimizu
  * @author Dan Zheng
+ * @author Yanming Zhou
  */
 class JdbcTemplateAutoConfigurationTests {
 
@@ -64,6 +65,10 @@ class JdbcTemplateAutoConfigurationTests {
 			assertThat(jdbcTemplate.getFetchSize()).isEqualTo(-1);
 			assertThat(jdbcTemplate.getQueryTimeout()).isEqualTo(-1);
 			assertThat(jdbcTemplate.getMaxRows()).isEqualTo(-1);
+			assertThat(jdbcTemplate.isIgnoreWarnings()).isEqualTo(true);
+			assertThat(jdbcTemplate.isSkipResultsProcessing()).isEqualTo(false);
+			assertThat(jdbcTemplate.isSkipUndeclaredResults()).isEqualTo(false);
+			assertThat(jdbcTemplate.isResultsMapCaseInsensitive()).isEqualTo(false);
 		});
 	}
 
@@ -71,7 +76,10 @@ class JdbcTemplateAutoConfigurationTests {
 	void testJdbcTemplateWithCustomProperties() {
 		this.contextRunner
 			.withPropertyValues("spring.jdbc.template.fetch-size:100", "spring.jdbc.template.query-timeout:60",
-					"spring.jdbc.template.max-rows:1000")
+					"spring.jdbc.template.max-rows:1000", "spring.jdbc.template.ignore-warnings:false",
+					"spring.jdbc.template.skip-results-processing:true",
+					"spring.jdbc.template.skip-undeclared-results:true",
+					"spring.jdbc.template.results-map-case-insensitive:true")
 			.run((context) -> {
 				assertThat(context).hasSingleBean(JdbcOperations.class);
 				JdbcTemplate jdbcTemplate = context.getBean(JdbcTemplate.class);
@@ -79,6 +87,10 @@ class JdbcTemplateAutoConfigurationTests {
 				assertThat(jdbcTemplate.getFetchSize()).isEqualTo(100);
 				assertThat(jdbcTemplate.getQueryTimeout()).isEqualTo(60);
 				assertThat(jdbcTemplate.getMaxRows()).isEqualTo(1000);
+				assertThat(jdbcTemplate.isIgnoreWarnings()).isEqualTo(false);
+				assertThat(jdbcTemplate.isSkipResultsProcessing()).isEqualTo(true);
+				assertThat(jdbcTemplate.isSkipUndeclaredResults()).isEqualTo(true);
+				assertThat(jdbcTemplate.isResultsMapCaseInsensitive()).isEqualTo(true);
 			});
 	}
 


### PR DESCRIPTION
- ignore-warnings
- skip-results-processing
- skip-undeclared-results
- results-map-case-insensitive

Fix GH-44419