### PR TITLE
fix(docs): Fix broken links to testcontainers-junit-jupiter

### DIFF
--- a/buildSrc/src/main/resources/org/springframework/boot/build/antora/antora-asciidoc-attributes.properties
+++ b/buildSrc/src/main/resources/org/springframework/boot/build/antora/antora-asciidoc-attributes.properties
@@ -77,6 +77,7 @@ url-spring-data-rest-site=https://spring.io/projects/spring-data-rest
 url-spring-data-rest-javadoc=https://docs.spring.io/spring-data/rest/docs/{dotxversion-spring-data-rest}/api
 url-spring-data-site=https://spring.io/projects/spring-data
 url-testcontainers-docs=https://java.testcontainers.org
+url-testcontainers-junit-jupiter-javadoc=https://javadoc.io/doc/org.testcontainers/junit-jupiter/{version-testcontainers-junit-jupiter}
 url-testcontainers-activemq-javadoc=https://javadoc.io/doc/org.testcontainers/activemq/{version-testcontainers-activemq}
 url-testcontainers-cassandra-javadoc=https://javadoc.io/doc/org.testcontainers/cassandra/{version-testcontainers-cassandra}
 url-testcontainers-couchbase-javadoc=https://javadoc.io/doc/org.testcontainers/couchbase/{version-testcontainers-couchbase}

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
@@ -29,11 +29,11 @@ TIP: This method of managing containers is often used in combination with xref:#
 == Using the JUnit Extension
 
 Testcontainers provides a JUnit extension which can be used to manage containers in your tests.
-The extension is activated by applying the javadoc:org.testcontainers.junit.jupiter.Testcontainers[format=annotation] annotation from Testcontainers to your test class.
+The extension is activated by applying the javadoc:{url-testcontainers-junit-jupiter}/org.testcontainers.junit.jupiter.Testcontainers[format=annotation] annotation from Testcontainers to your test class.
 
-You can then use the javadoc:org.testcontainers.junit.jupiter.Container[format=annotation] annotation on static container fields.
+You can then use the javadoc:{url-testcontainers-junit-jupiter}/org.testcontainers.junit.jupiter.Container[format=annotation] annotation on static container fields.
 
-The javadoc:org.testcontainers.junit.jupiter.Testcontainers[format=annotation] annotation can be used on vanilla JUnit tests, or in combination with javadoc:org.springframework.boot.test.context.SpringBootTest[format=annotation]:
+The javadoc:{url-testcontainers-junit-jupiter}/org.testcontainers.junit.jupiter.Testcontainers[format=annotation] annotation can be used on vanilla JUnit tests, or in combination with javadoc:org.springframework.boot.test.context.SpringBootTest[format=annotation]:
 
 include-code::MyIntegrationTests[]
 


### PR DESCRIPTION
The updated links were semi-broken. They did not point to where they shall point, but redirected to the docs startpage.

The build fails due to the following, so please dont start the CI yet :)
I am struggeling to find out where the version is picked up from.
Grepping for the other testcontainer url definitions did lead me to the [anthora.yml](spring-boot-project/spring-boot-docs/src/docs/antora/antora.yml) which apparently picks the versions up from the version catalog.
However I struggle to find the catalog.

I'd be happy if a maintainer could point me to the right place or fixup the commit directly.
Thanks!