### PR TITLE
Fix typo: Correct "intial" to "initial" in parameter names and comments

### DIFF
--- a/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthEndpointSupportTests.java
+++ b/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthEndpointSupportTests.java
@@ -360,7 +360,7 @@ abstract class HealthEndpointSupportTests<E extends HealthEndpointSupport<H, D>,
 		return createRegistry((registrations) -> registrations.accept(name, contributor));
 	}
 
-	protected abstract R createRegistry(Consumer<BiConsumer<String, C>> intialRegistrations);
+	protected abstract R createRegistry(Consumer<BiConsumer<String, C>> initialRegistrations);
 
 	protected abstract C createContributor(Health health);
 

--- a/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthEndpointTests.java
+++ b/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthEndpointTests.java
@@ -111,8 +111,8 @@ class HealthEndpointTests extends
 
 	@Override
 	protected HealthContributorRegistry createRegistry(
-			Consumer<BiConsumer<String, HealthContributor>> intialRegistrations) {
-		return new DefaultHealthContributorRegistry(Collections.emptyList(), intialRegistrations);
+			Consumer<BiConsumer<String, HealthContributor>> initialRegistrations) {
+		return new DefaultHealthContributorRegistry(Collections.emptyList(), initialRegistrations);
 	}
 
 	@Override

--- a/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthEndpointWebExtensionTests.java
+++ b/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/HealthEndpointWebExtensionTests.java
@@ -104,8 +104,8 @@ class HealthEndpointWebExtensionTests extends
 
 	@Override
 	protected HealthContributorRegistry createRegistry(
-			Consumer<BiConsumer<String, HealthContributor>> intialRegistrations) {
-		return new DefaultHealthContributorRegistry(Collections.emptyList(), intialRegistrations);
+			Consumer<BiConsumer<String, HealthContributor>> initialRegistrations) {
+		return new DefaultHealthContributorRegistry(Collections.emptyList(), initialRegistrations);
 	}
 
 	@Override

--- a/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/ReactiveHealthEndpointWebExtensionTests.java
+++ b/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/health/ReactiveHealthEndpointWebExtensionTests.java
@@ -108,8 +108,8 @@ class ReactiveHealthEndpointWebExtensionTests extends
 
 	@Override
 	protected ReactiveHealthContributorRegistry createRegistry(
-			Consumer<BiConsumer<String, ReactiveHealthContributor>> intialRegistrations) {
-		return new DefaultReactiveHealthContributorRegistry(Collections.emptyList(), intialRegistrations);
+			Consumer<BiConsumer<String, ReactiveHealthContributor>> initialRegistrations) {
+		return new DefaultReactiveHealthContributorRegistry(Collections.emptyList(), initialRegistrations);
 	}
 
 	@Override

