### PR TITLE
Fix typo in variable name

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/batch/BatchAutoConfiguration.java
@@ -104,7 +104,7 @@ public class BatchAutoConfiguration {
 
 		private final PlatformTransactionManager transactionManager;
 
-		private final TaskExecutor taskExector;
+		private final TaskExecutor taskExecutor;
 
 		private final BatchProperties properties;
 
@@ -123,7 +123,7 @@ public class BatchAutoConfiguration {
 				ObjectProvider<JobParametersConverter> jobParametersConverter) {
 			this.dataSource = batchDataSource.getIfAvailable(() -> dataSource);
 			this.transactionManager = batchTransactionManager.getIfAvailable(() -> transactionManager);
-			this.taskExector = batchTaskExecutor.getIfAvailable();
+			this.taskExecutor = batchTaskExecutor.getIfAvailable();
 			this.properties = properties;
 			this.batchConversionServiceCustomizers = batchConversionServiceCustomizers.orderedStream().toList();
 			this.executionContextSerializer = executionContextSerializer.getIfAvailable();
@@ -180,7 +180,7 @@ public class BatchAutoConfiguration {
 
 		@Override
 		protected TaskExecutor getTaskExecutor() {
-			return (this.taskExector != null) ? this.taskExector : super.getTaskExecutor();
+			return (this.taskExecutor != null) ? this.taskExecutor : super.getTaskExecutor();
 		}
 
 	}


### PR DESCRIPTION
This PR fixes a minor typo in the variable name `taskExector` → `taskExecutor` in `BatchAutoConfiguration`.

The type of the field is `TaskExecutor`, so the corrected spelling improves naming consistency and avoids confusion when reading or searching the codebase.

A scan of the Spring Boot codebase suggests that this is the only occurrence of the `Exector` misspelling.

No functional changes.


<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
