### PR TITLE
DockerRegistryConfigAuthentication uses the wrong serverUrl as a fallback for the Credentials helper

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/DockerRegistryConfigAuthentication.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/DockerRegistryConfigAuthentication.java
@@ -85,14 +85,13 @@ class DockerRegistryConfigAuthentication implements DockerRegistryAuthentication
 	private DockerRegistryAuthentication getAuthentication(String serverUrl) {
 		Credential credentialsFromHelper = getCredentialsFromHelper(serverUrl);
 		Map.Entry<String, Auth> authConfigEntry = getAuthConfigEntry(serverUrl);
-		serverUrl = (authConfigEntry != null) ? authConfigEntry.getKey() : serverUrl;
 		Auth authConfig = (authConfigEntry != null) ? authConfigEntry.getValue() : null;
 		if (credentialsFromHelper != null) {
 			return getAuthentication(credentialsFromHelper, authConfig, serverUrl);
 		}
-		if (authConfigEntry != null) {
-			return DockerRegistryAuthentication.user(authConfig.getUsername(), authConfig.getPassword(), serverUrl,
-					authConfig.getEmail());
+		if (authConfig != null) {
+			return DockerRegistryAuthentication.user(authConfig.getUsername(), authConfig.getPassword(),
+					authConfigEntry.getKey(), authConfig.getEmail());
 		}
 		return this.fallback;
 	}


### PR DESCRIPTION
Before this commit, the credential helper used the `serverUrl`  from the `Map.Entry<String,Auth>` as a fallback. However, the helper only uses the `email` from the `auths`.

<details>

https://github.com/docker/cli/blob/b24e7f85a488da13dc2d5be87acdaab2652634bb/cli/config/credentials/native_store.go#L42-L56

```go
func (c *nativeStore) Get(serverAddress string) (types.AuthConfig, error) {
	// load user email if it exist or an empty auth config.
	auth, _ := c.fileStore.Get(serverAddress)
	creds, err := c.getCredentialsFromStore(serverAddress)
	if err != nil {
		return auth, err
	}
	auth.Username = creds.Username
	auth.IdentityToken = creds.IdentityToken
	auth.Password = creds.Password
	auth.ServerAddress = creds.ServerAddress
	return auth, nil
}
```