--- a/module/spring-boot-health/src/main/java/org/springframework/boot/health/registry/AbstractRegistry.java
+++ b/module/spring-boot-health/src/main/java/org/springframework/boot/health/registry/AbstractRegistry.java
@@ -49,12 +49,12 @@ abstract class AbstractRegistry<C, E> {
 
 	AbstractRegistry(BiFunction<String, C, E> entryAdapter,
 			Collection<? extends HealthContributorNameValidator> nameValidators,
-			Consumer<BiConsumer<String, C>> intialRegistrations) {
+			Consumer<BiConsumer<String, C>> initialRegistrations) {
 		this.nameValidators = (nameValidators != null) ? List.copyOf(nameValidators) : Collections.emptyList();
 		this.entryAdapter = entryAdapter;
 		Map<String, C> contributors = new LinkedHashMap<>();
-		if (intialRegistrations != null) {
-			intialRegistrations.accept((name, contributor) -> registerContributor(contributors, name, contributor));
+		if (initialRegistrations != null) {
+			initialRegistrations.accept((name, contributor) -> registerContributor(contributors, name, contributor));
 		}
 		this.contributors = Collections.unmodifiableMap(contributors);
 	}

--- a/module/spring-boot-health/src/main/java/org/springframework/boot/health/registry/DefaultHealthContributorRegistry.java
+++ b/module/spring-boot-health/src/main/java/org/springframework/boot/health/registry/DefaultHealthContributorRegistry.java
@@ -43,11 +43,11 @@ public class DefaultHealthContributorRegistry extends AbstractRegistry<HealthCon
 	/**
 	 * Create a new {@link DefaultHealthContributorRegistry} instance.
 	 * @param nameValidators the name validators to apply
-	 * @param intialRegistrations callback to setup any initial registrations
+	 * @param initialRegistrations callback to setup any initial registrations
 	 */
 	public DefaultHealthContributorRegistry(Collection<? extends HealthContributorNameValidator> nameValidators,
-			Consumer<BiConsumer<String, HealthContributor>> intialRegistrations) {
-		super(Entry::new, nameValidators, intialRegistrations);
+			Consumer<BiConsumer<String, HealthContributor>> initialRegistrations) {
+		super(Entry::new, nameValidators, initialRegistrations);
 	}
 
 	@Override

--- a/module/spring-boot-health/src/main/java/org/springframework/boot/health/registry/DefaultReactiveHealthContributorRegistry.java
+++ b/module/spring-boot-health/src/main/java/org/springframework/boot/health/registry/DefaultReactiveHealthContributorRegistry.java
@@ -43,11 +43,11 @@ public class DefaultReactiveHealthContributorRegistry extends AbstractRegistry<R
 	/**
 	 * Create a new {@link DefaultReactiveHealthContributorRegistry} instance.
 	 * @param nameValidators the name validators to apply
-	 * @param intialRegistrations callback to setup any initial registrations
+	 * @param initialRegistrations callback to setup any initial registrations
 	 */
 	public DefaultReactiveHealthContributorRegistry(Collection<? extends HealthContributorNameValidator> nameValidators,
-			Consumer<BiConsumer<String, ReactiveHealthContributor>> intialRegistrations) {
-		super(Entry::new, nameValidators, intialRegistrations);
+			Consumer<BiConsumer<String, ReactiveHealthContributor>> initialRegistrations) {
+		super(Entry::new, nameValidators, initialRegistrations);
 	}
 
 	@Override

--- a/module/spring-boot-health/src/test/java/org/springframework/boot/health/registry/AbstractHealthContributorRegistryTests.java
+++ b/module/spring-boot-health/src/test/java/org/springframework/boot/health/registry/AbstractHealthContributorRegistryTests.java
@@ -127,9 +127,9 @@ abstract class AbstractHealthContributorRegistryTests<C, E> {
 
 	@Test
 	void nameValidatorsValidateMapKeys() {
-		assertThatIllegalStateException().isThrownBy(() -> createRegistry(testValidator(), (intialRegistrations) -> {
-			intialRegistrations.accept("ok", mockHealthIndicator());
-			intialRegistrations.accept("fail", mockHealthIndicator());
+		assertThatIllegalStateException().isThrownBy(() -> createRegistry(testValidator(), (initialRegistrations) -> {
+			initialRegistrations.accept("ok", mockHealthIndicator());
+			initialRegistrations.accept("fail", mockHealthIndicator());
 		})).withMessage("Failed validation");
 	}
 
@@ -147,7 +147,7 @@ abstract class AbstractHealthContributorRegistryTests<C, E> {
 
 	protected abstract AbstractRegistry<C, E> createRegistry(
 			Collection<? extends HealthContributorNameValidator> nameValidators,
-			Consumer<BiConsumer<String, C>> intialRegistrations);
+			Consumer<BiConsumer<String, C>> initialRegistrations);
 
 	protected abstract C mockHealthIndicator();
 

--- a/module/spring-boot-health/src/test/java/org/springframework/boot/health/registry/DefaultHealthContributorRegistryTests.java
+++ b/module/spring-boot-health/src/test/java/org/springframework/boot/health/registry/DefaultHealthContributorRegistryTests.java
@@ -38,8 +38,8 @@ class DefaultHealthContributorRegistryTests
 	@Override
 	protected AbstractRegistry<HealthContributor, Entry> createRegistry(
 			Collection<? extends HealthContributorNameValidator> nameValidators,
-			Consumer<BiConsumer<String, HealthContributor>> intialRegistrations) {
-		return new DefaultHealthContributorRegistry(nameValidators, intialRegistrations);
+			Consumer<BiConsumer<String, HealthContributor>> initialRegistrations) {
+		return new DefaultHealthContributorRegistry(nameValidators, initialRegistrations);
 	}
 
 	@Override

--- a/module/spring-boot-health/src/test/java/org/springframework/boot/health/registry/DefaultReactiveHealthContributorRegistryTests.java
+++ b/module/spring-boot-health/src/test/java/org/springframework/boot/health/registry/DefaultReactiveHealthContributorRegistryTests.java
@@ -38,8 +38,8 @@ class DefaultReactiveHealthContributorRegistryTests
 	@Override
 	protected AbstractRegistry<ReactiveHealthContributor, Entry> createRegistry(
 			Collection<? extends HealthContributorNameValidator> nameValidators,
-			Consumer<BiConsumer<String, ReactiveHealthContributor>> intialRegistrations) {
-		return new DefaultReactiveHealthContributorRegistry(nameValidators, intialRegistrations);
+			Consumer<BiConsumer<String, ReactiveHealthContributor>> initialRegistrations) {
+		return new DefaultReactiveHealthContributorRegistry(nameValidators, initialRegistrations);
 	}
 
 	@Override


### PR DESCRIPTION
This pull request fixes a recurring typo where "intial" was used instead of the correct spelling "initial". The typo was found in:

- Variable and parameter names
- Code comments
- Test method names

### Changes
- Renamed all instances of `intial` to `initial` in both source and test files.
- Updated corresponding comments and documentation for consistency.

These changes do not affect any runtime behavior or public API and are limited to improving code readability and correctness.

No functional changes are introduced.