### PR TITLE
Update to spring-doc-actions v0.0.19

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,7 +45,7 @@ jobs:
         BUILD_VERSION: ${{ github.event.inputs.build-version }}
       run: node run.js --no-checkout
     - name: Sync Documentation
-      uses: spring-io/spring-doc-actions/rsync-antora-reference@v0.0.18
+      uses: spring-io/spring-doc-actions/rsync-antora-reference@v0.0.19
       with:
         docs-username: ${{ secrets.DOCS_USERNAME }}
         docs-host: ${{ secrets.DOCS_HOST }}
@@ -56,7 +56,7 @@ jobs:
         BUILD_REFNAME: ${{ github.event.inputs.build-refname }}
         BUILD_VERSION: ${{ github.event.inputs.build-version }}
     - name: Bust Cloudflare Cache
-      uses: spring-io/spring-doc-actions/bust-cloudflare-antora-cache@v0.0.18
+      uses: spring-io/spring-doc-actions/bust-cloudflare-antora-cache@v0.0.19
       with:
         context-root: spring-boot
         context-path: /


### PR DESCRIPTION
This will update to spring-doc-actions v0.0.19 which will publish a zip file at https://docs.spring.io/spring-boot/spring-boot-docs.zip