### PR TITLE
Fix description of spring.batch.job.enabled

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -340,7 +340,7 @@
     {
       "name": "spring.batch.job.enabled",
       "type": "java.lang.Boolean",
-      "description": "Execute all Spring Batch jobs in the context on startup.",
+      "description": "Whether to execute a Spring Batch job on startup. A job is only launched if a single one in the context or a specific name is provided.",
       "defaultValue": true
     },
     {


### PR DESCRIPTION
The description for 'spring.batch.job.enabled' was misleading as it stated "Execute all Spring Batch jobs".

https://docs.spring.io/spring-boot/appendix/application-properties/index.html

![image](https://github.com/user-attachments/assets/5ea8c319-8810-4b9f-9742-5b0e40543d57)

The JobLauncherApplicationRunner does not launch multiple jobs by the commit - https://github.com/spring-projects/spring-boot/commit/55d6a87fefcd1f258a0ca5bc104b82b3bebf8aa1 .

This PR updates the description to reflect the actual behavior.

For reference, my previous pull request had a similar objective.

https://github.com/spring-projects/spring-boot/pull/34596
