### PR TITLE
Add support for omitting the SameSite attribute from the session cookie

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionAutoConfiguration.java
@@ -97,7 +97,9 @@ public class SessionAutoConfiguration {
 			map.from(cookie::getHttpOnly).to(cookieSerializer::setUseHttpOnlyCookie);
 			map.from(cookie::getSecure).to(cookieSerializer::setUseSecureCookie);
 			map.from(cookie::getMaxAge).asInt(Duration::getSeconds).to(cookieSerializer::setCookieMaxAge);
-			map.from(cookie::getSameSite).as(SameSite::attributeValue).to(cookieSerializer::setSameSite);
+			map.from(cookie::getSameSite)
+				.as((sameSite) -> (sameSite == SameSite.UNSET) ? null : sameSite.attributeValue())
+				.to(cookieSerializer::setSameSite);
 			map.from(cookie::getPartitioned).to(cookieSerializer::setPartitioned);
 			cookieSerializerCustomizers.orderedStream().forEach((customizer) -> customizer.customize(cookieSerializer));
 			return cookieSerializer;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/session/SessionAutoConfiguration.java
@@ -97,9 +97,7 @@ public class SessionAutoConfiguration {
 			map.from(cookie::getHttpOnly).to(cookieSerializer::setUseHttpOnlyCookie);
 			map.from(cookie::getSecure).to(cookieSerializer::setUseSecureCookie);
 			map.from(cookie::getMaxAge).asInt(Duration::getSeconds).to(cookieSerializer::setCookieMaxAge);
-			map.from(cookie::getSameSite)
-				.as((sameSite) -> (sameSite == SameSite.UNSET) ? null : sameSite.attributeValue())
-				.to(cookieSerializer::setSameSite);
+			map.from(cookie::getSameSite).as(SameSite::attributeValue).to(cookieSerializer::setSameSite);
 			map.from(cookie::getPartitioned).to(cookieSerializer::setPartitioned);
 			cookieSerializerCustomizers.orderedStream().forEach((customizer) -> customizer.customize(cookieSerializer));
 			return cookieSerializer;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebSessionIdResolverAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebSessionIdResolverAutoConfiguration.java
@@ -77,12 +77,8 @@ public class WebSessionIdResolverAutoConfiguration {
 		map.from(cookie::getSecure).to(builder::secure);
 		map.from(cookie::getMaxAge).to(builder::maxAge);
 		map.from(cookie::getPartitioned).to(builder::partitioned);
-		map.from(getSameSite(cookie)).to(builder::sameSite);
-	}
-
-	private String getSameSite(Cookie properties) {
-		SameSite sameSite = properties.getSameSite();
-		return (sameSite != null && sameSite != SameSite.UNSET) ? sameSite.attributeValue() : null;
+		map.from(cookie::getSameSite)
+			.to(((sameSite) -> builder.sameSite((sameSite == SameSite.UNSET) ? null : sameSite.attributeValue())));
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebSessionIdResolverAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebSessionIdResolverAutoConfiguration.java
@@ -77,8 +77,7 @@ public class WebSessionIdResolverAutoConfiguration {
 		map.from(cookie::getSecure).to(builder::secure);
 		map.from(cookie::getMaxAge).to(builder::maxAge);
 		map.from(cookie::getPartitioned).to(builder::partitioned);
-		map.from(cookie::getSameSite)
-			.to(((sameSite) -> builder.sameSite((sameSite == SameSite.UNSET) ? null : sameSite.attributeValue())));
+		map.from(cookie::getSameSite).as(SameSite::attributeValue).to(builder::sameSite);
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebSessionIdResolverAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/WebSessionIdResolverAutoConfiguration.java
@@ -82,7 +82,7 @@ public class WebSessionIdResolverAutoConfiguration {
 
 	private String getSameSite(Cookie properties) {
 		SameSite sameSite = properties.getSameSite();
-		return (sameSite != null) ? sameSite.attributeValue() : null;
+		return (sameSite != null && sameSite != SameSite.UNSET) ? sameSite.attributeValue() : null;
 	}
 
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
@@ -171,6 +171,16 @@ class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurationTest
 	}
 
 	@Test
+	void sessionCookieSameSiteUnsetIsAppliedToAutoConfiguredCookieSerializer() {
+		this.contextRunner.withUserConfiguration(SessionRepositoryConfiguration.class)
+			.withPropertyValues("server.servlet.session.cookie.sameSite=unset")
+			.run((context) -> {
+				DefaultCookieSerializer cookieSerializer = context.getBean(DefaultCookieSerializer.class);
+				assertThat(cookieSerializer).hasFieldOrPropertyWithValue("sameSite", null);
+			});
+	}
+
+	@Test
 	void autoConfiguredCookieSerializerIsUsedBySessionRepositoryFilter() {
 		this.contextRunner.withUserConfiguration(SessionRepositoryConfiguration.class)
 			.withPropertyValues("server.port=0")

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/session/SessionAutoConfigurationTests.java
@@ -171,9 +171,9 @@ class SessionAutoConfigurationTests extends AbstractSessionAutoConfigurationTest
 	}
 
 	@Test
-	void sessionCookieSameSiteUnsetIsAppliedToAutoConfiguredCookieSerializer() {
+	void sessionCookieSameSiteOmittedIsAppliedToAutoConfiguredCookieSerializer() {
 		this.contextRunner.withUserConfiguration(SessionRepositoryConfiguration.class)
-			.withPropertyValues("server.servlet.session.cookie.sameSite=unset")
+			.withPropertyValues("server.servlet.session.cookie.sameSite=omitted")
 			.run((context) -> {
 				DefaultCookieSerializer cookieSerializer = context.getBean(DefaultCookieSerializer.class);
 				assertThat(cookieSerializer).hasFieldOrPropertyWithValue("sameSite", null);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfigurationTests.java
@@ -677,8 +677,8 @@ class WebFluxAutoConfigurationTests {
 	}
 
 	@Test
-	void sessionCookieUnsetConfigurationShouldBeApplied() {
-		this.contextRunner.withPropertyValues("server.reactive.session.cookie.same-site:unset")
+	void sessionCookieOmittedConfigurationShouldBeApplied() {
+		this.contextRunner.withPropertyValues("server.reactive.session.cookie.same-site:omitted")
 			.run(assertExchangeWithSession((exchange) -> {
 				List<ResponseCookie> cookies = exchange.getResponse().getCookies().get("SESSION");
 				assertThat(cookies).extracting(ResponseCookie::getSameSite).containsOnlyNulls();

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfigurationTests.java
@@ -676,6 +676,15 @@ class WebFluxAutoConfigurationTests {
 			}));
 	}
 
+	@Test
+	void sessionCookieUnsetConfigurationShouldBeApplied() {
+		this.contextRunner.withPropertyValues("server.reactive.session.cookie.same-site:unset")
+			.run(assertExchangeWithSession((exchange) -> {
+				List<ResponseCookie> cookies = exchange.getResponse().getCookies().get("SESSION");
+				assertThat(cookies).extracting(ResponseCookie::getSameSite).containsOnlyNulls();
+			}));
+	}
+
 	@ParameterizedTest
 	@ValueSource(classes = { ServerProperties.class, WebFluxProperties.class })
 	void propertiesAreNotEnabledInNonWebApplication(Class<?> propertiesClass) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyServletWebServerFactory.java
@@ -284,7 +284,7 @@ public class JettyServletWebServerFactory extends AbstractServletWebServerFactor
 	private void configureSession(WebAppContext context) {
 		SessionHandler handler = context.getSessionHandler();
 		SameSite sessionSameSite = getSession().getCookie().getSameSite();
-		if (sessionSameSite != null && sessionSameSite != SameSite.UNSET) {
+		if (sessionSameSite != null && sessionSameSite != SameSite.OMITTED) {
 			handler.setSameSite(HttpCookie.SameSite.valueOf(sessionSameSite.name()));
 		}
 		Duration sessionTimeout = getSession().getTimeout();

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/jetty/JettyServletWebServerFactory.java
@@ -284,7 +284,7 @@ public class JettyServletWebServerFactory extends AbstractServletWebServerFactor
 	private void configureSession(WebAppContext context) {
 		SessionHandler handler = context.getSessionHandler();
 		SameSite sessionSameSite = getSession().getCookie().getSameSite();
-		if (sessionSameSite != null) {
+		if (sessionSameSite != null && sessionSameSite != SameSite.UNSET) {
 			handler.setSameSite(HttpCookie.SameSite.valueOf(sessionSameSite.name()));
 		}
 		Duration sessionTimeout = getSession().getTimeout();

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
@@ -998,11 +998,12 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 		@Override
 		public String generateHeader(Cookie cookie, HttpServletRequest request) {
 			SameSite sameSite = getSameSite(cookie);
-			if (sameSite == null || sameSite == SameSite.UNSET) {
+			String sameSiteValue = (sameSite != null) ? sameSite.attributeValue() : null;
+			if (sameSiteValue == null) {
 				return super.generateHeader(cookie, request);
 			}
 			Rfc6265CookieProcessor delegate = new Rfc6265CookieProcessor();
-			delegate.setSameSiteCookies(sameSite.attributeValue());
+			delegate.setSameSiteCookies(sameSiteValue);
 			return delegate.generateHeader(cookie, request);
 		}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory.java
@@ -998,7 +998,7 @@ public class TomcatServletWebServerFactory extends AbstractServletWebServerFacto
 		@Override
 		public String generateHeader(Cookie cookie, HttpServletRequest request) {
 			SameSite sameSite = getSameSite(cookie);
-			if (sameSite == null) {
+			if (sameSite == null || sameSite == SameSite.UNSET) {
 				return super.generateHeader(cookie, request);
 			}
 			Rfc6265CookieProcessor delegate = new Rfc6265CookieProcessor();

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactory.java
@@ -635,7 +635,10 @@ public class UndertowServletWebServerFactory extends AbstractServletWebServerFac
 		private void beforeCommit(HttpServerExchange exchange) {
 			for (Cookie cookie : exchange.responseCookies()) {
 				SameSite sameSite = getSameSite(asServletCookie(cookie));
-				if (sameSite != null) {
+				if (sameSite == SameSite.UNSET) {
+					cookie.setSameSite(false);
+				}
+				else if (sameSite != null) {
 					cookie.setSameSiteMode(sameSite.attributeValue());
 				}
 			}

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactory.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/undertow/UndertowServletWebServerFactory.java
@@ -635,7 +635,7 @@ public class UndertowServletWebServerFactory extends AbstractServletWebServerFac
 		private void beforeCommit(HttpServerExchange exchange) {
 			for (Cookie cookie : exchange.responseCookies()) {
 				SameSite sameSite = getSameSite(asServletCookie(cookie));
-				if (sameSite == SameSite.UNSET) {
+				if (sameSite == SameSite.OMITTED) {
 					cookie.setSameSite(false);
 				}
 				else if (sameSite != null) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/Cookie.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/Cookie.java
@@ -146,9 +146,9 @@ public class Cookie {
 	public enum SameSite {
 
 		/**
-		 * Don't set the SameSite cookie attribute.
+		 * The SameSite cookie attribute will be omitted when creating the cookie.
 		 */
-		UNSET("Unset"),
+		OMITTED(null),
 
 		/**
 		 * Cookies are sent in both first-party and cross-origin requests.

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/Cookie.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/server/Cookie.java
@@ -146,6 +146,11 @@ public class Cookie {
 	public enum SameSite {
 
 		/**
+		 * Don't set the SameSite cookie attribute.
+		 */
+		UNSET("Unset"),
+
+		/**
 		 * Cookies are sent in both first-party and cross-origin requests.
 		 */
 		NONE("None"),

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
@@ -881,7 +881,7 @@ public abstract class AbstractServletWebServerFactoryTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(mode = EnumSource.Mode.EXCLUDE, names = "UNSET")
+	@EnumSource(mode = EnumSource.Mode.EXCLUDE, names = "OMITTED")
 	void sessionCookieSameSiteAttributeCanBeConfiguredAndOnlyAffectsSessionCookies(SameSite sameSite) throws Exception {
 		AbstractServletWebServerFactory factory = getFactory();
 		factory.getSession().getCookie().setSameSite(sameSite);
@@ -896,7 +896,7 @@ public abstract class AbstractServletWebServerFactoryTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(mode = EnumSource.Mode.EXCLUDE, names = "UNSET")
+	@EnumSource(mode = EnumSource.Mode.EXCLUDE, names = "OMITTED")
 	void sessionCookieSameSiteAttributeCanBeConfiguredAndOnlyAffectsSessionCookiesWhenUsingCustomName(SameSite sameSite)
 			throws Exception {
 		AbstractServletWebServerFactory factory = getFactory();
@@ -950,9 +950,9 @@ public abstract class AbstractServletWebServerFactoryTests {
 	}
 
 	@Test
-	void cookieSameSiteSuppliersShouldNotAffectUnsetSameSite() throws IOException, URISyntaxException {
+	void cookieSameSiteSuppliersShouldNotAffectOmittedSameSite() throws IOException, URISyntaxException {
 		AbstractServletWebServerFactory factory = getFactory();
-		factory.getSession().getCookie().setSameSite(SameSite.UNSET);
+		factory.getSession().getCookie().setSameSite(SameSite.OMITTED);
 		factory.getSession().getCookie().setName("SESSIONCOOKIE");
 		factory.addCookieSameSiteSuppliers(CookieSameSiteSupplier.ofStrict());
 		factory.addInitializers(new ServletRegistrationBean<>(new CookieServlet(false), "/"));

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/servlet/server/AbstractServletWebServerFactoryTests.java
@@ -881,7 +881,7 @@ public abstract class AbstractServletWebServerFactoryTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource
+	@EnumSource(mode = EnumSource.Mode.EXCLUDE, names = "UNSET")
 	void sessionCookieSameSiteAttributeCanBeConfiguredAndOnlyAffectsSessionCookies(SameSite sameSite) throws Exception {
 		AbstractServletWebServerFactory factory = getFactory();
 		factory.getSession().getCookie().setSameSite(sameSite);
@@ -896,7 +896,7 @@ public abstract class AbstractServletWebServerFactoryTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource
+	@EnumSource(mode = EnumSource.Mode.EXCLUDE, names = "UNSET")
 	void sessionCookieSameSiteAttributeCanBeConfiguredAndOnlyAffectsSessionCookiesWhenUsingCustomName(SameSite sameSite)
 			throws Exception {
 		AbstractServletWebServerFactory factory = getFactory();
@@ -946,6 +946,23 @@ public abstract class AbstractServletWebServerFactoryTests {
 		List<String> setCookieHeaders = clientResponse.getHeaders().get("Set-Cookie");
 		assertThat(setCookieHeaders).satisfiesExactlyInAnyOrder(
 				(header) -> assertThat(header).contains("SESSIONCOOKIE").contains("SameSite=Lax"),
+				(header) -> assertThat(header).contains("test=test").contains("SameSite=Strict"));
+	}
+
+	@Test
+	void cookieSameSiteSuppliersShouldNotAffectUnsetSameSite() throws IOException, URISyntaxException {
+		AbstractServletWebServerFactory factory = getFactory();
+		factory.getSession().getCookie().setSameSite(SameSite.UNSET);
+		factory.getSession().getCookie().setName("SESSIONCOOKIE");
+		factory.addCookieSameSiteSuppliers(CookieSameSiteSupplier.ofStrict());
+		factory.addInitializers(new ServletRegistrationBean<>(new CookieServlet(false), "/"));
+		this.webServer = factory.getWebServer();
+		this.webServer.start();
+		ClientHttpResponse clientResponse = getClientResponse(getLocalUrl("/"));
+		assertThat(clientResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+		List<String> setCookieHeaders = clientResponse.getHeaders().get("Set-Cookie");
+		assertThat(setCookieHeaders).satisfiesExactlyInAnyOrder(
+				(header) -> assertThat(header).contains("SESSIONCOOKIE").doesNotContain("SameSite"),
 				(header) -> assertThat(header).contains("test=test").contains("SameSite=Strict"));
 	}
 


### PR DESCRIPTION
The main reason for this pull request is to make it easier to disable setting the SameSite cookie in the Spring Session `CookieSerializer`. The default for the Spring Session is Lax. However, this does not work when using SAML with POST redirect, when the cookie is Lax, then the session cookie will not be sent when the redirect happens and thus the authentication will not work (see https://stackoverflow.com/questions/60068271/samesite-attribute-break-saml-flow/60096206#60096206 and https://www.linkedin.com/pulse/samesite-cookie-infinite-redirections-saml-digvijay-singh/).

The current workaround I have is to expose the following bean

```java
@Bean
public DefaultCookieSerializerCustomizer disableSameSite() {
    return cookieSerializer -> cookieSerializer.setSameSite(null);
}
```

i.e. use the serializer to disable the cookie.

If this PR is accepted it would make it easier to configure this without the need to expose a bean by just doing 

```properties
server.servlet.session.cookie.same-site=unset
```

