### PR TITLE
Allow APIKey to be used as authentication method for Elasticsearch

### DIFF
--- a/module/spring-boot-elasticsearch/src/main/java/org/springframework/boot/elasticsearch/autoconfigure/ElasticsearchConnectionDetails.java
+++ b/module/spring-boot-elasticsearch/src/main/java/org/springframework/boot/elasticsearch/autoconfigure/ElasticsearchConnectionDetails.java
@@ -58,6 +58,14 @@ public interface ElasticsearchConnectionDetails extends ConnectionDetails {
 	}
 
 	/**
+	 * APIKey for authentication with Elasticsearch.
+	 * @return APIKey for authentication with Elasticsearch or {@code null}
+	 */
+	default @Nullable String getAPIKey() {
+		return null;
+	}
+
+	/**
 	 * Prefix added to the path of every request sent to Elasticsearch.
 	 * @return prefix added to the path of every request sent to Elasticsearch or
 	 * {@code null}

--- a/module/spring-boot-elasticsearch/src/main/java/org/springframework/boot/elasticsearch/autoconfigure/ElasticsearchProperties.java
+++ b/module/spring-boot-elasticsearch/src/main/java/org/springframework/boot/elasticsearch/autoconfigure/ElasticsearchProperties.java
@@ -48,6 +48,10 @@ public class ElasticsearchProperties {
 	 * Password for authentication with Elasticsearch.
 	 */
 	private @Nullable String password;
+	/**
+	 * APIKey for authentication with Elasticsearch.
+	 */
+	private @Nullable String APIKey;
 
 	/**
 	 * Connection timeout used when communicating with Elasticsearch.
@@ -93,6 +97,14 @@ public class ElasticsearchProperties {
 
 	public void setPassword(@Nullable String password) {
 		this.password = password;
+	}
+
+	public @Nullable String getAPIKey() {
+		return this.APIKey;
+	}
+
+	public void setAPIKey(@Nullable String APIKey) {
+		this.APIKey = APIKey;
 	}
 
 	public Duration getConnectionTimeout() {

--- a/module/spring-boot-elasticsearch/src/main/java/org/springframework/boot/elasticsearch/autoconfigure/ElasticsearchRestClientConfigurations.java
+++ b/module/spring-boot-elasticsearch/src/main/java/org/springframework/boot/elasticsearch/autoconfigure/ElasticsearchRestClientConfigurations.java
@@ -36,7 +36,9 @@ import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.reactor.ssl.SSLBufferMode;
 import org.apache.hc.core5.util.Timeout;
@@ -67,6 +69,7 @@ import org.springframework.util.StringUtils;
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Laura Trotta
  */
 class ElasticsearchRestClientConfigurations {
 
@@ -99,6 +102,11 @@ class ElasticsearchRestClientConfigurations {
 				.stream()
 				.map((node) -> new HttpHost(node.protocol().getScheme(), node.hostname(), node.port()))
 				.toArray(HttpHost[]::new));
+			if (connectionDetails.getAPIKey() != null) {
+				builder.setDefaultHeaders(new Header[]{
+						new BasicHeader("Authorization", "ApiKey " + connectionDetails.getAPIKey()),
+				});
+			}
 			builder.setHttpClientConfigCallback((httpClientBuilder) -> builderCustomizers.orderedStream()
 				.forEach((customizer) -> customizer.customize(httpClientBuilder)));
 			builder.setConnectionManagerCallback((connectionManagerBuilder) -> builderCustomizers.orderedStream()
@@ -273,6 +281,11 @@ class ElasticsearchRestClientConfigurations {
 		@Override
 		public @Nullable String getPassword() {
 			return this.properties.getPassword();
+		}
+
+		@Override
+		public @Nullable String getAPIKey() {
+			return this.properties.getAPIKey();
 		}
 
 		@Override


### PR DESCRIPTION
APIKey is a popular authentication method for elasticsearch, available both for local installations and for cloud instances; in fact, it's the [recommended way to setup](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/8.18/connecting.html) the Elasticsearch Java client!

This PR adds `spring.elasticsearch.apikey` as one of the elasticsearch properties, so that users will be able to setup a connection simply with:
```
spring.elasticsearch.uris=${ES_SERVER_URL}
spring.elasticsearch.apikey=${ES_APIKEY}
```
If this gets merged I will also take care of the documentation of affected repos ([spring-ai](https://github.com/spring-projects/spring-ai), [spring-data-elasticsearch](https://github.com/spring-projects/spring-data-elasticsearch)) to add and describe the new property.

Disclaimer: I am one of the maintainer of https://github.com/elastic/elasticsearch-java