### PR TITLE
Replace deprecated Project.task()

### DIFF
--- a/spring-boot-project/spring-boot-devtools/build.gradle
+++ b/spring-boot-project/spring-boot-devtools/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 	testRuntimeOnly("io.r2dbc:r2dbc-h2")
 }
 
-task syncIntTestDependencies(type: Sync) {
+tasks.register("syncIntTestDependencies", Sync) {
 	destinationDir = file(layout.buildDirectory.dir("dependencies"))
 	from {
 		configurations.intTestDependencies

--- a/spring-boot-project/spring-boot-docs/build.gradle
+++ b/spring-boot-project/spring-boot-docs/build.gradle
@@ -230,38 +230,38 @@ task aggregatedJavadoc(type: Javadoc) {
 	}
 }
 
-task documentTestSlices(type: org.springframework.boot.build.test.autoconfigure.DocumentTestSlices) {
+tasks.register("documentTestSlices", org.springframework.boot.build.test.autoconfigure.DocumentTestSlices) {
 	testSlices = configurations.testSlices
 	outputFile = layout.buildDirectory.file("generated/docs/test-auto-configuration/documented-slices.adoc")
 }
 
-task documentStarters(type: org.springframework.boot.build.starters.DocumentStarters) {
+tasks.register("documentStarters", org.springframework.boot.build.starters.DocumentStarters) {
 	outputDir = layout.buildDirectory.dir("generated/docs/using/starters/")
 }
 
-task documentAutoConfigurationClasses(type: org.springframework.boot.build.autoconfigure.DocumentAutoConfigurationClasses) {
+tasks.register("documentAutoConfigurationClasses", org.springframework.boot.build.autoconfigure.DocumentAutoConfigurationClasses) {
 	autoConfiguration = configurations.autoConfiguration
 	outputDir = layout.buildDirectory.dir("generated/docs/auto-configuration-classes/documented-auto-configuration-classes/")
 }
 
-task documentDependencyVersionCoordinates(type: org.springframework.boot.build.docs.DocumentManagedDependencies) {
+tasks.register("documentDependencyVersionCoordinates", org.springframework.boot.build.docs.DocumentManagedDependencies) {
 	outputFile = layout.buildDirectory.file("generated/docs/dependency-versions/documented-coordinates.adoc")
 	resolvedBoms = configurations.resolvedBom
 }
 
-task documentDependencyVersionProperties(type: org.springframework.boot.build.docs.DocumentVersionProperties) {
+tasks.register("documentDependencyVersionProperties", org.springframework.boot.build.docs.DocumentVersionProperties) {
 	outputFile = layout.buildDirectory.file("generated/docs/dependency-versions/documented-properties.adoc")
 	resolvedBoms = configurations.resolvedBom
 }
 
-task documentConfigurationProperties(type: org.springframework.boot.build.context.properties.DocumentConfigurationProperties) {
+tasks.register("documentConfigurationProperties", org.springframework.boot.build.context.properties.DocumentConfigurationProperties) {
 	configurationPropertyMetadata = configurations.configurationProperties
 	outputDir = layout.buildDirectory.dir("generated/docs/application-properties")
 }
 
-task documentDevtoolsPropertyDefaults(type: org.springframework.boot.build.devtools.DocumentDevtoolsPropertyDefaults) {}
+tasks.register("documentDevtoolsPropertyDefaults", org.springframework.boot.build.devtools.DocumentDevtoolsPropertyDefaults) {}
 
-task runRemoteSpringApplicationExample(type: org.springframework.boot.build.docs.ApplicationRunner) {
+tasks.register("runRemoteSpringApplicationExample", org.springframework.boot.build.docs.ApplicationRunner) {
 	classpath = configurations.remoteSpringApplicationExample
 	mainClass = "org.springframework.boot.devtools.RemoteSpringApplication"
 	args = ["https://myapp.example.com", "--spring.devtools.remote.secret=secret", "--spring.devtools.livereload.port=0"]
@@ -271,7 +271,7 @@ task runRemoteSpringApplicationExample(type: org.springframework.boot.build.docs
 	normalizeLiveReloadPort()
 }
 
-task runSpringApplicationExample(type: org.springframework.boot.build.docs.ApplicationRunner) {
+tasks.register("runSpringApplicationExample", org.springframework.boot.build.docs.ApplicationRunner) {
 	classpath = configurations.springApplicationExample + sourceSets.main.output
 	mainClass = "org.springframework.boot.docs.features.logexample.MyApplication"
 	args = ["--server.port=0"]
@@ -280,7 +280,7 @@ task runSpringApplicationExample(type: org.springframework.boot.build.docs.Appli
 	normalizeTomcatPort()
 }
 
-task runLoggingFormatExample(type: org.springframework.boot.build.docs.ApplicationRunner) {
+tasks.register("runLoggingFormatExample", org.springframework.boot.build.docs.ApplicationRunner) {
 	classpath = configurations.springApplicationExample + sourceSets.main.output
 	mainClass = "org.springframework.boot.docs.features.logexample.MyApplication"
 	args = ["--spring.main.banner-mode=off", "--server.port=0", "--spring.application.name=myapp"]

--- a/spring-boot-project/spring-boot-test-autoconfigure/build.gradle
+++ b/spring-boot-project/spring-boot-test-autoconfigure/build.gradle
@@ -135,7 +135,7 @@ test {
 	include "**/*Tests.class"
 }
 
-task testSliceMetadata(type: org.springframework.boot.build.test.autoconfigure.TestSliceMetadata) {
+tasks.register("testSliceMetadata", org.springframework.boot.build.test.autoconfigure.TestSliceMetadata) {
 	sourceSet = sourceSets.main
 	outputFile = layout.buildDirectory.file("test-slice-metadata.properties")
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-antlib/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-antlib/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 	implementation("org.springframework:spring-core")
 }
 
-task syncIntegrationTestSources(type: Sync) {
+tasks.register("syncIntegrationTestSources", Sync) {
 	destinationDir = file(layout.buildDirectory.dir("it"))
 	from file("src/it")
 	filter(springRepositoryTransformers.ant())
@@ -39,7 +39,7 @@ processResources {
 	inputs.property "version", version
 }
 
-task integrationTest {
+tasks.register("integrationTest") {
 	dependsOn syncIntegrationTestSources, jar
 	def resultsDir = file(layout.buildDirectory.dir("test-results/integrationTest"))
 	inputs.dir(file("src/it")).withPathSensitivity(PathSensitivity.RELATIVE).withPropertyName("source")

--- a/spring-boot-project/spring-boot-tools/spring-boot-cli/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-cli/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 	testImplementation("org.springframework:spring-test")
 }
 
-task fullJar(type: Jar) {
+tasks.register("fullJar", Jar) {
 	dependsOn configurations.loader
 	archiveClassifier = "full"
 	entryCompression = "stored"
@@ -89,7 +89,7 @@ def configureArchive(archive) {
 	}
 }
 
-task zip(type: Zip) {
+tasks.register("zip", Zip) {
 	archiveClassifier = "bin"
 	configureArchive it
 }
@@ -98,14 +98,14 @@ intTest {
 	dependsOn zip
 }
 
-task tar(type: Tar) {
+tasks.register("tar", Tar) {
 	compression = "gzip"
 	archiveExtension = "tar.gz"
 	configureArchive it
 }
 
 if (BuildProperties.get(project).buildType() == BuildType.OPEN_SOURCE) {
-	task homebrewFormula(type: org.springframework.boot.build.cli.HomebrewFormula) {
+	tasks.register("homebrewFormula", org.springframework.boot.build.cli.HomebrewFormula) {
 		dependsOn tar
 		outputDir = layout.buildDirectory.dir("homebrew")
 		template = file("src/main/homebrew/spring-boot.rb")

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/build.gradle
@@ -87,7 +87,7 @@ gradlePlugin {
 	}
 }
 
-task preparePluginValidationClasses(type: Copy) {
+tasks.register("preparePluginValidationClasses", Copy) {
 	destinationDir = layout.buildDirectory.dir("classes/java/pluginValidation").get().asFile
 	from(sourceSets.main.output.classesDirs) {
 		exclude "**/CreateBootStartScripts.class"

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/getting-started/typical-plugins.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/getting-started/typical-plugins.gradle
@@ -7,7 +7,7 @@ plugins {
 apply plugin: 'io.spring.dependency-management'
 // end::apply[]
 
-task verify {
+tasks.register("verify") {
 	doLast {
 		plugins.getPlugin(org.gradle.api.plugins.JavaPlugin.class)
 		plugins.getPlugin(io.spring.gradle.dependencymanagement.DependencyManagementPlugin.class)

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/managing-dependencies/custom-version.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/examples/managing-dependencies/custom-version.gradle
@@ -24,7 +24,7 @@ repositories {
 	}
 }
 
-task slf4jVersion {
+tasks.register("slf4jVersion") {
 	doLast {
 		println dependencyManagement.managedVersions['org.slf4j:slf4j-api']
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/DependencyManagementPluginActionIntegrationTests.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/DependencyManagementPluginActionIntegrationTests.gradle
@@ -22,7 +22,7 @@ repositories {
 	}
 }
 
-task doesNotHaveDependencyManagement {
+tasks.register("doesNotHaveDependencyManagement") {
 	def extensions = project.extensions
 	doLast {
 		if (extensions.findByName('dependencyManagement') != null) {
@@ -31,7 +31,7 @@ task doesNotHaveDependencyManagement {
 	}
 }
 
-task hasDependencyManagement {
+tasks.register("hasDependencyManagement") {
 	doLast {
 		if (!dependencyManagement.managedVersions) {
 			throw new GradleException('No managed versions have been configured')

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/KotlinPluginActionIntegrationTests-kotlinVersionPropertyIsSet.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/KotlinPluginActionIntegrationTests-kotlinVersionPropertyIsSet.gradle
@@ -26,7 +26,7 @@ dependencies {
 	implementation('org.jetbrains.kotlin:kotlin-stdlib-jdk8')
 }
 
-task kotlinVersion {
+tasks.register("kotlinVersion") {
 	def properties = project.properties
 	doLast {
 		def kotlinVersion = properties.getOrDefault('kotlin.version', 'none')

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/KotlinPluginActionIntegrationTests-noKotlinVersionPropertyWithoutKotlinPlugin.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/KotlinPluginActionIntegrationTests-noKotlinVersionPropertyWithoutKotlinPlugin.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '{version}'
 }
 
-task kotlinVersion {
+tasks.register("kotlinVersion") {
 	def properties = project.properties
 	doLast {
 		def kotlinVersion = properties.getOrDefault('kotlin.version', 'none')

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-basicExecution.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-basicExecution.gradle
@@ -4,7 +4,7 @@ plugins {
 
 version = '0.1.0'
 
-task buildInfo(type: org.springframework.boot.gradle.tasks.buildinfo.BuildInfo) {
+tasks.register("buildInfo", org.springframework.boot.gradle.tasks.buildinfo.BuildInfo) {
 	properties {
 		artifact = 'foo'
 		group = 'foo'

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-defaultValues.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-defaultValues.gradle
@@ -2,4 +2,4 @@ plugins {
 	id 'org.springframework.boot' version '{version}' apply false
 }
 
-task buildInfo(type: org.springframework.boot.gradle.tasks.buildinfo.BuildInfo)
+tasks.register("buildInfo", org.springframework.boot.gradle.tasks.buildinfo.BuildInfo)

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-excludeProperties.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-excludeProperties.gradle
@@ -5,6 +5,6 @@ plugins {
 group = 'foo'
 version = '0.1.0'
 
-task buildInfo(type: org.springframework.boot.gradle.tasks.buildinfo.BuildInfo) {
+tasks.register("buildInfo", org.springframework.boot.gradle.tasks.buildinfo.BuildInfo) {
 	excludes = ['group', 'artifact', 'version', 'name']
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-notUpToDateWhenExecutedTwiceAsTimeChanges.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-notUpToDateWhenExecutedTwiceAsTimeChanges.gradle
@@ -2,4 +2,4 @@ plugins {
 	id 'org.springframework.boot' version '{version}' apply false
 }
 
-task buildInfo(type: org.springframework.boot.gradle.tasks.buildinfo.BuildInfo)
+tasks.register("buildInfo", org.springframework.boot.gradle.tasks.buildinfo.BuildInfo)

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-notUpToDateWhenExecutedTwiceWithFixedTimeAndChangedGradlePropertiesProjectVersion.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-notUpToDateWhenExecutedTwiceWithFixedTimeAndChangedGradlePropertiesProjectVersion.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '{version}' apply false
 }
 
-task buildInfo(type: org.springframework.boot.gradle.tasks.buildinfo.BuildInfo) {
+tasks.register("buildInfo", org.springframework.boot.gradle.tasks.buildinfo.BuildInfo) {
 	excludes = ["time"]
 	properties {
 		artifact = 'example'

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-notUpToDateWhenExecutedTwiceWithFixedTimeAndChangedProjectVersion.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-notUpToDateWhenExecutedTwiceWithFixedTimeAndChangedProjectVersion.gradle
@@ -4,7 +4,7 @@ plugins {
 
 version = '{projectVersion}'
 
-task buildInfo(type: org.springframework.boot.gradle.tasks.buildinfo.BuildInfo) {
+tasks.register("buildInfo", org.springframework.boot.gradle.tasks.buildinfo.BuildInfo) {
 	excludes = ["time"]
 	properties {
 		artifact = 'example'

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-reproducibleOutputWithFixedTime.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-reproducibleOutputWithFixedTime.gradle
@@ -2,6 +2,6 @@ plugins {
 	id 'org.springframework.boot' version '{version}' apply false
 }
 
-task buildInfo(type: org.springframework.boot.gradle.tasks.buildinfo.BuildInfo) {
+tasks.register("buildInfo", org.springframework.boot.gradle.tasks.buildinfo.BuildInfo) {
 	excludes = ["time"]
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-upToDateWhenExecutedTwiceWithFixedTime.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoIntegrationTests-upToDateWhenExecutedTwiceWithFixedTime.gradle
@@ -2,6 +2,6 @@ plugins {
 	id 'org.springframework.boot' version '{version}' apply false
 }
 
-task buildInfo(type: org.springframework.boot.gradle.tasks.buildinfo.BuildInfo) {
+tasks.register("buildInfo", org.springframework.boot.gradle.tasks.buildinfo.BuildInfo) {
 	excludes = ["time"]
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-customLayers.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-customLayers.gradle
@@ -38,13 +38,13 @@ dependencies {
 	implementation("org.springframework:spring-core:5.2.5.RELEASE")
 }
 
-task listLayers(type: JavaExec) {
+tasks.register("listLayers", JavaExec) {
 	classpath = bootJar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "list-layers"
 }
 
-task extractLayers(type: JavaExec) {
+tasks.register("extractLayers", JavaExec) {
 	classpath = bootJar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "extract", "--layers", "--launcher", "--destination", ".", "--force"

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-explodedApplicationClasspath.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-explodedApplicationClasspath.gradle
@@ -15,13 +15,13 @@ dependencies {
 	implementation("org.apache.commons:commons-lang3:3.9")
 }
 
-task explode(type: Sync) {
+tasks.register("explode", Sync) {
 	dependsOn(bootJar)
 	destinationDir = layout.buildDirectory.dir("exploded").get().asFile
 	from zipTree(files(bootJar).singleFile)
 }
 
-task launch(type: JavaExec) {
+tasks.register("launch", JavaExec) {
 	classpath = files(explode)
 	mainClass = 'org.springframework.boot.loader.launch.JarLauncher'
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-implicitLayers.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-implicitLayers.gradle
@@ -21,13 +21,13 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-logging:2.2.0.RELEASE")
 }
 
-task listLayers(type: JavaExec) {
+tasks.register("listLayers", JavaExec) {
 	classpath = bootJar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "list-layers"
 }
 
-task extractLayers(type: JavaExec) {
+tasks.register("extractLayers", JavaExec) {
 	classpath = bootJar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "extract", "--layers", "--launcher", "--destination", ".", "--force"

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-layersWithCustomSourceSet.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-layersWithCustomSourceSet.gradle
@@ -24,13 +24,13 @@ dependencies {
 	implementation("org.springframework:spring-core:5.2.5.RELEASE")
 }
 
-task listLayers(type: JavaExec) {
+tasks.register("listLayers", JavaExec) {
 	classpath = bootJar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "list-layers"
 }
 
-task extractLayers(type: JavaExec) {
+tasks.register("extractLayers", JavaExec) {
 	classpath = bootJar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "extract", "--layers", "--launcher", "--destination", ".", "--force"

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-multiModuleCustomLayers.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-multiModuleCustomLayers.gradle
@@ -55,13 +55,13 @@ dependencies {
 	implementation("org.springframework:spring-core:5.2.5.RELEASE")
 }
 
-task listLayers(type: JavaExec) {
+tasks.register("listLayers", JavaExec) {
 	classpath = bootJar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "list-layers"
 }
 
-task extractLayers(type: JavaExec) {
+tasks.register("extractLayers", JavaExec) {
 	classpath = bootJar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "extract", "--layers", "--launcher", "--destination", ".", "--force"

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-multiModuleImplicitLayers.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-multiModuleImplicitLayers.gradle
@@ -33,13 +33,13 @@ dependencies {
 	implementation("org.springframework:spring-core:5.2.5.RELEASE")
 }
 
-task listLayers(type: JavaExec) {
+tasks.register("listLayers", JavaExec) {
 	classpath = bootJar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "list-layers"
 }
 
-task extractLayers(type: JavaExec) {
+tasks.register("extractLayers", JavaExec) {
 	classpath = bootJar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "extract", "--layers", "--launcher", "--destination", ".", "--force"

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-packagedApplicationClasspath.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootJarIntegrationTests-packagedApplicationClasspath.gradle
@@ -4,7 +4,7 @@ plugins {
 	id 'org.springframework.boot' version '{version}'
 }
 
-task launch(type: JavaExec) {
+tasks.register("launch", JavaExec) {
 	classpath = files(bootJar)
 }
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootWarIntegrationTests-customLayers.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootWarIntegrationTests-customLayers.gradle
@@ -39,13 +39,13 @@ dependencies {
 	implementation("org.springframework:spring-core:5.2.5.RELEASE")
 }
 
-task listLayers(type: JavaExec) {
+tasks.register("listLayers", JavaExec) {
 	classpath = bootWar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "list-layers"
 }
 
-task extractLayers(type: JavaExec) {
+tasks.register("extractLayers", JavaExec) {
 	classpath = bootWar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "extract", "--layers", "--launcher", "--destination", ".", "--force"

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootWarIntegrationTests-implicitLayers.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootWarIntegrationTests-implicitLayers.gradle
@@ -22,13 +22,13 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-logging:2.2.0.RELEASE")
 }
 
-task listLayers(type: JavaExec) {
+tasks.register("listLayers", JavaExec) {
 	classpath = bootWar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "list-layers"
 }
 
-task extractLayers(type: JavaExec) {
+tasks.register("extractLayers", JavaExec) {
 	classpath = bootWar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "extract", "--layers", "--launcher", "--destination", ".", "--force"

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootWarIntegrationTests-layersWithCustomSourceSet.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootWarIntegrationTests-layersWithCustomSourceSet.gradle
@@ -25,13 +25,13 @@ dependencies {
 	implementation("org.springframework:spring-core:5.2.5.RELEASE")
 }
 
-task listLayers(type: JavaExec) {
+tasks.register("listLayers", JavaExec) {
 	classpath = bootWar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "list-layers"
 }
 
-task extractLayers(type: JavaExec) {
+tasks.register("extractLayers", JavaExec) {
 	classpath = bootWar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "extract", "--layers", "--launcher", "--destination", ".", "--force"

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootWarIntegrationTests-multiModuleCustomLayers.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootWarIntegrationTests-multiModuleCustomLayers.gradle
@@ -56,13 +56,13 @@ dependencies {
 	implementation("org.springframework:spring-core:5.2.5.RELEASE")
 }
 
-task listLayers(type: JavaExec) {
+tasks.register("listLayers", JavaExec) {
 	classpath = bootWar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "list-layers"
 }
 
-task extractLayers(type: JavaExec) {
+tasks.register("extractLayers", JavaExec) {
 	classpath = bootWar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "extract", "--layers", "--launcher", "--destination", ".", "--force"

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootWarIntegrationTests-multiModuleImplicitLayers.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/BootWarIntegrationTests-multiModuleImplicitLayers.gradle
@@ -34,13 +34,13 @@ dependencies {
 	implementation("org.springframework:spring-core:5.2.5.RELEASE")
 }
 
-task listLayers(type: JavaExec) {
+tasks.register("listLayers", JavaExec) {
 	classpath = bootWar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "list-layers"
 }
 
-task extractLayers(type: JavaExec) {
+tasks.register("extractLayers", JavaExec) {
 	classpath = bootWar.outputs.files
 	systemProperties = [ "jarmode": "tools" ]
 	args "extract", "--layers", "--launcher", "--destination", ".", "--force"

--- a/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 	testImplementation("org.zeroturnaround:zt-zip:1.13")
 }
 
-task reproducibleLoaderJar(type: Jar) {
+tasks.register("reproducibleLoaderJar", Jar) {
 	dependsOn configurations.loader
 	from {
 		zipTree(configurations.loader.incoming.files.singleFile).matching {
@@ -54,7 +54,7 @@ task reproducibleLoaderJar(type: Jar) {
 	destinationDirectory = file(generatedResources.map {it.dir("META-INF/loader") })
 }
 
-task reproducibleLoaderClassicJar(type: Jar) {
+tasks.register("reproducibleLoaderClassicJar", Jar) {
 	dependsOn configurations.loaderClassic
 	from {
 		zipTree(configurations.loaderClassic.incoming.files.singleFile).matching {
@@ -69,7 +69,7 @@ task reproducibleLoaderClassicJar(type: Jar) {
 	destinationDirectory = file(generatedResources.map { it.dir("META-INF/loader") })
 }
 
-task toolsJar(type: Sync) {
+tasks.register("toolsJar", Sync) {
 	dependsOn configurations.jarmode
 	from {
 		file(configurations.jarmode.incoming.files.singleFile)

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/build.gradle
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/build.gradle
@@ -90,7 +90,7 @@ ext {
 	xsdVersion = versionElements[0] + "." + versionElements[1]
 }
 
-task copySettingsXml(type: Copy) {
+tasks.register("copySettingsXml", Copy) {
 	from file("src/intTest/projects/settings.xml")
 	into layout.buildDirectory.dir("generated-resources/settings")
 	filter(springRepositoryTransformers.mavenSettings())
@@ -121,7 +121,7 @@ javadoc {
 	}
 }
 
-task xsdResources(type: Sync) {
+tasks.register("xsdResources", Sync) {
 	from "src/main/xsd/layers-${project.ext.xsdVersion}.xsd"
 	into layout.buildDirectory.dir("generated/resources/xsd/org/springframework/boot/maven")
 	rename { fileName -> "layers.xsd" }

--- a/spring-boot-project/spring-boot/build.gradle
+++ b/spring-boot-project/spring-boot/build.gradle
@@ -154,7 +154,7 @@ dependencies {
 	tomcatDistribution("org.apache.tomcat:tomcat:${tomcatVersion}@zip")
 }
 
-task extractTomcatConfigProperties(type: Sync) {
+tasks.register("extractTomcatConfigProperties", Sync) {
 	destinationDir = file(tomcatConfigProperties)
 	from {
 		zipTree(configurations.tomcatDistribution.incoming.files.singleFile).matching {

--- a/spring-boot-system-tests/spring-boot-image-tests/build.gradle
+++ b/spring-boot-system-tests/spring-boot-image-tests/build.gradle
@@ -12,7 +12,7 @@ configurations {
 	}
 }
 
-task syncMavenRepository(type: Sync) {
+tasks.register("syncMavenRepository", Sync) {
 	from configurations.app
 	into layout.buildDirectory.dir("system-test-maven-repository")
 }

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/build.gradle
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-launch-script-tests/build.gradle
@@ -23,24 +23,24 @@ dependencies {
 	dockerTestImplementation("org.testcontainers:testcontainers")
 }
 
-task syncMavenRepository(type: Sync) {
+tasks.register("syncMavenRepository", Sync) {
 	from configurations.app
 	into layout.buildDirectory.dir("docker-test-maven-repository")
 }
 
-task syncAppSource(type: org.springframework.boot.build.SyncAppSource) {
+tasks.register("syncAppSource", org.springframework.boot.build.SyncAppSource) {
 	sourceDirectory = file("spring-boot-launch-script-tests-app")
 	destinationDirectory = file(layout.buildDirectory.dir("spring-boot-launch-script-tests-app"))
 }
 
-task buildApp(type: GradleBuild) {
+tasks.register("buildApp", GradleBuild) {
 	dependsOn syncAppSource, syncMavenRepository
 	dir = layout.buildDirectory.dir("spring-boot-launch-script-tests-app")
 	startParameter.buildCacheEnabled = false
 	tasks  = ["build"]
 }
 
-task downloadJdk(type: Download) {
+tasks.register("downloadJdk", Download) {
 	def destFolder = new File(project.gradle.gradleUserHomeDir, "caches/springboot/downloads/jdk/bellsoft")
 	destFolder.mkdirs()
 	src "https://download.bell-sw.com/java/${jdkVersion}/bellsoft-jdk${jdkVersion}-linux-${jdkArch}.tar.gz"
@@ -50,7 +50,7 @@ task downloadJdk(type: Download) {
 	retries 3
 }
 
-task syncJdkDownloads(type: Sync) {
+tasks.register("syncJdkDownloads", Sync) {
 	dependsOn downloadJdk
 	from "${project.gradle.gradleUserHomeDir}/caches/springboot/downloads/jdk/bellsoft/"
 	include "bellsoft-jdk${jdkVersion}-linux-${jdkArch}.tar.gz"

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-loader-classic-tests/build.gradle
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-loader-classic-tests/build.gradle
@@ -20,17 +20,17 @@ dependencies {
 	dockerTestImplementation("org.testcontainers:testcontainers")
 }
 
-task syncMavenRepository(type: Sync) {
+tasks.register("syncMavenRepository", Sync) {
 	from configurations.app
 	into layout.buildDirectory.dir("docker-test-maven-repository")
 }
 
-task syncAppSource(type: org.springframework.boot.build.SyncAppSource) {
+tasks.register("syncAppSource", org.springframework.boot.build.SyncAppSource) {
 	sourceDirectory = file("spring-boot-loader-classic-tests-app")
 	destinationDirectory = file(layout.buildDirectory.dir("spring-boot-loader-classic-tests-app"))
 }
 
-task buildApp(type: GradleBuild) {
+tasks.register("buildApp", GradleBuild) {
 	dependsOn syncAppSource, syncMavenRepository
 	dir = layout.buildDirectory.dir("spring-boot-loader-classic-tests-app")
 	startParameter.buildCacheEnabled = false

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-loader-tests/build.gradle
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-loader-tests/build.gradle
@@ -26,36 +26,36 @@ dependencies {
 	dockerTestImplementation("org.testcontainers:testcontainers")
 }
 
-task syncMavenRepository(type: Sync) {
+tasks.register("syncMavenRepository", Sync) {
 	from configurations.app
 	into layout.buildDirectory.dir("docker-test-maven-repository")
 }
 
-task syncAppSource(type: org.springframework.boot.build.SyncAppSource) {
+tasks.register("syncAppSource", org.springframework.boot.build.SyncAppSource) {
 	sourceDirectory = file("spring-boot-loader-tests-app")
 	destinationDirectory = file(layout.buildDirectory.dir("spring-boot-loader-tests-app"))
 }
 
-task buildApp(type: GradleBuild) {
+tasks.register("buildApp", GradleBuild) {
 	dependsOn syncAppSource, syncMavenRepository
 	dir = layout.buildDirectory.dir("spring-boot-loader-tests-app")
 	startParameter.buildCacheEnabled = false
 	tasks  = ["build"]
 }
 
-task syncSignedJarAppSource(type: org.springframework.boot.build.SyncAppSource) {
+tasks.register("syncSignedJarAppSource", org.springframework.boot.build.SyncAppSource) {
 	sourceDirectory = file("spring-boot-loader-tests-signed-jar")
 	destinationDirectory = file(layout.buildDirectory.dir("spring-boot-loader-tests-signed-jar"))
 }
 
-task buildSignedJarApp(type: GradleBuild) {
+tasks.register("buildSignedJarApp", GradleBuild) {
 	dependsOn syncSignedJarAppSource, syncMavenRepository
 	dir = layout.buildDirectory.dir("spring-boot-loader-tests-signed-jar")
 	startParameter.buildCacheEnabled = false
 	tasks  = ["build"]
 }
 
-task downloadJdk(type: Download) {
+tasks.register("downloadJdk", Download) {
 	def destFolder = new File(project.gradle.gradleUserHomeDir, "caches/springboot/downloads/jdk/oracle")
 	destFolder.mkdirs()
 	src "https://download.oracle.com/java/17/archive/jdk-${oracleJdkVersion}_linux-${oracleJdkArch}_bin.tar.gz"
@@ -65,7 +65,7 @@ task downloadJdk(type: Download) {
 	retries 3
 }
 
-task syncJdkDownloads(type: Sync) {
+tasks.register("syncJdkDownloads", Sync) {
 	dependsOn downloadJdk
 	from "${project.gradle.gradleUserHomeDir}/caches/springboot/downloads/jdk/oracle/"
 	include "jdk-${oracleJdkVersion}_linux-${oracleJdkArch}_bin.tar.gz"

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/build.gradle
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-server-tests/build.gradle
@@ -28,19 +28,19 @@ dependencies {
 	testRuntimeOnly(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-logging"))
 }
 
-task syncTestRepository(type: Sync) {
+tasks.register("syncTestRepository", Sync) {
 	destinationDir = file(layout.buildDirectory.dir("test-repository"))
 	from {
 		configurations.testRepository
 	}
 }
 
-task syncAppSource(type: org.springframework.boot.build.SyncAppSource) {
+tasks.register("syncAppSource", org.springframework.boot.build.SyncAppSource) {
 	sourceDirectory = file("spring-boot-server-tests-app")
 	destinationDirectory = file(layout.buildDirectory.dir("spring-boot-server-tests-app"))
 }
 
-task buildApps(type: GradleBuild) {
+tasks.register("buildApps", GradleBuild) {
 	dependsOn syncAppSource, syncTestRepository
 	dir = layout.buildDirectory.dir("spring-boot-server-tests-app")
 	startParameter.buildCacheEnabled = false

--- a/spring-boot-tests/spring-boot-integration-tests/spring-boot-sni-tests/build.gradle
+++ b/spring-boot-tests/spring-boot-integration-tests/spring-boot-sni-tests/build.gradle
@@ -27,17 +27,17 @@ dependencies {
 	intTestImplementation("org.testcontainers:testcontainers")
 }
 
-task syncMavenRepository(type: Sync) {
+tasks.register("syncMavenRepository", Sync) {
 	from configurations.app
 	into layout.buildDirectory.dir("int-test-maven-repository")
 }
 
-task syncReactiveServerAppSource(type: org.springframework.boot.build.SyncAppSource) {
+tasks.register("syncReactiveServerAppSource", org.springframework.boot.build.SyncAppSource) {
 	sourceDirectory = file("spring-boot-sni-reactive-app")
 	destinationDirectory = file(layout.buildDirectory.dir("spring-boot-sni-reactive-app"))
 }
 
-task buildReactiveServerApps(type: GradleBuild) {
+tasks.register("buildReactiveServerApps", GradleBuild) {
 	dependsOn syncReactiveServerAppSource, syncMavenRepository
 	dir = layout.buildDirectory.dir("spring-boot-sni-reactive-app")
 	startParameter.buildCacheEnabled = false
@@ -48,12 +48,12 @@ task buildReactiveServerApps(type: GradleBuild) {
 	]
 }
 
-task syncServletServerAppSource(type: org.springframework.boot.build.SyncAppSource) {
+tasks.register("syncServletServerAppSource", org.springframework.boot.build.SyncAppSource) {
 	sourceDirectory = file("spring-boot-sni-servlet-app")
 	destinationDirectory = file(layout.buildDirectory.dir("spring-boot-sni-servlet-app"))
 }
 
-task buildServletServerApps(type: GradleBuild) {
+tasks.register("buildServletServerApps", GradleBuild) {
 	dependsOn syncServletServerAppSource, syncMavenRepository
 	dir = layout.buildDirectory.dir("spring-boot-sni-servlet-app")
 	startParameter.buildCacheEnabled = false
@@ -63,12 +63,12 @@ task buildServletServerApps(type: GradleBuild) {
 	]
 }
 
-task syncClientAppSource(type: org.springframework.boot.build.SyncAppSource) {
+tasks.register("syncClientAppSource", org.springframework.boot.build.SyncAppSource) {
 	sourceDirectory = file("spring-boot-sni-client-app")
 	destinationDirectory = file(layout.buildDirectory.dir("spring-boot-sni-client-app"))
 }
 
-task buildClientApp(type: GradleBuild) {
+tasks.register("buildClientApp", GradleBuild) {
 	dependsOn syncClientAppSource, syncMavenRepository
 	dir = layout.buildDirectory.dir("spring-boot-sni-client-app")
 	startParameter.buildCacheEnabled = false

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-ant/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-ant/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
-task syncTestRepository(type: Sync) {
+tasks.register("syncTestRepository", Sync) {
 	destinationDir = file(layout.buildDirectory.dir("test-repository"))
 	from configurations.testRepository
 	rename {
@@ -48,14 +48,14 @@ task syncTestRepository(type: Sync) {
 	}
 }
 
-task syncAntSources(type: Sync) {
+tasks.register("syncAntSources", Sync) {
 	destinationDir = file(layout.buildDirectory.dir("ant"))
 	from project.layout.projectDirectory
 	include "*.xml"
 	filter(springRepositoryTransformers.ant())
 }
 
-task antRun(type: JavaExec) {
+tasks.register("antRun", JavaExec) {
 	workingDir = layout.buildDirectory.dir("ant")
 	dependsOn syncTestRepository, syncAntSources, configurations.antDependencies
 	classpath = configurations.antDependencies;
@@ -67,7 +67,7 @@ task antRun(type: JavaExec) {
 	]
 }
 
-task test(type: Test) {
+tasks.register("test", Test) {
 	dependsOn antRun
 	testClassesDirs = sourceSets.test.output.classesDirs
 	classpath = sourceSets.test.runtimeClasspath


### PR DESCRIPTION
This PR replaces deprecated `Project.task()` with `tasks.register()`.

I couldn't simply replace the `aggregatedJavadoc` task as it didn't work with the following failure:

https://github.com/spring-projects/spring-boot/blob/e87d5d7a41ea65c52d1a2ae2cc243c6bd303bde2/spring-boot-project/spring-boot-docs/build.gradle#L207

```
* What went wrong:
A problem occurred evaluating project ':spring-boot-project:spring-boot-docs'.
> Could not create task ':spring-boot-project:spring-boot-docs:aggregatedJavadoc'.
   > Gradle#projectsEvaluated(Closure) on build 'spring-boot-build' cannot be executed in the current context.
```

See https://docs.gradle.org/current/userguide/upgrading_version_8.html#source_level_deprecation_of_project_task_methods