### PR TITLE
Use method reference instead of lambda expression

### DIFF
--- a/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/context/DynamicPropertySourceMethodsImporter.java
+++ b/spring-boot-project/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/context/DynamicPropertySourceMethodsImporter.java
@@ -50,7 +50,7 @@ class DynamicPropertySourceMethodsImporter {
 		if (methods.isEmpty()) {
 			return;
 		}
-		methods.forEach((method) -> assertValid(method));
+		methods.forEach(this::assertValid);
 		RootBeanDefinition registrarDefinition = new RootBeanDefinition();
 		registrarDefinition.setBeanClass(DynamicPropertySourcePropertyRegistrar.class);
 		ConstructorArgumentValues arguments = new ConstructorArgumentValues();


### PR DESCRIPTION
Refactor explicit loops to forEach method references for improved readability.