### PR TITLE
fix: don't auto-start jetty service for negative port

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -53,6 +53,17 @@ bom {
 			releaseNotes("https://github.com/eclipse-ee4j/angus-mail/releases/tag/{version}")
 		}
 	}
+	library("Armeria", "1.32.0") {
+		group("com.linecorp.armeria") {
+			imports = [
+				"armeria-bom"
+			]
+		}
+		links {
+			site("https://armeria.dev")
+			releaseNotes("https://armeria.dev/release-notes/{version}")
+		}
+	}
 	library("Artemis", "2.39.0") {
 		group("org.apache.activemq") {
 			imports = [

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
@@ -145,24 +145,23 @@ public class JettyWebServer implements WebServer {
 				return;
 			}
 			this.server.setConnectors(this.connectors);
-			if (!this.autoStart) {
-				return;
-			}
 			try {
 				this.server.start();
-				for (Handler handler : this.server.getHandlers()) {
-					handleDeferredInitialize(handler);
-				}
-				Connector[] connectors = this.server.getConnectors();
-				for (Connector connector : connectors) {
-					try {
-						connector.start();
+				if (this.autoStart) {
+					for (Handler handler : this.server.getHandlers()) {
+						handleDeferredInitialize(handler);
 					}
-					catch (IOException ex) {
-						if (connector instanceof NetworkConnector networkConnector) {
-							PortInUseException.throwIfPortBindingException(ex, networkConnector::getPort);
+					Connector[] connectors = this.server.getConnectors();
+					for (Connector connector : connectors) {
+						try {
+							connector.start();
 						}
-						throw ex;
+						catch (IOException ex) {
+							if (connector instanceof NetworkConnector networkConnector) {
+								PortInUseException.throwIfPortBindingException(ex, networkConnector::getPort);
+							}
+							throw ex;
+						}
 					}
 				}
 				this.started = true;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyWebServer.java
@@ -147,10 +147,10 @@ public class JettyWebServer implements WebServer {
 			this.server.setConnectors(this.connectors);
 			try {
 				this.server.start();
+				for (Handler handler : this.server.getHandlers()) {
+					handleDeferredInitialize(handler);
+				}
 				if (this.autoStart) {
-					for (Handler handler : this.server.getHandlers()) {
-						handleDeferredInitialize(handler);
-					}
 					Connector[] connectors = this.server.getConnectors();
 					for (Connector connector : connectors) {
 						try {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+	id "java"
+}
+
+description = "Spring Boot Armeria Jetty smoke test"
+
+ext {
+	armeriaVersion = "1.32.0"
+}
+
+dependencies {
+	implementation("com.linecorp.armeria:armeria:$armeriaVersion")
+	implementation("com.linecorp.armeria:armeria-spring-boot3-autoconfigure:$armeriaVersion")
+	implementation("com.linecorp.armeria:armeria-jetty12:$armeriaVersion")
+
+	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-web")) {
+		exclude module: "spring-boot-starter-tomcat"
+	}
+	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-jetty"))
+
+	testImplementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-test"))
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/build.gradle
@@ -4,14 +4,10 @@ plugins {
 
 description = "Spring Boot Armeria Jetty smoke test"
 
-ext {
-	armeriaVersion = "1.32.0"
-}
-
 dependencies {
-	implementation("com.linecorp.armeria:armeria:$armeriaVersion")
-	implementation("com.linecorp.armeria:armeria-spring-boot3-autoconfigure:$armeriaVersion")
-	implementation("com.linecorp.armeria:armeria-jetty12:$armeriaVersion")
+	implementation("com.linecorp.armeria:armeria")
+	implementation("com.linecorp.armeria:armeria-spring-boot3-autoconfigure")
+	implementation("com.linecorp.armeria:armeria-jetty12")
 
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-web")) {
 		exclude module: "spring-boot-starter-tomcat"

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/src/main/java/smoketest/armeria/jetty/ArmeriaConfiguration.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/src/main/java/smoketest/armeria/jetty/ArmeriaConfiguration.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.armeria.jetty;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.healthcheck.HealthChecker;
+import com.linecorp.armeria.server.jetty.JettyService;
+import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+import org.eclipse.jetty.server.Server;
+
+import org.springframework.boot.web.embedded.jetty.JettyWebServer;
+import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures an Armeria server to redirect the incoming requests to the Jetty instance
+ * provided by Spring Boot. It also sets up a {@link HealthChecker} so that it works well
+ * with a load balancer.
+ */
+@Configuration
+public class ArmeriaConfiguration {
+
+	/**
+	 * Returns a new {@link HealthChecker} that marks the server as unhealthy when Tomcat
+	 * becomes unavailable.
+	 */
+	@Bean
+	public HealthChecker jettyHealthChecker(ServletWebServerApplicationContext applicationContext) {
+		final Server server = jettyServer(applicationContext).getServer();
+		return server::isRunning;
+	}
+
+	/**
+	 * Returns a new {@link JettyService} that redirects the incoming requests to the
+	 * Jetty instance provided by Spring Boot.
+	 */
+	@Bean
+	public JettyService jettyService(ServletWebServerApplicationContext applicationContext) {
+		final JettyWebServer jettyWebServer = jettyServer(applicationContext);
+		return JettyService.of(jettyWebServer.getServer(), null);
+	}
+
+	/**
+	 * Returns a new {@link ArmeriaServerConfigurator} that is responsible for configuring
+	 * a {@link Server} using the given {@link ServerBuilder}.
+	 */
+	@Bean
+	public ArmeriaServerConfigurator armeriaServiceInitializer(JettyService jettyService) {
+		return sb -> sb.serviceUnder("/jetty", jettyService.decorate((delegate, ctx, req) -> {
+			ctx.addAdditionalResponseHeader("armeria-forwarded", "true");
+			return delegate.serve(ctx, req);
+		})).serviceUnder("/armeria", (ctx, req) -> HttpResponse.of("Hello from Armeria!"));
+	}
+
+	/**
+	 * Extracts a Jetty {@link Server} from Spring webapp context.
+	 */
+	private static JettyWebServer jettyServer(ServletWebServerApplicationContext applicationContext) {
+		return (JettyWebServer) applicationContext.getWebServer();
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/src/main/java/smoketest/armeria/jetty/ArmeriaConfiguration.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/src/main/java/smoketest/armeria/jetty/ArmeriaConfiguration.java
@@ -32,6 +32,8 @@ import org.springframework.context.annotation.Configuration;
  * Configures an Armeria server to redirect the incoming requests to the Jetty instance
  * provided by Spring Boot. It also sets up a {@link HealthChecker} so that it works well
  * with a load balancer.
+ *
+ * @author Dogac Eldenk
  */
 @Configuration
 public class ArmeriaConfiguration {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/src/main/java/smoketest/armeria/jetty/SampleArmeriaJettyApplication.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/src/main/java/smoketest/armeria/jetty/SampleArmeriaJettyApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.armeria.jetty;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SampleArmeriaJettyApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SampleArmeriaJettyApplication.class, args);
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/src/main/java/smoketest/armeria/jetty/service/HelloWorldService.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/src/main/java/smoketest/armeria/jetty/service/HelloWorldService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.armeria.jetty.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HelloWorldService {
+
+	@Value("${test.name:World}")
+	private String name;
+
+	public String getHelloMessage() {
+		return "Hello " + this.name;
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/src/main/java/smoketest/armeria/jetty/web/SampleController.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/src/main/java/smoketest/armeria/jetty/web/SampleController.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.armeria.jetty.web;
+
+import smoketest.armeria.jetty.service.HelloWorldService;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+public class SampleController {
+
+	private final HelloWorldService helloWorldService;
+
+	public SampleController(HelloWorldService helloWorldService) {
+		this.helloWorldService = helloWorldService;
+	}
+
+	@GetMapping("/")
+	@ResponseBody
+	public String helloWorld() {
+		return this.helloWorldService.getHelloMessage();
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/src/main/resources/config/application.yml
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/src/main/resources/config/application.yml
@@ -1,0 +1,7 @@
+# Prevent the embedded Jetty from opening a TCP/IP port.
+server.port: -1
+---
+armeria:
+  ports:
+    - port: 0
+      protocols: HTTP

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/src/test/java/smoketest/armeria/jetty/SampleArmeriaJettyApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-jetty/src/test/java/smoketest/armeria/jetty/SampleArmeriaJettyApplicationTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.armeria.jetty;
+
+import com.linecorp.armeria.server.Server;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Basic integration tests for demo application.
+ *
+ * @author Dogac Eldenk
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+class SampleArmeriaJettyApplicationTests {
+
+	@Autowired
+	private Server server;
+
+	@Autowired
+	private TestRestTemplate restTemplate;
+
+	@BeforeEach
+	void setup() {
+		DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory("http://127.0.0.1:" + server.activeLocalPort());
+		this.restTemplate.getRestTemplate().setUriTemplateHandler(factory);
+	}
+
+	@Test
+	void testJetty() {
+		ResponseEntity<String> entity = this.restTemplate.getForEntity("/jetty", String.class);
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(entity.getBody()).isEqualTo("Hello World");
+		assertThat(entity.getHeaders().getFirst("armeria-forwarded")).isEqualTo("true");
+	}
+
+	@Test
+	void testArmeria() {
+		ResponseEntity<String> entity = this.restTemplate.getForEntity("/armeria", String.class);
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(entity.getBody()).isEqualTo("Hello from Armeria!");
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/build.gradle
@@ -4,14 +4,10 @@ plugins {
 
 description = "Spring Boot Armeria Tomcat smoke test"
 
-ext {
-	armeriaVersion = "1.32.0"
-}
-
 dependencies {
-	implementation("com.linecorp.armeria:armeria:$armeriaVersion")
-	implementation("com.linecorp.armeria:armeria-spring-boot3-autoconfigure:$armeriaVersion")
-	implementation("com.linecorp.armeria:armeria-tomcat10:$armeriaVersion")
+	implementation("com.linecorp.armeria:armeria")
+	implementation("com.linecorp.armeria:armeria-spring-boot3-autoconfigure")
+	implementation("com.linecorp.armeria:armeria-tomcat10")
 
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter"))
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-tomcat"))

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+	id "java"
+}
+
+description = "Spring Boot Armeria Tomcat smoke test"
+
+ext {
+	armeriaVersion = "1.32.0"
+}
+
+dependencies {
+	implementation("com.linecorp.armeria:armeria:$armeriaVersion")
+	implementation("com.linecorp.armeria:armeria-spring-boot3-autoconfigure:$armeriaVersion")
+	implementation("com.linecorp.armeria:armeria-tomcat10:$armeriaVersion")
+
+	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter"))
+	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-tomcat"))
+	implementation("org.springframework:spring-webmvc")
+
+	testImplementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-test"))
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/src/main/java/smoketest/armeria/tomcat/ArmeriaConfiguration.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/src/main/java/smoketest/armeria/tomcat/ArmeriaConfiguration.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.armeria.tomcat;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.healthcheck.HealthChecker;
+import com.linecorp.armeria.server.tomcat.TomcatService;
+import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+import org.apache.catalina.connector.Connector;
+
+import org.springframework.boot.web.embedded.tomcat.TomcatWebServer;
+import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures an Armeria {@link Server} to redirect the incoming requests to the Tomcat
+ * instance provided by Spring Boot. It also sets up a {@link HealthChecker} so that it
+ * works well with a load balancer.
+ */
+@Configuration
+public class ArmeriaConfiguration {
+
+	/**
+	 * Extracts a Tomcat {@link Connector} from Spring webapp context.
+	 */
+	public static Connector getConnector(ServletWebServerApplicationContext applicationContext) {
+		final TomcatWebServer container = (TomcatWebServer) applicationContext.getWebServer();
+
+		// Start the container to make sure all connectors are available.
+		container.start();
+		return container.getTomcat().getConnector();
+	}
+
+	/**
+	 * Returns a new {@link HealthChecker} that marks the server as unhealthy when Tomcat
+	 * becomes unavailable.
+	 */
+	@Bean
+	public HealthChecker tomcatConnectorHealthChecker(ServletWebServerApplicationContext applicationContext) {
+		final Connector connector = getConnector(applicationContext);
+		return () -> connector.getState().isAvailable();
+	}
+
+	/**
+	 * Returns a new {@link TomcatService} that redirects the incoming requests to the
+	 * Tomcat instance provided by Spring Boot.
+	 */
+	@Bean
+	public TomcatService tomcatService(ServletWebServerApplicationContext applicationContext) {
+		return TomcatService.of(getConnector(applicationContext));
+	}
+
+	/**
+	 * Returns a new {@link ArmeriaServerConfigurator} that is responsible for configuring
+	 * a {@link Server} using the given {@link ServerBuilder}.
+	 */
+	@Bean
+	public ArmeriaServerConfigurator armeriaServiceInitializer(TomcatService tomcatService) {
+
+		return sb -> sb.serviceUnder("/tomcat", tomcatService.decorate((delegate, ctx, req) -> {
+			ctx.addAdditionalResponseHeader("armeria-forwarded", "true");
+			return delegate.serve(ctx, req);
+		})).serviceUnder("/armeria", (ctx, req) -> HttpResponse.of("Hello from Armeria!"));
+
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/src/main/java/smoketest/armeria/tomcat/ArmeriaConfiguration.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/src/main/java/smoketest/armeria/tomcat/ArmeriaConfiguration.java
@@ -33,6 +33,8 @@ import org.springframework.context.annotation.Configuration;
  * Configures an Armeria {@link Server} to redirect the incoming requests to the Tomcat
  * instance provided by Spring Boot. It also sets up a {@link HealthChecker} so that it
  * works well with a load balancer.
+ *
+ * @author Dogac Eldenk
  */
 @Configuration
 public class ArmeriaConfiguration {

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/src/main/java/smoketest/armeria/tomcat/SampleArmeriaTomcatApplication.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/src/main/java/smoketest/armeria/tomcat/SampleArmeriaTomcatApplication.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.armeria.tomcat;
+
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class SampleArmeriaTomcatApplication {
+
+	private static final Log logger = LogFactory.getLog(SampleArmeriaTomcatApplication.class);
+
+	@Bean
+	protected ServletContextListener listener() {
+		return new ServletContextListener() {
+
+			@Override
+			public void contextInitialized(ServletContextEvent sce) {
+				logger.info("ServletContext initialized");
+			}
+
+			@Override
+			public void contextDestroyed(ServletContextEvent sce) {
+				logger.info("ServletContext destroyed");
+			}
+
+		};
+	}
+
+	public static void main(String[] args) {
+		SpringApplication.run(SampleArmeriaTomcatApplication.class, args);
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/src/main/java/smoketest/armeria/tomcat/service/HelloWorldService.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/src/main/java/smoketest/armeria/tomcat/service/HelloWorldService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.armeria.tomcat.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HelloWorldService {
+
+	@Value("${test.name:World}")
+	private String name;
+
+	public String getHelloMessage() {
+		return "Hello " + this.name;
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/src/main/java/smoketest/armeria/tomcat/web/SampleController.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/src/main/java/smoketest/armeria/tomcat/web/SampleController.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.armeria.tomcat.web;
+
+import smoketest.armeria.tomcat.service.HelloWorldService;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+public class SampleController {
+
+	private final HelloWorldService helloWorldService;
+
+	public SampleController(HelloWorldService helloWorldService) {
+		this.helloWorldService = helloWorldService;
+	}
+
+	@GetMapping("/")
+	@ResponseBody
+	public String helloWorld() {
+		return this.helloWorldService.getHelloMessage();
+	}
+
+}

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/src/main/resources/config/application.yml
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/src/main/resources/config/application.yml
@@ -1,0 +1,7 @@
+# Prevent the embedded Tomcat from opening a TCP/IP port.
+server.port: -1
+---
+armeria:
+  ports:
+    - port: 0
+      protocols: HTTP

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/src/test/java/smoketest/armeria/tomcat/SampleArmeriaTomcatApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-armeria-tomcat/src/test/java/smoketest/armeria/tomcat/SampleArmeriaTomcatApplicationTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package smoketest.armeria.tomcat;
+
+import com.linecorp.armeria.server.Server;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Basic integration tests for demo application.
+ *
+ * @author Dogac Eldenk
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+@ExtendWith(OutputCaptureExtension.class)
+class SampleArmeriaTomcatApplicationTests {
+
+	@Autowired
+	private Server server;
+
+	@Autowired
+	private TestRestTemplate restTemplate;
+
+	@BeforeEach
+	void setup() {
+		DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory("http://127.0.0.1:" + server.activeLocalPort());
+		this.restTemplate.getRestTemplate().setUriTemplateHandler(factory);
+	}
+
+	@Test
+	void testTomcat() {
+		ResponseEntity<String> entity = this.restTemplate.getForEntity("/tomcat", String.class);
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(entity.getBody()).isEqualTo("Hello World");
+		assertThat(entity.getHeaders().getFirst("armeria-forwarded")).isEqualTo("true");
+	}
+
+	@Test
+	void testArmeria() {
+		ResponseEntity<String> entity = this.restTemplate.getForEntity("/armeria", String.class);
+		assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(entity.getBody()).isEqualTo("Hello from Armeria!");
+	}
+
+}


### PR DESCRIPTION
Prevent Jetty Web Server from auto-starting and binding to a random port if `server.port` is set to a negative value. This issue is also reported in Armeria repository: https://github.com/line/armeria/issues/5039. We want to prevent Jetty/Tomcat from binding to a random port so that the traffic can be only handled via Armeria server and forwarded to Jetty.

Currently, when `server.port` is set to -1 in Tomcat servlet, it doesn't start the tomcat server on a random port.

> 2025-03-07T21:17:51.954-06:00  INFO 30944 --- [           main] s.tomcat.SampleTomcatApplication         : ServletContext initialized
2025-03-07T21:17:53.129-06:00  INFO 30944 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port -1 (http) with context path '/'
2025-03-07T21:17:53.148-06:00  INFO 30944 --- [           main] s.tomcat.SampleTomcatApplication         : Started SampleTomcatApplication in 1.97 seconds (process running for 2.223)


However, same behavior results in Jetty to start on a random port.

> 2025-03-07T21:15:34.947-06:00  INFO 30835 --- [           main] org.eclipse.jetty.server.Server          : Started oejs.Server@7a904f32{STARTING}[12.0.16,sto=0] @1145ms
2025-03-07T21:15:35.104-06:00  INFO 30835 --- [           main] o.s.b.web.embedded.jetty.JettyWebServer  : Jetty started on port 56372 (http/1.1) with context path '/'
2025-03-07T21:15:35.108-06:00  INFO 30835 --- [           main] smoketest.jetty.SampleJettyApplication   : Started SampleJettyApplication in 1.046 seconds (process running for 1.306)


After applying those changes, I have manually tested by creating `application.yml` under `resources/config` folder and set `server.port: -1` for both Jetty and Tomcat. My changes resulted Jetty to show a similar behavior with Tomcat.

> 2025-03-07T21:15:34.947-06:00  INFO 30835 --- [           main] org.eclipse.jetty.server.Server          : Started oejs.Server@7a904f32{STARTING}[12.0.16,sto=0] @1145ms
2025-03-07T21:15:35.104-06:00  INFO 30835 --- [           main] o.s.b.web.embedded.jetty.JettyWebServer  : Jetty started on port -1 (http/1.1) with context path '/'
2025-03-07T21:15:35.108-06:00  INFO 30835 --- [           main] smoketest.jetty.SampleJettyApplication   : Started SampleJettyApplication in 1.046 seconds (process running for 1.306)



