### PR TITLE
Add Javadoc since for GarbageCollectorInfo

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/ProcessInfo.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/ProcessInfo.java
@@ -243,6 +243,11 @@ public class ProcessInfo {
 
 		}
 
+		/**
+		 * Garbage collection information.
+		 *
+		 * @since 3.5.0
+		 */
 		public static class GarbageCollectorInfo {
 
 			private final String name;


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `GarbageCollectorInfo`.

See gh-44704