### PR TITLE
Micrometer "enable" annotations property does not cover observed aspect

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,12 +39,15 @@ import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegi
 import org.springframework.boot.actuate.autoconfigure.tracing.MicrometerTracingAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 
@@ -159,12 +162,31 @@ public class ObservationAutoConfiguration {
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(Advice.class)
+	@Conditional(ObservationAnnotationsEnabledCondition.class)
 	static class ObservedAspectConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
 		ObservedAspect observedAspect(ObservationRegistry observationRegistry) {
 			return new ObservedAspect(observationRegistry);
+		}
+
+	}
+
+	static final class ObservationAnnotationsEnabledCondition extends AnyNestedCondition {
+
+		ObservationAnnotationsEnabledCondition() {
+			super(ConfigurationPhase.PARSE_CONFIGURATION);
+		}
+
+		@ConditionalOnProperty(prefix = "micrometer.observations.annotations", name = "enabled", havingValue = "true")
+		static class MicrometerObservationsEnabledCondition {
+
+		}
+
+		@ConditionalOnProperty(prefix = "management.observations.annotations", name = "enabled", havingValue = "true")
+		static class ManagementObservationsEnabledCondition {
+
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/ObservationAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,11 +66,13 @@ import static org.mockito.Mockito.mock;
 class ObservationAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().with(MetricsRun.simple())
+		.withPropertyValues("management.observations.annotations.enabled=true")
 		.withClassLoader(new FilteredClassLoader("io.micrometer.tracing"))
 		.withConfiguration(AutoConfigurations.of(ObservationAutoConfiguration.class));
 
 	private final ApplicationContextRunner tracingContextRunner = new ApplicationContextRunner()
 		.with(MetricsRun.simple())
+		.withPropertyValues("management.observations.annotations.enabled=true")
 		.withUserConfiguration(TracerConfiguration.class)
 		.withConfiguration(AutoConfigurations.of(ObservationAutoConfiguration.class));
 
@@ -141,6 +143,7 @@ class ObservationAutoConfigurationTests {
 	@Test
 	void supplyMeterHandlerAndGroupingWhenMicrometerCoreAndTracingAreOnClassPathButThereIsNoTracer() {
 		new ApplicationContextRunner().with(MetricsRun.simple())
+			.withPropertyValues("management.observations.annotations.enabled=true")
 			.withConfiguration(AutoConfigurations.of(ObservationAutoConfiguration.class))
 			.run((context) -> {
 				ObservationRegistry observationRegistry = context.getBean(ObservationRegistry.class);
@@ -178,6 +181,20 @@ class ObservationAutoConfigurationTests {
 	@Test
 	void allowsObservedAspectToBeDisabled() {
 		this.contextRunner.withClassLoader(new FilteredClassLoader(Advice.class))
+			.run((context) -> assertThat(context).doesNotHaveBean(ObservedAspect.class));
+	}
+
+	@Test
+	void allowsObservedAspectToBeEnabledWithDeprecatedProperty() {
+		this.contextRunner
+			.withPropertyValues("management.observations.annotations.enabled=false",
+					"micrometer.observations.annotations.enabled=true")
+			.run((context) -> assertThat(context).hasSingleBean(ObservedAspect.class));
+	}
+
+	@Test
+	void allowsObservedAspectToBeDisabledWithProperty() {
+		this.contextRunner.withPropertyValues("management.observations.annotations.enabled=false")
 			.run((context) -> assertThat(context).doesNotHaveBean(ObservedAspect.class));
 	}
 


### PR DESCRIPTION
See #45599 

When merging this into **main**, `ObservationAnnotationsEnabledCondition` should be removed and replaced with `@ConditionalOnBooleanProperty("management.observations.annotations.enabled")`, and the test `allowsObservedAspectToBeEnabledWithDeprecatedProperty` should also be removed.

Target branch is **3.3.x**
