### PR TITLE
Remove buildConsumerProperties(SslBundles) from KafkaProperties

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaProperties.java
@@ -187,21 +187,8 @@ public class KafkaProperties {
 	 * instance
 	 */
 	public Map<String, Object> buildConsumerProperties() {
-		return buildConsumerProperties(null);
-	}
-
-	/**
-	 * Create an initial map of consumer properties from the state of this instance.
-	 * <p>
-	 * This allows you to add additional properties, if necessary, and override the
-	 * default {@code kafkaConsumerFactory} bean.
-	 * @param sslBundles bundles providing SSL trust material
-	 * @return the consumer properties initialized with the customizations defined on this
-	 * instance
-	 */
-	public Map<String, Object> buildConsumerProperties(SslBundles sslBundles) {
-		Map<String, Object> properties = buildCommonProperties(sslBundles);
-		properties.putAll(this.consumer.buildProperties(sslBundles));
+		Map<String, Object> properties = buildCommonProperties(null);
+		properties.putAll(this.consumer.buildProperties(null));
 		return properties;
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/kafka/KafkaPropertiesTests.java
@@ -27,8 +27,6 @@ import org.springframework.boot.autoconfigure.kafka.KafkaProperties.Cleanup;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties.IsolationLevel;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties.Listener;
 import org.springframework.boot.context.properties.source.MutuallyExclusiveConfigurationPropertiesException;
-import org.springframework.boot.ssl.DefaultSslBundleRegistry;
-import org.springframework.boot.ssl.SslBundle;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.kafka.core.CleanupConfig;
 import org.springframework.kafka.core.KafkaAdmin;
@@ -36,7 +34,6 @@ import org.springframework.kafka.listener.ContainerProperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link KafkaProperties}.
@@ -46,8 +43,6 @@ import static org.mockito.Mockito.mock;
  * @author Scott Frederick
  */
 class KafkaPropertiesTests {
-
-	private final SslBundle sslBundle = mock(SslBundle.class);
 
 	@Test
 	void isolationLevelEnumConsistentWithKafkaVersion() {
@@ -102,15 +97,6 @@ class KafkaPropertiesTests {
 	}
 
 	@Test
-	void sslBundleConfiguration() {
-		KafkaProperties properties = new KafkaProperties();
-		properties.getSsl().setBundle("myBundle");
-		Map<String, Object> consumerProperties = properties
-			.buildConsumerProperties(new DefaultSslBundleRegistry("myBundle", this.sslBundle));
-		assertThat(consumerProperties).doesNotContainKey(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG);
-	}
-
-	@Test
 	void sslPropertiesWhenKeyStoreLocationAndKeySetShouldThrowException() {
 		KafkaProperties properties = new KafkaProperties();
 		properties.getSsl().setKeyStoreKey("-----BEGIN");
@@ -126,42 +112,6 @@ class KafkaPropertiesTests {
 		properties.getSsl().setTrustStoreCertificates("-----BEGIN");
 		assertThatExceptionOfType(MutuallyExclusiveConfigurationPropertiesException.class)
 			.isThrownBy(properties::buildConsumerProperties);
-	}
-
-	@Test
-	void sslPropertiesWhenKeyStoreLocationAndBundleSetShouldThrowException() {
-		KafkaProperties properties = new KafkaProperties();
-		properties.getSsl().setBundle("myBundle");
-		properties.getSsl().setKeyStoreLocation(new ClassPathResource("ksLoc"));
-		assertThatExceptionOfType(MutuallyExclusiveConfigurationPropertiesException.class).isThrownBy(
-				() -> properties.buildConsumerProperties(new DefaultSslBundleRegistry("myBundle", this.sslBundle)));
-	}
-
-	@Test
-	void sslPropertiesWhenKeyStoreKeyAndBundleSetShouldThrowException() {
-		KafkaProperties properties = new KafkaProperties();
-		properties.getSsl().setBundle("myBundle");
-		properties.getSsl().setKeyStoreKey("-----BEGIN");
-		assertThatExceptionOfType(MutuallyExclusiveConfigurationPropertiesException.class).isThrownBy(
-				() -> properties.buildConsumerProperties(new DefaultSslBundleRegistry("myBundle", this.sslBundle)));
-	}
-
-	@Test
-	void sslPropertiesWhenTrustStoreLocationAndBundleSetShouldThrowException() {
-		KafkaProperties properties = new KafkaProperties();
-		properties.getSsl().setBundle("myBundle");
-		properties.getSsl().setTrustStoreLocation(new ClassPathResource("tsLoc"));
-		assertThatExceptionOfType(MutuallyExclusiveConfigurationPropertiesException.class).isThrownBy(
-				() -> properties.buildConsumerProperties(new DefaultSslBundleRegistry("myBundle", this.sslBundle)));
-	}
-
-	@Test
-	void sslPropertiesWhenTrustStoreCertificatesAndBundleSetShouldThrowException() {
-		KafkaProperties properties = new KafkaProperties();
-		properties.getSsl().setBundle("myBundle");
-		properties.getSsl().setTrustStoreCertificates("-----BEGIN");
-		assertThatExceptionOfType(MutuallyExclusiveConfigurationPropertiesException.class).isThrownBy(
-				() -> properties.buildConsumerProperties(new DefaultSslBundleRegistry("myBundle", this.sslBundle)));
 	}
 
 	@Test


### PR DESCRIPTION
This PR removes the deprecated buildConsumerProperties(SslBundles) method from the KafkaProperties class.

It also removes the test code that uses the removed method.

[gh-45722](https://github.com/spring-projects/spring-boot/issues/45722)