### PR TITLE
L trotta/main

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchConnectionDetails.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchConnectionDetails.java
@@ -55,6 +55,10 @@ public interface ElasticsearchConnectionDetails extends ConnectionDetails {
 		return null;
 	}
 
+	default String getAPIKey() {
+		return null;
+	}
+
 	/**
 	 * Prefix added to the path of every request sent to Elasticsearch.
 	 * @return prefix added to the path of every request sent to Elasticsearch or

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchProperties.java
@@ -46,6 +46,10 @@ public class ElasticsearchProperties {
 	 * Password for authentication with Elasticsearch.
 	 */
 	private String password;
+	/**
+	 * APIKey for authentication with Elasticsearch.
+	 */
+	private String APIKey;
 
 	/**
 	 * Connection timeout used when communicating with Elasticsearch.
@@ -92,6 +96,15 @@ public class ElasticsearchProperties {
 	public void setPassword(String password) {
 		this.password = password;
 	}
+
+	public String getAPIKey() {
+		return this.APIKey;
+	}
+
+	public void setAPIKey(String APIKey) {
+		this.APIKey = APIKey;
+	}
+
 
 	public Duration getConnectionTimeout() {
 		return this.connectionTimeout;

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientConfigurations.java
@@ -64,6 +64,7 @@ import org.springframework.util.StringUtils;
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Laura Trotta
  */
 class ElasticsearchRestClientConfigurations {
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientConfigurations.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientConfigurations.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 
+import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
@@ -32,6 +33,7 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.impl.nio.reactor.IOReactorConfig;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
@@ -94,6 +96,11 @@ class ElasticsearchRestClientConfigurations {
 				.stream()
 				.map((node) -> new HttpHost(node.hostname(), node.port(), node.protocol().getScheme()))
 				.toArray(HttpHost[]::new));
+			if (connectionDetails.getAPIKey() != null) {
+				builder.setDefaultHeaders(new Header[]{
+					new BasicHeader("Authorization", "ApiKey " + connectionDetails.getAPIKey()),
+				});
+			}
 			builder.setHttpClientConfigCallback((httpClientBuilder) -> {
 				builderCustomizers.orderedStream().forEach((customizer) -> customizer.customize(httpClientBuilder));
 				SslBundle sslBundle = connectionDetails.getSslBundle();
@@ -258,6 +265,11 @@ class ElasticsearchRestClientConfigurations {
 		@Override
 		public String getPassword() {
 			return this.properties.getPassword();
+		}
+
+		@Override
+		public String getAPIKey() {
+			return this.properties.getAPIKey();
 		}
 
 		@Override

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfigurationTests.java
@@ -19,7 +19,9 @@ package org.springframework.boot.autoconfigure.elasticsearch;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
@@ -125,6 +127,24 @@ class ElasticsearchRestClientAutoConfigurationTests {
 			RestClient client = context.getBean(RestClient.class);
 			assertThat(client.getNodes().stream().map(Node::getHost).map(HttpHost::toString))
 				.containsExactly("http://localhost:9876");
+		});
+	}
+
+	@Test
+	void configureUriWithAPiKey() {
+		this.contextRunner.withPropertyValues("spring.elasticsearch.uris=http://user@localhost:9200","spring.elasticsearch.apikey=some-apiKey").run((context) -> {
+			RestClient client = context.getBean(RestClient.class);
+			assertThat(client.getNodes().stream().map(Node::getHost).map(HttpHost::toString))
+					.containsExactly("http://localhost:9200");
+			assertThat(client)
+					.extracting("defaultHeaders", InstanceOfAssertFactories.list(Header.class))
+					.satisfies(( defaultHeaders) -> {
+						Optional<? extends Header> authHeader = defaultHeaders.stream()
+								.filter(x -> x.getName().equals("Authorization"))
+								.findFirst();
+						assertThat(authHeader).isPresent();
+						assertThat(authHeader.get().getValue()).isEqualTo("ApiKey some-apiKey");
+					});
 		});
 	}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/elasticsearch/ElasticsearchRestClientAutoConfigurationTests.java
@@ -62,6 +62,7 @@ import static org.mockito.Mockito.mock;
  * @author Andy Wilkinson
  * @author Moritz Halbritter
  * @author Phillip Webb
+ * @author Laura Trotta
  */
 class ElasticsearchRestClientAutoConfigurationTests {
 


### PR DESCRIPTION
APIKey is a popular authentication method for elasticsearch, available both for local installations and for cloud instances; in fact, it's the [recommended way to setup](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/8.18/connecting.html) the Elasticsearch Java client!

This PR adds spring.elasticsearch.apikey as one of the elasticsearch properties, so that users will be able to setup a connection simply with:

spring.elasticsearch.uris=${ES_SERVER_URL}
spring.elasticsearch.apikey=${ES_APIKEY}
If this gets merged I will also take care of the documentation of affected repos ([spring-ai](https://github.com/spring-projects/spring-ai), [spring-data-elasticsearch](https://github.com/spring-projects/spring-data-elasticsearch)) to add and describe the new property.

Disclaimer: I am one of the maintainer of https://github.com/elastic/elasticsearch-java