### PR TITLE
Add missing link to external metrics backend

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/docs/antora/modules/api/pages/rest/actuator/metrics.adoc
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/docs/antora/modules/api/pages/rest/actuator/metrics.adoc
@@ -4,7 +4,7 @@
 The `metrics` endpoint provides access to application metrics to diagnose the metrics the application has recorded.
 This endpoint should not be "scraped" or used as a metrics backend in production.
 Its purpose is to show the currently registered metrics so users can see what metrics are available, what their current values are, and if triggering certain operations cause any change in certain values.
-If you want to diagnose your applications through the metrics they collect, you should use an external metrics backend.
+If you want to diagnose your applications through the metrics they collect, you should use an xref:reference:actuator/metrics.adoc[external metrics backend].
 In this case, the `metrics` endpoint can still be useful.
 
 


### PR DESCRIPTION
Add the missing link from https://github.com/spring-projects/spring-boot/pull/44767
but doing this right now it fails the `antora` task (haven't looked deeper into why).

See gh-44767
