### PR TITLE
Remove unnecessary toString() call

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/antora/GenerateAntoraPlaybook.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/antora/GenerateAntoraPlaybook.java
@@ -111,7 +111,7 @@ public abstract class GenerateAntoraPlaybook extends DefaultTask {
 		return project.provider(() -> {
 			Path playbookDir = toRealPath(getOutputFile().get().getAsFile().toPath()).getParent();
 			Path outputDir = toRealPath(siteDirectory);
-			return "." + File.separator + playbookDir.relativize(outputDir).toString();
+			return "." + File.separator + playbookDir.relativize(outputDir);
 		});
 	}
 

--- a/spring-boot-project/spring-boot-test-autoconfigure/src/dockerTest/java/org/springframework/boot/test/autoconfigure/jdbc/AutoConfigureTestDatabaseDockerComposeIntegrationTests.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/dockerTest/java/org/springframework/boot/test/autoconfigure/jdbc/AutoConfigureTestDatabaseDockerComposeIntegrationTests.java
@@ -83,7 +83,7 @@ class AutoConfigureTestDatabaseDockerComposeIntegrationTests {
 				Files.writeString(composeFile, composeFileContent);
 				TestPropertySourceUtils.addInlinedPropertiesToEnvironment(applicationContext,
 						"spring.docker.compose.skip.in-tests=false", "spring.docker.compose.stop.command=down",
-						"spring.docker.compose.file=" + composeFile.toAbsolutePath().toString());
+						"spring.docker.compose.file=" + composeFile.toAbsolutePath());
 			}
 			catch (IOException ex) {
 				throw new UncheckedIOException(ex);


### PR DESCRIPTION
Remove unnecessary toString() call from [GenerateAntoraPlaybook.java](https://github.com/spring-projects/spring-boot/compare/main...PiyalAhmed:remove-unnecessary-tostring-call?expand=1#diff-3e6776c7aaea77b064123e103f9d4599d9620a2cfdbc054e7c68d169f4adcca8) and [AutoConfigureTestDatabaseDockerComposeIntegrationTests.java](https://github.com/spring-projects/spring-boot/compare/main...PiyalAhmed:remove-unnecessary-tostring-call?expand=1#diff-bf0254e56d658a77cbea50aa006127596e85ac22c887e7513b8252d5c28d5308)