### PR TITLE
Fix typo in documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/http-exchanges.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/http-exchanges.adoc
@@ -16,4 +16,4 @@ You can use the `httpexchanges` endpoint to obtain information about the request
 
 To customize the items that are included in each recorded exchange, use the configprop:management.httpexchanges.recording.include[] configuration property.
 
-To disable recoding entirely, set configprop:management.httpexchanges.recording.enabled[] to `false`.
+To disable recording entirely, set configprop:management.httpexchanges.recording.enabled[] to `false`.


### PR DESCRIPTION
This pull request fixed a tiny typo in the [documentation](https://docs.spring.io/spring-boot/reference/actuator/http-exchanges.html#actuator.http-exchanges), I stumbled upon today.