### PR TITLE
Align default value of maxParameterCount with Tomcat (1000)

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -517,7 +517,7 @@ public class ServerProperties {
 		 * Maximum number of parameters (GET plus POST) that will be automatically parsed
 		 * by the container. A value of less than 0 means no limit.
 		 */
-		private int maxParameterCount = 10000;
+		private int maxParameterCount = 1000;
 
 		/**
 		 * Whether to use APR.


### PR DESCRIPTION
This PR updates the default value of `maxParameterCount` in `ServerProperties.Tomcat` from `10000` to `1000` to align with the default value used in Tomcat.

See: [Tomcat source](https://github.com/apache/tomcat/blob/cd2cb43579161cdd17cdebf49d4a4b828a45cccb/webapps/docs/config/http.xml#L181)

If the current value was set to 10000 intentionally, please feel free to close this PR. Just wanted to flag the discrepancy in case it was unintentional.

If the current value is indeed intentional and you feel it would be helpful to clarify this in the JavaDoc, I’d be happy to submit a follow-up PR for that as well.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
