### PR TITLE
Remove extra ".0" in prohibit.versionRange for jOOQ

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1051,7 +1051,7 @@ bom {
 	}
 	library("jOOQ", "3.19.21") {
 		prohibit {
-			versionRange "[3.20.0.0,)"
+			versionRange "[3.20.0,)"
 			because "it requires Java 21"
 		}
 		group("org.jooq") {


### PR DESCRIPTION
This PR removes extra ".0" in prohibit.versionRange for jOOQ as it seems to have been added accidentally.