### PR TITLE
Fix dependencies

### DIFF
--- a/spring-boot-project/spring-boot-integration/build.gradle
+++ b/spring-boot-project/spring-boot-integration/build.gradle
@@ -29,11 +29,10 @@ dependencies {
 	api(project(":spring-boot-project:spring-boot"))
 	api("org.springframework.integration:spring-integration-core")
 
-	implementation(project(":spring-boot-project:spring-boot-sql"))
+	implementation(project(":spring-boot-project:spring-boot-jdbc"))
 
 	optional(project(":spring-boot-project:spring-boot-actuator-autoconfigure"))
 	optional(project(":spring-boot-project:spring-boot-autoconfigure"))
-	optional(project(":spring-boot-project:spring-boot-jdbc"))
 	optional(project(":spring-boot-project:spring-boot-metrics"))
 	optional(project(":spring-boot-project:spring-boot-rsocket"))
 	optional("org.springframework.integration:spring-integration-jdbc")

--- a/spring-boot-project/spring-boot-integration/src/main/java/org/springframework/boot/integration/autoconfigure/IntegrationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-integration/src/main/java/org/springframework/boot/integration/autoconfigure/IntegrationAutoConfiguration.java
@@ -41,6 +41,7 @@ import org.springframework.boot.autoconfigure.thread.Threading;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.boot.context.properties.source.MutuallyExclusiveConfigurationPropertiesException;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
 import org.springframework.boot.jdbc.init.DataSourceScriptDatabaseInitializer;
 import org.springframework.boot.sql.autoconfigure.init.OnDatabaseInitializationCondition;
 import org.springframework.boot.task.SimpleAsyncTaskSchedulerBuilder;
@@ -88,8 +89,8 @@ import org.springframework.util.StringUtils;
  * @since 4.0.0
  */
 @AutoConfiguration(beforeName = "org.springframework.boot.rsocket.autoconfigure.RSocketMessagingAutoConfiguration",
-		after = { JmxAutoConfiguration.class, TaskSchedulingAutoConfiguration.class },
-		afterName = "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration")
+		after = { DataSourceAutoConfiguration.class, JmxAutoConfiguration.class,
+				TaskSchedulingAutoConfiguration.class })
 @ConditionalOnClass(EnableIntegration.class)
 @EnableConfigurationProperties({ IntegrationProperties.class, JmxProperties.class })
 public class IntegrationAutoConfiguration {

--- a/spring-boot-project/spring-boot-quartz/build.gradle
+++ b/spring-boot-project/spring-boot-quartz/build.gradle
@@ -30,11 +30,10 @@ dependencies {
 	api("org.quartz-scheduler:quartz")
 	api("org.springframework:spring-context-support")
 
-	implementation(project(":spring-boot-project:spring-boot-sql"))
+	implementation(project(":spring-boot-project:spring-boot-jdbc"))
 
 	optional(project(":spring-boot-project:spring-boot-actuator-autoconfigure"))
 	optional(project(":spring-boot-project:spring-boot-autoconfigure"))
-	optional(project(":spring-boot-project:spring-boot-jdbc"))
 	optional(project(":spring-boot-project:spring-boot-hibernate"))
 
 	testImplementation(project(":spring-boot-project:spring-boot-flyway"))

--- a/spring-boot-project/spring-boot-quartz/src/main/java/org/springframework/boot/quartz/autoconfigure/QuartzAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-quartz/src/main/java/org/springframework/boot/quartz/autoconfigure/QuartzAutoConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
 import org.springframework.boot.sql.autoconfigure.init.OnDatabaseInitializationCondition;
 import org.springframework.boot.sql.init.dependency.DatabaseInitializationDependencyConfigurer;
 import org.springframework.context.ApplicationContext;
@@ -51,10 +52,11 @@ import org.springframework.transaction.PlatformTransactionManager;
  *
  * @author Vedran Pavic
  * @author Stephane Nicoll
+ * @author Yanming Zhou
  * @since 4.0.0
  */
-@AutoConfiguration(afterName = { "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration",
-		"org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration" })
+@AutoConfiguration(after = DataSourceAutoConfiguration.class,
+		afterName = { "org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration" })
 @ConditionalOnClass({ Scheduler.class, SchedulerFactoryBean.class, PlatformTransactionManager.class })
 @EnableConfigurationProperties(QuartzProperties.class)
 public class QuartzAutoConfiguration {


### PR DESCRIPTION
Both `IntegrationDataSourceScriptDatabaseInitializer` and `QuartzDataSourceScriptDatabaseInitializer` extend `DataSourceScriptDatabaseInitializer` from `spring-boot-jdbc` which should be required dependency.
