### PR TITLE
Allow @Name to be used on record components

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -84,6 +84,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Pavel Anisimov
  * @author Scott Frederick
  * @author Moritz Halbritter
+ * @author Yanming Zhou
  */
 class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGenerationTests {
 
@@ -490,6 +491,32 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 		ConfigurationMetadata metadata = compile(source);
 		assertThat(metadata).has(Metadata.withProperty("implicit.some-string"));
 		assertThat(metadata).has(Metadata.withProperty("implicit.some-integer"));
+	}
+
+	@Test
+	void recordPropertiesWithName() {
+		String source = """
+				@org.springframework.boot.configurationsample.ConfigurationProperties("implicit")
+				public record ExampleRecord(
+					@org.springframework.boot.configurationsample.Name("for") String forString) {
+				}
+				""";
+		ConfigurationMetadata metadata = compile(source);
+		assertThat(metadata).has(Metadata.withProperty("implicit.for"));
+	}
+
+	@Test
+	void recordPropertiesWithNameAndDefaultValue() {
+		String source = """
+				@org.springframework.boot.configurationsample.ConfigurationProperties("implicit")
+				public record ExampleRecord(
+					@org.springframework.boot.configurationsample.Name("for")
+					@org.springframework.boot.configurationsample.DefaultValue("example")
+					String forString) {
+				}
+				""";
+		ConfigurationMetadata metadata = compile(source);
+		assertThat(metadata).has(Metadata.withProperty("implicit.for", String.class).withDefaultValue("example"));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/Name.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/Name.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,9 @@ import java.lang.annotation.Target;
  * dependency on the real annotation).
  *
  * @author Phillip Webb
+ * @author Yanming Zhou
  */
-@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Name {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Name.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Name.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,10 +32,11 @@ import java.lang.annotation.Target;
  *
  * @author Phillip Webb
  * @author Lasse Wulff
+ * @author Yanming Zhou
  * @since 2.4.0
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.RECORD_COMPONENT })
 @Documented
 public @interface Name {
 


### PR DESCRIPTION
It's not actually necessary, but it's better to align with `@DefaultValue`.

See https://github.com/spring-projects/spring-boot/pull/29010
