### PR TITLE
Unlike the Docker CLI, "\x00" characters are not trimmed from a decoded Docker Registry password

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/DockerConfigurationMetadata.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/DockerConfigurationMetadata.java
@@ -219,11 +219,11 @@ final class DockerConfigurationMetadata {
 		Auth(JsonNode node) {
 			super(node, MethodHandles.lookup());
 			String auth = valueAt("/auth", String.class);
-			if (StringUtils.hasText(auth)) {
+			if (StringUtils.hasLength(auth)) {
 				String[] parts = new String(Base64.getDecoder().decode(auth)).split(":", 2);
 				Assert.state(parts.length == 2, "Malformed auth in docker configuration metadata");
 				this.username = parts[0];
-				this.password = parts[1];
+				this.password = trim(parts[1], Character.MIN_VALUE);
 			}
 			else {
 				this.username = valueAt("/username", String.class);
@@ -242,6 +242,11 @@ final class DockerConfigurationMetadata {
 
 		String getEmail() {
 			return this.email;
+		}
+
+		private static String trim(String source, char character) {
+			source = StringUtils.trimLeadingCharacter(source, character);
+			return StringUtils.trimTrailingCharacter(source, character);
 		}
 
 	}

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/configuration/DockerConfigurationMetadataTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/configuration/DockerConfigurationMetadataTests.java
@@ -125,7 +125,7 @@ class DockerConfigurationMetadataTests extends AbstractJsonTests {
 			.containsEntry("gcr.io", "gcr");
 		assertThat(configuration.getAuths()).hasSize(3).hasEntrySatisfying("https://index.docker.io/v1/", (auth) -> {
 			assertThat(auth.getUsername()).isEqualTo("username");
-			assertThat(auth.getPassword()).isEqualTo("password");
+			assertThat(auth.getPassword()).isEqualTo("pass\u0000word");
 			assertThat(auth.getEmail()).isEqualTo("test@gmail.com");
 		}).hasEntrySatisfying("custom-registry.example.com", (auth) -> {
 			assertThat(auth.getUsername()).isEqualTo("customUser");

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/resources/org/springframework/boot/buildpack/platform/docker/configuration/with-auth/config.json
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/resources/org/springframework/boot/buildpack/platform/docker/configuration/with-auth/config.json
@@ -1,7 +1,7 @@
 {
   "auths": {
     "https://index.docker.io/v1/": {
-      "auth": "dXNlcm5hbWU6cGFzc3dvcmQ=",
+      "auth": "dXNlcm5hbWU6AABwYXNzAHdvcmQAAA==",
       "email": "test@gmail.com"
     },
     "custom-registry.example.com": {


### PR DESCRIPTION
Docker CLI trims "\x00" from the decoded password.


https://github.com/docker/cli/blob/c8f9187157753e366ee9f25524b56f90913b47a5/cli/config/configfile/file.go#L253