### PR TITLE
Extract JdbcConnectionDetails from DataSource conditionality

### DIFF
--- a/spring-boot-project/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/DataSourceAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/DataSourceAutoConfiguration.java
@@ -52,6 +52,7 @@ import org.springframework.util.StringUtils;
  * @author Stephane Nicoll
  * @author Kazuki Shimizu
  * @author Olga Maciaszek-Sharma
+ * @author Bart Enkelaar
  * @since 4.0.0
  */
 @AutoConfiguration(before = DataSourceInitializationAutoConfiguration.class)
@@ -77,12 +78,13 @@ public class DataSourceAutoConfiguration {
 			DataSourceConfiguration.Generic.class, DataSourceJmxConfiguration.class })
 	protected static class PooledDataSourceConfiguration {
 
-		@Bean
-		@ConditionalOnMissingBean(JdbcConnectionDetails.class)
-		PropertiesJdbcConnectionDetails jdbcConnectionDetails(DataSourceProperties properties) {
-			return new PropertiesJdbcConnectionDetails(properties);
-		}
+	}
 
+	@Bean
+	@Conditional(PooledDataSourceCondition.class)
+	@ConditionalOnMissingBean(JdbcConnectionDetails.class)
+	PropertiesJdbcConnectionDetails jdbcConnectionDetails(DataSourceProperties properties) {
+		return new PropertiesJdbcConnectionDetails(properties);
 	}
 
 	/**


### PR DESCRIPTION
### Context

In most of our applications we use flyway to migrate databases.  Since migration data sources usually have a very different connection usage profile than the regular process of processing HTTP calls or message queues, we configure a different datasource for flyway than we do for regular traffic.

For this custom configuration of a flyway datasource we need to mark the regular datasource as being the "primary" datasource, therefor we basically copy the AutoConfiguration from [DataSourceConfiguration.Hikari#dataSource](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/DataSourceConfiguration.java#L124) and we slap a `@Primary` on top of that, which we then use with a 

```kotlin
    @Bean
    @FlywayDataSource
    @ConfigurationProperties(prefix = "spring.flyway.datasource.hikari")
    fun migrationDataSource(primary: HikariDataSource): HikariDataSource =
        DataSourceBuilder.derivedFrom(primary).type(HikariDataSource::class.java).build()
```

For the flyway datasource.

### Problem

However we also like to use testcontainers for our database integration tests, which relies on the `JdbcConnectionDetails` abstraction to override the connection to the database to its newly started postgres container using the test containers `@ServiceConnection` mechanism.

This mechanism is not working as I'd expect it to work, since the `PropertiesJdbcConnectionDetails` bean is defined in the `PooledDataSourceConfiguration` which is `@ConditionalOnMissingBean({ DataSource.class, XADataSource.class })`.  However we want to have tje JdbcConnectionDetails in order to properly define our own `DataSource` class (Which seems to me to be the expected way those abstractions should interact).

### Workaround

Of course we can fix it with an optional bean inject (which is what I've done now) but conceptually I think it makes more sense (and would lead to simpler code) if `PropertiesJdbcConnectionDetails` is only `@ConditionalOnMissingBean(JdbcConnectionDetails.class)` and not also `@ConditionalOnMissingBean({ DataSource.class, XADataSource.class })`.

### Notes on merge request

- For now I've left the `@Conditional(PooledDataSourceCondition.class)` on it as well, but I think it should go as well.  Was just minimizing the amount of changes.
- I've shadowed this class in one of our applications to test and it seems to work well.
- I figured this counts as "more than cosmetic changes", but probably barely so, so feel free to tell me to drop the @author line
- If you give me some tips on how and where this sort of stuff is usually tested I'll happily add some tests, didn't seem to get any consistently failing tests with this change locally
