### PR TITLE
Add FONTS location to StaticResourceLocation

### DIFF
--- a/spring-boot-project/spring-boot-security/src/main/java/org/springframework/boot/security/autoconfigure/StaticResourceLocation.java
+++ b/spring-boot-project/spring-boot-security/src/main/java/org/springframework/boot/security/autoconfigure/StaticResourceLocation.java
@@ -50,7 +50,12 @@ public enum StaticResourceLocation {
 	/**
 	 * The {@code "favicon.ico"} resource.
 	 */
-	FAVICON("/favicon.*", "/*/icon-*");
+	FAVICON("/favicon.*", "/*/icon-*"),
+
+	/**
+	 * Resources under {@code "/fonts"}.
+	 */
+	FONTS("/fonts/**");
 
 	private final String[] patterns;
 

--- a/spring-boot-project/spring-boot-security/src/test/java/org/springframework/boot/security/autoconfigure/reactive/StaticResourceRequestTests.java
+++ b/spring-boot-project/spring-boot-security/src/test/java/org/springframework/boot/security/autoconfigure/reactive/StaticResourceRequestTests.java
@@ -57,6 +57,7 @@ class StaticResourceRequestTests {
 		assertMatcher(matcher).matches("/favicon.ico");
 		assertMatcher(matcher).matches("/favicon.png");
 		assertMatcher(matcher).matches("/icons/icon-48x48.png");
+		assertMatcher(matcher).matches("/fonts/font.woff2");
 		assertMatcher(matcher).doesNotMatch("/bar");
 	}
 


### PR DESCRIPTION
### Motivation
`StaticResourceLocation` handles common static assets (`CSS`, `JS`, `IMAGES`, …) but omits web-fonts.  
As a result, `PathRequest.toStaticResources()` does **not** match `/fonts/**`, forcing users to add custom ant matchers.  
Adding a dedicated `FONTS` location ("/fonts/**") removes that gap.

### Implementation
* New enum constant `FONTS("/fonts/**")` in `StaticResourceLocation`.
_No breaking changes; existing constants keep the same semantics._

### Tests
* Unit test verifies that `StaticResourceLocation ` now matches a `/fonts/font.woff2` request.