### PR TITLE
Refactor: Extract method 'setupAndRefreshContext' from SpringApplicat…

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -309,11 +309,9 @@ public class SpringApplication {
 			ApplicationArguments applicationArguments = new DefaultApplicationArguments(args);
 			ConfigurableEnvironment environment = prepareEnvironment(listeners, bootstrapContext, applicationArguments);
 			Banner printedBanner = printBanner(environment);
-			context = createApplicationContext();
-			context.setApplicationStartup(this.applicationStartup);
-			prepareContext(bootstrapContext, context, environment, listeners, applicationArguments, printedBanner);
-			refreshContext(context);
-			afterRefresh(context, applicationArguments);
+
+			context = setupAndRefreshContext(bootstrapContext, environment, listeners, applicationArguments, printedBanner);
+
 			startup.started();
 			if (this.properties.isLogStartupInfo()) {
 				new StartupInfoLogger(this.mainApplicationClass, environment).logStarted(getApplicationLog(), startup);
@@ -334,6 +332,19 @@ public class SpringApplication {
 		}
 		return context;
 	}
+
+	private ConfigurableApplicationContext setupAndRefreshContext(DefaultBootstrapContext bootstrapContext,
+        ConfigurableEnvironment environment, SpringApplicationRunListeners listeners,
+        ApplicationArguments applicationArguments, Banner printedBanner) {
+	
+	    ConfigurableApplicationContext context = createApplicationContext();
+	    context.setApplicationStartup(this.applicationStartup);
+	    prepareContext(bootstrapContext, context, environment, listeners, applicationArguments, printedBanner);
+	    refreshContext(context);
+	    afterRefresh(context, applicationArguments);
+	    return context;
+	}
+	
 
 	private DefaultBootstrapContext createBootstrapContext() {
 		DefaultBootstrapContext bootstrapContext = new DefaultBootstrapContext();


### PR DESCRIPTION
Esta refatoração extrai a lógica de preparação e atualização do ApplicationContext do método run(...) da classe SpringApplication para um novo método privado setupAndRefreshContext(...). A mudança visa reduzir o acoplamento dentro de run(), aumentar a legibilidade e separar claramente as responsabilidades, dado que o método run atualmente trata de múltiplas fases do ciclo de vida da aplicação.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
