### PR TITLE
Fix BootZipCopyAction.Processor.getDirMode(FileCopyDetails)

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootZipCopyAction.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootZipCopyAction.java
@@ -487,7 +487,7 @@ class BootZipCopyAction implements CopyAction {
 		}
 
 		private int getDirMode(FileCopyDetails details) {
-			return (BootZipCopyAction.this.fileMode != null) ? BootZipCopyAction.this.dirMode : getPermissions(details);
+			return (BootZipCopyAction.this.dirMode != null) ? BootZipCopyAction.this.dirMode : getPermissions(details);
 		}
 
 		private int getFileMode(FileCopyDetails details) {


### PR DESCRIPTION
This PR fixes `BootZipCopyAction.Processor.getDirMode(FileCopyDetails)` as it seems to reference a wrong one accidentally.

See gh-46193
