### PR TITLE
Escape the asterisk in spring-application.adoc

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/spring-application.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/spring-application.adoc
@@ -137,7 +137,7 @@ The `application.title`, `application.version`, and `application.formatted-versi
 The values will not be resolved if you are running an unpacked jar and starting it with `java -cp <classpath> <mainclass>`
 or running your application as a native image.
 
-To use the `application.*` properties, launch your application as a packed jar using `java -jar` or as an unpacked jar using `java org.springframework.boot.loader.launch.JarLauncher`.
+To use the `application.\*` properties, launch your application as a packed jar using `java -jar` or as an unpacked jar using `java org.springframework.boot.loader.launch.JarLauncher`.
 This will initialize the `application.*` banner properties before building the classpath and launching your app.
 ====
 


### PR DESCRIPTION
Asterisk needs to be escaped not to be interpreted as bold formatting.
Only the first asterisk needs to be escaped, second one is not interpreted as bold formatting.

Here's the error:
![image](https://github.com/user-attachments/assets/a0d39291-4677-46ca-9dda-583f642883bf)

Notice all the bold text in the second paragraph, and missing '*' asterisk in the name of the file, e.g. `application.*`

Here is how the error shows in adoc:
![image](https://github.com/user-attachments/assets/7aacfb1e-e09c-4f67-89d3-49c12070eb32)

Here's how it looks fixed in adoc:
![image](https://github.com/user-attachments/assets/77e57422-33db-4f2f-9d06-bc25a2595c25)

