### PR TITLE
Add garbage collector info to process info contributor

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/info/ProcessInfoTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/info/ProcessInfoTests.java
@@ -16,10 +16,13 @@
 
 package org.springframework.boot.info;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
+import org.springframework.boot.info.ProcessInfo.MemoryInfo;
 import org.springframework.boot.info.ProcessInfo.MemoryInfo.MemoryUsageInfo;
 import org.springframework.boot.info.ProcessInfo.VirtualThreadsInfo;
 
@@ -56,6 +59,12 @@ class ProcessInfoTests {
 		assertThat(nonHeapUsageInfo.getUsed()).isPositive().isLessThanOrEqualTo(nonHeapUsageInfo.getCommitted());
 		assertThat(nonHeapUsageInfo.getCommitted()).isPositive();
 		assertThat(nonHeapUsageInfo.getMax()).isEqualTo(-1);
+		List<MemoryInfo.GarbageCollectorInfo> garbageCollectors = processInfo.getMemory().getGarbageCollectors();
+		assertThat(garbageCollectors).isNotEmpty();
+		assertThat(garbageCollectors).allSatisfy((garbageCollector) -> {
+			assertThat(garbageCollector.getName()).isNotEmpty();
+			assertThat(garbageCollector.getCollectionCount()).isNotNegative();
+		});
 	}
 
 	@Test


### PR DESCRIPTION
Since GC algorithms can be selected by JVM ergonomics, it might not be trivial to know them since the decision usually depends on the available processors and the available memory. Especially in (containerized) environments where resource usage can be isolated (for example using control groups) or not necessarily trivial to discover.

<details>
<summary>Example outputs (click to reveal)</summary>

# BellSoft Liberica `23+38`

## `-XX:+UseSerialGC`
```json
"garbageCollectors": [
    {
        "name": "Copy",
        "collectionCount": 0
    },
    {
        "name": "MarkSweepCompact",
        "collectionCount": 2
    }
]
```

## `-XX:+UseParallelGC`
```json
"garbageCollectors": [
    {
        "name": "PS MarkSweep",
        "collectionCount": 2
    },
    {
        "name": "PS Scavenge",
        "collectionCount": 0
    }
]
```

## `-XX:+UseG1GC`
```json
"garbageCollectors": [
    {
        "name": "G1 Young Generation",
        "collectionCount": 8
    },
    {
        "name": "G1 Concurrent GC",
        "collectionCount": 4
    },
    {
        "name": "G1 Old Generation",
        "collectionCount": 0
    }
]
```

## `-XX:+UseZGC` (Generational ZGC)
```json
"garbageCollectors": [
    {
        "name": "ZGC Minor Cycles",
        "collectionCount": 0
    },
    {
        "name": "ZGC Minor Pauses",
        "collectionCount": 0
    },
    {
        "name": "ZGC Major Cycles",
        "collectionCount": 2
    },
    {
        "name": "ZGC Major Pauses",
        "collectionCount": 10
    }
]
```

## `-XX:+UseZGC -XX:-ZGenerational` (Non-Generational ZGC)
```json
"garbageCollectors": [
    {
        "name": "ZGC Cycles",
        "collectionCount": 2
    },
    {
        "name": "ZGC Pauses",
        "collectionCount": 6
    }
]
```

## `-XX:+UseShenandoahGC`
```json
"garbageCollectors": [
    {
        "name": "Shenandoah Pauses",
        "collectionCount": 8
    },
    {
        "name": "Shenandoah Cycles",
        "collectionCount": 2
    }
]
```

## `-XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC` (YOLO)
```json
"garbageCollectors": [
    {
        "name": "Epsilon Heap",
        "collectionCount": 0
    }
]
```

No CMS since it was removed in Java 14 and no Generational Shenandoah since it will be introduced in Java 24.

# IBM Semeru `23.0.2+7`, OpenJ9 `0.49.0`

## `-Xgcpolicy:balanced`
```json
"garbageCollectors": [
    {
        "name": "partial gc",
        "collectionCount": 0
    },
    {
        "name": "global garbage collect",
        "collectionCount": 0
    }
]
```

## `-Xgc:concurrentScavenge`
```json
"garbageCollectors": [
    {
        "name": "scavenge",
        "collectionCount": 10
    },
    {
        "name": "global",
        "collectionCount": 0
    }
]
```

# BellSoft Liberica NIK `23.0.0-1`
GraalVM Community `17.0.7+7-LTS`, native-image (SubstrateVM), G1 GC
```json
"garbageCollectors": [
    {
        "name": "young generation scavenger",
        "collectionCount": 0
    },
    {
        "name": "complete scavenger",
        "collectionCount": 0
    }
]
```
</details>