### PR TITLE
Reuse properties from field to create PropertiesKafkaConnectionDetails

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfiguration.java
@@ -93,9 +93,8 @@ public class KafkaAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(KafkaConnectionDetails.class)
-	PropertiesKafkaConnectionDetails kafkaConnectionDetails(KafkaProperties properties,
-			ObjectProvider<SslBundles> sslBundles) {
-		return new PropertiesKafkaConnectionDetails(properties, sslBundles.getIfAvailable());
+	PropertiesKafkaConnectionDetails kafkaConnectionDetails(ObjectProvider<SslBundles> sslBundles) {
+		return new PropertiesKafkaConnectionDetails(this.properties, sslBundles.getIfAvailable());
 	}
 
 	@Bean


### PR DESCRIPTION
AutoConfigurations such as `RabbitAutoConfiguration` and `CassandraAutoConfiguration` will reuse properties injected by the constructor.