### PR TITLE
Add a property to fail fast for unresolvable placeholders in @ConfigurationProperties

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBinder.java
@@ -49,8 +49,11 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.annotation.MergedAnnotations;
 import org.springframework.core.convert.ConversionService;
+import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertySources;
 import org.springframework.util.Assert;
+import org.springframework.util.PropertyPlaceholderHelper;
+import org.springframework.util.SystemPropertyUtils;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 import org.springframework.validation.annotation.Validated;
@@ -67,6 +70,8 @@ class ConfigurationPropertiesBinder {
 	private static final String BEAN_NAME = "org.springframework.boot.context.internalConfigurationPropertiesBinder";
 
 	private static final String VALIDATOR_BEAN_NAME = EnableConfigurationProperties.VALIDATOR_BEAN_NAME;
+
+	private static final String IGNORE_UNRESOLVABLE_PLACEHOLDER_PROPERTY = "spring.configurationproperties.ignore-unresolvable-placeholders";
 
 	private final ApplicationContext applicationContext;
 
@@ -191,7 +196,16 @@ class ConfigurationPropertiesBinder {
 	}
 
 	private PropertySourcesPlaceholdersResolver getPropertySourcesPlaceholdersResolver() {
-		return new PropertySourcesPlaceholdersResolver(this.propertySources);
+		return new PropertySourcesPlaceholdersResolver(this.propertySources, getPropertyPlaceholderHelper());
+	}
+
+	private PropertyPlaceholderHelper getPropertyPlaceholderHelper() {
+		Environment environment = this.applicationContext.getEnvironment();
+		boolean ignoreUnresolvablePlaceholders = environment.getProperty(IGNORE_UNRESOLVABLE_PLACEHOLDER_PROPERTY,
+				Boolean.class, true);
+		return new PropertyPlaceholderHelper(SystemPropertyUtils.PLACEHOLDER_PREFIX,
+				SystemPropertyUtils.PLACEHOLDER_SUFFIX, SystemPropertyUtils.VALUE_SEPARATOR,
+				SystemPropertyUtils.ESCAPE_CHARACTER, ignoreUnresolvablePlaceholders);
 	}
 
 	private List<ConversionService> getConversionServices() {

--- a/core/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -476,6 +476,13 @@
       "defaultValue": "application"
     },
     {
+      "name": "spring.configurationproperties.ignore-unresolvable-placeholders",
+      "type": "java.lang.Boolean",
+      "sourceType": "org.springframework.boot.context.properties.ConfigurationPropertiesBinder",
+      "description": "Whether unresolvable placeholders should be ignored or trigger an exception during the binding of configuration properties",
+      "defaultValue": "true"
+    },
+    {
       "name": "spring.jpa.defer-datasource-initialization",
       "type": "java.lang.Boolean",
       "description": "Whether to defer DataSource initialization until after any EntityManagerFactory beans have been created and initialized.",

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
@@ -187,6 +187,30 @@ class ConfigurationPropertiesTests {
 	}
 
 	@Test
+	void loadWhenIgnoreUnresolvablePlaceholdersSetsToFalseShouldFail() {
+		assertThatExceptionOfType(ConfigurationPropertiesBindException.class)
+			.isThrownBy(() -> load(BasicConfiguration.class, "name=${FOO}",
+					"spring.configurationproperties.ignore-unresolvable-placeholders=false"))
+			.withCauseInstanceOf(BindException.class)
+			.withStackTraceContaining("Could not resolve placeholder 'FOO'");
+	}
+
+	@Test
+	void loadWhenIgnoreUnresolvablePlaceholdersSetsToTrueShouldNotFail() {
+		load(BasicConfiguration.class, "name=${FOO}",
+				"spring.configurationproperties.ignore-unresolvable-placeholders=true");
+		BasicProperties properties = this.context.getBean(BasicProperties.class);
+		assertThat(properties.name).isEqualTo("${FOO}");
+	}
+
+	@Test
+	void loadWhenIgnoreUnresolvablePlaceholdersSetsToTrueByDefaultShouldNotFail() {
+		load(BasicConfiguration.class, "name=${FOO}");
+		BasicProperties properties = this.context.getBean(BasicProperties.class);
+		assertThat(properties.name).isEqualTo("${FOO}");
+	}
+
+	@Test
 	void loadWhenHasIgnoreUnknownFieldsFalseAndUnknownFieldsShouldFail() {
 		removeSystemProperties();
 		assertThatExceptionOfType(ConfigurationPropertiesBindException.class)


### PR DESCRIPTION
Introduce the `spring.configurationproperties.ignore-unresolvable-placeholders` property to control whether an exception should be thrown when a property placeholder `${...}` cannot be resolved.

See https://github.com/spring-projects/spring-boot/issues/18816
