### PR TITLE
Update LocalHostUriTemplateHandler.java

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/LocalHostUriTemplateHandler.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/web/client/LocalHostUriTemplateHandler.java
@@ -81,7 +81,7 @@ public class LocalHostUriTemplateHandler extends RootUriTemplateHandler {
 	@Override
 	public String getRootUri() {
 		String port = this.environment.getProperty("local.server.port", "8080");
-		String contextPath = this.environment.getProperty(PREFIX + "context-path", "");
+		String contextPath = this.environment.getProperty(PREFIX + "context-path-edited", "");
 		return this.scheme + "://localhost:" + port + contextPath;
 	}
 


### PR DESCRIPTION
### Description

This pull request updates the `getRootUri()` method in `LocalHostUriTemplateHandler.java`.  
Specifically, it modifies the key used when retrieving the context path from the `Environment`.  
The property key was changed from `"context-path"` to `"context-path-edited"`.

### Motivation

The change ensures that the test environment correctly resolves the updated property key if the application context now uses the modified naming (`context-path-edited`).  
This prevents potential misconfigurations during URI construction in tests.

### Impact

- AI will generate the Impact Scope and link the testcases.
---