### PR TITLE
Fix typo

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/SslInfo.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/info/SslInfo.java
@@ -50,7 +50,7 @@ public class SslInfo {
 
 	/**
 	 * Creates a new instance.
-	 * @param sslBundles the {@link SslBundles} to extract the info from threshold
+	 * @param sslBundles the {@link SslBundles} to extract the info from
 	 * @since 4.0.0
 	 */
 	public SslInfo(SslBundles sslBundles) {


### PR DESCRIPTION
It seems to have been appended accidentally in a8cb6cf21a11881c631ac5a8870b2d2e6efaa9ad.