### PR TITLE
Spring Data Cassandra tests are using the wrong property for customizing the repository type

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraRepositoriesAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/cassandra/CassandraRepositoriesAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,15 +79,15 @@ class CassandraRepositoriesAutoConfigurationTests {
 	@Test
 	void enablingReactiveRepositoriesDisablesImperativeRepositories() {
 		this.contextRunner.withUserConfiguration(DefaultConfiguration.class)
-			.withPropertyValues("spring.cassandra.repositories.type=reactive")
-			.run((context) -> assertThat(context).doesNotHaveBean(CityCassandraRepository.class));
+			.withPropertyValues("spring.data.cassandra.repositories.type=reactive")
+			.run((context) -> assertThat(context).doesNotHaveBean(CityRepository.class));
 	}
 
 	@Test
 	void enablingNoRepositoriesDisablesImperativeRepositories() {
 		this.contextRunner.withUserConfiguration(DefaultConfiguration.class)
-			.withPropertyValues("spring.cassandra.repositories.type=none")
-			.run((context) -> assertThat(context).doesNotHaveBean(CityCassandraRepository.class));
+			.withPropertyValues("spring.data.cassandra.repositories.type=none")
+			.run((context) -> assertThat(context).doesNotHaveBean(CityRepository.class));
 	}
 
 	private ManagedTypes getManagedTypes(AssertableApplicationContext context) {


### PR DESCRIPTION
The tests did not verify anything because `CityCassandraRepository` is located outside the `City` package, which includes the `CityRepository` and `ReactiveCityRepository` repositories only, and also because of an incorrect property name.


See https://github.com/spring-projects/spring-boot/issues/44929