### PR TITLE
Remove default value for OtlpMetricsProperties.url

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/build.gradle
@@ -175,6 +175,7 @@ dependencies {
 	testImplementation("org.springframework.restdocs:spring-restdocs-webtestclient")
 	testImplementation("org.springframework.security:spring-security-test")
 	testImplementation("org.yaml:snakeyaml")
+	testImplementation("uk.org.webcompere:system-stubs-jupiter:2.1.7")
 
 	testRuntimeOnly("jakarta.management.j2ee:jakarta.management.j2ee-api")
 	testRuntimeOnly("jakarta.transaction:jakarta.transaction-api")

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpMetricsProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpMetricsProperties.java
@@ -39,7 +39,7 @@ public class OtlpMetricsProperties extends StepRegistryProperties {
 	/**
 	 * URI of the OTLP server.
 	 */
-	private String url = "http://localhost:4318/v1/metrics";
+	private String url;
 
 	/**
 	 * Aggregation temporality of sums. It defines the way additive values are expressed.

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpMetricsPropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpMetricsPropertiesConfigAdapterTests.java
@@ -23,6 +23,7 @@ import io.micrometer.registry.otlp.AggregationTemporality;
 import io.micrometer.registry.otlp.HistogramFlavor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.org.webcompere.systemstubs.SystemStubs;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.export.otlp.OtlpMetricsExportAutoConfiguration.PropertiesOtlpMetricsConnectionDetails;
 import org.springframework.boot.actuate.autoconfigure.opentelemetry.OpenTelemetryProperties;
@@ -52,6 +53,23 @@ class OtlpMetricsPropertiesConfigAdapterTests {
 		this.openTelemetryProperties = new OpenTelemetryProperties();
 		this.environment = new MockEnvironment();
 		this.connectionDetails = new PropertiesOtlpMetricsConnectionDetails(this.properties);
+	}
+
+	@Test
+	void whenPropertiesUrlIsNotSetAdapterUrlReturnsDefault() {
+		assertThat(createAdapter().url()).isEqualTo("http://localhost:4318/v1/metrics");
+	}
+
+	@Test
+	void whenPropertiesUrlIsNotSetAndOtelExporterOtlpEndpointIsSetAdapterUrlUsesIt() throws Exception {
+		SystemStubs.withEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT", "https://my-endpoint")
+			.execute(() -> assertThat(createAdapter().url()).isEqualTo("https://my-endpoint/v1/metrics"));
+	}
+
+	@Test
+	void whenPropertiesUrlIsNotSetAndOtelExporterOtlpMetricsEndpointIsSetAdapterUrlUsesIt() throws Exception {
+		SystemStubs.withEnvironmentVariable("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://my-endpoint")
+			.execute(() -> assertThat(createAdapter().url()).isEqualTo("https://my-endpoint/v1/metrics"));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpMetricsPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpMetricsPropertiesTests.java
@@ -35,7 +35,6 @@ class OtlpMetricsPropertiesTests extends StepRegistryPropertiesTests {
 		OtlpMetricsProperties properties = new OtlpMetricsProperties();
 		OtlpConfig config = OtlpConfig.DEFAULT;
 		assertStepRegistryDefaultValues(properties, config);
-		assertThat(properties.getUrl()).isEqualTo(config.url());
 		assertThat(properties.getAggregationTemporality()).isSameAs(config.aggregationTemporality());
 		assertThat(properties.getHistogramFlavor()).isSameAs(config.histogramFlavor());
 		assertThat(properties.getMaxScale()).isEqualTo(config.maxScale());


### PR DESCRIPTION
Unlike Micrometer, Spring Boot's Micrometer integration doesn't support the `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` environment variables due to its default value.

This PR removes the default value for the `OtlpMetricsProperties.url` property to try to align with Micrometer.