### PR TITLE
Fix AliasX509ExtendedKeyManager to process both server and client aliases properly

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/AliasKeyManagerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/AliasKeyManagerFactory.java
@@ -26,6 +26,10 @@ import java.security.PrivateKey;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -42,6 +46,7 @@ import javax.net.ssl.X509ExtendedKeyManager;
  * {@link KeyManagerFactory#getKeyManagers()} is final.
  *
  * @author Scott Frederick
+ * @author Stéphane Gobancé
  */
 final class AliasKeyManagerFactory extends KeyManagerFactory {
 
@@ -105,23 +110,27 @@ final class AliasKeyManagerFactory extends KeyManagerFactory {
 		}
 
 		@Override
-		public String chooseEngineClientAlias(String[] strings, Principal[] principals, SSLEngine sslEngine) {
-			return this.delegate.chooseEngineClientAlias(strings, principals, sslEngine);
+		public String chooseEngineClientAlias(String[] keyTypes, Principal[] issuers, SSLEngine sslEngine) {
+			return findFirstMatchingAlias(keyTypes, issuers, this::getClientAliases)
+				.orElseGet(() -> this.delegate.chooseEngineClientAlias(keyTypes, issuers, sslEngine));
 		}
 
 		@Override
-		public String chooseEngineServerAlias(String s, Principal[] principals, SSLEngine sslEngine) {
-			return this.alias;
+		public String chooseEngineServerAlias(String keyType, Principal[] issuers, SSLEngine sslEngine) {
+			return findFirstMatchingAlias(keyType, issuers, this::getServerAliases)
+				.orElseGet(() -> this.delegate.chooseEngineServerAlias(keyType, issuers, sslEngine));
 		}
 
 		@Override
-		public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
-			return this.delegate.chooseClientAlias(keyType, issuers, socket);
+		public String chooseClientAlias(String[] keyTypes, Principal[] issuers, Socket socket) {
+			return findFirstMatchingAlias(keyTypes, issuers, this::getClientAliases)
+				.orElseGet(() -> this.delegate.chooseClientAlias(keyTypes, issuers, socket));
 		}
 
 		@Override
 		public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
-			return this.delegate.chooseServerAlias(keyType, issuers, socket);
+			return findFirstMatchingAlias(keyType, issuers, this::getServerAliases)
+				.orElseGet(() -> this.delegate.chooseServerAlias(keyType, issuers, socket));
 		}
 
 		@Override
@@ -142,6 +151,50 @@ final class AliasKeyManagerFactory extends KeyManagerFactory {
 		@Override
 		public String[] getServerAliases(String keyType, Principal[] issuers) {
 			return this.delegate.getServerAliases(keyType, issuers);
+		}
+
+		/**
+		 * Gets this key manager's alias if it matches the given key algorithm and has
+		 * been issued by any of the specified issuers (might be {@code null}, meaning
+		 * issuer does not matter) otherwise returns an {@link Optional#empty() empty
+		 * result }.
+		 * @param keyType the required key algorithm.
+		 * @param issuers the list of acceptable CA issuer subject names or {@code null}
+		 * if it does not matter which issuers are used.
+		 * @param finder the function to find the underlying available key aliases.
+		 * @return this key manager's alias if appropriate or an empty result otherwise.
+		 */
+		private Optional<String> findFirstMatchingAlias(String keyType, Principal[] issuers, KeyAliasFinder finder) {
+			return findFirstMatchingAlias(new String[] { keyType }, issuers, finder);
+		}
+
+		/**
+		 * Gets this key manager's alias if it matches any of the given key algorithms and
+		 * has been issued by any of the specified issuers (might be {@code null}, meaning
+		 * issuer does not matter) otherwise returns an {@link Optional#empty() empty
+		 * result }.
+		 * @param keyTypes the required key algorithms.
+		 * @param issuers the list of acceptable CA issuer subject names or {@code null}
+		 * if it does not matter which issuers are used.
+		 * @param finder the function to find the underlying available key aliases.
+		 * @return this key manager's alias if appropriate or an empty result otherwise.
+		 */
+		private Optional<String> findFirstMatchingAlias(String[] keyTypes, Principal[] issuers, KeyAliasFinder finder) {
+			return Optional.ofNullable(keyTypes)
+				.flatMap((types) -> Stream.of(types)
+					.filter(Objects::nonNull)
+					.map((type) -> finder.apply(type, issuers))
+					.filter(Objects::nonNull)
+					.flatMap(Stream::of)
+					.filter(this.alias::equals)
+					.findFirst());
+		}
+
+		/**
+		 * Typed-BiFunction for better readability.
+		 */
+		private interface KeyAliasFinder extends BiFunction<String, Principal[], String[]> {
+
 		}
 
 	}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/AliasKeyManagerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/AliasKeyManagerFactory.java
@@ -111,26 +111,22 @@ final class AliasKeyManagerFactory extends KeyManagerFactory {
 
 		@Override
 		public String chooseEngineClientAlias(String[] keyTypes, Principal[] issuers, SSLEngine sslEngine) {
-			return findFirstMatchingAlias(keyTypes, issuers, this::getClientAliases)
-				.orElseGet(() -> this.delegate.chooseEngineClientAlias(keyTypes, issuers, sslEngine));
+			return findFirstMatchingAlias(keyTypes, issuers, this::getClientAliases).orElse(null);
 		}
 
 		@Override
 		public String chooseEngineServerAlias(String keyType, Principal[] issuers, SSLEngine sslEngine) {
-			return findFirstMatchingAlias(keyType, issuers, this::getServerAliases)
-				.orElseGet(() -> this.delegate.chooseEngineServerAlias(keyType, issuers, sslEngine));
+			return findFirstMatchingAlias(keyType, issuers, this::getServerAliases).orElse(null);
 		}
 
 		@Override
 		public String chooseClientAlias(String[] keyTypes, Principal[] issuers, Socket socket) {
-			return findFirstMatchingAlias(keyTypes, issuers, this::getClientAliases)
-				.orElseGet(() -> this.delegate.chooseClientAlias(keyTypes, issuers, socket));
+			return findFirstMatchingAlias(keyTypes, issuers, this::getClientAliases).orElse(null);
 		}
 
 		@Override
 		public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
-			return findFirstMatchingAlias(keyType, issuers, this::getServerAliases)
-				.orElseGet(() -> this.delegate.chooseServerAlias(keyType, issuers, socket));
+			return findFirstMatchingAlias(keyType, issuers, this::getServerAliases).orElse(null);
 		}
 
 		@Override

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/ssl/AliasKeyManagerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/ssl/AliasKeyManagerFactoryTests.java
@@ -23,32 +23,298 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.X509ExtendedKeyManager;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 /**
- * Tests for {@link AliasKeyManagerFactory}.
+ * Tests for {@link org.springframework.boot.ssl.AliasKeyManagerFactory}.
  *
  * @author Phillip Webb
+ * @author Stéphane Gobancé
  */
 class AliasKeyManagerFactoryTests {
 
 	@Test
-	void chooseEngineServerAliasReturnsAlias() throws Exception {
-		KeyManagerFactory delegate = mock(KeyManagerFactory.class);
-		given(delegate.getKeyManagers()).willReturn(new KeyManager[] { mock(X509ExtendedKeyManager.class) });
-		AliasKeyManagerFactory factory = new AliasKeyManagerFactory(delegate, "test-alias",
-				KeyManagerFactory.getDefaultAlgorithm());
+	void chooseEngineServerAliasReturnsTestAliasMatchingSupportedDelegateAliasAndAlgorithm() throws Exception {
+
+		final String delegateSupportedAlgorithm = "supported-alg";
+		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
+		final String delegateChosenAlias = delegateSupportedAlias[0];
+		final String testAlias = delegateSupportedAlias[1];
+		final String testAlgorithm = delegateSupportedAlgorithm;
+		final String expectedAlias = testAlias;
+
+		KeyManagerFactory delegate = mockServerKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
+				delegateChosenAlias);
+		AliasKeyManagerFactory factory = createAliasKeyManagerFactory(testAlias, delegate);
+		X509ExtendedKeyManager x509KeyManager = getX509ExtendedKeyManager(factory);
+
+		String chosenAlias = x509KeyManager.chooseEngineServerAlias(testAlgorithm, null, null);
+		assertThat(chosenAlias).isEqualTo(expectedAlias);
+	}
+
+	@Test
+	void chooseEngineServerAliasReturnsDelegateAliasWhenTestAliasIsUnknown() throws Exception {
+
+		final String delegateSupportedAlgorithm = "supported-alg";
+		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
+		final String delegateChosenAlias = delegateSupportedAlias[0];
+		final String testAlias = "unknown-alias";
+		final String testAlgorithm = delegateSupportedAlgorithm;
+		final String expectedAlias = delegateChosenAlias;
+
+		KeyManagerFactory delegate = mockServerKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
+				delegateChosenAlias);
+		AliasKeyManagerFactory factory = createAliasKeyManagerFactory(testAlias, delegate);
+		X509ExtendedKeyManager x509KeyManager = getX509ExtendedKeyManager(factory);
+
+		String chosenAlias = x509KeyManager.chooseEngineServerAlias(testAlgorithm, null, null);
+		assertThat(chosenAlias).isEqualTo(expectedAlias);
+	}
+
+	@Test
+	void chooseEngineServerAliasReturnsNullWhenAlgorithmDoesNotMatch() throws Exception {
+
+		final String delegateSupportedAlgorithm = "supported-alg";
+		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
+		final String delegateChosenAlias = delegateSupportedAlias[1];
+		final String testAlias = delegateSupportedAlias[0];
+		final String testAlgorithm = "other-alg";
+		final String expectedAlias = null;
+
+		KeyManagerFactory delegate = mockServerKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
+				delegateChosenAlias);
+		AliasKeyManagerFactory factory = createAliasKeyManagerFactory(testAlias, delegate);
+		X509ExtendedKeyManager x509KeyManager = getX509ExtendedKeyManager(factory);
+
+		String chosenAlias = x509KeyManager.chooseEngineServerAlias(testAlgorithm, null, null);
+		assertThat(chosenAlias).isEqualTo(expectedAlias);
+	}
+
+	@Test
+	void chooseServerAliasReturnsTestAliasMatchingSupportedDelegateAliasAndAlgorithm() throws Exception {
+
+		final String delegateSupportedAlgorithm = "supported-alg";
+		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
+		final String delegateChosenAlias = delegateSupportedAlias[0];
+		final String testAlias = delegateSupportedAlias[1];
+		final String testAlgorithm = delegateSupportedAlgorithm;
+		final String expectedAlias = testAlias;
+
+		KeyManagerFactory delegate = mockServerKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
+				delegateChosenAlias);
+		AliasKeyManagerFactory factory = createAliasKeyManagerFactory(testAlias, delegate);
+		X509ExtendedKeyManager x509KeyManager = getX509ExtendedKeyManager(factory);
+
+		String chosenAlias = x509KeyManager.chooseServerAlias(testAlgorithm, null, null);
+		assertThat(chosenAlias).isEqualTo(expectedAlias);
+	}
+
+	@Test
+	void chooseServerAliasReturnsDelegateAliasWhenTestAliasIsUnknown() throws Exception {
+
+		final String delegateSupportedAlgorithm = "supported-alg";
+		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
+		final String delegateChosenAlias = delegateSupportedAlias[0];
+		final String testAlias = "unknown-alias";
+		final String testAlgorithm = delegateSupportedAlgorithm;
+		final String expectedAlias = delegateChosenAlias;
+
+		KeyManagerFactory delegate = mockServerKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
+				delegateChosenAlias);
+		AliasKeyManagerFactory factory = createAliasKeyManagerFactory(testAlias, delegate);
+		X509ExtendedKeyManager x509KeyManager = getX509ExtendedKeyManager(factory);
+
+		String chosenAlias = x509KeyManager.chooseServerAlias(testAlgorithm, null, null);
+		assertThat(chosenAlias).isEqualTo(expectedAlias);
+	}
+
+	@Test
+	void chooseServerAliasReturnsNullWhenAlgorithmDoesNotMatch() throws Exception {
+
+		final String delegateSupportedAlgorithm = "supported-alg";
+		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
+		final String delegateChosenAlias = delegateSupportedAlias[1];
+		final String testAlias = delegateSupportedAlias[0];
+		final String testAlgorithm = "other-alg";
+		final String expectedAlias = null;
+
+		KeyManagerFactory delegate = mockServerKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
+				delegateChosenAlias);
+		AliasKeyManagerFactory factory = createAliasKeyManagerFactory(testAlias, delegate);
+		X509ExtendedKeyManager x509KeyManager = getX509ExtendedKeyManager(factory);
+
+		String chosenAlias = x509KeyManager.chooseServerAlias(testAlgorithm, null, null);
+		assertThat(chosenAlias).isEqualTo(expectedAlias);
+	}
+
+	@Test
+	void chooseEngineClientAliasReturnsTestAliasMatchingSupportedDelegateAliasAndAlgorithm() throws Exception {
+
+		final String delegateSupportedAlgorithm = "supported-alg";
+		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
+		final String delegateChosenAlias = delegateSupportedAlias[0];
+		final String testAlias = delegateSupportedAlias[1];
+		final String[] testAlgorithms = new String[] { delegateSupportedAlgorithm };
+		final String expectedAlias = testAlias;
+
+		KeyManagerFactory delegate = mockClientKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
+				delegateChosenAlias);
+		AliasKeyManagerFactory factory = createAliasKeyManagerFactory(testAlias, delegate);
+		X509ExtendedKeyManager x509KeyManager = getX509ExtendedKeyManager(factory);
+
+		String chosenAlias = x509KeyManager.chooseEngineClientAlias(testAlgorithms, null, null);
+		assertThat(chosenAlias).isEqualTo(expectedAlias);
+	}
+
+	@Test
+	void chooseEngineClientAliasReturnsDelegateAliasWhenTestAliasIsUnknown() throws Exception {
+
+		final String delegateSupportedAlgorithm = "supported-alg";
+		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
+		final String delegateChosenAlias = delegateSupportedAlias[0];
+		final String testAlias = "unknown-alias";
+		final String[] testAlgorithms = new String[] { delegateSupportedAlgorithm };
+		final String expectedAlias = delegateChosenAlias;
+
+		KeyManagerFactory delegate = mockClientKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
+				delegateChosenAlias);
+		AliasKeyManagerFactory factory = createAliasKeyManagerFactory(testAlias, delegate);
+		X509ExtendedKeyManager x509KeyManager = getX509ExtendedKeyManager(factory);
+
+		String chosenAlias = x509KeyManager.chooseEngineClientAlias(testAlgorithms, null, null);
+		assertThat(chosenAlias).isEqualTo(expectedAlias);
+	}
+
+	@Test
+	void chooseEngineClientAliasReturnsNullWhenAlgorithmDoesNotMatch() throws Exception {
+
+		final String delegateSupportedAlgorithm = "supported-alg";
+		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
+		final String delegateChosenAlias = delegateSupportedAlias[1];
+		final String testAlias = delegateSupportedAlias[0];
+		final String[] testAlgorithms = new String[] { "other-alg" };
+		final String expectedAlias = null;
+
+		KeyManagerFactory delegate = mockClientKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
+				delegateChosenAlias);
+		AliasKeyManagerFactory factory = createAliasKeyManagerFactory(testAlias, delegate);
+		X509ExtendedKeyManager x509KeyManager = getX509ExtendedKeyManager(factory);
+
+		String chosenAlias = x509KeyManager.chooseEngineClientAlias(testAlgorithms, null, null);
+		assertThat(chosenAlias).isEqualTo(expectedAlias);
+	}
+
+	@Test
+	void chooseClientAliasReturnsTestAliasMatchingSupportedDelegateAliasAndAlgorithm() throws Exception {
+
+		final String delegateSupportedAlgorithm = "supported-alg";
+		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
+		final String delegateChosenAlias = delegateSupportedAlias[0];
+		final String testAlias = delegateSupportedAlias[1];
+		final String[] testAlgorithms = new String[] { delegateSupportedAlgorithm };
+		final String expectedAlias = testAlias;
+
+		KeyManagerFactory delegate = mockClientKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
+				delegateChosenAlias);
+		AliasKeyManagerFactory factory = createAliasKeyManagerFactory(testAlias, delegate);
+		X509ExtendedKeyManager x509KeyManager = getX509ExtendedKeyManager(factory);
+
+		String chosenAlias = x509KeyManager.chooseClientAlias(testAlgorithms, null, null);
+		assertThat(chosenAlias).isEqualTo(expectedAlias);
+	}
+
+	@Test
+	void chooseClientAliasReturnsDelegateAliasWhenTestAliasIsUnknown() throws Exception {
+
+		final String delegateSupportedAlgorithm = "supported-alg";
+		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
+		final String delegateChosenAlias = delegateSupportedAlias[0];
+		final String testAlias = "unknown-alias";
+		final String[] testAlgorithms = new String[] { delegateSupportedAlgorithm };
+		final String expectedAlias = delegateChosenAlias;
+
+		KeyManagerFactory delegate = mockClientKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
+				delegateChosenAlias);
+		AliasKeyManagerFactory factory = createAliasKeyManagerFactory(testAlias, delegate);
+		X509ExtendedKeyManager x509KeyManager = getX509ExtendedKeyManager(factory);
+
+		String chosenAlias = x509KeyManager.chooseClientAlias(testAlgorithms, null, null);
+		assertThat(chosenAlias).isEqualTo(expectedAlias);
+	}
+
+	@Test
+	void chooseClientAliasReturnsNullWhenAlgorithmDoesNotMatch() throws Exception {
+
+		final String delegateSupportedAlgorithm = "supported-alg";
+		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
+		final String delegateChosenAlias = delegateSupportedAlias[1];
+		final String testAlias = delegateSupportedAlias[0];
+		final String[] testAlgorithms = new String[] { "other-alg" };
+		final String expectedAlias = null;
+
+		KeyManagerFactory delegate = mockClientKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
+				delegateChosenAlias);
+		AliasKeyManagerFactory factory = createAliasKeyManagerFactory(testAlias, delegate);
+		X509ExtendedKeyManager x509KeyManager = getX509ExtendedKeyManager(factory);
+
+		String chosenAlias = x509KeyManager.chooseClientAlias(testAlgorithms, null, null);
+		assertThat(chosenAlias).isEqualTo(expectedAlias);
+	}
+
+	private static AliasKeyManagerFactory createAliasKeyManagerFactory(String alias, KeyManagerFactory delegate)
+			throws Exception {
+		AliasKeyManagerFactory factory = new AliasKeyManagerFactory(delegate, alias, delegate.getAlgorithm());
 		factory.init(null, null);
-		KeyManager[] keyManagers = factory.getKeyManagers();
-		X509ExtendedKeyManager x509KeyManager = (X509ExtendedKeyManager) Arrays.stream(keyManagers)
+		return factory;
+	}
+
+	private static X509ExtendedKeyManager getX509ExtendedKeyManager(KeyManagerFactory factory) {
+		return Arrays.stream(factory.getKeyManagers())
 			.filter(X509ExtendedKeyManager.class::isInstance)
+			.map(X509ExtendedKeyManager.class::cast)
 			.findAny()
 			.get();
-		String chosenAlias = x509KeyManager.chooseEngineServerAlias(null, null, null);
-		assertThat(chosenAlias).isEqualTo("test-alias");
+	}
+
+	private static KeyManagerFactory mockServerKeyManagerFactory(String algorithm, String[] serverAliases,
+			String serverChosenAlias) {
+
+		return mockKeyManagerFactory(algorithm, serverAliases, serverChosenAlias, null, null);
+	}
+
+	private static KeyManagerFactory mockClientKeyManagerFactory(String algorithm, String[] clientAliases,
+			String clientChosenAlias) {
+
+		return mockKeyManagerFactory(algorithm, null, null, clientAliases, clientChosenAlias);
+	}
+
+	private static KeyManagerFactory mockKeyManagerFactory(String algorithm, String[] serverAliases,
+			String serverChosenAlias, String[] clientAliases, String clientChosenAlias) {
+
+		KeyManagerFactory delegate = mock(KeyManagerFactory.class);
+		X509ExtendedKeyManager x509KeyManagerMock = mock(X509ExtendedKeyManager.class);
+		given(delegate.getAlgorithm()).willReturn(algorithm);
+		given(delegate.getKeyManagers()).willReturn(new KeyManager[] { x509KeyManagerMock });
+		given(x509KeyManagerMock.getServerAliases(eq(algorithm), any())).willReturn(serverAliases);
+		given(x509KeyManagerMock.chooseServerAlias(eq(algorithm), any(), any())).willReturn(serverChosenAlias);
+		given(x509KeyManagerMock.chooseEngineServerAlias(eq(algorithm), any(), any())).willReturn(serverChosenAlias);
+		given(x509KeyManagerMock.getClientAliases(eq(algorithm), any())).willReturn(clientAliases);
+		given(x509KeyManagerMock.chooseClientAlias(argThat(arrayContains(algorithm)), any(), any()))
+			.willReturn(clientChosenAlias);
+		given(x509KeyManagerMock.chooseEngineClientAlias(argThat(arrayContains(algorithm)), any(), any()))
+			.willReturn(clientChosenAlias);
+		return delegate;
+	}
+
+	private static ArgumentMatcher<String[]> arrayContains(String expected) {
+		return (array) -> array != null && Arrays.asList(array).contains(expected);
 	}
 
 }

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/ssl/AliasKeyManagerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/ssl/AliasKeyManagerFactoryTests.java
@@ -60,14 +60,14 @@ class AliasKeyManagerFactoryTests {
 	}
 
 	@Test
