### PR TITLE
Per-meter configuration for OtlpMetricsProperties

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpMetricsProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpMetricsProperties.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.metrics.export.otlp;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -53,9 +54,14 @@ public class OtlpMetricsProperties extends StepRegistryProperties {
 	private Map<String, String> headers;
 
 	/**
-	 * Histogram type to be preferred when histogram publishing is enabled.
+	 * Default histogram type when histogram publishing is enabled.
 	 */
 	private HistogramFlavor histogramFlavor = HistogramFlavor.EXPLICIT_BUCKET_HISTOGRAM;
+
+	/**
+	 * Per meter histogram type to be preferred when histogram publishing is enabled.
+	 */
+	private Map<String, HistogramFlavor> histogramFlavorPerMeter = new LinkedHashMap<>();
 
 	/**
 	 * Max scale to use for exponential histograms, if configured.
@@ -63,10 +69,16 @@ public class OtlpMetricsProperties extends StepRegistryProperties {
 	private int maxScale = 20;
 
 	/**
-	 * Maximum number of buckets to be used for exponential histograms, if configured.
-	 * This has no effect on explicit bucket histograms.
+	 * Default maximum number of buckets to be used for exponential histograms, if
+	 * configured. This has no effect on explicit bucket histograms.
 	 */
 	private int maxBucketCount = 160;
+
+	/**
+	 * Per meter number of max buckets used for exponential histograms, if configured.
+	 * This has no effect on explicit bucket histograms.
+	 */
+	private Map<String, Integer> maxBucketsPerMeter = new LinkedHashMap<>();
 
 	/**
 	 * Time unit for exported metrics.
@@ -105,6 +117,14 @@ public class OtlpMetricsProperties extends StepRegistryProperties {
 		this.histogramFlavor = histogramFlavor;
 	}
 
+	public Map<String, HistogramFlavor> getHistogramFlavorPerMeter() {
+		return this.histogramFlavorPerMeter;
+	}
+
+	public void setHistogramFlavorPerMeter(Map<String, HistogramFlavor> histogramFlavorPerMeter) {
+		this.histogramFlavorPerMeter = histogramFlavorPerMeter;
+	}
+
 	public int getMaxScale() {
 		return this.maxScale;
 	}
@@ -119,6 +139,14 @@ public class OtlpMetricsProperties extends StepRegistryProperties {
 
 	public void setMaxBucketCount(int maxBucketCount) {
 		this.maxBucketCount = maxBucketCount;
+	}
+
+	public Map<String, Integer> getMaxBucketsPerMeter() {
+		return this.maxBucketsPerMeter;
+	}
+
+	public void setMaxBucketsPerMeter(Map<String, Integer> maxBucketsPerMeter) {
+		this.maxBucketsPerMeter = maxBucketsPerMeter;
 	}
 
 	public TimeUnit getBaseTimeUnit() {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpMetricsPropertiesConfigAdapter.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpMetricsPropertiesConfigAdapter.java
@@ -89,6 +89,16 @@ class OtlpMetricsPropertiesConfigAdapter extends StepRegistryPropertiesConfigAda
 	}
 
 	@Override
+	public Map<String, HistogramFlavor> histogramFlavorPerMeter() {
+		return get(OtlpMetricsProperties::getHistogramFlavorPerMeter, OtlpConfig.super::histogramFlavorPerMeter);
+	}
+
+	@Override
+	public Map<String, Integer> maxBucketsPerMeter() {
+		return get(OtlpMetricsProperties::getMaxBucketsPerMeter, OtlpConfig.super::maxBucketsPerMeter);
+	}
+
+	@Override
 	public int maxScale() {
 		return get(OtlpMetricsProperties::getMaxScale, OtlpConfig.super::maxScale);
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpMetricsPropertiesConfigAdapterTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpMetricsPropertiesConfigAdapterTests.java
@@ -111,6 +111,19 @@ class OtlpMetricsPropertiesConfigAdapterTests {
 	}
 
 	@Test
+	void whenPropertiesHistogramFlavorPerMeterIsNotSetAdapterHistogramFlavorReturnsEmptyMap() {
+		assertThat(createAdapter().histogramFlavorPerMeter()).isEmpty();
+	}
+
+	@Test
+	void whenPropertiesHistogramFlavorPerMeterIsSetAdapterHistogramFlavorPerMeterReturnsIt() {
+		this.properties
+			.setHistogramFlavorPerMeter(Map.of("my.histograms", HistogramFlavor.BASE2_EXPONENTIAL_BUCKET_HISTOGRAM));
+		assertThat(createAdapter().histogramFlavorPerMeter()).containsEntry("my.histograms",
+				HistogramFlavor.BASE2_EXPONENTIAL_BUCKET_HISTOGRAM);
+	}
+
+	@Test
 	void whenPropertiesMaxScaleIsNotSetAdapterMaxScaleReturns20() {
 		assertThat(createAdapter().maxScale()).isEqualTo(20);
 	}
@@ -130,6 +143,17 @@ class OtlpMetricsPropertiesConfigAdapterTests {
 	void whenPropertiesMaxBucketCountIsSetAdapterMaxBucketCountReturnsIt() {
 		this.properties.setMaxBucketCount(6);
 		assertThat(createAdapter().maxBucketCount()).isEqualTo(6);
+	}
+
+	@Test
+	void whenPropertiesMaxBucketsPerMeterIsNotSetAdapterMaxBucketsPerMeterReturnsEmptyMap() {
+		assertThat(createAdapter().maxBucketsPerMeter()).isEmpty();
+	}
+
+	@Test
+	void whenPropertiesMaxBucketsPerMeterIsSetAdapterMaxBucketsPerMeterReturnsIt() {
+		this.properties.setMaxBucketsPerMeter(Map.of("my.histograms", 111));
+		assertThat(createAdapter().maxBucketsPerMeter()).containsEntry("my.histograms", 111);
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpMetricsPropertiesTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/metrics/export/otlp/OtlpMetricsPropertiesTests.java
@@ -37,8 +37,10 @@ class OtlpMetricsPropertiesTests extends StepRegistryPropertiesTests {
 		assertStepRegistryDefaultValues(properties, config);
 		assertThat(properties.getAggregationTemporality()).isSameAs(config.aggregationTemporality());
 		assertThat(properties.getHistogramFlavor()).isSameAs(config.histogramFlavor());
+		assertThat(properties.getHistogramFlavorPerMeter()).isEqualTo(config.histogramFlavorPerMeter());
 		assertThat(properties.getMaxScale()).isEqualTo(config.maxScale());
 		assertThat(properties.getMaxBucketCount()).isEqualTo(config.maxBucketCount());
+		assertThat(properties.getMaxBucketsPerMeter()).isEqualTo(config.maxBucketsPerMeter());
 		assertThat(properties.getBaseTimeUnit()).isSameAs(config.baseTimeUnit());
 	}
 

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1548,7 +1548,7 @@ bom {
 			releaseNotes("https://github.com/apache/maven-war-plugin/releases/tag/maven-war-plugin-{version}")
 		}
 	}
-	library("Micrometer", "1.15.0-SNAPSHOT") {
+	library("Micrometer", "1.15.0-RC1") {
 		considerSnapshots()
 		group("io.micrometer") {
 			modules = [


### PR DESCRIPTION
Adds configuration properties support for the new OtlpConfig methods `histogramFlavorPerMeter` and `maxBucketsPerMeter`. The existing `histogramFlavor` and `maxBucketCount` configuration properties are used as defaults when there isn't a specific per-meter configuration set.

See https://github.com/micrometer-metrics/micrometer/pull/5974
