### PR TITLE
Rename MVC view prefix/suffix properties to be JSP specific

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
@@ -38,6 +38,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
@@ -139,6 +140,7 @@ import org.springframework.web.util.UrlPathHelper;
  * @author Bruce Brouwer
  * @author Artsiom Yudovin
  * @author Scott Frederick
+ * @author daewon kim
  * @since 2.0.0
  */
 @AutoConfiguration(after = { DispatcherServletAutoConfiguration.class, TaskExecutionAutoConfiguration.class,
@@ -282,10 +284,20 @@ public class WebMvcAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
+		@ConditionalOnProperty(prefix = "spring.mvc.view", name = {"prefix", "suffix"})
 		public InternalResourceViewResolver defaultViewResolver() {
 			InternalResourceViewResolver resolver = new InternalResourceViewResolver();
 			resolver.setPrefix(this.mvcProperties.getView().getPrefix());
 			resolver.setSuffix(this.mvcProperties.getView().getSuffix());
+			return resolver;
+		}
+
+		@Bean
+		@ConditionalOnProperty(prefix = "spring.mvc.jsp", name = {"prefix", "suffix"})
+		public InternalResourceViewResolver jspViewResolver() {
+			InternalResourceViewResolver resolver = new InternalResourceViewResolver();
+			resolver.setPrefix(this.mvcProperties.getJsp().getPrefix());
+			resolver.setSuffix(this.mvcProperties.getJsp().getSuffix());
 			return resolver;
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.java
@@ -284,7 +284,7 @@ public class WebMvcAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		@ConditionalOnProperty(prefix = "spring.mvc.view", name = {"prefix", "suffix"})
+		@ConditionalOnProperty(prefix = "spring.mvc.view", name = { "prefix", "suffix" })
 		public InternalResourceViewResolver defaultViewResolver() {
 			InternalResourceViewResolver resolver = new InternalResourceViewResolver();
 			resolver.setPrefix(this.mvcProperties.getView().getPrefix());
@@ -293,7 +293,7 @@ public class WebMvcAutoConfiguration {
 		}
 
 		@Bean
-		@ConditionalOnProperty(prefix = "spring.mvc.jsp", name = {"prefix", "suffix"})
+		@ConditionalOnProperty(prefix = "spring.mvc.jsp", name = { "prefix", "suffix" })
 		public InternalResourceViewResolver jspViewResolver() {
 			InternalResourceViewResolver resolver = new InternalResourceViewResolver();
 			resolver.setPrefix(this.mvcProperties.getJsp().getPrefix());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcProperties.java
@@ -36,6 +36,7 @@ import org.springframework.validation.DefaultMessageCodesResolver;
  * @author Eddú Meléndez
  * @author Brian Clozel
  * @author Vedran Pavic
+ * @author daewon kim
  * @since 2.0.0
  */
 @ConfigurationProperties("spring.mvc")
@@ -90,6 +91,8 @@ public class WebMvcProperties {
 	private final Servlet servlet = new Servlet();
 
 	private final View view = new View();
+
+	private final Jsp jsp = new Jsp();
 
 	private final Contentnegotiation contentnegotiation = new Contentnegotiation();
 
@@ -175,6 +178,10 @@ public class WebMvcProperties {
 
 	public View getView() {
 		return this.view;
+	}
+
+	public Jsp getJsp() {
+		return this.jsp;
 	}
 
 	public Contentnegotiation getContentnegotiation() {
@@ -279,6 +286,36 @@ public class WebMvcProperties {
 
 		/**
 		 * Spring MVC view suffix.
+		 */
+		private String suffix;
+
+		public String getPrefix() {
+			return this.prefix;
+		}
+
+		public void setPrefix(String prefix) {
+			this.prefix = prefix;
+		}
+
+		public String getSuffix() {
+			return this.suffix;
+		}
+
+		public void setSuffix(String suffix) {
+			this.suffix = suffix;
+		}
+
+	}
+
+	public static class Jsp {
+
+		/**
+		 * Spring MVC jsp prefix.
+		 */
+		private String prefix;
+
+		/**
+		 * Spring MVC jsp suffix.
 		 */
 		private String suffix;
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfigurationTests.java
@@ -142,6 +142,7 @@ import org.springframework.web.servlet.support.SessionFlashMapManager;
 import org.springframework.web.servlet.view.AbstractView;
 import org.springframework.web.servlet.view.ContentNegotiatingViewResolver;
 import org.springframework.web.servlet.view.DefaultRequestToViewNameTranslator;
+import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.util.UrlPathHelper;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -160,6 +161,7 @@ import static org.mockito.Mockito.mock;
  * @author Artsiom Yudovin
  * @author Scott Frederick
  * @author Vedran Pavic
+ * @author daewon kim
  */
 class WebMvcAutoConfigurationTests {
 
@@ -1026,6 +1028,22 @@ class WebMvcAutoConfigurationTests {
 				.asInstanceOf(InstanceOfAssertFactories.list(Class.class))
 				.containsExactly(HighestOrderedControllerAdvice.class, ProblemDetailsExceptionHandler.class,
 						OrderedControllerAdviceBeansConfiguration.LowestOrderedControllerAdvice.class));
+	}
+
+	@Test
+	void jspViewResolverIsAutoConfiguredWhenJspPrefixIsSet() {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(WebMvcAutoConfiguration.class))
+			.withPropertyValues("spring.mvc.jsp.prefix=/WEB-INF/views/", "spring.mvc.jsp.suffix=.jsp")
+			.run((context) -> {
+				assertThat(context).hasSingleBean(InternalResourceViewResolver.class);
+
+				InternalResourceViewResolver resolver = context.getBean(InternalResourceViewResolver.class);
+				String prefix = (String) ReflectionTestUtils.getField(resolver, "prefix");
+				String suffix = (String) ReflectionTestUtils.getField(resolver, "suffix");
+
+				assertThat(prefix).isEqualTo("/WEB-INF/views/");
+				assertThat(suffix).isEqualTo(".jsp");
+			});
 	}
 
 	private void assertResourceHttpRequestHandler(AssertableWebApplicationContext context,

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/WebMvcPropertiesTests.java
@@ -61,6 +61,15 @@ class WebMvcPropertiesTests {
 			.satisfies((ex) -> assertThat(Throwables.getRootCause(ex)).hasMessage("'path' must not contain wildcards"));
 	}
 
+	@Test
+	void jspViewPropertiesBindingCorrectly() {
+		bind("spring.mvc.jsp.prefix", "/WEB-INF/views/");
+		bind("spring.mvc.jsp.suffix", ".jsp");
+
+		assertThat(this.properties.getJsp().getPrefix()).isEqualTo("/WEB-INF/views/");
+		assertThat(this.properties.getJsp().getSuffix()).isEqualTo(".jsp");
+	}
+
 	private void bind(String name, String value) {
 		bind(Collections.singletonMap(name, value));
 	}


### PR DESCRIPTION
Overview
---
- Updated WebMvcProperties to include a nested Jsp class for hierarchical binding.
- Registered a jspViewResolver bean when spring.mvc.jsp.prefix and spring.mvc.jsp.suffix are set.
- Added tests to verify property binding for JSP-specific prefix and suffix.


Related
---
ISSUE: #44924 

Note
---
I’m aware that the issue is currently labeled with `status: pending-design-work`, which suggests that the final design direction might still be under consideration. This implementation reflects my current understanding of the issue and is intended to serve as a starting point for discussion.

If this approach doesn't align with the intended design direction, please feel free to close the PR or share feedback — I’m happy to revise or take a different direction as needed. Thank you!
