### PR TITLE
test: add DockerCli tests for command generation and constructor

### DIFF
--- a/spring-boot-project/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/core/DockerCliIntegrationTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/core/DockerCliIntegrationTests.java
@@ -63,7 +63,7 @@ class DockerCliIntegrationTests {
 
 	@Test
 	void runBasicCommand() {
-		DockerCli cli = new DockerCli(null, null);
+		DockerCli cli = new DockerCli((File) null, null);
 		List<DockerCliContextResponse> context = cli.run(new DockerCliCommand.Context());
 		assertThat(context).isNotEmpty();
 	}
@@ -72,7 +72,7 @@ class DockerCliIntegrationTests {
 	void runLifecycle() throws IOException {
 		File composeFile = createComposeFile("redis-compose.yaml");
 		String projectName = UUID.randomUUID().toString();
-		DockerCli cli = new DockerCli(null, new DockerComposeOptions(DockerComposeFile.of(composeFile),
+		DockerCli cli = new DockerCli((File) null, new DockerComposeOptions(DockerComposeFile.of(composeFile),
 				Collections.emptySet(), List.of("--project-name=" + projectName)));
 		try {
 			// Verify that no services are running (this is a fresh compose project)
@@ -112,7 +112,7 @@ class DockerCliIntegrationTests {
 	@Test
 	void shouldWorkWithMultipleComposeFiles() throws IOException {
 		List<File> composeFiles = createComposeFiles();
-		DockerCli cli = new DockerCli(null,
+		DockerCli cli = new DockerCli((File) null,
 				new DockerComposeOptions(DockerComposeFile.of(composeFiles), Set.of("dev"), Collections.emptyList()));
 		try {
 			// List the config and verify that both redis are there

--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DockerCli.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DockerCli.java
@@ -68,6 +68,15 @@ class DockerCli {
 		this.composeVersion = ComposeVersion.of(this.dockerCommands.get(Type.DOCKER_COMPOSE).version());
 	}
 
+	// 테스트나 DI에서 사용하는 생성자
+	DockerCli(ProcessRunner processRunner, DockerComposeOptions dockerComposeOptions) {
+		this.processRunner = processRunner;
+		this.dockerCommands = dockerCommandsCache.computeIfAbsent(
+				new File("."), (key) -> new DockerCommands(this.processRunner));
+		this.dockerComposeOptions = (dockerComposeOptions != null) ? dockerComposeOptions : DockerComposeOptions.none();
+		this.composeVersion = ComposeVersion.of(this.dockerCommands.get(Type.DOCKER_COMPOSE).version());
+	}
+
 	/**
 	 * Run the given {@link DockerCli} command and return the response.
 	 * @param <R> the response type
@@ -89,7 +98,9 @@ class DockerCli {
 		return (line) -> logLevel.log(logger, line);
 	}
 
-	private List<String> createCommand(Type type) {
+
+
+	List<String> createCommand(Type type) {
 		return switch (type) {
 			case DOCKER -> new ArrayList<>(this.dockerCommands.get(type).command());
 			case DOCKER_COMPOSE -> {

--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DockerCompose.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DockerCompose.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.docker.compose.core;
 
+import java.io.File;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -142,7 +143,7 @@ public interface DockerCompose {
 	 */
 	static DockerCompose get(DockerComposeFile file, String hostname, Set<String> activeProfiles,
 			List<String> arguments) {
-		DockerCli cli = new DockerCli(null, new DockerComposeOptions(file, activeProfiles, arguments));
+		DockerCli cli = new DockerCli((File) null, new DockerComposeOptions(file, activeProfiles, arguments));
 		return new DefaultDockerCompose(cli, hostname);
 	}
 

--- a/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DockerCliTests.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DockerCliTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docker.compose.core;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.docker.compose.core.DockerCli.DockerComposeOptions;
+import org.springframework.boot.docker.compose.core.DockerCliCommand.Type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+class DockerCliTests {
+	@Test
+	void createCommandWithDockerComposeShouldIncludeCorrectOptions() {
+		ProcessRunner mockProcessRunner = mock(ProcessRunner.class);
+		when(mockProcessRunner.run(any(String[].class))).thenReturn("{\"version\":\"1.0.0\"}");
+
+		DockerComposeFile mockFile = mock(DockerComposeFile.class);
+		when(mockFile.getFiles()).thenReturn(List.of(new File("docker-compose.yml")));
+
+		DockerCli.DockerComposeOptions options = new DockerCli.DockerComposeOptions(mockFile, Set.of("dev"), List.of("--verbose"));
+		DockerCli cli = new DockerCli(mockProcessRunner, options);
+
+		List<String> command = cli.createCommand(DockerCliCommand.Type.DOCKER_COMPOSE);
+		assertThat(command).contains("--file", "docker-compose.yml", "--profile", "dev", "--verbose");
+	}
+
+	@Test
+	void fileConstructorShouldInitializeCorrectly_whenDockerIsRunning() {
+		// assume docker is running (아니면 생략 가능)
+		Assumptions.assumeTrue(new File("/var/run/docker.sock").exists() || System.getProperty("os.name").startsWith("Windows"));
+
+		DockerComposeFile mockFile = mock(DockerComposeFile.class);
+		when(mockFile.getFiles()).thenReturn(List.of(new File("docker-compose.yml")));
+
+		DockerCli.DockerComposeOptions options = new DockerCli.DockerComposeOptions(mockFile, Set.of("dev"), List.of("--verbose"));
+
+		DockerCli cli = new DockerCli(new File("."), options); // ✅ 여기! 기존 생성자 직접 호출
+
+		List<String> command = cli.createCommand(DockerCliCommand.Type.DOCKER_COMPOSE);
+
+		assertThat(command).contains("--file", "docker-compose.yml", "--profile", "dev", "--verbose");
+	}
+
+}


### PR DESCRIPTION
### Description

This PR improves test coverage for `DockerCli` in the `spring-boot-docker-compose` module.

It adds:
- A unit test for `createCommand()` using mocked dependencies
- A test for the file-based constructor (with assumptions) to ensure compatibility in Docker environments

These tests ensure that command generation and constructor paths are covered and validated.
