### PR TITLE
Add config-view actuator endpoint to expose runtime config with sources

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/configview/ConfigViewEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/configview/ConfigViewEndpoint.java
@@ -1,0 +1,42 @@
+package org.springframework.boot.actuate.configview;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.PropertySource;
+
+import java.util.*;
+
+@Endpoint(id = "config-view")
+public class ConfigViewEndpoint {
+
+	private final ConfigurableEnvironment environment;
+
+	public ConfigViewEndpoint(ConfigurableEnvironment environment) {
+		this.environment = environment;
+	}
+
+	@ReadOperation
+	public List<ConfigProperty> configProperties() {
+		List<ConfigProperty> results = new ArrayList<>();
+
+		for (PropertySource<?> propertySource : environment.getPropertySources()) {
+			if (propertySource instanceof EnumerablePropertySource<?> enumerable) {
+				for (String propertyName : enumerable.getPropertyNames()) {
+					Object value = enumerable.getProperty(propertyName);
+					String displayValue = isSensitive(propertyName) ? "****" : String.valueOf(value);
+					results.add(new ConfigProperty(propertyName, displayValue, propertySource.getName()));
+				}
+			}
+		}
+		return results;
+	}
+
+	private boolean isSensitive(String name) {
+		String lower = name.toLowerCase();
+		return lower.contains("password") || lower.contains("secret") || lower.contains("token") || lower.contains("key");
+	}
+
+	public record ConfigProperty(String key, String value, String source) {}
+}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/configview/ConfigViewEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/configview/ConfigViewEndpointAutoConfiguration.java
@@ -1,0 +1,17 @@
+package org.springframework.boot.actuate.autoconfigure.configview;
+
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
+import org.springframework.boot.actuate.configview.ConfigViewEndpoint;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnAvailableEndpoint(endpoint = ConfigViewEndpoint.class)
+public class ConfigViewEndpointAutoConfiguration {
+
+	@Bean
+	public ConfigViewEndpoint configViewEndpoint(ConfigurableEnvironment environment) {
+		return new ConfigViewEndpoint(environment);
+	}
+}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/configview/ConfigViewEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/configview/ConfigViewEndpointTests.java
@@ -1,0 +1,34 @@
+package org.springframework.boot.actuate.configview;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.*;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigViewEndpointTests {
+
+	@Test
+	void returnsAllConfigProperties() {
+		ConfigurableEnvironment env = new StandardEnvironment();
+		Map<String, Object> props = new HashMap<>();
+		props.put("my.custom.key", "value");
+		props.put("spring.datasource.password", "supersecret");
+		env.getPropertySources().addFirst(new MapPropertySource("test", props));
+
+		ConfigViewEndpoint endpoint = new ConfigViewEndpoint(env);
+		List<ConfigViewEndpoint.ConfigProperty> result = endpoint.configProperties();
+
+		assertThat(result).anySatisfy(prop -> {
+			assertThat(prop.key()).isEqualTo("my.custom.key");
+			assertThat(prop.value()).isEqualTo("value");
+			assertThat(prop.source()).isEqualTo("test");
+		});
+
+		assertThat(result).anySatisfy(prop -> {
+			assertThat(prop.key()).isEqualTo("spring.datasource.password");
+			assertThat(prop.value()).isEqualTo("****");
+		});
+	}
+}


### PR DESCRIPTION
This PR adds a new Actuator endpoint `/actuator/config-view` that exposes a runtime view of all configuration properties, their current values (with sensitive data masked), and their sources.

Features:
- Lists config properties from all EnumerablePropertySources
- Shows property name, value, and source
- Masks sensitive values (e.g., passwords, tokens)
- Provides diagnostics for debugging config issues

Example output:
[
  { "key": "server.port", "value": "8080", "source": "application.properties" },
  { "key": "spring.datasource.password", "value": "****", "source": "env" }
]

Use case: Developers and operators can quickly debug which config values are in effect, especially when using layered configs like profiles, env vars, and config servers.
