### PR TITLE
Assign distinct order values to Management customizers to prevent con…

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementWebServerFactoryCustomizer.java
@@ -68,7 +68,7 @@ public class ManagementWebServerFactoryCustomizer<T extends ConfigurableWebServe
 
 	@Override
 	public int getOrder() {
-		return 0;
+		return Ordered.HIGHEST_PRECEDENCE + 10;
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/servlet/WebMvcEndpointChildContextConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/servlet/WebMvcEndpointChildContextConfiguration.java
@@ -128,7 +128,7 @@ class WebMvcEndpointChildContextConfiguration {
 
 		@Override
 		public int getOrder() {
-			return 0;
+			return Ordered.HIGHEST_PRECEDENCE + 11;
 		}
 
 	}


### PR DESCRIPTION
Closes #45728

This PR fixes a bug where `ManagementWebServerFactoryCustomizer` and `ManagementErrorPageCustomizer` had the same `getOrder()` value, which could lead to non-deterministic customizer execution during application startup.

Changes made:
- Updated `ManagementWebServerFactoryCustomizer` to return `Ordered.HIGHEST_PRECEDENCE + 10`
- Updated `ManagementErrorPageCustomizer` to return `Ordered.HIGHEST_PRECEDENCE + 11`

This ensures deterministic order between the two customizers.