### PR TITLE
MongoDB's dependency management is missing Kotlin coroutine driver modules

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1570,10 +1570,12 @@ bom {
 			modules = [
 				"bson",
 				"bson-record-codec",
+				"bson-kotlin",
 				"mongodb-driver-core",
 				"mongodb-driver-legacy",
 				"mongodb-driver-reactivestreams",
-				"mongodb-driver-sync"
+				"mongodb-driver-sync",
+				"mongodb-driver-kotlin-coroutine"
 			]
 		}
 		links {


### PR DESCRIPTION
Currently to keep same version of coroutine driver we need to make nasty trick

```kotlin 
val mongodbVersion: String? = dependencyManagement.importedProperties["mongodb.version"]

dependencies {
    implementation("org.mongodb:mongodb-driver-kotlin-coroutine:${mongodbVersion}")
    implementation("org.mongodb:bson-kotlin:${mongodbVersion}")
}
```

It would be much easier to keep that version in spring bom.


