### PR TITLE
Use ThreadLocal.remove() instead of set(null)

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/SpringApplicationTests.java
@@ -159,6 +159,7 @@ import static org.mockito.Mockito.spy;
  * @author Tadaya Tsuyukubo
  * @author Yanming Zhou
  * @author Sijun Yang
+ * @author Giheon Do
  */
 @ExtendWith(OutputCaptureExtension.class)
 class SpringApplicationTests {
@@ -1369,7 +1370,7 @@ class SpringApplicationTests {
 			.run()
 			.getApplicationContext();
 		assertThat(ExampleAdditionalConfig.local.get()).isNotNull();
-		ExampleAdditionalConfig.local.set(null);
+		ExampleAdditionalConfig.local.remove();
 	}
 
 	@Test


### PR DESCRIPTION
Use ThreadLocal.remove() instead of set(null) to prevent memory leak

- Replaced usages of `ThreadLocal.set(null)` with `ThreadLocal.remove()` to properly clear thread-local values.

Previously, `ThreadLocal.set(null)` was used to clear the ThreadLocal variable. However, this only sets the value to null and leaves an entry in the thread’s local variable map, which can lead to memory leaks. Instead, by using `ThreadLocal.remove()`, we can properly remove the ThreadLocal variable from the thread's local variable map, preventing memory leaks.

I have reviewed the codebase, and this was the only place where set(null) needed to be replaced with remove().

Let me know if you have any concerns or suggestions for further improvement.
Thank you for your time and consideration!