### PR TITLE
Reuse parsed expression in SpelValueExpressionResolver

### DIFF
--- a/spring-boot-project/spring-boot-observation/src/test/java/org/springframework/boot/observation/autoconfigure/SpelValueExpressionResolverTests.java
+++ b/spring-boot-project/spring-boot-observation/src/test/java/org/springframework/boot/observation/autoconfigure/SpelValueExpressionResolverTests.java
@@ -20,6 +20,8 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.test.util.ReflectionTestUtils;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
@@ -42,6 +44,19 @@ class SpelValueExpressionResolverTests {
 	void checkInvalidExpression() {
 		var value = Map.of("foo", Pair.of(1, 2));
 		assertThatIllegalStateException().isThrownBy(() -> this.resolver.resolve("['bar'].first", value));
+	}
+
+	@Test
+	void checkParserReuse() {
+		var map = (Map<?, ?>) ReflectionTestUtils.getField(this.resolver, "expressionMap");
+
+		this.resolver.resolve("length", "foo");
+		this.resolver.resolve("length", "bar");
+
+		assertThat(map).hasSize(1);
+
+		this.resolver.resolve("isEmpty", "foo");
+		assertThat(map).hasSize(2);
 	}
 
 	record Pair(int first, int second) {


### PR DESCRIPTION
So far expression is parsed everytime the value is resolved.
My proposal is to reuse the parsed expression.
Since the value resolver is used only for a predefined set of expressions the map should contain only a few items.
