### PR TITLE
Exclude AutoConfiguredCompositeMeterRegistry from global registry

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MeterRegistryPostProcessor.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/MeterRegistryPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.springframework.context.ApplicationContext;
  * @author Jon Schneider
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Yanming Zhou
  */
 class MeterRegistryPostProcessor implements BeanPostProcessor, SmartInitializingSingleton {
 
@@ -116,7 +117,8 @@ class MeterRegistryPostProcessor implements BeanPostProcessor, SmartInitializing
 	}
 
 	private void addToGlobalRegistryIfNecessary(MeterRegistry meterRegistry) {
-		if (this.properties.getObject().isUseGlobalRegistry() && !isGlobalRegistry(meterRegistry)) {
+		if (this.properties.getObject().isUseGlobalRegistry() && !isGlobalRegistry(meterRegistry)
+				&& !isAutoConfiguredComposite(meterRegistry)) {
 			Metrics.addRegistry(meterRegistry);
 		}
 	}


### PR DESCRIPTION
I think it's not necessary to add Spring Boot's auto-configured one to global registry, feel free to close if I'm wrong.