### PR TITLE
feat(logging): add support for JSON structured logging via spring.logging.json.enabled

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/logging/JsonLoggingAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/logging/JsonLoggingAutoConfiguration.java
@@ -1,0 +1,35 @@
+package org.springframework.boot.autoconfigure.logging;
+
+import jakarta.annotation.PostConstruct;
+import net.logstash.logback.encoder.LogstashEncoder;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+/**
+ * Auto-configuration to enable JSON structured logging using Logstash encoder.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(name = "spring.logging.json.enabled", havingValue = "true")
+@EnableConfigurationProperties(JsonLoggingProperties.class)
+public class JsonLoggingAutoConfiguration {
+
+	@PostConstruct
+	public void configureJsonLogging() {
+		LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+		LogstashEncoder encoder = new LogstashEncoder();
+		ConsoleAppender<ILoggingEvent> consoleAppender = new ConsoleAppender<>();
+		consoleAppender.setContext(context);
+		consoleAppender.setEncoder(encoder);
+		consoleAppender.start();
+
+		ch.qos.logback.classic.Logger rootLogger = context.getLogger("ROOT");
+		rootLogger.detachAndStopAllAppenders();
+		rootLogger.addAppender(consoleAppender);
+	}
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/logging/JsonLoggingProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/logging/JsonLoggingProperties.java
@@ -1,0 +1,23 @@
+package org.springframework.boot.autoconfigure.logging;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for JSON structured logging.
+ */
+@ConfigurationProperties(prefix = "spring.logging.json")
+public class JsonLoggingProperties {
+
+	/**
+	 * Enable JSON formatted structured logging.
+	 */
+	private boolean enabled = false;
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -152,3 +152,4 @@ org.springframework.boot.autoconfigure.websocket.servlet.WebSocketServletAutoCon
 org.springframework.boot.autoconfigure.websocket.servlet.WebSocketMessagingAutoConfiguration
 org.springframework.boot.autoconfigure.webservices.WebServicesAutoConfiguration
 org.springframework.boot.autoconfigure.webservices.client.WebServiceTemplateAutoConfiguration
+org.springframework.boot.autoconfigure.logging.JsonLoggingAutoConfiguration

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/logging/JsonLoggingAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/logging/JsonLoggingAutoConfigurationTests.java
@@ -1,0 +1,37 @@
+package org.springframework.boot.autoconfigure.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.core.Appender;
+import net.logstash.logback.encoder.LogstashEncoder;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonLoggingAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(JsonLoggingAutoConfiguration.class))
+			.withPropertyValues("spring.logging.json.enabled=true");
+
+	@Test
+	void jsonLoggingEnabled_shouldUseLogstashEncoder() {
+		contextRunner.run(context -> {
+			LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+			Logger rootLogger = loggerContext.getLogger("ROOT");
+
+			Appender<?> appender = rootLogger.getAppender("console"); // You may have set a name or use first appender
+			assertThat(appender).isNotNull();
+
+			// Check if encoder is LogstashEncoder
+			if (appender instanceof ch.qos.logback.core.ConsoleAppender<?>) {
+				Object encoder = ((ch.qos.logback.core.ConsoleAppender<?>) appender).getEncoder();
+				assertThat(encoder).isInstanceOf(LogstashEncoder.class);
+			}
+		});
+	}
+}

--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -2638,6 +2638,11 @@ bom {
 			site("https://github.com/eclipse-ee4j/yasson")
 			releaseNotes("https://github.com/eclipse-ee4j/yasson/releases/tag/{version}")
 		}
+
+		dependencies {
+			api "net.logstash.logback:logstash-logback-encoder:7.4"
+		}
+
 	}
 }
 


### PR DESCRIPTION
Problem

Spring Boot does not currently offer native support for enabling JSON-formatted structured logging via a configuration property. Developers often have to manually configure logback.xml or custom appenders to integrate with observability tools like ELK, Loki, or CloudWatch.

This creates unnecessary boilerplate and increases setup complexity, especially for developers who prefer convention over configuration.

Solution

This PR introduces a simple toggle to enable structured JSON logging using:

spring.logging.json.enabled=true

When enabled, it configures the root logger to use LogstashEncoder from the logstash-logback-encoder library, outputting structured logs in JSON format.

Key Highlights

New config binding class: JsonLoggingProperties

New auto-configuration: JsonLoggingAutoConfiguration (conditionally activated)

Integration with logstash-logback-encoder

Added spring.logging.json.enabled config flag

Registered auto-config in AutoConfiguration.imports

Included unit test to verify encoder is applied

No impact on existing users (opt-in feature only)

Example Usage

spring: logging: json: enabled: true

Once enabled, logs are output in structured format like:

{ "@timestamp": "2025-04-22T12:00:00.000+00:00", "level": "INFO", "message": "Application started", "logger_name": "com.example.Main", "thread_name": "main" }

Motivation

Simplifies developer setup for structured logging

Aligns with Spring Boot’s philosophy of zero-XML and config-based behavior

Improves compatibility with logging and observability pipelines

Let me know if anything needs improvement. Thanks for reviewing!