### PR TITLE
Extract constant and unify messages in Log4JCoreLoggerContextCondition

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/Log4J2MetricsAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/Log4J2MetricsAutoConfiguration.java
@@ -54,20 +54,20 @@ public class Log4J2MetricsAutoConfiguration {
 
 	static class Log4JCoreLoggerContextCondition extends SpringBootCondition {
 
+		private static final String LOGGER_CONTEXT_CLASS_NAME = "org.apache.logging.log4j.core.LoggerContext";
+
 		@Override
 		public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
 			LoggerContext loggerContext = LogManager.getContext(false);
 			try {
-				if (Class.forName("org.apache.logging.log4j.core.LoggerContext").isInstance(loggerContext)) {
-					return ConditionOutcome
-						.match("LoggerContext was an instance of org.apache.logging.log4j.core.LoggerContext");
+				if (Class.forName(LOGGER_CONTEXT_CLASS_NAME).isInstance(loggerContext)) {
+					return ConditionOutcome.match("LoggerContext was an instance of " + LOGGER_CONTEXT_CLASS_NAME);
 				}
 			}
 			catch (Throwable ex) {
 				// Continue with no match
 			}
-			return ConditionOutcome
-				.noMatch("Logger context was not an instance of org.apache.logging.log4j.core.LoggerContext");
+			return ConditionOutcome.noMatch("LoggerContext was not an instance of " + LOGGER_CONTEXT_CLASS_NAME);
 		}
 
 	}


### PR DESCRIPTION
This PR improves the readability and consistency of `Log4JCoreLoggerContextCondition` by:

- Extracting the fully qualified class name `"org.apache.logging.log4j.core.LoggerContext"` into a constant named `LOGGER_CONTEXT_CLASS_NAME`
- Using the constant in both the runtime type check (`Class.forName(...)`) and the `ConditionOutcome.match()` / `noMatch()` messages
- Unifying the wording of outcome messages by replacing "Logger context" with "LoggerContext", to match the class name and reduce ambiguity

These small improvements help reduce duplication and improve maintainability without changing any functional logic.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
