### PR TITLE
Make @Component a javadoc link

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/using/spring-beans-and-dependency-injection.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/using/spring-beans-and-dependency-injection.adoc
@@ -5,7 +5,7 @@ You are free to use any of the standard Spring Framework techniques to define yo
 We generally recommend using constructor injection to wire up dependencies and javadoc:org.springframework.context.annotation.ComponentScan[format=annotation] to find beans.
 
 If you structure your code as suggested above (locating your application class in a top package), you can add javadoc:org.springframework.context.annotation.ComponentScan[format=annotation] without any arguments or use the javadoc:org.springframework.boot.autoconfigure.SpringBootApplication[format=annotation] annotation which implicitly includes it.
-All of your application components (`@Component`, javadoc:org.springframework.stereotype.Service[format=annotation], javadoc:org.springframework.stereotype.Repository[format=annotation], javadoc:org.springframework.stereotype.Controller[format=annotation], and others) are automatically registered as Spring Beans.
+All of your application components (javadoc:org.springframework.stereotype.Component[format=annotation], javadoc:org.springframework.stereotype.Service[format=annotation], javadoc:org.springframework.stereotype.Repository[format=annotation], javadoc:org.springframework.stereotype.Controller[format=annotation], and others) are automatically registered as Spring Beans.
 
 The following example shows a javadoc:org.springframework.stereotype.Service[format=annotation] Bean that uses constructor injection to obtain a required `RiskAssessor` bean:
 


### PR DESCRIPTION
This pull request fixes a small inconsistency in the Spring Boot documentation.

In the [Spring Beans and Dependency Injection](https://docs.spring.io/spring-boot/reference/using/spring-beans-and-dependency-injection.html) section, the `@Component` annotation was not rendered as a javadoc link, unlike other annotations in the same sentence (such as `@Service`, `@Repository`, and `@Controller`).

This change makes `@Component` consistent with the others by using the `javadoc:` syntax.

Fixes #45246