### PR TITLE
 DataSouceBuilder can fail with a NPE when the driver is null

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DataSourceBuilder.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jdbc/DataSourceBuilder.java
@@ -508,6 +508,9 @@ public final class DataSourceBuilder<T extends DataSource> {
 		}
 
 		private String convertToString(V value) {
+			if (value == null) {
+				return null;
+			}
 			if (String.class.equals(this.type)) {
 				return (String) value;
 			}
@@ -712,7 +715,8 @@ public final class DataSourceBuilder<T extends DataSource> {
 		@SuppressWarnings("unchecked")
 		SimpleDataSourceProperties() {
 			add(DataSourceProperty.URL, SimpleDriverDataSource::getUrl, SimpleDriverDataSource::setUrl);
-			add(DataSourceProperty.DRIVER_CLASS_NAME, Class.class, (dataSource) -> dataSource.getDriver().getClass(),
+			add(DataSourceProperty.DRIVER_CLASS_NAME, Class.class,
+					(dataSource) -> dataSource.getDriver() == null ? null : dataSource.getDriver().getClass(),
 					SimpleDriverDataSource::setDriverClass);
 			add(DataSourceProperty.USERNAME, SimpleDriverDataSource::getUsername, SimpleDriverDataSource::setUsername);
 			add(DataSourceProperty.PASSWORD, SimpleDriverDataSource::getPassword, SimpleDriverDataSource::setPassword);

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DataSourceBuilderTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/jdbc/DataSourceBuilderTests.java
@@ -359,6 +359,16 @@ class DataSourceBuilderTests {
 	}
 
 	@Test
+	void buildWhenDerivedFromSimpleDriverDataSourceWithDriverNotSetSucceeds() throws Exception {
+		SimpleDriverDataSource dataSource = new SimpleDriverDataSource();
+		dataSource.setUsername("test");
+		dataSource.setPassword("secret");
+		dataSource.setUrl("jdbc:postgresql://localhost:5432/postgres");
+		assertThatNoException()
+			.isThrownBy(() -> DataSourceBuilder.derivedFrom(dataSource).type(SimpleDriverDataSource.class).build());
+	}
+
+	@Test
 	void buildWhenDerivedFromOracleDataSourceWithPasswordSetReturnsDataSource() throws Exception {
 		oracle.jdbc.datasource.impl.OracleDataSource dataSource = new oracle.jdbc.datasource.impl.OracleDataSource();
 		dataSource.setUser("test");


### PR DESCRIPTION
This PR fixes a potential `NullPointerException` in `SimpleDataSourceProperties` when mapping the driver class name property.

When a `SimpleDriverDataSource` is created without explicitly setting a driver, calling `dataSource.getDriver().getClass()` throws NPE because `getDriver()` returns `null`.

Added null check to safely handle the case when no driver is configured, returning `null` instead of throwing NPE.