### PR TITLE
Fix progress calculation using proper Integer unboxing method

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/TotalProgressListener.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/TotalProgressListener.java
@@ -120,7 +120,7 @@ public abstract class TotalProgressListener<E extends ImageProgressUpdateEvent> 
 		}
 
 		int getProgress() {
-			return withinPercentageBounds((this.progressByStatus.values().stream().mapToInt(Integer::valueOf).sum())
+			return withinPercentageBounds((this.progressByStatus.values().stream().mapToInt(Integer::intValue).sum())
 					/ this.progressByStatus.size());
 		}
 


### PR DESCRIPTION
## Description
This PR fixes the Integer conversion in the `getProgress()` method by replacing `Integer::valueOf` with `Integer::intValue`. The original code incorrectly used `valueOf` which is meant for converting other types to Integer objects, while `intValue()` is the correct method for unboxing Integer objects to primitive int values.

## Changes
- Modified `getProgress()` method in the progress calculation logic
- Replaced `Integer::valueOf` with `Integer::intValue` for proper unboxing
- Improved semantic clarity of the code without affecting functionality

## Reasoning
`progressByStatus.values()` returns a collection of Integer objects. When processing these values with `mapToInt()`, we need to extract the primitive int value from each Integer object. The `valueOf()` method is meant for creating Integer objects from other types (like String), while `intValue()` is designed for extracting the primitive value from an Integer object.