### PR TITLE
Configuration properties changelog generator misses items that are removed without prior deprecation

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata-changelog-generator/src/main/java/org/springframework/boot/configurationmetadata/changelog/Changelog.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata-changelog-generator/src/main/java/org/springframework/boot/configurationmetadata/changelog/Changelog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataRepository;
+import org.springframework.boot.configurationmetadata.Deprecation;
 
 /**
  * A changelog containing differences computed from two repositories of configuration
@@ -32,6 +33,7 @@ import org.springframework.boot.configurationmetadata.ConfigurationMetadataRepos
  * @author Stephane Nicoll
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Yoobin Yoon
  */
 record Changelog(String oldVersionNumber, String newVersionNumber, List<Difference> differences) {
 
@@ -48,14 +50,24 @@ record Changelog(String oldVersionNumber, String newVersionNumber, List<Differen
 			String id = oldProperty.getId();
 			seenIds.add(id);
 			ConfigurationMetadataProperty newProperty = newMetadata.getAllProperties().get(id);
-			Difference difference = Difference.compute(oldProperty, newProperty);
-			if (difference != null) {
-				differences.add(difference);
+			if (newProperty == null) {
+				differences.add(new Difference(DifferenceType.DELETED, oldProperty, null));
+			}
+			else {
+				Difference difference = Difference.compute(oldProperty, newProperty);
+				if (difference != null) {
+					differences.add(difference);
+				}
 			}
 		}
 		for (ConfigurationMetadataProperty newProperty : newMetadata.getAllProperties().values()) {
-			if ((!seenIds.contains(newProperty.getId())) && (!newProperty.isDeprecated())) {
-				differences.add(new Difference(DifferenceType.ADDED, null, newProperty));
+			if (!seenIds.contains(newProperty.getId())) {
+				if (newProperty.isDeprecated() && newProperty.getDeprecation().getLevel() == Deprecation.Level.ERROR) {
+					differences.add(new Difference(DifferenceType.DELETED, null, newProperty));
+				}
+				else if (!newProperty.isDeprecated()) {
+					differences.add(new Difference(DifferenceType.ADDED, null, newProperty));
+				}
 			}
 		}
 		return List.copyOf(differences);

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata-changelog-generator/src/test/java/org/springframework/boot/configurationmetadata/changelog/ChangelogTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata-changelog-generator/src/test/java/org/springframework/boot/configurationmetadata/changelog/ChangelogTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Stephane Nicoll
  * @author Andy Wilkinson
+ * @author Yoobin Yoon
  */
 class ChangelogTests {
 
@@ -38,7 +39,7 @@ class ChangelogTests {
 		assertThat(differences).isNotNull();
 		assertThat(differences.oldVersionNumber()).isEqualTo("1.0");
 		assertThat(differences.newVersionNumber()).isEqualTo("2.0");
-		assertThat(differences.differences()).hasSize(4);
+		assertThat(differences.differences()).hasSize(5);
 		List<Difference> added = differences.differences()
 			.stream()
 			.filter((difference) -> difference.type() == DifferenceType.ADDED)
@@ -49,10 +50,12 @@ class ChangelogTests {
 			.stream()
 			.filter((difference) -> difference.type() == DifferenceType.DELETED)
 			.toList();
-		assertThat(deleted).hasSize(2)
+		assertThat(deleted).hasSize(3)
 			.anySatisfy((entry) -> assertProperty(entry.oldProperty(), "test.delete", String.class, "delete"))
 			.anySatisfy(
-					(entry) -> assertProperty(entry.newProperty(), "test.delete.deprecated", String.class, "delete"));
+					(entry) -> assertProperty(entry.newProperty(), "test.delete.deprecated", String.class, "delete"))
+			.anySatisfy((entry) -> assertProperty(entry.newProperty(), "test.removed.directly", String.class,
+					"directlyRemoved"));
 		List<Difference> deprecated = differences.differences()
 			.stream()
 			.filter((difference) -> difference.type() == DifferenceType.DEPRECATED)

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata-changelog-generator/src/test/resources/sample-2.0.json
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata-changelog-generator/src/test/resources/sample-2.0.json
@@ -31,6 +31,17 @@
         "replacement": "test.add",
         "reason": "it was just bad"
       }
+    },
+    {
+      "name": "test.removed.directly",
+      "type": "java.lang.String",
+      "description": "Test property removed without prior deprecation.",
+      "defaultValue": "directlyRemoved",
+      "deprecation": {
+        "level": "error",
+        "replacement": "test.new.property",
+        "reason": "Removed in Upgrade 10"
+      }
     }
   ]
 }

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata-changelog-generator/src/test/resources/sample.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata-changelog-generator/src/test/resources/sample.adoc
@@ -32,4 +32,8 @@ _None_.
 | `test.delete.deprecated`
 | `test.add`
 | it was just bad
+
+| `test.removed.directly`
+| `test.new.property`
+| Removed in Upgrade 10
 |======================


### PR DESCRIPTION
## Issue
Closes #40075 

The configuration properties changelog generator misses items that are removed without prior deprecation. When a property is removed without being deprecated first (like during the Flyway 10 upgrade), these changes are reflected in the metadata but not included in the generated changelog.

## Solution
Modified the `computeDifferences` method in the `Changelog` class to detect properties that only exist in the new metadata with error-level deprecation and properly mark them as DELETED in the changelog. This ensures that properties that are added to a new version with error-level deprecation (indicating immediate removal) are correctly included in the "Removed in X.X" section of the changelog.

Specifically, added logic to check for properties in the new metadata that
1. Don't exist in the old metadata
2. Have an error-level deprecation
3. Should be classified as DELETED rather than being ignored

## Tests
The existing test `diffContainsDifferencesBetweenLeftAndRightInputs` already verifies this functionality by testing that properties with error-level deprecation are properly classified as DELETED. 

To make the test cover this fix, we enhanced the `sample-2.0.json` test data to include an additional property (`test.removed.directly`) that demonstrates a property removed without prior deprecation, marked with error-level deprecation and a reason "Removed in Upgrade 10".

After fix, this test confirms that both regular removed properties and those marked with error-level deprecation are correctly included in the changelog.
