### PR TITLE
Add support for OpenTelemetry's service.namespace

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryResourceAttributes.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryResourceAttributes.java
@@ -99,6 +99,7 @@ public final class OpenTelemetryResourceAttributes {
 		});
 		attributes.computeIfAbsent("service.name", (k) -> getApplicationName());
 		attributes.computeIfAbsent("service.group", (k) -> getApplicationGroup());
+		attributes.computeIfAbsent("service.namespace", (key) -> getServiceNamespace());
 		attributes.forEach(consumer);
 	}
 
@@ -106,9 +107,16 @@ public final class OpenTelemetryResourceAttributes {
 		return this.environment.getProperty("spring.application.name", DEFAULT_SERVICE_NAME);
 	}
 
+	@Deprecated(since = "3.5.0", forRemoval = true)
+	// See https://github.com/spring-projects/spring-boot/issues/44411 for potential
+	// information about deprecation of "service.group" attribute
 	private String getApplicationGroup() {
 		String applicationGroup = this.environment.getProperty("spring.application.group");
 		return (StringUtils.hasLength(applicationGroup)) ? applicationGroup : null;
+	}
+
+	private String getServiceNamespace() {
+		return this.environment.getProperty("spring.application.group");
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryAutoConfigurationTests.java
@@ -107,6 +107,22 @@ class OpenTelemetryAutoConfigurationTests {
 	}
 
 	@Test
+	void shouldApplyServiceNamespaceIfApplicationGroupIsSet() {
+		this.runner.withPropertyValues("spring.application.group=my-group").run((context) -> {
+			Resource resource = context.getBean(Resource.class);
+			assertThat(resource.getAttributes().asMap()).containsEntry(AttributeKey.stringKey("service.namespace"), "my-group");
+		});
+	}
+
+	@Test
+	void shouldNOtApplyServiceNamespaceIfApplicationGroupIsNotSet() {
+		this.runner.run((context -> {
+			Resource resource = context.getBean(Resource.class);
+			assertThat(resource.getAttributes().asMap()).doesNotContainKey(AttributeKey.stringKey("service.namespace"));
+		}));
+	}
+
+	@Test
 	void shouldFallbackToDefaultApplicationNameIfSpringApplicationNameIsNotSet() {
 		this.runner.run((context) -> {
 			Resource resource = context.getBean(Resource.class);


### PR DESCRIPTION
Add OTEL service attribute `service.namespace`. The value is set to same value as `service.group` currently. Since there is no specific environment variable to specify the `service.namespace` prescribed by OTEL, following chain is used to decide the value:

- management.opentelemetry.resource-attributes configuration property
- OTEL_RESOURCE_ATTRIBUTES environment variable
- If `service.group` is configured, then set it to same name
- Otherwise empty

Closes #44411 

