### PR TITLE
Apply detekt for unused imports to spring-boot-docs

### DIFF
--- a/spring-boot-project/spring-boot-docs/build.gradle
+++ b/spring-boot-project/spring-boot-docs/build.gradle
@@ -8,6 +8,7 @@ plugins {
 	id "org.springframework.boot.antora-dependencies"
 	id "org.springframework.boot.deployed"
 	id 'org.jetbrains.kotlin.jvm'
+	id "io.gitlab.arturbosch.detekt" version "1.23.8"
 }
 
 description = "Spring Boot Docs"
@@ -198,6 +199,10 @@ dependencies {
 
 dokkatoo {
 	moduleName.set("Spring Boot Kotlin API")
+}
+
+detekt {
+	config.setFrom("detekt.yml")
 }
 
 def aggregatedJavadoc = tasks.register('aggregatedJavadoc', Javadoc) {

--- a/spring-boot-project/spring-boot-docs/detekt.yml
+++ b/spring-boot-project/spring-boot-docs/detekt.yml
@@ -1,0 +1,3 @@
+style:
+  UnusedImports:
+    active: true

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/security/enablehttps/MySecurityConfig.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/security/enablehttps/MySecurityConfig.kt
@@ -18,7 +18,6 @@ package org.springframework.boot.docs.howto.security.enablehttps
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.security.config.Customizer
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.web.SecurityFilterChain
 

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/io/restclient/clienthttprequestfactory/configuration/MyClientHttpConfiguration.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/io/restclient/clienthttprequestfactory/configuration/MyClientHttpConfiguration.kt
@@ -4,7 +4,6 @@ import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.net.ProxySelector
-import java.net.http.HttpClient
 
 @Configuration(proxyBeanMethods = false)
 class MyClientHttpConfiguration {

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/io/restclient/webclient/configuration/MyConnectorHttpConfiguration.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/io/restclient/webclient/configuration/MyConnectorHttpConfiguration.kt
@@ -4,7 +4,6 @@ import org.springframework.boot.http.client.reactive.ClientHttpConnectorBuilder;
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.net.ProxySelector
-import java.net.http.HttpClient
 
 @Configuration(proxyBeanMethods = false)
 class MyConnectorHttpConfiguration {


### PR DESCRIPTION
This PR applies detekt for unused imports to the `spring-boot-docs` module.

This PR also removes unused imports that have been detected by it.

See gh-45555