### PR TITLE
Fix documentation links to buildpacks.io

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/native-image/advanced-topics.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/native-image/advanced-topics.adoc
@@ -54,13 +54,13 @@ NOTE: Your executable jar must include AOT generated assets such as generated cl
 === Using Buildpacks
 
 Spring Boot applications usually use Cloud Native Buildpacks through the Maven (`mvn spring-boot:build-image`) or Gradle (`gradle bootBuildImage`) integrations.
-You can, however, also use https://buildpacks.io//docs/tools/pack/[`pack`] to turn an AOT processed Spring Boot executable jar into a native container image.
+You can, however, also use {url-buildpacks-docs}/for-platform-operators/how-to/integrate-ci/pack/[`pack`] to turn an AOT processed Spring Boot executable jar into a native container image.
 
 
 First, make sure that a Docker daemon is available (see https://docs.docker.com/installation/#installation[Get Docker] for more details).
 https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user[Configure it to allow non-root user] if you are on Linux.
 
-You also need to install `pack` by following https://buildpacks.io//docs/tools/pack/#install[the installation guide on buildpacks.io].
+You also need to install `pack` by following {url-buildpacks-docs}/for-platform-operators/how-to/integrate-ci/pack/#install[the installation guide on buildpacks.io].
 
 Assuming an AOT processed Spring Boot executable jar built as `myproject-0.0.1-SNAPSHOT.jar` is in the `target` directory, run:
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/packaging-oci-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/packaging-oci-image.adoc
@@ -105,8 +105,8 @@ For more details, see also xref:packaging-oci-image.adoc#build-image.examples.do
 [[build-image.customization]]
 == Image Customizations
 
-The plugin invokes a {url-buildpacks-docs}/concepts/components/builder/[builder] to orchestrate the generation of an image.
-The builder includes multiple {url-buildpacks-docs}/concepts/components/buildpack[buildpacks] that can inspect the application to influence the generated image.
+The plugin invokes a {url-buildpacks-docs}/for-app-developers/concepts/builder/[builder] to orchestrate the generation of an image.
+The builder includes multiple {url-buildpacks-docs}/for-app-developers/concepts/buildpack/[buildpacks] that can inspect the application to influence the generated image.
 By default, the plugin chooses a builder image.
 The name of the generated image is deduced from project properties.
 
@@ -123,7 +123,7 @@ The following table summarizes the available properties and their default values
 
 | `trustBuilder`
 | `--trustBuilder`
-| Whether to treat the builder as https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/concepts/trusted_builders/#what-is-a-trusted-builder[trusted].
+| Whether to treat the builder as {url-buildpacks-docs}/for-platform-operators/how-to/integrate-ci/pack/concepts/trusted_builders/#what-is-a-trusted-builder[trusted].
 | `true` if the builder is one of `paketobuildpacks/builder-jammy-java-tiny`, `paketobuildpacks/builder-noble-java-tiny`, `paketobuildpacks/builder-jammy-tiny`, `paketobuildpacks/builder-jammy-base`, `paketobuildpacks/builder-jammy-full`, `paketobuildpacks/builder-jammy-buildpackless-tiny`, `paketobuildpacks/builder-jammy-buildpackless-base`, `paketobuildpacks/builder-jammy-buildpackless-full`, `gcr.io/buildpacks/builder`, `heroku/builder`; `false` otherwise.
 
 | `imagePlatform`
@@ -232,7 +232,7 @@ The value can be a named volume or a bind mount location.
 | `--createdDate`
 | A date that will be used to set the `Created` field in the generated image's metadata.
 The value must be a string in the ISO 8601 instant format, or `now` to use the current date and time.
-| A fixed date that enables https://buildpacks.io/docs/features/reproducibility/[build reproducibility].
+| A fixed date that enables {url-buildpacks-docs}/for-app-developers/concepts/reproducibility/[build reproducibility].
 
 | `applicationDirectory`
 | `--applicationDirectory`
@@ -459,7 +459,7 @@ A path to a gzipped tar file containing buildpack content:
 * `\file:///path/to/buildpack.tgz`
 * `/path/to/buildpack.tgz`
 
-An OCI image containing a https://buildpacks.io/docs/buildpack-author-guide/package-a-buildpack/[packaged buildpack]:
+An OCI image containing a {url-buildpacks-docs}/for-buildpack-authors/how-to/distribute-buildpacks/package-buildpack/[packaged buildpack]:
 
 * `docker://example/buildpack`
 * `docker:///example/buildpack:latest`

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/pages/build-image.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/pages/build-image.adoc
@@ -120,8 +120,8 @@ For more details, see also xref:build-image.adoc#build-image.examples.docker[exa
 [[build-image.customization]]
 == Image Customizations
 
-The plugin invokes a {url-buildpacks-docs}/concepts/components/builder/[builder] to orchestrate the generation of an image.
-The builder includes multiple {url-buildpacks-docs}/concepts/components/buildpack[buildpacks] that can inspect the application to influence the generated image.
+The plugin invokes a {url-buildpacks-docs}/for-app-developers/concepts/builder/[builder] to orchestrate the generation of an image.
+The builder includes multiple {url-buildpacks-docs}/for-app-developers/concepts/buildpack/[buildpacks] that can inspect the application to influence the generated image.
 By default, the plugin chooses a builder image.
 The name of the generated image is deduced from project properties.
 
@@ -139,7 +139,7 @@ The following table summarizes the available parameters and their default values
 
 | `trustBuilder` +
 (`spring-boot.build-image.trustBuilder`)
-| Whether to treat the builder as https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/concepts/trusted_builders/#what-is-a-trusted-builder[trusted].
+| Whether to treat the builder as {url-buildpacks-docs}/for-platform-operators/how-to/integrate-ci/pack/concepts/trusted_builders/#what-is-a-trusted-builder[trusted].
 | `true` if the builder is one of `paketobuildpacks/builder-jammy-java-tiny`, `paketobuildpacks/builder-noble-java-tiny`, `paketobuildpacks/builder-jammy-tiny`, `paketobuildpacks/builder-jammy-base`, `paketobuildpacks/builder-jammy-full`, `paketobuildpacks/builder-jammy-buildpackless-tiny`, `paketobuildpacks/builder-jammy-buildpackless-base`, `paketobuildpacks/builder-jammy-buildpackless-full`, `gcr.io/buildpacks/builder`, `heroku/builder`; `false` otherwise.
 
 | `imagePlatform` +
@@ -238,7 +238,7 @@ The value can be a named volume or a bind mount location.
 (`spring-boot.build-image.createdDate`)
 | A date that will be used to set the `Created` field in the generated image's metadata.
 The value must be a string in the ISO 8601 instant format, or `now` to use the current date and time.
-| A fixed date that enables https://buildpacks.io/docs/features/reproducibility/[build reproducibility].
+| A fixed date that enables {url-buildpacks-docs}/for-app-developers/concepts/reproducibility/[build reproducibility].
 
 
 | `applicationDirectory` +
@@ -401,7 +401,7 @@ A path to a gzipped tar file containing buildpack content:
 * `\file:///path/to/buildpack.tgz`
 * `/path/to/buildpack.tgz`
 
-An OCI image containing a https://buildpacks.io/docs/buildpack-author-guide/package-a-buildpack/[packaged buildpack]:
+An OCI image containing a {url-buildpacks-docs}/for-buildpack-authors/how-to/distribute-buildpacks/package-buildpack/[packaged buildpack]:
 
 * `docker://example/buildpack`
 * `docker:///example/buildpack:latest`


### PR DESCRIPTION
Hi, browsing [this documentation page](https://docs.spring.io/spring-boot/maven-plugin/build-image.html) I noticed that some buildpacks.io links were broken (the builder and buildbacks in [this section](https://docs.spring.io/spring-boot/maven-plugin/build-image.html#build-image.customization) to be precise).

I updated them with the correct url. While I was at it I also tried reviewing the other links too.