### PR TITLE
Example of using prometheus-metrics-exporter-pushgateway has wrong artifactId

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/metrics.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/metrics.adoc
@@ -559,7 +559,7 @@ To enable Prometheus Pushgateway support, add the following dependency to your p
 ----
 <dependency>
 	<groupId>io.prometheus</groupId>
-	<artifactId>io.prometheus:prometheus-metrics-exporter-pushgateway</artifactId>
+	<artifactId>prometheus-metrics-exporter-pushgateway</artifactId>
 </dependency>
 ----
 


### PR DESCRIPTION
MAven coordinates for io.prometheus:prometheus-metrics-exporter-pushgateway were duplicating the groupId inside the artifactId.
