### PR TITLE
Update 'for removal' versions > 3.5.0 to 4.0.0

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionOutcome.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionOutcome.java
@@ -153,7 +153,7 @@ public class ConditionOutcome {
 	 * @param outcome the outcome to inverse
 	 * @return the inverse of the condition outcome
 	 * @since 1.3.0
-	 * @deprecated since 3.5.0 for removal in 3.7.0 in favor of
+	 * @deprecated since 3.5.0 for removal in 4.0.0 in favor of
 	 * {@link #ConditionOutcome(boolean, ConditionMessage)}
 	 */
 	@Deprecated(since = "3.5.0", forRemoval = true)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/DefaultJmsListenerContainerFactoryConfigurer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jms/DefaultJmsListenerContainerFactoryConfigurer.java
@@ -101,7 +101,7 @@ public final class DefaultJmsListenerContainerFactoryConfigurer {
 	 * Set the {@link ObservationRegistry} to use.
 	 * @param observationRegistry the {@link ObservationRegistry}
 	 * @since 3.2.1
-	 * @deprecated since 3.3.10 for removal in 3.6.0 as this should have been package
+	 * @deprecated since 3.3.10 for removal in 4.0.0 as this should have been package
 	 * private
 	 */
 	@Deprecated(since = "3.3.10", forRemoval = true)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaConnectionDetails.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaConnectionDetails.java
@@ -94,7 +94,7 @@ public interface KafkaConnectionDetails extends ConnectionDetails {
 	/**
 	 * Returns the list of bootstrap servers used for consumers.
 	 * @return the list of bootstrap servers used for consumers
-	 * @deprecated since 3.5.0 for removal in 3.7.0 in favor of {@link #getConsumer()}
+	 * @deprecated since 3.5.0 for removal in 4.0.0 in favor of {@link #getConsumer()}
 	 */
 	@Deprecated(since = "3.5.0", forRemoval = true)
 	default List<String> getConsumerBootstrapServers() {
@@ -104,7 +104,7 @@ public interface KafkaConnectionDetails extends ConnectionDetails {
 	/**
 	 * Returns the list of bootstrap servers used for producers.
 	 * @return the list of bootstrap servers used for producers
-	 * @deprecated since 3.5.0 for removal in 3.7.0 in favor of {@link #getProducer()}
+	 * @deprecated since 3.5.0 for removal in 4.0.0 in favor of {@link #getProducer()}
 	 */
 	@Deprecated(since = "3.5.0", forRemoval = true)
 	default List<String> getProducerBootstrapServers() {
@@ -114,7 +114,7 @@ public interface KafkaConnectionDetails extends ConnectionDetails {
 	/**
 	 * Returns the list of bootstrap servers used for the admin.
 	 * @return the list of bootstrap servers used for the admin
-	 * @deprecated since 3.5.0 for removal in 3.7.0 in favor of {@link #getAdmin()}
+	 * @deprecated since 3.5.0 for removal in 4.0.0 in favor of {@link #getAdmin()}
 	 */
 	@Deprecated(since = "3.5.0", forRemoval = true)
 	default List<String> getAdminBootstrapServers() {
@@ -124,7 +124,7 @@ public interface KafkaConnectionDetails extends ConnectionDetails {
 	/**
 	 * Returns the list of bootstrap servers used for Kafka Streams.
 	 * @return the list of bootstrap servers used for Kafka Streams
-	 * @deprecated since 3.5.0 for removal in 3.7.0 in favor of {@link #getStreams()}
+	 * @deprecated since 3.5.0 for removal in 4.0.0 in favor of {@link #getStreams()}
 	 */
 	@Deprecated(since = "3.5.0", forRemoval = true)
 	default List<String> getStreamsBootstrapServers() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/StandardMongoClientSettingsBuilderCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/StandardMongoClientSettingsBuilderCustomizer.java
@@ -55,7 +55,7 @@ public class StandardMongoClientSettingsBuilderCustomizer implements MongoClient
 	 * @param uuidRepresentation the uuid representation
 	 * @param ssl the ssl properties
 	 * @param sslBundles the ssl bundles
-	 * @deprecated since 3.5.0 for removal in 3.7.0 in favor of
+	 * @deprecated since 3.5.0 for removal in 4.0.0 in favor of
 	 * {@link #StandardMongoClientSettingsBuilderCustomizer(MongoConnectionDetails, UuidRepresentation)}
 	 */
 	@Deprecated(forRemoval = true, since = "3.5.0")

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/JpaBaseConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/JpaBaseConfiguration.java
@@ -159,7 +159,7 @@ public abstract class JpaBaseConfiguration {
 	/**
 	 * Return the vendor-specific properties.
 	 * @return the vendor properties
-	 * @deprecated since 3.4.4 for removal in 3.6.0 in favor of
+	 * @deprecated since 3.4.4 for removal in 4.0.0 in favor of
 	 * {@link #getVendorProperties(DataSource)}
 	 */
 	@Deprecated(since = "3.4.4", forRemoval = true)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/ClientsConfiguredCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/client/ClientsConfiguredCondition.java
@@ -35,7 +35,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
  *
  * @author Madhura Bhave
  * @since 2.1.0
- * @deprecated since 3.5.0 for removal in 3.7.0 in favor of
+ * @deprecated since 3.5.0 for removal in 4.0.0 in favor of
  * {@link ConditionalOnOAuth2ClientRegistrationProperties @ConditionalOnOAuth2ClientRegistrationConfigured}
  */
 @Deprecated(since = "3.5.0", forRemoval = true)

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/IssuerUriCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/IssuerUriCondition.java
@@ -26,12 +26,13 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.util.StringUtils;
 
 /**
- * Condition for creating {@link JwtDecoder} by oidc issuer location.
+ * Condition that checks that a JWT issuer URI is configured correctly for
+ * {@code spring.security.oauth2.resourceserver.jwt.issuer-uri}.
  *
- * @author Artsiom Yudovin
- * @since 2.1.0
- * @deprecated since 3.5.0 for removal in 3.7.0 in favor of
- * {@link ConditionalOnIssuerLocationJwtDecoder @ConditionalOnIssuerLocationJwtDecoder}
+ * @author Phillip Webb
+ * @since 3.3.0
+ * @deprecated since 3.5.0 for removal in 4.0.0 in favor of
+ * {@code org.springframework.boot.autoconfigure.security.oauth2.server.resource.IssuerUriCondition}
  */
 @Deprecated(since = "3.5.0", forRemoval = true)
 public class IssuerUriCondition extends SpringBootCondition {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/KeyValueCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/KeyValueCondition.java
@@ -25,12 +25,13 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.util.StringUtils;
 
 /**
- * Condition for creating a jwt decoder using a public key value.
+ * Condition that check that a JWT key value configuration exists for
+ * {@code spring.security.oauth2.resourceserver.jwt.key-value}.
  *
- * @author Madhura Bhave
- * @since 2.2.0
- * @deprecated since 3.5.0 for removal in 3.7.0 in favor of
- * {@link ConditionalOnPublicKeyJwtDecoder @ConditionalOnPublicKeyJwtDecoder}
+ * @author Phillip Webb
+ * @since 3.3.0
+ * @deprecated since 3.5.0 for removal in 4.0.0 in favor of
+ * {@code org.springframework.boot.autoconfigure.security.oauth2.server.resource.KeyValueCondition}
  */
 @Deprecated(since = "3.5.0", forRemoval = true)
 public class KeyValueCondition extends SpringBootCondition {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/AntPathRequestMatcherProvider.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/AntPathRequestMatcherProvider.java
@@ -26,7 +26,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
  *
  * @author Madhura Bhave
  * @since 2.1.8
- * @deprecated since 3.5.0 for removal in 3.8.0 along with {@link RequestMatcherProvider}
+ * @deprecated since 3.5.0 for removal in 4.0.0 along with {@link RequestMatcherProvider}
  */
 @Deprecated(since = "3.5.0", forRemoval = true)
 @SuppressWarnings("removal")

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/RequestMatcherProvider.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/servlet/RequestMatcherProvider.java
@@ -19,13 +19,12 @@ package org.springframework.boot.autoconfigure.security.servlet;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
 /**
- * Interface that can be used to provide a {@link RequestMatcher} that can be used with
- * Spring Security.
+ * Interface for components that provide {@link RequestMatcher}.
  *
  * @author Madhura Bhave
- * @since 2.0.5
- * @deprecated since 3.5.0 for removal in 3.7.0 in favor of
- * {@code org.springframework.boot.actuate.autoconfigure.security.servlet.RequestMatcherProvider}
+ * @since 2.1.7
+ * @deprecated since 3.5.0 for removal in 4.0.0 in favor of
+ * {@code org.springframework.security.web.util.matcher.RequestMatcherProvider}
  */
 @Deprecated(since = "3.5.0", forRemoval = true)
 @FunctionalInterface

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/ConditionReportApplicationContextFailureProcessor.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/ConditionReportApplicationContextFailureProcessor.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.ApplicationContextFailureProcessor;
  * @author Phillip Webb
  * @author Scott Frederick
  * @since 3.0.0
- * @deprecated in 3.2.11 for removal in 3.6.0
+ * @deprecated in 3.2.11 for removal in 4.0.0
  */
 @Deprecated(since = "3.2.11", forRemoval = true)
 public class ConditionReportApplicationContextFailureProcessor implements ApplicationContextFailureProcessor {

--- a/spring-boot-project/spring-boot-testcontainers/src/dockerTest/java/org/springframework/boot/testcontainers/service/connection/cassandra/DeprecatedCassandraContainerConnectionDetailsFactoryTests.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/dockerTest/java/org/springframework/boot/testcontainers/service/connection/cassandra/DeprecatedCassandraContainerConnectionDetailsFactoryTests.java
@@ -36,8 +36,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for {@link DeprecatedCassandraContainerConnectionDetailsFactory}.
  *
+ * @author Moritz Halbritter
  * @author Andy Wilkinson
- * @deprecated since 3.4.0 for removal in 3.6.0
+ * @author Phillip Webb
+ * @deprecated since 3.4.0 for removal in 4.0.0
  */
 @SpringJUnitConfig
 @Testcontainers(disabledWithoutDocker = true)

--- a/spring-boot-project/spring-boot-testcontainers/src/dockerTest/java/org/springframework/boot/testcontainers/service/connection/kafka/DeprecatedConfluentKafkaContainerConnectionDetailsFactoryIntegrationTests.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/dockerTest/java/org/springframework/boot/testcontainers/service/connection/kafka/DeprecatedConfluentKafkaContainerConnectionDetailsFactoryIntegrationTests.java
@@ -41,12 +41,12 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link DeprecatedConfluentKafkaContainerConnectionDetailsFactory}.
+ * Integration tests for {@link DeprecatedConfluentKafkaContainerConnectionDetailsFactory}.
  *
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
- * @deprecated since 3.4.0 for removal in 3.6.0
+ * @deprecated since 3.4.0 for removal in 4.0.0
  */
 @SpringJUnitConfig
 @Testcontainers(disabledWithoutDocker = true)

--- a/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/lifecycle/BeforeTestcontainerUsedEvent.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/lifecycle/BeforeTestcontainerUsedEvent.java
@@ -26,7 +26,7 @@ import org.springframework.test.context.DynamicPropertyRegistrar;
  *
  * @author Andy Wilkinson
  * @since 3.2.6
- * @deprecated since 3.4.0 for removal in 3.6.0 in favor of property registration using a
+ * @deprecated since 3.4.0 for removal in 4.0.0 in favor of property registration using a
  * {@link DynamicPropertyRegistrar} bean that injects the {@link Container} from which the
  * properties will be sourced.
  */

--- a/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/properties/TestcontainersPropertySource.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/properties/TestcontainersPropertySource.java
@@ -54,7 +54,7 @@ import org.springframework.util.function.SupplierUtils;
  *
  * @author Phillip Webb
  * @since 3.1.0
- * @deprecated since 3.4.0 for removal in 3.6.0 in favor of declaring one or more
+ * @deprecated since 3.4.0 for removal in 4.0.0 in favor of declaring one or more
  * {@link DynamicPropertyRegistrar} beans.
  */
 @SuppressWarnings("removal")
@@ -204,5 +204,15 @@ public class TestcontainersPropertySource extends MapPropertySource {
 		}
 
 	}
+
+	/**
+	 * Configures a {@link GenericContainer} to collect properties and install a
+	 * {@link PropertySource} containing it.
+	 * @param container the container to configure
+	 * @return the configured container
+	 * @param <T> the {@link GenericContainer} type
+	 * @deprecated since 3.4.0 for removal in 4.0.0 in favor of declaring one or more
+	 * {@link Catalog} classes using the {@link Import} annotation
+	 */
 
 }

--- a/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/cassandra/DeprecatedCassandraContainerConnectionDetailsFactory.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/cassandra/DeprecatedCassandraContainerConnectionDetailsFactory.java
@@ -28,15 +28,15 @@ import org.springframework.boot.testcontainers.service.connection.ContainerConne
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 
 /**
- * {@link ContainerConnectionDetailsFactory} to create {@link CassandraConnectionDetails}
- * from a {@link ServiceConnection @ServiceConnection}-annotated
- * {@link CassandraContainer}.
+ * Implementation of {@link ConnectionDetailsFactory} that provides
+ * {@link CassandraConnectionDetails} from a deprecated {@link CassandraContainer}.
  *
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
- * @deprecated since 3.4.0 for removal in 3.6.0 in favor of
- * {@link CassandraContainerConnectionDetailsFactory}.
+ * @since 3.1.0
+ * @deprecated since 3.4.0 for removal in 4.0.0 in favor of
+ * {@link CassandraContainerConnectionDetailsFactory}
  */
 @Deprecated(since = "3.4.0", forRemoval = true)
 class DeprecatedCassandraContainerConnectionDetailsFactory

--- a/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/kafka/DeprecatedConfluentKafkaContainerConnectionDetailsFactory.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/kafka/DeprecatedConfluentKafkaContainerConnectionDetailsFactory.java
@@ -27,14 +27,15 @@ import org.springframework.boot.testcontainers.service.connection.ContainerConne
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 
 /**
- * {@link ContainerConnectionDetailsFactory} to create {@link KafkaConnectionDetails} from
- * a {@link ServiceConnection @ServiceConnection}-annotated {@link KafkaContainer}.
+ * Implementation of {@link ConnectionDetailsFactory} that provides
+ * {@link KafkaConnectionDetails} from the deprecated {@link KafkaContainer}.
  *
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
- * @deprecated since 3.4.0 for removal in 3.6.0 in favor of
- * {@link ConfluentKafkaContainerConnectionDetailsFactory}.
+ * @since 3.1.0
+ * @deprecated since 3.4.0 for removal in 4.0.0 in favor of
+ * {@link ConfluentKafkaContainerConnectionDetailsFactory}
  */
 @Deprecated(since = "3.4.0", forRemoval = true)
 class DeprecatedConfluentKafkaContainerConnectionDetailsFactory

--- a/spring-boot-project/spring-boot-testcontainers/src/test/java/org/springframework/boot/testcontainers/properties/TestcontainersPropertySourceTests.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/test/java/org/springframework/boot/testcontainers/properties/TestcontainersPropertySourceTests.java
@@ -41,7 +41,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * Tests for {@link TestcontainersPropertySource}.
  *
  * @author Phillip Webb
- * @deprecated since 3.4.0 for removal in 3.6.0
+ * @author Andy Wilkinson
+ * @since 3.1.0
+ * @deprecated since 3.4.0 for removal in 4.0.0
  */
 @SuppressWarnings("removal")
 @Deprecated(since = "3.4.0", forRemoval = true)

--- a/spring-boot-project/spring-boot-tools/spring-boot-test-support-docker/src/main/java/org/springframework/boot/testsupport/container/TestImage.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-test-support-docker/src/main/java/org/springframework/boot/testsupport/container/TestImage.java
@@ -87,7 +87,7 @@ public enum TestImage {
 	/**
 	 * A container image suitable for testing Cassandra using the deprecated
 	 * {@link org.testcontainers.containers.CassandraContainer}.
-	 * @deprecated since 3.4.0 for removal in 3.6.0 in favor of {@link #CASSANDRA}
+	 * @deprecated since 3.4.0 for removal in 4.0.0 in favor of {@link #CASSANDRA}
 	 */
 	@SuppressWarnings("deprecation")
 	@Deprecated(since = "3.4.0", forRemoval = true)
@@ -139,7 +139,7 @@ public enum TestImage {
 	/**
 	 * A container image suitable for testing Confluent's distribution of Kafka using the
 	 * deprecated {@link org.testcontainers.containers.KafkaContainer}.
-	 * @deprecated since 3.4.0 for removal in 3.6.0 in favor of {@link #CONFLUENT_KAFKA}
+	 * @deprecated since 3.4.0 for removal in 4.0.0 in favor of {@link #CONFLUENT_KAFKA}
 	 */
 	@SuppressWarnings("deprecation")
 	@Deprecated(since = "3.4.0", forRemoval = true)

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-jpa/src/test/java/smoketest/data/jpa/SpyBeanSampleDataJpaApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-data-jpa/src/test/java/smoketest/data/jpa/SpyBeanSampleDataJpaApplicationTests.java
@@ -30,10 +30,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.then;
 
 /**
- * Tests for {@link SampleDataJpaApplication} that use {@link SpyBean @SpyBean}.
+ * Tests that spy beans can be used with JPA.
  *
- * @author Andy Wilkinson
- * @deprecated since 3.4.0 for removal in 3.6.0
+ * @author Phillip Webb
+ * @deprecated since 3.4.0 for removal in 4.0.0
  */
 @SuppressWarnings("removal")
 @Deprecated(since = "3.4.0", forRemoval = true)


### PR DESCRIPTION
   Fixes #44959
   
Since 3.5.x is the last 3x generation, this PR updates all our deprecation removal versions from >3.5.0 (like 3.6.0, 3.7.0, etc.) to 4.0.0. This ensures a consistent deprecation timeline with no scheduled removals in versions that won't exist.
   
The updates are only to JavaDoc comments, not to the actual code or @Deprecated annotations, which don't contain version-specific removal information.