### PR TITLE
Rename 'spring.http.client' properties to 'spring.http.clients'

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/client/HttpClientProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/http/client/HttpClientProperties.java
@@ -30,7 +30,7 @@ import org.springframework.boot.http.client.ClientHttpRequestFactorySettings.Red
  * @author Phillip Webb
  * @since 3.4.0
  */
-@ConfigurationProperties("spring.http.client")
+@ConfigurationProperties("spring.http.clients")
 public class HttpClientProperties {
 
 	/**

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/http/client/HttpClientAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/http/client/HttpClientAutoConfigurationTests.java
@@ -53,7 +53,7 @@ class HttpClientAutoConfigurationTests {
 
 	@Test
 	void configuresDefinedClientHttpRequestFactoryBuilder() {
-		this.contextRunner.withPropertyValues("spring.http.client.factory=simple")
+		this.contextRunner.withPropertyValues("spring.http.clients.factory=simple")
 			.run((context) -> assertThat(context.getBean(ClientHttpRequestFactoryBuilder.class))
 				.isInstanceOf(SimpleClientHttpRequestFactoryBuilder.class));
 	}
@@ -61,8 +61,8 @@ class HttpClientAutoConfigurationTests {
 	@Test
 	void configuresClientHttpRequestFactorySettings() {
 		this.contextRunner.withPropertyValues(sslPropertyValues().toArray(String[]::new))
-			.withPropertyValues("spring.http.client.redirects=dont-follow", "spring.http.client.connect-timeout=10s",
-					"spring.http.client.read-timeout=20s", "spring.http.client.ssl.bundle=test")
+			.withPropertyValues("spring.http.clients.redirects=dont-follow", "spring.http.clients.connect-timeout=10s",
+					"spring.http.clients.read-timeout=20s", "spring.http.clients.ssl.bundle=test")
 			.run((context) -> {
 				ClientHttpRequestFactorySettings settings = context.getBean(ClientHttpRequestFactorySettings.class);
 				assertThat(settings.redirects()).isEqualTo(Redirects.DONT_FOLLOW);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/client/RestClientAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/client/RestClientAutoConfigurationTests.java
@@ -162,7 +162,7 @@ class RestClientAutoConfigurationTests {
 	void whenHasFactoryProperty() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(HttpMessageConvertersAutoConfiguration.class))
 			.withUserConfiguration(RestClientConfig.class)
-			.withPropertyValues("spring.http.client.factory=simple")
+			.withPropertyValues("spring.http.clients.factory=simple")
 			.run((context) -> {
 				assertThat(context).hasSingleBean(RestClient.class);
 				RestClient restClient = context.getBean(RestClient.class);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/client/RestTemplateAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/client/RestTemplateAutoConfigurationTests.java
@@ -197,7 +197,7 @@ class RestTemplateAutoConfigurationTests {
 	void whenHasFactoryProperty() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(HttpMessageConvertersAutoConfiguration.class))
 			.withUserConfiguration(RestTemplateConfig.class)
-			.withPropertyValues("spring.http.client.factory=simple")
+			.withPropertyValues("spring.http.clients.factory=simple")
 			.run((context) -> {
 				assertThat(context).hasSingleBean(RestTemplate.class);
 				RestTemplate restTemplate = context.getBean(RestTemplate.class);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/webservices/client/WebServiceTemplateAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/webservices/client/WebServiceTemplateAutoConfigurationTests.java
@@ -99,7 +99,7 @@ class WebServiceTemplateAutoConfigurationTests {
 	@Test
 	void whenHasFactoryProperty() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(HttpMessageConvertersAutoConfiguration.class))
-			.withPropertyValues("spring.http.client.factory=simple")
+			.withPropertyValues("spring.http.clients.factory=simple")
 			.run(assertWebServiceTemplateBuilder((builder) -> {
 				WebServiceTemplate webServiceTemplate = builder.build();
 				assertThat(webServiceTemplate.getMessageSenders()).hasSize(1);

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/io/rest-client.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/io/rest-client.adoc
@@ -209,14 +209,14 @@ If multiple clients are available on the classpath, and not global configuration
 [[io.rest-client.clienthttprequestfactory.configuration]]
 === Global HTTP Client Configuration
 
-If the auto-detected HTTP client does not meet your needs, you can use the configprop:spring.http.client.factory[] property to pick a specific factory.
+If the auto-detected HTTP client does not meet your needs, you can use the configprop:spring.http.clients.factory[] property to pick a specific factory.
 For example, if you have Apache HttpClient on your classpath, but you prefer Jetty's javadoc:org.eclipse.jetty.client.HttpClient[] you can add the following:
 
 [configprops,yaml]
 ----
 spring:
   http:
-    client:
+    clients:
       factory: jetty
 ----
 
@@ -227,7 +227,7 @@ For example, you may want to change timeouts and if redirects are followed:
 ----
 spring:
   http:
-    client:
+    clients:
       connect-timeout: 2s
       read-timeout: 1s
       redirects: dont-follow

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-groovy-templates/src/test/java/smoketest/groovytemplates/SampleGroovyTemplateApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-groovy-templates/src/test/java/smoketest/groovytemplates/SampleGroovyTemplateApplicationTests.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Dave Syer
  */
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = "spring.http.client.redirects=dont-follow")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = "spring.http.clients.redirects=dont-follow")
 class SampleGroovyTemplateApplicationTests {
 
 	@LocalServerPort

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-method-security/src/test/java/smoketest/security/method/SampleMethodSecurityApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-method-security/src/test/java/smoketest/security/method/SampleMethodSecurityApplicationTests.java
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Dave Syer
  * @author Scott Frederick
  */
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = "spring.http.client.factory=simple")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = "spring.http.clients.factory=simple")
 class SampleMethodSecurityApplicationTests {
 
 	@LocalServerPort

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-thymeleaf/src/test/java/smoketest/web/thymeleaf/SampleWebUiApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-web-thymeleaf/src/test/java/smoketest/web/thymeleaf/SampleWebUiApplicationTests.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Dave Syer
  */
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = "spring.http.client.redirects=dont-follow")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = "spring.http.clients.redirects=dont-follow")
 class SampleWebUiApplicationTests {
 
 	@Autowired


### PR DESCRIPTION
This PR renames the properties from `spring.http.client` to `spring.http.clients` to follow the same pattern used elsewhere in Spring Boot (like `properties.actuator.management.endpoints`).

The change affects
- The main `HttpClientProperties` class configuration property
- All test files using these properties
- Documentation in rest-client.adoc

This is a breaking change for anyone already using the `spring.http.client.*` properties in the 3.4.0 milestone.

Fixes #44958