### PR TITLE
Make heapdump endpoint restricted by default

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/management/HeapDumpWebEndpointAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/management/HeapDumpWebEndpointAutoConfigurationTests.java
@@ -36,13 +36,13 @@ class HeapDumpWebEndpointAutoConfigurationTests {
 
 	@Test
 	void runShouldCreateIndicator() {
-		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(HeapDumpWebEndpoint.class));
+		this.contextRunner.withPropertyValues("management.endpoint.heapdump.access:UNRESTRICTED")
+			.run((context) -> assertThat(context).hasSingleBean(HeapDumpWebEndpoint.class));
 	}
 
 	@Test
 	void runWhenDisabledShouldNotCreateIndicator() {
-		this.contextRunner.withPropertyValues("management.endpoint.heapdump.enabled:false")
-			.run((context) -> assertThat(context).doesNotHaveBean(HeapDumpWebEndpoint.class));
+		this.contextRunner.run((context) -> assertThat(context).doesNotHaveBean(HeapDumpWebEndpoint.class));
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/management/HeapDumpWebEndpointDocumentationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/management/HeapDumpWebEndpointDocumentationTests.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.restdocs.cli.CliDocumentation;
 import org.springframework.restdocs.cli.CurlRequestSnippet;
 import org.springframework.restdocs.operation.Operation;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.FileCopyUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +41,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
  *
  * @author Andy Wilkinson
  */
+@TestPropertySource(properties = "management.endpoint.heapdump.access=unrestricted")
 class HeapDumpWebEndpointDocumentationTests extends MockMvcEndpointDocumentationTests {
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/management/HeapDumpWebEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/management/HeapDumpWebEndpoint.java
@@ -36,6 +36,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.boot.actuate.endpoint.Access;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
@@ -56,7 +57,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Andy Wilkinson
  * @since 2.0.0
  */
-@WebEndpoint(id = "heapdump")
+@WebEndpoint(id = "heapdump", defaultAccess = Access.NONE)
 public class HeapDumpWebEndpoint {
 
 	private final long timeout;

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/endpoints.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/endpoints.adoc
@@ -120,7 +120,7 @@ If your application is a web application (Spring MVC, Spring WebFlux, or Jersey)
 [[actuator.endpoints.controlling-access]]
 == Controlling Access to Endpoints
 
-By default, access to all endpoints except for `shutdown` is unrestricted.
+By default, access to all endpoints except for `shutdown` and `heapdump` is unrestricted.
 To configure the permitted access to an endpoint, use its `management.endpoint.<id>.access` property.
 The following example allows unrestricted access to the `shutdown` endpoint:
 


### PR DESCRIPTION
In Spring Boot, all actuator endpoints other than `shutdown` are "unrestricted" by default.
For misconfigured Spring Boot applications, it would improve security when the `heapdump` actuator endpoint is restricted by default.