### PR TITLE
Skip registering all OTLP tracing related beans if tracing is disabled

### DIFF
--- a/spring-boot-project/spring-boot-tracing/src/main/java/org/springframework/boot/tracing/autoconfigure/otlp/OtlpTracingAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-tracing/src/main/java/org/springframework/boot/tracing/autoconfigure/otlp/OtlpTracingAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.tracing.autoconfigure.ConditionalOnEnabledTracing;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -44,10 +45,12 @@ import org.springframework.context.annotation.Import;
  * @author Jonatan Ivanov
  * @author Moritz Halbritter
  * @author Eddú Meléndez
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration
 @ConditionalOnClass({ OtelTracer.class, SdkTracerProvider.class, OpenTelemetry.class, OtlpHttpSpanExporter.class })
+@ConditionalOnEnabledTracing("otlp")
 @EnableConfigurationProperties(OtlpTracingProperties.class)
 @Import({ OtlpTracingConfigurations.ConnectionDetails.class, OtlpTracingConfigurations.Exporters.class })
 public class OtlpTracingAutoConfiguration {

--- a/spring-boot-project/spring-boot-tracing/src/main/java/org/springframework/boot/tracing/autoconfigure/otlp/OtlpTracingConfigurations.java
+++ b/spring-boot-project/spring-boot-tracing/src/main/java/org/springframework/boot/tracing/autoconfigure/otlp/OtlpTracingConfigurations.java
@@ -28,7 +28,6 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.tracing.autoconfigure.ConditionalOnEnabledTracing;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.Assert;
@@ -38,6 +37,7 @@ import org.springframework.util.Assert;
  *
  * @author Moritz Halbritter
  * @author Eddú Meléndez
+ * @author Yanming Zhou
  */
 final class OtlpTracingConfigurations {
 
@@ -77,7 +77,6 @@ final class OtlpTracingConfigurations {
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnMissingBean({ OtlpGrpcSpanExporter.class, OtlpHttpSpanExporter.class })
 	@ConditionalOnBean(OtlpTracingConnectionDetails.class)
-	@ConditionalOnEnabledTracing("otlp")
 	static class Exporters {
 
 		@Bean

--- a/spring-boot-project/spring-boot-tracing/src/test/java/org/springframework/boot/tracing/autoconfigure/otlp/OtlpTracingAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-tracing/src/test/java/org/springframework/boot/tracing/autoconfigure/otlp/OtlpTracingAutoConfigurationTests.java
@@ -44,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Jonatan Ivanov
  * @author Moritz Halbritter
  * @author Eddú Meléndez
+ * @author Yanming Zhou
  */
 class OtlpTracingAutoConfigurationTests {
 
@@ -69,6 +70,15 @@ class OtlpTracingAutoConfigurationTests {
 		this.contextRunner.withPropertyValues("management.otlp.tracing.endpoint=http://localhost:4318/v1/traces")
 			.run((context) -> assertThat(context).hasSingleBean(OtlpHttpSpanExporter.class)
 				.hasSingleBean(SpanExporter.class));
+	}
+
+	@Test
+	void shouldNotSupplyBeansIfTracingDisabled() {
+		this.tracingDisabledContextRunner
+			.withPropertyValues("management.otlp.tracing.endpoint=http://localhost:4318/v1/traces")
+			.run((context) -> assertThat(context).doesNotHaveBean(OtlpTracingProperties.class)
+				.doesNotHaveBean(OtlpTracingConnectionDetails.class)
+				.doesNotHaveBean(SpanExporter.class));
 	}
 
 	@Test


### PR DESCRIPTION
Before this commit, `OtlpTracingProperties` and `OtlpTracingConnectionDetails` are registered even if tracing is disabled.