### PR TITLE
Introduce 'spring.test.print-condition-evaluation-report' property to control whether the condition evaluation report should be printed when the ApplicationContext fails to start

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/OnFailureConditionReportContextCustomizerFactory.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/OnFailureConditionReportContextCustomizerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,17 @@ class OnFailureConditionReportContextCustomizerFactory implements ContextCustomi
 
 		@Override
 		public void onApplicationEvent(ApplicationFailedEvent event) {
-			System.err.println(new ConditionEvaluationReportMessage(this.reportSupplier.get()));
+			if (shouldPrintReport(event.getApplicationContext())) {
+				System.err.println(new ConditionEvaluationReportMessage(this.reportSupplier.get()));
+			}
+		}
+
+		private static boolean shouldPrintReport(ConfigurableApplicationContext context) {
+			if (context == null) {
+				return true;
+			}
+			return context.getEnvironment()
+				.getProperty("spring.test.print-condition-evaluation-report", Boolean.class, true);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -17,6 +17,12 @@
       "type": "java.lang.Boolean",
       "description": "Whether observability should be auto-configured in tests.",
       "defaultValue": "false"
+    },
+    {
+      "name": "spring.test.print-condition-evaluation-report",
+      "type": "java.lang.Boolean",
+      "description": "Whether the condition evaluation report should be printed when the ApplicationContext fails to start.",
+      "defaultValue": "true"
     }
   ]
 }


### PR DESCRIPTION
See https://github.com/spring-projects/spring-boot/issues/44045