### PR TITLE
Polish OpenTelemetryResourceAttributes

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryResourceAttributesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryResourceAttributesTests.java
@@ -121,7 +121,7 @@ class OpenTelemetryResourceAttributesTests {
 	void illegalArgumentExceptionShouldBeThrownWhenDecodingIllegalHexCharPercentEncodedValue() {
 		this.environmentVariables.put("OTEL_RESOURCE_ATTRIBUTES", "key=abc%ß");
 		assertThatIllegalArgumentException().isThrownBy(this::getAttributes)
-			.withMessage("Failed to decode percent-encoded characters at index 3 in the value: 'abc%ß'");
+			.withMessage("Invalid encoded sequence \"%ß\"");
 	}
 
 	@Test
@@ -134,7 +134,7 @@ class OpenTelemetryResourceAttributesTests {
 	void illegalArgumentExceptionShouldBeThrownWhenDecodingInvalidPercentEncodedValue() {
 		this.environmentVariables.put("OTEL_RESOURCE_ATTRIBUTES", "key=%");
 		assertThatIllegalArgumentException().isThrownBy(this::getAttributes)
-			.withMessage("Failed to decode percent-encoded characters at index 0 in the value: '%'");
+			.withMessage("Invalid encoded sequence \"%\"");
 	}
 
 	@Test


### PR DESCRIPTION
Update `OpenTelemetryResourceAttributes` to use `StringUtils.uriDecode(...)`, as it provides the same functionality as the custom `decode(...)` method.

