### PR TITLE
Validate that sslInfo is not null in SslHealthIndicator constructor

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/ssl/SslHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/ssl/SslHealthIndicator.java
@@ -35,7 +35,7 @@ import org.springframework.util.Assert;
  * {@link Status#OUT_OF_SERVICE} when a certificate is invalid.
  *
  * @author Jonatan Ivanov
- * @author geniuus
+ * @author Young Jae You
  * @since 3.4.0
  */
 public class SslHealthIndicator extends AbstractHealthIndicator {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/ssl/SslHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/ssl/SslHealthIndicator.java
@@ -34,7 +34,7 @@ import org.springframework.boot.info.SslInfo.CertificateInfo;
  * {@link Status#OUT_OF_SERVICE} when a certificate is invalid.
  *
  * @author Jonatan Ivanov
- * @author geniusYoo
+ * @author geniuus
  * @since 3.4.0
  */
 public class SslHealthIndicator extends AbstractHealthIndicator {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/ssl/SslHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/ssl/SslHealthIndicator.java
@@ -34,6 +34,7 @@ import org.springframework.boot.info.SslInfo.CertificateInfo;
  * {@link Status#OUT_OF_SERVICE} when a certificate is invalid.
  *
  * @author Jonatan Ivanov
+ * @author geniuus
  * @since 3.4.0
  */
 public class SslHealthIndicator extends AbstractHealthIndicator {
@@ -41,6 +42,8 @@ public class SslHealthIndicator extends AbstractHealthIndicator {
 	private final SslInfo sslInfo;
 
 	public SslHealthIndicator(SslInfo sslInfo) {
+		super("SSL health check failed");
+		Assert.notNull(sslInfo, "'sslInfo' must not be null");
 		this.sslInfo = sslInfo;
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/ssl/SslHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/ssl/SslHealthIndicator.java
@@ -28,6 +28,7 @@ import org.springframework.boot.info.SslInfo;
 import org.springframework.boot.info.SslInfo.BundleInfo;
 import org.springframework.boot.info.SslInfo.CertificateChainInfo;
 import org.springframework.boot.info.SslInfo.CertificateInfo;
+import org.springframework.util.Assert;
 
 /**
  * {@link HealthIndicator} that checks the certificates the application uses and reports

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/ssl/SslHealthIndicator.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/ssl/SslHealthIndicator.java
@@ -34,7 +34,7 @@ import org.springframework.boot.info.SslInfo.CertificateInfo;
  * {@link Status#OUT_OF_SERVICE} when a certificate is invalid.
  *
  * @author Jonatan Ivanov
- * @author geniuus
+ * @author geniusYoo
  * @since 3.4.0
  */
 public class SslHealthIndicator extends AbstractHealthIndicator {


### PR DESCRIPTION
The SslHealthIndicator constructor previously did not validate if the provided SslInfo instance was null. This could potentially lead to a NullPointerException later when the doHealthCheck method is invoked if the SslInfo bean was not properly configured or available.

This commit adds an Assert.notNull check for the sslInfo parameter to ensure fail-fast behavior during application startup or bean creation. This aligns with the common practice in other Spring Boot components and health indicators where essential dependencies are validated in the constructor.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
