### PR TITLE
Upgrade to jOOQ 3.19.24 and use its BOM

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -1032,18 +1032,13 @@ bom {
 			]
 		}
 	}
-	library("jOOQ", "3.19.23") {
+	library("jOOQ", "3.19.24") {
 		prohibit {
 			versionRange "[3.20.0,)"
 			because "it requires Java 21"
 		}
 		group("org.jooq") {
-			modules = [
-				"jooq",
-				"jooq-codegen",
-				"jooq-kotlin",
-				"jooq-meta"
-			]
+			bom("jooq-bom")
 			plugins = [
 				"jooq-codegen-maven"
 			]


### PR DESCRIPTION
jOOQ started publishing a BOM with versions [3.18.31](https://github.com/jOOQ/jOOQ/releases/tag/version-3.18.31),  [3.19.24](https://github.com/jOOQ/jOOQ/releases/tag/version-3.19.24), and [3.20.5](https://github.com/jOOQ/jOOQ/releases/tag/version-3.20.5). This PR updates jOOQ from 3.19.23 to 3.19.24 and replaces the dependency management of selected jOOQ modules with the BOM.