### PR TITLE
ConnectionDetailsFactories should use the context class loader to load factories

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/service/connection/ConnectionDetailsFactories.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/service/connection/ConnectionDetailsFactories.java
@@ -47,8 +47,26 @@ public class ConnectionDetailsFactories {
 
 	private final List<Registration<?, ?>> registrations = new ArrayList<>();
 
+	/**
+	 * Create a new {@link ConnectionDetailsFactories} instance. This constructor uses the
+	 * class loader of {@link ConnectionDetailsFactory} class to load the factories.
+	 */
 	public ConnectionDetailsFactories() {
-		this(SpringFactoriesLoader.forDefaultResourceLocation(ConnectionDetailsFactory.class.getClassLoader()));
+		this(false);
+	}
+
+	/**
+	 * Create a new {@link ConnectionDetailsFactories} instance. This constructor takes a
+	 * boolean argument to determine whether the context class loader should be used to
+	 * load the factories. If {@code true} and the context class loader is available it
+	 * will be used otherwise the class loader of {@link ConnectionDetailsFactory} class
+	 * will be used.
+	 * @param useContextClassLoader if {@code true} and the context class loader is
+	 * available it will be used otherwise the class loader of
+	 * {@link ConnectionDetailsFactory} class will be used.
+	 */
+	public ConnectionDetailsFactories(boolean useContextClassLoader) {
+		this(SpringFactoriesLoader.forDefaultResourceLocation(getClassLoader(useContextClassLoader)));
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -105,6 +123,24 @@ public class ConnectionDetailsFactories {
 		}
 		result.sort(Comparator.comparing(Registration::factory, AnnotationAwareOrderComparator.INSTANCE));
 		return List.copyOf(result);
+	}
+
+	/**
+	 * Return the {@link ClassLoader} to use for loading factories.
+	 * <p>
+	 * The default implementation returns the context class loader of the current thread
+	 * or the class loader of this class if the context class loader is {@code null}.
+	 * @param useContextClassLoader if {@code true} and the context class loader is
+	 * available it will be used otherwise the class loader of
+	 * {@link ConnectionDetailsFactory} class will be used
+	 * @return the class loader to use for loading factories
+	 */
+	private static ClassLoader getClassLoader(boolean useContextClassLoader) {
+		if (!useContextClassLoader) {
+			return ConnectionDetailsFactory.class.getClassLoader();
+		}
+		final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		return (classLoader != null) ? classLoader : getClassLoader(false);
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/lifecycle/DockerComposeProperties.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/lifecycle/DockerComposeProperties.java
@@ -47,6 +47,11 @@ public class DockerComposeProperties {
 	private boolean enabled = true;
 
 	/**
+	 * Whether to try to use the context class loader for connection details factories.
+	 */
+	private boolean useContextClassLoader = false;
+
+	/**
 	 * Arguments to pass to the Docker Compose command.
 	 */
 	private final List<String> arguments = new ArrayList<>();
@@ -89,8 +94,16 @@ public class DockerComposeProperties {
 		return this.enabled;
 	}
 
+	public boolean isUseContextClassLoader() {
+		return this.useContextClassLoader;
+	}
+
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
+	}
+
+	public void setUseContextClassLoader(boolean useContextClassLoader) {
+		this.useContextClassLoader = useContextClassLoader;
 	}
 
 	public List<String> getArguments() {
@@ -137,7 +150,7 @@ public class DockerComposeProperties {
 		return this.readiness;
 	}
 
-	static DockerComposeProperties get(Binder binder) {
+	public static DockerComposeProperties get(Binder binder) {
 		return binder.bind(NAME, DockerComposeProperties.class).orElseGet(DockerComposeProperties::new);
 	}
 


### PR DESCRIPTION
Add flag to determine whether to use context class loader or `ConnectionDetailsFactory` class loader in `ConnectionDetailsFactories`.

Implements #45010.

I introduced a new constructor in `ConnectionDetailsFactories` that allows selecting between the thread’s context class loader and the `ConnectionDetailsFactory` class's class loader. retains the previous behavior to ensure backward compatibility.

Additionally, I extended `DockerComposeProperties` with a new flag (defaulting to `false`) that reflects this setting. The `DockerComposeServiceConnectionsApplicationListener` now uses this flag when creating the `ConnectionDetailsFactories`.

I chose this approach to maintain the old behavior by default. If there's consensus that always using the thread’s context class loader is sufficient, I’m happy to simplify the implementation accordingly.