-	void chooseEngineServerAliasReturnsDelegateAliasWhenTestAliasIsUnknown() throws Exception {
+	void chooseEngineServerAliasReturnsNullWhenTestAliasIsUnknown() throws Exception {
 
 		final String delegateSupportedAlgorithm = "supported-alg";
 		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
 		final String delegateChosenAlias = delegateSupportedAlias[0];
 		final String testAlias = "unknown-alias";
 		final String testAlgorithm = delegateSupportedAlgorithm;
-		final String expectedAlias = delegateChosenAlias;
+		final String expectedAlias = null;
 
 		KeyManagerFactory delegate = mockServerKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
 				delegateChosenAlias);
@@ -117,14 +117,14 @@ class AliasKeyManagerFactoryTests {
 	}
 
 	@Test
-	void chooseServerAliasReturnsDelegateAliasWhenTestAliasIsUnknown() throws Exception {
+	void chooseServerAliasReturnsNullWhenTestAliasIsUnknown() throws Exception {
 
 		final String delegateSupportedAlgorithm = "supported-alg";
 		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
 		final String delegateChosenAlias = delegateSupportedAlias[0];
 		final String testAlias = "unknown-alias";
 		final String testAlgorithm = delegateSupportedAlgorithm;
-		final String expectedAlias = delegateChosenAlias;
+		final String expectedAlias = null;
 
 		KeyManagerFactory delegate = mockServerKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
 				delegateChosenAlias);
@@ -174,14 +174,14 @@ class AliasKeyManagerFactoryTests {
 	}
 
 	@Test
-	void chooseEngineClientAliasReturnsDelegateAliasWhenTestAliasIsUnknown() throws Exception {
+	void chooseEngineClientAliasReturnsNullWhenTestAliasIsUnknown() throws Exception {
 
 		final String delegateSupportedAlgorithm = "supported-alg";
 		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
 		final String delegateChosenAlias = delegateSupportedAlias[0];
 		final String testAlias = "unknown-alias";
 		final String[] testAlgorithms = new String[] { delegateSupportedAlgorithm };
-		final String expectedAlias = delegateChosenAlias;
+		final String expectedAlias = null;
 
 		KeyManagerFactory delegate = mockClientKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
 				delegateChosenAlias);
@@ -231,14 +231,14 @@ class AliasKeyManagerFactoryTests {
 	}
 
 	@Test
-	void chooseClientAliasReturnsDelegateAliasWhenTestAliasIsUnknown() throws Exception {
+	void chooseClientAliasReturnsNullWhenTestAliasIsUnknown() throws Exception {
 
 		final String delegateSupportedAlgorithm = "supported-alg";
 		final String[] delegateSupportedAlias = new String[] { "alias0", "alias1", "alias2" };
 		final String delegateChosenAlias = delegateSupportedAlias[0];
 		final String testAlias = "unknown-alias";
 		final String[] testAlgorithms = new String[] { delegateSupportedAlgorithm };
-		final String expectedAlias = delegateChosenAlias;
+		final String expectedAlias = null;
 
 		KeyManagerFactory delegate = mockClientKeyManagerFactory(delegateSupportedAlgorithm, delegateSupportedAlias,
 				delegateChosenAlias);


### PR DESCRIPTION
SpringBoot provides a default implementation of the `org.springframework.boot.ssl.SslManagerBundle` interface (`DefaultSslManagerBundle`) that allows to specify a `SslBundleKey` (referencing the private key within the associated `KeyStore`) to be used for establishing an SSL connection. This feature, added in SpringBoot 3.1.0, is really appreciable as it simplifies a lot the selection of the private key to be used during SSL handshake.
However, the thing is that the underlying implementation (`AliasX509ExtendedKeyManager`) only considers the server-side of an SSL connection. If a client has to communicate with multiple partners through mTLS protocol and has a single KeyStore containing its private keys, it cannot select the appropriate key alias to be used with the related partner.

My proposal is to support this use case and to make  `AliasX509ExtendedKeyManager` working similarly for both server and client sides. That's the first point.

Then, looking more in details at the implementation, I noticed that the selected alias was returned unconditionally at the server side. I think it is not correct as SSL handshake is expected to reach an agreement between client and server, especially regarding the key algorithm to be used. Here, this algorithm is not taken into account meaning that although the key with the specified alias could exist in the underlying `KeyStore`, it could also be of the wrong type.
Thus, my implementation gets inspired by the JDK default implementation (`sun.security.ssl.SunX509KeyManagerImpl`) in which the alias selection is made by calling the getServerAliases(keyType, ...) or getClientAliases(keyType, ...) for restricting the choice to compatible keys only.

Finally, the `AliasX509ExtendedKeyManager` current implementation also only considers the transport-independent [SSLEngine](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/net/ssl/SSLEngine.html) but not the `Socket`-specific one. To cover all use cases, the implementation should also apply the same alias selection logic to the `Socket`-specific methods. That's what I did actually and factorized this logic for all contexts. 