### PR TITLE
Avoid using deprecated Log4j exception converter constructors

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/ExtendedWhitespaceThrowablePatternConverter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/ExtendedWhitespaceThrowablePatternConverter.java
@@ -44,7 +44,7 @@ public final class ExtendedWhitespaceThrowablePatternConverter extends LogEventP
 	private ExtendedWhitespaceThrowablePatternConverter(Configuration configuration, String[] options) {
 		super("WhitespaceExtendedThrowable", "throwable");
 		this.delegate = ExtendedThrowablePatternConverter.newInstance(configuration, options);
-		this.separator = WhitespaceThrowablePatternConverter.readSeparatorOption(options);
+		this.separator = ((ExtendedThrowablePatternConverter) this.delegate).getOptions().getSeparator();
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/ExtendedWhitespaceThrowablePatternConverter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/ExtendedWhitespaceThrowablePatternConverter.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.pattern.ConverterKeys;
 import org.apache.logging.log4j.core.pattern.ExtendedThrowablePatternConverter;
+import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
 import org.apache.logging.log4j.core.pattern.PatternConverter;
 import org.apache.logging.log4j.core.pattern.ThrowablePatternConverter;
 
@@ -34,22 +35,30 @@ import org.apache.logging.log4j.core.pattern.ThrowablePatternConverter;
  */
 @Plugin(name = "ExtendedWhitespaceThrowablePatternConverter", category = PatternConverter.CATEGORY)
 @ConverterKeys({ "xwEx", "xwThrowable", "xwException" })
-public final class ExtendedWhitespaceThrowablePatternConverter extends ThrowablePatternConverter {
+public final class ExtendedWhitespaceThrowablePatternConverter extends LogEventPatternConverter {
 
-	private final ExtendedThrowablePatternConverter delegate;
+	private final LogEventPatternConverter delegate;
+
+	private final String separator;
 
 	private ExtendedWhitespaceThrowablePatternConverter(Configuration configuration, String[] options) {
-		super("WhitespaceExtendedThrowable", "throwable", options, configuration);
+		super("WhitespaceExtendedThrowable", "throwable");
 		this.delegate = ExtendedThrowablePatternConverter.newInstance(configuration, options);
+		this.separator = WhitespaceThrowablePatternConverter.readSeparatorOption(options);
 	}
 
 	@Override
 	public void format(LogEvent event, StringBuilder buffer) {
 		if (event.getThrown() != null) {
-			buffer.append(this.options.getSeparator());
+			buffer.append(this.separator);
 			this.delegate.format(event, buffer);
-			buffer.append(this.options.getSeparator());
+			buffer.append(this.separator);
 		}
+	}
+
+	@Override
+	public boolean handlesThrowable() {
+		return true;
 	}
 
 	/**

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/WhitespaceThrowablePatternConverter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/WhitespaceThrowablePatternConverter.java
@@ -43,18 +43,7 @@ public final class WhitespaceThrowablePatternConverter extends LogEventPatternCo
 	private WhitespaceThrowablePatternConverter(Configuration configuration, String[] options) {
 		super("WhitespaceThrowable", "throwable");
 		this.delegate = ExtendedThrowablePatternConverter.newInstance(configuration, options);
-		this.separator = readSeparatorOption(options);
-	}
-
-	static String readSeparatorOption(String[] options) {
-		if (options != null) {
-			for (String option : options) {
-				if (option != null && option.startsWith("separator(") && option.endsWith(")")) {
-					return option.substring("separator(".length(), option.length() - 1);
-				}
-			}
-		}
-		return System.lineSeparator();
+		this.separator = ((ExtendedThrowablePatternConverter) this.delegate).getOptions().getSeparator();
 	}
 
 	@Override

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/ExtendedWhitespaceThrowablePatternConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/ExtendedWhitespaceThrowablePatternConverterTests.java
@@ -19,7 +19,7 @@ package org.springframework.boot.logging.log4j2;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
-import org.apache.logging.log4j.core.pattern.ThrowablePatternConverter;
+import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class ExtendedWhitespaceThrowablePatternConverterTests {
 
-	private final ThrowablePatternConverter converter = ExtendedWhitespaceThrowablePatternConverter
+	private final LogEventPatternConverter converter = ExtendedWhitespaceThrowablePatternConverter
 		.newInstance(new DefaultConfiguration(), new String[] {});
 
 	@Test

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/WhitespaceThrowablePatternConverterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/WhitespaceThrowablePatternConverterTests.java
@@ -19,7 +19,7 @@ package org.springframework.boot.logging.log4j2;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
-import org.apache.logging.log4j.core.pattern.ThrowablePatternConverter;
+import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class WhitespaceThrowablePatternConverterTests {
 
-	private final ThrowablePatternConverter converter = WhitespaceThrowablePatternConverter
+	private final LogEventPatternConverter converter = WhitespaceThrowablePatternConverter
 		.newInstance(new DefaultConfiguration(), new String[] {});
 
 	@Test


### PR DESCRIPTION
Log4j `2.25.0` deprecated `ThrowablePatternConverter` ctors, where they are employed in Spring Boot's `[Extended]WhitespaceThrowablePatternConverter` – see apache/logging-log4j2#3809. This PR amends these classes to avoid using deprecated ctors.