### PR TITLE
docs(#45747): remove management.health.influxdb.enabled documentation

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -167,12 +167,6 @@
       }
     },
     {
-      "name": "management.health.influxdb.enabled",
-      "type": "java.lang.Boolean",
-      "description": "Whether to enable InfluxDB health check.",
-      "defaultValue": true
-    },
-    {
       "name": "management.health.jms.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to enable JMS health check.",


### PR DESCRIPTION
This PR removes `management.health.influxdb.enabled` configuration property from `additional-spring-configuration-metadata.json`.

closes #45747 
