### PR TITLE
Use ConfigurableApplicationContext.BOOTSTRAP_EXECUTOR_BEAN_NAME where possible

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/task/TaskExecutorConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/task/TaskExecutorConfigurations.java
@@ -30,6 +30,7 @@ import org.springframework.boot.task.SimpleAsyncTaskExecutorBuilder;
 import org.springframework.boot.task.SimpleAsyncTaskExecutorCustomizer;
 import org.springframework.boot.task.ThreadPoolTaskExecutorBuilder;
 import org.springframework.boot.task.ThreadPoolTaskExecutorCustomizer;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -167,17 +168,16 @@ class TaskExecutorConfigurations {
 	@Configuration(proxyBeanMethods = false)
 	static class BootstrapExecutorConfiguration {
 
-		private static final String BOOTSTRAP_EXECUTOR_NAME = "bootstrapExecutor";
-
 		@Bean
 		static BeanFactoryPostProcessor bootstrapExecutorAliasPostProcessor() {
 			return (beanFactory) -> {
-				boolean hasBootstrapExecutor = beanFactory.containsBean(BOOTSTRAP_EXECUTOR_NAME);
+				boolean hasBootstrapExecutor = beanFactory
+					.containsBean(ConfigurableApplicationContext.BOOTSTRAP_EXECUTOR_BEAN_NAME);
 				boolean hasApplicationTaskExecutor = beanFactory
 					.containsBean(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME);
 				if (!hasBootstrapExecutor && hasApplicationTaskExecutor) {
 					beanFactory.registerAlias(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME,
-							BOOTSTRAP_EXECUTOR_NAME);
+							ConfigurableApplicationContext.BOOTSTRAP_EXECUTOR_BEAN_NAME);
 				}
 			};
 		}


### PR DESCRIPTION
This PR changes to use the `ConfigurableApplicationContext.BOOTSTRAP_EXECUTOR_BEAN_NAME` where possible.