### PR TITLE
Add support for configuring Tomcat connector maxPartCount and maxPartHeaderSize

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/ServerProperties.java
@@ -73,6 +73,7 @@ import org.springframework.util.unit.DataSize;
  * @author Florian Storz
  * @author Michael Weidmann
  * @author Lasse Wulff
+ * @author Daeho Kwon
  * @since 1.0.0
  */
 @ConfigurationProperties("server")
@@ -520,6 +521,21 @@ public class ServerProperties {
 		private int maxParameterCount = 10000;
 
 		/**
+		 * The maximum total number of parts permitted in a request where the content type
+		 * is multipart/form-data. This limit is in addition to maxParameterCount.
+		 * Requests that exceed this limit will be rejected. A value of less than 0 means
+		 * no limit.
+		 */
+		private int maxPartCount = 10;
+
+		/**
+		 * The maximum number of header bytes permitted per part in a request where the
+		 * content type is multipart/form-data. Requests that exceed this limit will be
+		 * rejected. A value of less than 0 means no limit.
+		 */
+		private DataSize maxPartHeaderSize = DataSize.ofBytes(512);
+
+		/**
 		 * Whether to use APR.
 		 */
 		private UseApr useApr = UseApr.NEVER;
@@ -686,6 +702,22 @@ public class ServerProperties {
 
 		public void setMaxParameterCount(int maxParameterCount) {
 			this.maxParameterCount = maxParameterCount;
+		}
+
+		public int getMaxPartCount() {
+			return this.maxPartCount;
+		}
+
+		public void setMaxPartCount(int maxPartCount) {
+			this.maxPartCount = maxPartCount;
+		}
+
+		public DataSize getMaxPartHeaderSize() {
+			return this.maxPartHeaderSize;
+		}
+
+		public void setMaxPartHeaderSize(DataSize maxPartHeaderSize) {
+			this.maxPartHeaderSize = maxPartHeaderSize;
 		}
 
 		public UseApr getUseApr() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizer.java
@@ -62,6 +62,7 @@ import org.springframework.util.unit.DataSize;
  * @author Parviz Rozikov
  * @author Florian Storz
  * @author Michael Weidmann
+ * @author Daeho Kwon
  * @since 2.0.0
  */
 public class TomcatWebServerFactoryCustomizer
@@ -121,6 +122,10 @@ public class TomcatWebServerFactoryCustomizer
 			.to((maxHttpFormPostSize) -> customizeMaxHttpFormPostSize(factory, maxHttpFormPostSize));
 		map.from(properties::getMaxParameterCount)
 			.to((maxParameterCount) -> customizeMaxParameterCount(factory, maxParameterCount));
+		map.from(properties::getMaxPartCount).to((maxPartCount) -> customizeMaxPartCount(factory, maxPartCount));
+		map.from(properties::getMaxPartHeaderSize)
+			.asInt(DataSize::toBytes)
+			.to((maxPartHeaderSize) -> customizeMaxPartHeaderSize(factory, maxPartHeaderSize));
 		map.from(properties::getAccesslog)
 			.when(ServerProperties.Tomcat.Accesslog::isEnabled)
 			.to((enabled) -> customizeAccessLog(factory));
@@ -296,6 +301,14 @@ public class TomcatWebServerFactoryCustomizer
 
 	private void customizeMaxParameterCount(ConfigurableTomcatWebServerFactory factory, int maxParameterCount) {
 		factory.addConnectorCustomizers((connector) -> connector.setMaxParameterCount(maxParameterCount));
+	}
+
+	private void customizeMaxPartCount(ConfigurableTomcatWebServerFactory factory, int maxPartCount) {
+		factory.addConnectorCustomizers((connector) -> connector.setMaxPartCount(maxPartCount));
+	}
+
+	private void customizeMaxPartHeaderSize(ConfigurableTomcatWebServerFactory factory, int maxPartHeaderSize) {
+		factory.addConnectorCustomizers((connector) -> connector.setMaxPartHeaderSize(maxPartHeaderSize));
 	}
 
 	private void customizeAccessLog(ConfigurableTomcatWebServerFactory factory) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/ServerPropertiesTests.java
@@ -71,6 +71,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Parviz Rozikov
  * @author Lasse Wulff
  * @author Moritz Halbritter
+ * @author Daeho Kwon
  */
 @DirtiesUrlFactories
 class ServerPropertiesTests {
@@ -255,6 +256,18 @@ class ServerPropertiesTests {
 	}
 
 	@Test
+	void testCustomizeTomcatMaxPartCount() {
+		bind("server.tomcat.max-part-count", "20");
+		assertThat(this.properties.getTomcat().getMaxPartCount()).isEqualTo(20);
+	}
+
+	@Test
+	void testCustomizeTomcatMaxPartHeaderSize() {
+		bind("server.tomcat.max-part-header-size", "1024");
+		assertThat(this.properties.getTomcat().getMaxPartHeaderSize()).isEqualTo(DataSize.ofKilobytes(1));
+	}
+
+	@Test
 	void testCustomizeTomcatMinSpareThreads() {
 		bind("server.tomcat.threads.min-spare", "10");
 		assertThat(this.properties.getTomcat().getThreads().getMinSpare()).isEqualTo(10);
@@ -391,6 +404,17 @@ class ServerPropertiesTests {
 	void tomcatMaxParameterCountMatchesConnectorDefault() {
 		assertThat(this.properties.getTomcat().getMaxParameterCount())
 			.isEqualTo(getDefaultConnector().getMaxParameterCount());
+	}
+
+	@Test
+	void tomcatMaxPartCountMatchesConnectorDefault() {
+		assertThat(this.properties.getTomcat().getMaxPartCount()).isEqualTo(getDefaultConnector().getMaxPartCount());
+	}
+
+	@Test
+	void tomcatMaxPartHeaderSizeMatchesConnectorDefault() {
+		assertThat(this.properties.getTomcat().getMaxPartHeaderSize().toBytes())
+			.isEqualTo(getDefaultConnector().getMaxPartHeaderSize());
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizerTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/embedded/TomcatWebServerFactoryCustomizerTests.java
@@ -59,6 +59,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Victor Mandujano
  * @author Parviz Rozikov
  * @author Moritz Halbritter
+ * @author Daeho Kwon
  */
 class TomcatWebServerFactoryCustomizerTests {
 
@@ -199,6 +200,20 @@ class TomcatWebServerFactoryCustomizerTests {
 		bind("server.tomcat.max-parameter-count=100");
 		customizeAndRunServer(
 				(server) -> assertThat(server.getTomcat().getConnector().getMaxParameterCount()).isEqualTo(100));
+	}
+
+	@Test
+	void customMaxPartCount() {
+		bind("server.tomcat.max-part-count=20");
+		customizeAndRunServer(
+				(server) -> assertThat(server.getTomcat().getConnector().getMaxPartCount()).isEqualTo(20));
+	}
+
+	@Test
+	void customMaxPartHeaderSize() {
+		bind("server.tomcat.max-part-header-size=1024");
+		customizeAndRunServer(
+				(server) -> assertThat(server.getTomcat().getConnector().getMaxPartHeaderSize()).isEqualTo(1024));
 	}
 
 	@Test


### PR DESCRIPTION
This PR addresses gh-45881.

- Expose `server.tomcat.max-part-count` (default 10)  
- Expose `server.tomcat.max-part-header-size` (default 512B)  
- Bind in `TomcatWebServerFactoryCustomizer`  
- Add tests for custom and default values  


<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
