### PR TITLE
Update documentation to reflect changes in TestRestTemplate's default redirect behavior

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/test-utilities.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/test-utilities.adoc
@@ -55,8 +55,9 @@ It is recommended, but not mandatory, to use the Apache HTTP Client (version 5.1
 If you have that on your classpath, the javadoc:org.springframework.boot.test.web.client.TestRestTemplate[] responds by configuring the client appropriately.
 If you do use Apache's HTTP client, some additional test-friendly features are enabled:
 
-* Redirects are not followed (so you can assert the response location).
 * Cookies are ignored (so the template is stateless).
+
+By default, `TestRestTemplate` follows redirects in the same way as `RestTemplate`, regardless of which HTTP client implementation is used.
 
 javadoc:org.springframework.boot.test.web.client.TestRestTemplate[] can be instantiated directly in your integration tests, as shown in the following example:
 


### PR DESCRIPTION
fix issue:  #45842
I went though the previous PR and changed the documentation . 

I have removed :
Redirects are not followed  (so you can assert the response location).
I added :
By default, `TestRestTemplate` follows redirects in the same way as `RestTemplate`, regardless of which HTTP client implementation is used.

please feel free to suggest any changes . 


