### PR TITLE
Throw `VerificationException` for build verification failures

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureCheck.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureCheck.java
@@ -31,7 +31,6 @@ import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.EvaluationResult;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.GradleException;
 import org.gradle.api.Task;
 import org.gradle.api.Transformer;
 import org.gradle.api.file.DirectoryProperty;
@@ -49,6 +48,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.VerificationException;
 
 /**
  * {@link Task} that checks for architecture problems.
@@ -86,7 +86,7 @@ public abstract class ArchitectureCheck extends DefaultTask {
 		File outputFile = getOutputDirectory().file("failure-report.txt").get().getAsFile();
 		writeViolationReport(violations, outputFile);
 		if (!violations.isEmpty()) {
-			throw new GradleException("Architecture check failed. See '" + outputFile + "' for details.");
+			throw new VerificationException("Architecture check failed. See '" + outputFile + "' for details.");
 		}
 	}
 

--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/CheckBom.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/CheckBom.java
@@ -34,7 +34,6 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.artifact.versioning.Restriction;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.file.RegularFile;
@@ -44,6 +43,7 @@ import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.VerificationException;
 
 import org.springframework.boot.build.bom.Library.Group;
 import org.springframework.boot.build.bom.Library.ImportedBom;
@@ -94,7 +94,7 @@ public abstract class CheckBom extends DefaultTask {
 			System.out.println();
 			errors.forEach(System.out::println);
 			System.out.println();
-			throw new GradleException("Bom check failed. See previous output for details.");
+			throw new VerificationException("Bom check failed. See previous output for details.");
 		}
 	}
 

--- a/buildSrc/src/main/java/org/springframework/boot/build/context/properties/CheckAdditionalSpringConfigurationMetadata.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/context/properties/CheckAdditionalSpringConfigurationMetadata.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gradle.api.GradleException;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.InputFiles;
@@ -40,6 +39,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.VerificationException;
 
 /**
  * {@link SourceTask} that checks additional Spring configuration metadata files.
@@ -70,7 +70,7 @@ public abstract class CheckAdditionalSpringConfigurationMetadata extends SourceT
 		File reportFile = getReportLocation().get().getAsFile();
 		Files.write(reportFile.toPath(), report, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
 		if (report.hasProblems()) {
-			throw new GradleException(
+			throw new VerificationException(
 					"Problems found in additional Spring configuration metadata. See " + reportFile + " for details.");
 		}
 	}

--- a/buildSrc/src/main/java/org/springframework/boot/build/context/properties/CheckSpringConfigurationMetadata.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/context/properties/CheckSpringConfigurationMetadata.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.GradleException;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.Input;
@@ -40,6 +39,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.VerificationException;
 
 /**
  * {@link SourceTask} that checks {@code spring-configuration-metadata.json} files.
@@ -70,7 +70,7 @@ public abstract class CheckSpringConfigurationMetadata extends DefaultTask {
 		File reportFile = getReportLocation().get().getAsFile();
 		Files.write(reportFile.toPath(), report, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
 		if (report.hasProblems()) {
-			throw new GradleException(
+			throw new VerificationException(
 					"Problems found in Spring configuration metadata. See " + reportFile + " for details.");
 		}
 	}

--- a/buildSrc/src/main/java/org/springframework/boot/build/springframework/CheckFactoriesFile.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/springframework/CheckFactoriesFile.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.GradleException;
 import org.gradle.api.Task;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
@@ -43,6 +42,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.VerificationException;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
 import org.springframework.core.io.support.SpringFactoriesLoader;
@@ -112,7 +112,7 @@ public abstract class CheckFactoriesFile extends DefaultTask {
 		File outputFile = getOutputDirectory().file("failure-report.txt").get().getAsFile();
 		writeReport(factoriesFile, problems, outputFile);
 		if (!problems.isEmpty()) {
-			throw new GradleException("%s check failed. See '%s' for details".formatted(this.path, outputFile));
+			throw new VerificationException("%s check failed. See '%s' for details".formatted(this.path, outputFile));
 		}
 	}
 


### PR DESCRIPTION
Verification failures are generally failures which verify correctness, e.g., failures caused by test, compilation, linting, etc. Non-verification failures are generally failures related to the build toolchain, e.g., failures caused by dependency resolution, build configuration, etc.

Develocity attempts to classify failures based on context, but it doesn't always classify correctly. By default, most failures are classified as non-verification. By explicitly throwing a `VerificationException` for verification task failures, the failures will be appropriately classified.

[Here](https://ge.solutions-team.gradle.com/scans/failures?failures.failureClassification=verification&failures.failureMessage=*Architecture%20check%20failed*&search.startTimeMax=1744657777665&search.startTimeMin=1744002000000&search.timeZoneId=America%2FChicago) is a Build Scan showing the behavior with these changes. You'll notice these `Architecture check` failures are categorized as _verification_ rather than _non-verification_, which is the case when you look in [the Spring Develocity instance](https://ge.spring.io/scans/failures?failures.failureMessage=*Architecture%20check%20failed*&search.rootProjectNames=spring-boot-build&search.startTimeMax=1744657906806&search.startTimeMin=1742187600000&search.timeZoneId=America%2FChicago).

See also: https://docs.gradle.com/develocity/failure-classification