### PR TITLE
Polishing BatchAutoConfigurationTests

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfigurationTests.java
@@ -122,23 +122,22 @@ class BatchAutoConfigurationTests {
 
 	@Test
 	void testDefaultContext() {
-		this.contextRunner.withUserConfiguration(TestConfiguration.class, EmbeddedDataSourceConfiguration.class)
-			.run((context) -> {
-				assertThat(context).hasSingleBean(JobRepository.class);
-				assertThat(context).hasSingleBean(JobLauncher.class);
-				assertThat(context).hasSingleBean(JobExplorer.class);
-				assertThat(context).hasSingleBean(JobRegistry.class);
-				assertThat(context).hasSingleBean(JobOperator.class);
-				assertThat(context.getBean(BatchProperties.class).getJdbc().getInitializeSchema())
-					.isEqualTo(DatabaseInitializationMode.EMBEDDED);
-				assertThat(new JdbcTemplate(context.getBean(DataSource.class))
-					.queryForList("select * from BATCH_JOB_EXECUTION")).isEmpty();
-			});
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class).run((context) -> {
+			assertThat(context).hasSingleBean(JobRepository.class);
+			assertThat(context).hasSingleBean(JobLauncher.class);
+			assertThat(context).hasSingleBean(JobExplorer.class);
+			assertThat(context).hasSingleBean(JobRegistry.class);
+			assertThat(context).hasSingleBean(JobOperator.class);
+			assertThat(context.getBean(BatchProperties.class).getJdbc().getInitializeSchema())
+				.isEqualTo(DatabaseInitializationMode.EMBEDDED);
+			assertThat(new JdbcTemplate(context.getBean(DataSource.class))
+				.queryForList("select * from BATCH_JOB_EXECUTION")).isEmpty();
+		});
 	}
 
 	@Test
 	void autoconfigurationBacksOffEntirelyIfSpringJdbcAbsent() {
-		this.contextRunner.withUserConfiguration(TestConfiguration.class, EmbeddedDataSourceConfiguration.class)
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
 			.withClassLoader(new FilteredClassLoader(DatabasePopulator.class))
 			.run((context) -> {
 				assertThat(context).doesNotHaveBean(JobLauncherApplicationRunner.class);
@@ -262,7 +261,7 @@ class BatchAutoConfigurationTests {
 
 	@Test
 	void testDisableSchemaLoader() {
-		this.contextRunner.withUserConfiguration(TestConfiguration.class, EmbeddedDataSourceConfiguration.class)
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
 			.withPropertyValues("spring.datasource.generate-unique-name=true",
 					"spring.batch.jdbc.initialize-schema:never")
 			.run((context) -> {
@@ -279,7 +278,7 @@ class BatchAutoConfigurationTests {
 	@Test
 	void testUsingJpa() {
 		this.contextRunner
-			.withUserConfiguration(TestConfiguration.class, EmbeddedDataSourceConfiguration.class,
+			.withUserConfiguration(TestJpaConfiguration.class, EmbeddedDataSourceConfiguration.class,
 					HibernateJpaAutoConfiguration.class)
 			.run((context) -> {
 				PlatformTransactionManager transactionManager = context.getBean(PlatformTransactionManager.class);
@@ -297,11 +296,9 @@ class BatchAutoConfigurationTests {
 	@Test
 	@WithPackageResources("custom-schema.sql")
 	void testRenamePrefix() {
-		this.contextRunner
-			.withUserConfiguration(TestConfiguration.class, EmbeddedDataSourceConfiguration.class,
-					HibernateJpaAutoConfiguration.class)
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
 			.withPropertyValues("spring.datasource.generate-unique-name=true",
-					"spring.batch.jdbc.schema:classpath:custom-schema.sql", "spring.batch.jdbc.tablePrefix:PREFIX_")
+					"spring.batch.jdbc.schema:classpath:custom-schema.sql", "spring.batch.jdbc.table-prefix:PREFIX_")
 			.run((context) -> {
 				assertThat(context).hasSingleBean(JobLauncher.class);
 				assertThat(context.getBean(BatchProperties.class).getJdbc().getInitializeSchema())
@@ -318,7 +315,7 @@ class BatchAutoConfigurationTests {
 	@Test
 	void testCustomizeJpaTransactionManagerUsingProperties() {
 		this.contextRunner
-			.withUserConfiguration(TestConfiguration.class, EmbeddedDataSourceConfiguration.class,
+			.withUserConfiguration(TestJpaConfiguration.class, EmbeddedDataSourceConfiguration.class,
 					HibernateJpaAutoConfiguration.class)
 			.withPropertyValues("spring.transaction.default-timeout:30",
 					"spring.transaction.rollback-on-commit-failure:true")
@@ -333,7 +330,7 @@ class BatchAutoConfigurationTests {
 
 	@Test
 	void testCustomizeDataSourceTransactionManagerUsingProperties() {
-		this.contextRunner.withUserConfiguration(TestConfiguration.class, EmbeddedDataSourceConfiguration.class)
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
 			.withPropertyValues("spring.transaction.default-timeout:30",
 					"spring.transaction.rollback-on-commit-failure:true")
 			.run((context) -> {
@@ -347,36 +344,32 @@ class BatchAutoConfigurationTests {
 
 	@Test
 	void testBatchDataSource() {
-		this.contextRunner.withUserConfiguration(TestConfiguration.class, BatchDataSourceConfiguration.class)
-			.run((context) -> {
-				assertThat(context).hasSingleBean(SpringBootBatchConfiguration.class)
-					.hasSingleBean(BatchDataSourceScriptDatabaseInitializer.class)
-					.hasBean("batchDataSource");
-				DataSource batchDataSource = context.getBean("batchDataSource", DataSource.class);
-				assertThat(context.getBean(SpringBootBatchConfiguration.class).getDataSource())
-					.isEqualTo(batchDataSource);
-				assertThat(context.getBean(BatchDataSourceScriptDatabaseInitializer.class))
-					.hasFieldOrPropertyWithValue("dataSource", batchDataSource);
-			});
+		this.contextRunner.withUserConfiguration(BatchDataSourceConfiguration.class).run((context) -> {
+			assertThat(context).hasSingleBean(SpringBootBatchConfiguration.class)
+				.hasSingleBean(BatchDataSourceScriptDatabaseInitializer.class)
+				.hasBean("batchDataSource");
+			DataSource batchDataSource = context.getBean("batchDataSource", DataSource.class);
+			assertThat(context.getBean(SpringBootBatchConfiguration.class).getDataSource()).isEqualTo(batchDataSource);
+			assertThat(context.getBean(BatchDataSourceScriptDatabaseInitializer.class))
+				.hasFieldOrPropertyWithValue("dataSource", batchDataSource);
+		});
 	}
 
 	@Test
 	void testBatchTransactionManager() {
-		this.contextRunner.withUserConfiguration(TestConfiguration.class, BatchTransactionManagerConfiguration.class)
-			.run((context) -> {
-				assertThat(context).hasSingleBean(SpringBootBatchConfiguration.class);
-				PlatformTransactionManager batchTransactionManager = context.getBean("batchTransactionManager",
-						PlatformTransactionManager.class);
-				assertThat(context.getBean(SpringBootBatchConfiguration.class).getTransactionManager())
-					.isEqualTo(batchTransactionManager);
-			});
+		this.contextRunner.withUserConfiguration(BatchTransactionManagerConfiguration.class).run((context) -> {
+			assertThat(context).hasSingleBean(SpringBootBatchConfiguration.class);
+			PlatformTransactionManager batchTransactionManager = context.getBean("batchTransactionManager",
+					PlatformTransactionManager.class);
+			assertThat(context.getBean(SpringBootBatchConfiguration.class).getTransactionManager())
+				.isEqualTo(batchTransactionManager);
+		});
 	}
 
 	@Test
 	void testBatchTaskExecutor() {
 		this.contextRunner
-			.withUserConfiguration(TestConfiguration.class, BatchTaskExecutorConfiguration.class,
-					EmbeddedDataSourceConfiguration.class)
+			.withUserConfiguration(BatchTaskExecutorConfiguration.class, EmbeddedDataSourceConfiguration.class)
 			.run((context) -> {
 				assertThat(context).hasSingleBean(SpringBootBatchConfiguration.class).hasBean("batchTaskExecutor");
 				TaskExecutor batchTaskExecutor = context.getBean("batchTaskExecutor", TaskExecutor.class);
@@ -390,22 +383,20 @@ class BatchAutoConfigurationTests {
 
 	@Test
 	void jobRepositoryBeansDependOnBatchDataSourceInitializer() {
-		this.contextRunner.withUserConfiguration(TestConfiguration.class, EmbeddedDataSourceConfiguration.class)
-			.run((context) -> {
-				ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
-				String[] jobRepositoryNames = beanFactory.getBeanNamesForType(JobRepository.class);
-				assertThat(jobRepositoryNames).isNotEmpty();
-				for (String jobRepositoryName : jobRepositoryNames) {
-					assertThat(beanFactory.getBeanDefinition(jobRepositoryName).getDependsOn())
-						.contains("batchDataSourceInitializer");
-				}
-			});
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class).run((context) -> {
+			ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+			String[] jobRepositoryNames = beanFactory.getBeanNamesForType(JobRepository.class);
+			assertThat(jobRepositoryNames).isNotEmpty();
+			for (String jobRepositoryName : jobRepositoryNames) {
+				assertThat(beanFactory.getBeanDefinition(jobRepositoryName).getDependsOn())
+					.contains("batchDataSourceInitializer");
+			}
+		});
 	}
 
 	@Test
 	void jobRepositoryBeansDependOnFlyway() {
-		this.contextRunner.withUserConfiguration(TestConfiguration.class, EmbeddedDataSourceConfiguration.class)
-			.withUserConfiguration(FlywayAutoConfiguration.class)
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class, FlywayAutoConfiguration.class)
 			.withPropertyValues("spring.batch.initialize-schema=never")
 			.run((context) -> {
 				ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
@@ -421,8 +412,8 @@ class BatchAutoConfigurationTests {
 	@Test
 	@WithResource(name = "db/changelog/db.changelog-master.yaml", content = "databaseChangeLog:")
 	void jobRepositoryBeansDependOnLiquibase() {
-		this.contextRunner.withUserConfiguration(TestConfiguration.class, EmbeddedDataSourceConfiguration.class)
-			.withUserConfiguration(LiquibaseAutoConfiguration.class)
+		this.contextRunner
+			.withUserConfiguration(EmbeddedDataSourceConfiguration.class, LiquibaseAutoConfiguration.class)
 			.withPropertyValues("spring.batch.initialize-schema=never")
 			.run((context) -> {
 				ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
@@ -436,8 +427,7 @@ class BatchAutoConfigurationTests {
 
 	@Test
 	void whenTheUserDefinesTheirOwnBatchDatabaseInitializerThenTheAutoConfiguredInitializerBacksOff() {
-		this.contextRunner
-			.withUserConfiguration(TestConfiguration.class, CustomBatchDatabaseInitializerConfiguration.class)
+		this.contextRunner.withUserConfiguration(CustomBatchDatabaseInitializerConfiguration.class)
 			.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class,
 					DataSourceTransactionManagerAutoConfiguration.class))
 			.run((context) -> assertThat(context).hasSingleBean(BatchDataSourceScriptDatabaseInitializer.class)
@@ -447,7 +437,7 @@ class BatchAutoConfigurationTests {
 
 	@Test
 	void whenTheUserDefinesTheirOwnDatabaseInitializerThenTheAutoConfiguredBatchInitializerRemains() {
-		this.contextRunner.withUserConfiguration(TestConfiguration.class, CustomDatabaseInitializerConfiguration.class)
+		this.contextRunner.withUserConfiguration(CustomDatabaseInitializerConfiguration.class)
 			.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class,
 					DataSourceTransactionManagerAutoConfiguration.class))
 			.run((context) -> assertThat(context).hasSingleBean(BatchDataSourceScriptDatabaseInitializer.class)
@@ -456,8 +446,9 @@ class BatchAutoConfigurationTests {
 
 	@Test
 	void conversionServiceCustomizersAreCalled() {
-		this.contextRunner.withUserConfiguration(TestConfiguration.class, EmbeddedDataSourceConfiguration.class)
-			.withUserConfiguration(ConversionServiceCustomizersConfiguration.class)
+		this.contextRunner
+			.withUserConfiguration(EmbeddedDataSourceConfiguration.class,
+					ConversionServiceCustomizersConfiguration.class)
 			.run((context) -> {
 				BatchConversionServiceCustomizer customizer = context.getBean("batchConversionServiceCustomizer",
 						BatchConversionServiceCustomizer.class);
@@ -506,8 +497,8 @@ class BatchAutoConfigurationTests {
 
 	@Test
 	void customExecutionContextSerializerIsUsed() {
-		this.contextRunner.withUserConfiguration(TestConfiguration.class, EmbeddedDataSourceConfiguration.class)
-			.withUserConfiguration(CustomExecutionContextConfiguration.class)
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+			.withBean(ExecutionContextSerializer.class, Jackson2ExecutionContextStringSerializer::new)
 			.run((context) -> {
 				assertThat(context).hasSingleBean(Jackson2ExecutionContextStringSerializer.class);
 				assertThat(context.getBean(SpringBootBatchConfiguration.class).getExecutionContextSerializer())
@@ -517,12 +508,11 @@ class BatchAutoConfigurationTests {
 
 	@Test
 	void defaultExecutionContextSerializerIsUsed() {
-		this.contextRunner.withUserConfiguration(TestConfiguration.class, EmbeddedDataSourceConfiguration.class)
-			.run((context) -> {
-				assertThat(context).doesNotHaveBean(ExecutionContextSerializer.class);
-				assertThat(context.getBean(SpringBootBatchConfiguration.class).getExecutionContextSerializer())
-					.isInstanceOf(DefaultExecutionContextSerializer.class);
-			});
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class).run((context) -> {
+			assertThat(context).doesNotHaveBean(ExecutionContextSerializer.class);
+			assertThat(context.getBean(SpringBootBatchConfiguration.class).getExecutionContextSerializer())
+				.isInstanceOf(DefaultExecutionContextSerializer.class);
+		});
 	}
 
 	@Test
@@ -634,7 +624,7 @@ class BatchAutoConfigurationTests {
 	}
 
 	@TestAutoConfigurationPackage(City.class)
-	static class TestConfiguration {
+	static class TestJpaConfiguration {
 
 	}
 
@@ -908,16 +898,6 @@ class BatchAutoConfigurationTests {
 		@Order(2)
 		BatchConversionServiceCustomizer anotherBatchConversionServiceCustomizer() {
 			return mock(BatchConversionServiceCustomizer.class);
-		}
-
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	static class CustomExecutionContextConfiguration {
-
-		@Bean
-		ExecutionContextSerializer executionContextSerializer() {
-			return new Jackson2ExecutionContextStringSerializer();
 		}
 
 	}


### PR DESCRIPTION
1. Rename `TestConfiguration` to `TestJpaConfiguration` and remove unnecessary reference.
2. Use `withBean` instead of `withUserConfiguration` to avoid new configuration class.
3. Use kebab-case for configuration key.

