### PR TITLE
Restore visibility for DockerComposeProperties.get()

### DIFF
--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/lifecycle/DockerComposeProperties.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/lifecycle/DockerComposeProperties.java
@@ -137,7 +137,7 @@ public class DockerComposeProperties {
 		return this.readiness;
 	}
 
-	public static DockerComposeProperties get(Binder binder) {
+	static DockerComposeProperties get(Binder binder) {
 		return binder.bind(NAME, DockerComposeProperties.class).orElseGet(DockerComposeProperties::new);
 	}
 


### PR DESCRIPTION
This PR reverts the visibility change for the `DockerComposeProperties.get()` that has been made in #45014  as it doesn't seem to be necessary.