### PR TITLE
Add actuator endpoint to expose application.yaml

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/configfile/ConfigFileEndpointAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/configfile/ConfigFileEndpointAutoConfiguration.java
@@ -1,0 +1,24 @@
+package org.springframework.boot.actuate.autoconfigure.configfile;
+
+import org.springframework.boot.actuate.configfile.ConfigFileEndpoint;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.core.env.Environment;
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(ConfigFileEndpointProperties.class)
+@ConditionalOnProperty(prefix = "management.endpoint.configfile", name = "enabled", havingValue = "true")
+public class ConfigFileEndpointAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnAvailableEndpoint
+	public ConfigFileEndpoint configFileEndpoint(Environment environment, ConfigFileEndpointProperties props) {
+		return new ConfigFileEndpoint(environment, new java.util.HashSet<>(props.getSensitiveKeys()));
+	}
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/configfile/ConfigFileEndpointProperties.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/configfile/ConfigFileEndpointProperties.java
@@ -1,0 +1,28 @@
+package org.springframework.boot.actuate.autoconfigure.configfile;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import java.util.List;
+
+@ConfigurationProperties("management.endpoint.configfile")
+public class ConfigFileEndpointProperties {
+
+	private boolean enabled = false;
+
+	private List<String> sensitiveKeys = List.of("password", "secret", "token");
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public List<String> getSensitiveKeys() {
+		return sensitiveKeys;
+	}
+
+	public void setSensitiveKeys(List<String> sensitiveKeys) {
+		this.sensitiveKeys = sensitiveKeys;
+	}
+}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -14,3 +14,6 @@ org.springframework.boot.actuate.autoconfigure.tracing.LogCorrelationEnvironment
 # Application Listeners
 org.springframework.context.ApplicationListener=\
 org.springframework.boot.actuate.autoconfigure.tracing.OpenTelemetryEventPublisherBeansApplicationListener
+
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.springframework.boot.actuate.autoconfigure.configfile.ConfigFileEndpointAutoConfiguration

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/configfile/ConfigFileEndPoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/configfile/ConfigFileEndPoint.java
@@ -1,0 +1,50 @@
+package org.springframework.boot.actuate.configfile;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+@Endpoint(id = "configfile")
+public class ConfigFileEndpoint {
+
+	private final Environment environment;
+	private final List<String> sensitiveKeys;
+
+	public ConfigFileEndpoint(Environment environment, List<String> sensitiveKeys) {
+		this.environment = environment;
+		this.sensitiveKeys = sensitiveKeys;
+	}
+
+	@ReadOperation
+	public Map<String, Object> config() {
+		Map<String, Object> properties = new LinkedHashMap<>();
+
+		if (environment instanceof ConfigurableEnvironment configurableEnvironment) {
+			for (PropertySource<?> source : configurableEnvironment.getPropertySources()) {
+				if (source.getName().contains("applicationConfig")) {
+					if (source.getSource() instanceof Map<?, ?> map) {
+						for (Map.Entry<?, ?> entry : map.entrySet()) {
+							String key = String.valueOf(entry.getKey());
+							Object value = sensitiveKeys.stream().anyMatch(key::contains) ? "****" : entry.getValue();
+							properties.put(key, value);
+						}
+					}
+				}
+			}
+		}
+
+		return properties.entrySet().stream()
+				.sorted(Map.Entry.comparingByKey())
+				.collect(Collectors.toMap(
+						Map.Entry::getKey,
+						Map.Entry::getValue,
+						(e1, e2) -> e1,
+						LinkedHashMap::new
+				));
+	}
+}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/configfile/ConfigFileEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/configfile/ConfigFileEndpointTests.java
@@ -1,0 +1,25 @@
+package org.springframework.boot.actuate.configfile;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigFileEndpointTests {
+
+	@Test
+	void sensitiveKeysAreRedacted() {
+		MockEnvironment env = new MockEnvironment();
+		env.setProperty("db.password", "supersecret");
+		env.setProperty("api.key", "abc123");
+
+		ConfigFileEndpoint endpoint = new ConfigFileEndpoint(env, Set.of("password", "key"));
+		Map<String, Object> config = endpoint.config();
+
+		assertThat(config.get("db.password")).isEqualTo("****");
+		assertThat(config.get("api.key")).isEqualTo("****");
+	}
+}

--- a/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/asciidoc/actuator.adoc
@@ -1,0 +1,30 @@
+[[actuator.endpoints.configfile]]
+=== configfile
+
+The `configfile` endpoint exposes the current configuration from `application.yaml` or `application.properties`.
+It is **disabled by default**.
+
+You can enable it with:
+
+[source,yaml]
+----
+management:
+  endpoint:
+    configfile:
+      enabled: true
+      sensitive-keys:
+        - password
+        - token
+        - secret
+----
+
+Sensitive keys are redacted with `****`.
+
+.Example output
+[source,json]
+----
+{
+  "server.port": "8080",
+  "db.password": "****"
+}
+----


### PR DESCRIPTION
Summary

This pull request adds a new Spring Boot Actuator endpoint at /actuator/configfile. The endpoint exposes the application's effective configuration properties, typically loaded from application.yaml or application.properties. It is disabled by default and supports redacting sensitive keys.

Feature Details

- Adds a new endpoint class using `@Endpoint(id = "configfile")`
- Includes an auto-configuration class under `spring-boot-actuator-autoconfigure`
- Registers the auto-configuration in `spring.factories`
- Adds a configuration properties class for controlling the endpoint
- Allows users to configure a list of sensitive keys to redact
- Redacts values of sensitive keys by default (e.g., keys containing "password", "secret", "token")
- Includes a unit test for redaction behavior
- Adds related documentation to the `actuator.adoc` file

Security Consideration

To protect sensitive data, the endpoint redacts values for keys containing common sensitive terms like "password", "token", or "secret". These can be customized by users through configuration.

Example Configuration

```yaml
management:
  endpoint:
    configfile:
      enabled: true
      sensitive-keys:
        - password
        - token
        - secret
```

Example Output

```json
{
  "server.port": "8080",
  "db.password": "****"
}
```

How to Test

1. Enable the endpoint in `application.yaml` using the example configuration above.
2. Start the application.
3. Send a GET request to /actuator/configfile.
4. Confirm that configuration keys and values are returned, with sensitive values redacted.

Motivation

This feature enables safe inspection of runtime configuration, which is helpful for debugging and operational support. The endpoint is disabled by default and includes security-focused defaults to avoid exposing sensitive information.
