### PR TITLE
Remove unused SHA-1 hash from UNPACK markers

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootZipCopyAction.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootZipCopyAction.java
@@ -22,13 +22,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -578,25 +575,16 @@ class BootZipCopyAction implements CopyAction {
 
 		private static final int BUFFER_SIZE = 32 * 1024;
 
-		private final MessageDigest messageDigest;
+		private final boolean unpack;
 
 		private final CRC32 crc = new CRC32();
 
 		private long size;
 
 		StoredEntryPreparator(InputStream inputStream, boolean unpack) throws IOException {
-			this.messageDigest = (unpack) ? sha1Digest() : null;
+			this.unpack = unpack;
 			try (inputStream) {
 				load(inputStream);
-			}
-		}
-
-		private static MessageDigest sha1Digest() {
-			try {
-				return MessageDigest.getInstance("SHA-1");
-			}
-			catch (NoSuchAlgorithmException ex) {
-				throw new IllegalStateException(ex);
 			}
 		}
 
@@ -605,9 +593,6 @@ class BootZipCopyAction implements CopyAction {
 			int bytesRead;
 			while ((bytesRead = inputStream.read(buffer)) != -1) {
 				this.crc.update(buffer, 0, bytesRead);
-				if (this.messageDigest != null) {
-					this.messageDigest.update(buffer, 0, bytesRead);
-				}
 				this.size += bytesRead;
 			}
 		}
@@ -617,8 +602,8 @@ class BootZipCopyAction implements CopyAction {
 			entry.setCompressedSize(this.size);
 			entry.setCrc(this.crc.getValue());
 			entry.setMethod(ZipEntry.STORED);
-			if (this.messageDigest != null) {
-				entry.setComment("UNPACK:" + HexFormat.of().formatHex(this.messageDigest.digest()));
+			if (this.unpack) {
+				entry.setComment("UNPACK:");
 			}
 		}
 

--- a/loader/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/AbstractJarWriter.java
+++ b/loader/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/AbstractJarWriter.java
@@ -24,12 +24,9 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.HexFormat;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.jar.JarEntry;
@@ -320,25 +317,16 @@ public abstract class AbstractJarWriter implements LoaderClassesWriter {
 
 		private static final int BUFFER_SIZE = 32 * 1024;
 
-		private final MessageDigest messageDigest;
+		private final boolean unpack;
 
 		private final CRC32 crc = new CRC32();
 
 		private long size;
 
 		StoredEntryPreparator(InputStream inputStream, boolean unpack) throws IOException {
-			this.messageDigest = (unpack) ? sha1Digest() : null;
+			this.unpack = unpack;
 			try (inputStream) {
 				load(inputStream);
-			}
-		}
-
-		private static MessageDigest sha1Digest() {
-			try {
-				return MessageDigest.getInstance("SHA-1");
-			}
-			catch (NoSuchAlgorithmException ex) {
-				throw new IllegalStateException(ex);
 			}
 		}
 
@@ -347,9 +335,6 @@ public abstract class AbstractJarWriter implements LoaderClassesWriter {
 			int bytesRead;
 			while ((bytesRead = inputStream.read(buffer)) != -1) {
 				this.crc.update(buffer, 0, bytesRead);
-				if (this.messageDigest != null) {
-					this.messageDigest.update(buffer, 0, bytesRead);
-				}
 				this.size += bytesRead;
 			}
 		}
@@ -359,8 +344,8 @@ public abstract class AbstractJarWriter implements LoaderClassesWriter {
 			entry.setCompressedSize(this.size);
 			entry.setCrc(this.crc.getValue());
 			entry.setMethod(ZipEntry.STORED);
-			if (this.messageDigest != null) {
-				entry.setComment("UNPACK:" + HexFormat.of().formatHex(this.messageDigest.digest()));
+			if (this.unpack) {
+				entry.setComment("UNPACK:");
 			}
 		}
 

--- a/loader/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/AbstractPackagerTests.java
+++ b/loader/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/AbstractPackagerTests.java
@@ -208,8 +208,7 @@ abstract class AbstractPackagerTests<P extends Packager> {
 		ZipEntry entry = getPackagedEntry("BOOT-INF/lib/" + libJarFile.getName());
 		assertThat(entry.getTime()).isEqualTo(JAN_1_1985);
 		entry = getPackagedEntry("BOOT-INF/lib/" + libJarFileToUnpack.getName());
-		assertThat(entry.getComment()).startsWith("UNPACK:");
-		assertThat(entry.getComment()).hasSize(47);
+		assertThat(entry.getComment()).isEqualTo("UNPACK:");
 	}
 
 	@Test


### PR DESCRIPTION
This PR removes the unused SHA-1 hash calculation from UNPACK markers in the JAR/WAR packaging process.

**Current behavior:**
When creating executable JARs/WARs, Spring Boot calculates a SHA-1 hash for entries that require unpacking and appends it to the entry comment as `UNPACK:<hash>`. However, this hash is never used - only the `UNPACK:` prefix is checked.

**Changes made:**
- Removed SHA-1 hash calculation from `StoredEntryPreparator` in both `BootZipCopyAction` and `AbstractJarWriter`
- Changed the UNPACK comment from `UNPACK:<sha1-hash>` to simply `UNPACK:`
- Updated tests to match the new format

**Performance improvement:**
This eliminates unnecessary file reads during packaging. Previously, files could be read up to 3 times (CRC calculation, SHA-1 hash, and actual copying). Removing the hash calculation reduces I/O operations and memory usage, especially beneficial for large libraries.

Fixes #46183