### PR TITLE
Replace String.format with concatenation in CorrelationIdFormatter

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/CorrelationIdFormatter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/CorrelationIdFormatter.java
@@ -76,7 +76,7 @@ public final class CorrelationIdFormatter {
 
 	private CorrelationIdFormatter(List<Part> parts) {
 		this.parts = parts;
-		this.blank = String.format("[%s] ", parts.stream().map(Part::blank).collect(Collectors.joining(" ")));
+		this.blank = "[" + parts.stream().map(Part::blank).collect(Collectors.joining(" ")) + "] ";
 	}
 
 	/**


### PR DESCRIPTION
Replace `String.format()` with string concatenation for simple text joining in `CorrelationIdFormatter`.

**Changes:**
- Use `"[" + ... + "] "` instead of `String.format("[%s] ", ...)` in constructor

**Motivation:**
- Improves performance for simple string concatenation (no actual formatting needed)
- String concatenation is more appropriate when no format specifiers are used
- Reduces unnecessary overhead of format string parsing

This change maintains identical functionality while using a more efficient approach for basic string joining.