### PR TITLE
Wrong jOOQ exception translator with empty db name 

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/DefaultExceptionTranslatorExecuteListener.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jooq/DefaultExceptionTranslatorExecuteListener.java
@@ -114,7 +114,7 @@ final class DefaultExceptionTranslatorExecuteListener implements ExceptionTransl
 		private SQLExceptionTranslator apply(SQLDialect dialect) {
 			String dbName = getSpringDbName(dialect);
 			return (dbName != null) ? new SQLErrorCodeSQLExceptionTranslator(dbName)
-					: new SQLStateSQLExceptionTranslator();
+					: new SQLErrorCodeSQLExceptionTranslator();
 		}
 
 		private String getSpringDbName(SQLDialect dialect) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/DefaultExceptionTranslatorExecuteListenerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/jooq/DefaultExceptionTranslatorExecuteListenerTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.autoconfigure.jooq;
 
 import java.sql.SQLException;
+import java.sql.SQLSyntaxErrorException;
 import java.util.function.Function;
 
 import org.jooq.Configuration;
@@ -94,11 +95,18 @@ class DefaultExceptionTranslatorExecuteListenerTests {
 	static Object[] exceptionTranslatesSqlExceptions() {
 		return new Object[] { new Object[] { SQLDialect.DERBY, sqlException("42802") },
 				new Object[] { SQLDialect.H2, sqlException(42000) },
+				new Object[] { SQLDialect.H2, new SQLSyntaxErrorException() },
 				new Object[] { SQLDialect.HSQLDB, sqlException(-22) },
+				new Object[] { SQLDialect.HSQLDB, new SQLSyntaxErrorException() },
 				new Object[] { SQLDialect.MARIADB, sqlException(1054) },
+				new Object[] { SQLDialect.MARIADB, new SQLSyntaxErrorException() },
 				new Object[] { SQLDialect.MYSQL, sqlException(1054) },
+				new Object[] { SQLDialect.MYSQL, new SQLSyntaxErrorException() },
 				new Object[] { SQLDialect.POSTGRES, sqlException("03000") },
-				new Object[] { SQLDialect.SQLITE, sqlException("21000") } };
+				new Object[] { SQLDialect.POSTGRES, new SQLSyntaxErrorException() },
+				new Object[] { SQLDialect.SQLITE, new SQLSyntaxErrorException() },
+				new Object[] { SQLDialect.SQLITE, sqlException("21000") },
+		};
 	}
 
 	private static SQLException sqlException(String sqlState) {


### PR DESCRIPTION
Fix default exception translator for jooq translator without special db name handling

fix #44869