### PR TITLE
Assign distinct order values to Management customizers to prevent con…

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementWebServerFactoryCustomizer.java
@@ -68,7 +68,7 @@ public class ManagementWebServerFactoryCustomizer<T extends ConfigurableWebServe
 
 	@Override
 	public int getOrder() {
-		return 0;
+		return Ordered.HIGHEST_PRECEDENCE + 10;
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/servlet/WebMvcEndpointChildContextConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/servlet/WebMvcEndpointChildContextConfiguration.java
@@ -128,7 +128,7 @@ class WebMvcEndpointChildContextConfiguration {
 
 		@Override
 		public int getOrder() {
-			return 0;
+			return Ordered.HIGHEST_PRECEDENCE + 11;
 		}
 
 	}


### PR DESCRIPTION
Closes #45728

Currently, both `ManagementWebServerFactoryCustomizer` and `ManagementErrorPageCustomizer` return the same order value, which can lead to non-deterministic behavior during application startup.

This pull request assigns distinct order values using the `Ordered` interface:
- `ManagementWebServerFactoryCustomizer`: returns `Ordered.HIGHEST_PRECEDENCE + 10`
- `ManagementErrorPageCustomizer`: returns `Ordered.HIGHEST_PRECEDENCE + 11`

This change ensures a deterministic execution order for the management-related web server customizers.
