### PR TITLE
Inconsistency in code style and make source code easier to understand

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ApplicationProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ApplicationProperties.java
@@ -37,13 +37,13 @@ class ApplicationProperties {
 	 * Whether bean definition overriding, by registering a definition with the same name
 	 * as an existing definition, is allowed.
 	 */
-	private boolean allowBeanDefinitionOverriding;
+	private boolean allowBeanDefinitionOverriding = false;
 
 	/**
 	 * Whether to allow circular references between beans and automatically try to resolve
 	 * them.
 	 */
-	private boolean allowCircularReferences;
+	private boolean allowCircularReferences = false;
 
 	/**
 	 * Mode used to display the banner when the application runs.
@@ -53,7 +53,7 @@ class ApplicationProperties {
 	/**
 	 * Whether to keep the application alive even if there are no more non-daemon threads.
 	 */
-	private boolean keepAlive;
+	private boolean keepAlive = false;
 
 	/**
 	 * Whether initialization should be performed lazily.


### PR DESCRIPTION
In the `ApplicationProperties.java`, the `lazyInitialization` parameter explicitly declares its default value as `false`. However, the `keepAlive`, `allowCircularReferences`, and `allowBeanDefinitionOverriding` parameters do not have their default values of `false` explicitly declared, leading to an inconsistency in style. 

Before `Spring Boot 3.4`, a similar inconsistency existed, where in the `SpringApplication.java` file, `lazyInitialization` was explicitly set to default to false, whereas `keepAlive`, `allowCircularReferences`, and `allowBeanDefinitionOverriding` did not have their default values of `false` explicitly stated. 

In my opinion, explicitly declaring the default values for boolean objects makes them easier to understand.