### PR TITLE
Deprecation replacement for spring.codec.* properties has a typo

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/codec/CodecProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/codec/CodecProperties.java
@@ -45,7 +45,7 @@ public class CodecProperties {
 	 */
 	private DataSize maxInMemorySize;
 
-	@DeprecatedConfigurationProperty(since = "3.5.0", replacement = "spring.http.codec.log-request-details")
+	@DeprecatedConfigurationProperty(since = "3.5.0", replacement = "spring.http.codecs.log-request-details")
 	public boolean isLogRequestDetails() {
 		return this.logRequestDetails;
 	}
@@ -54,7 +54,7 @@ public class CodecProperties {
 		this.logRequestDetails = logRequestDetails;
 	}
 
-	@DeprecatedConfigurationProperty(since = "3.5.0", replacement = "spring.http.codec.max-in-memory-size")
+	@DeprecatedConfigurationProperty(since = "3.5.0", replacement = "spring.http.codecs.max-in-memory-size")
 	public DataSize getMaxInMemorySize() {
 		return this.maxInMemorySize;
 	}


### PR DESCRIPTION
The replacement properties for the now deprecated configuration properties `spring.codec.*` have a slight typo in them:
`spring.http.codec.log-request-details`
`spring.http.codec.max-in-memory-size`

The correct replacement properties should be:
`spring.http.codecs.log-request-details`
`spring.http.codecs.max-in-memory-size`

(note the missing **s** in codec**s**)

I noticed this when upgrading to Spring Boot 3.5 and saw the warning in IntelliJ:
![image](https://github.com/user-attachments/assets/69420b66-383a-44e0-b7fb-7328cfbad945)

![image](https://github.com/user-attachments/assets/cffc4c08-51a1-4c24-b690-e615ea32ed69)


See #44971