### PR TITLE
Use "2012-present" for copyright headers

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -7,6 +7,9 @@
 		<property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
 	</module>
 	<module name="io.spring.javaformat.checkstyle.SpringChecks" />
+	<module name="io.spring.javaformat.checkstyle.check.SpringHeaderCheck">
+		<property name="headerCopyrightPattern" value="2012-present" />
+	</module>
 	<module name="com.puppycrawl.tools.checkstyle.TreeWalker">
 		<module name="io.spring.javaformat.checkstyle.check.SpringDeprecatedCheck" />
 		<module name="io.spring.javaformat.checkstyle.check.SpringJUnit5Check" />

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/metrics/buffering/BufferedStartupStep.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/metrics/buffering/BufferedStartupStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-present the original author or authors.
+ * Copyright 2012-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/metrics/buffering/BufferingApplicationStartup.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/metrics/buffering/BufferingApplicationStartup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-present the original author or authors.
+ * Copyright 2012-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/metrics/buffering/StartupTimeline.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/metrics/buffering/StartupTimeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-present the original author or authors.
+ * Copyright 2012-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/ConstructorBound.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/ConstructorBound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-present the original author or authors.
+ * Copyright 2012-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/spring-boot/src/main/java/org/springframework/boot/convert/PeriodStyle.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/convert/PeriodStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-present the original author or authors.
+ * Copyright 2012-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/spring-boot/src/main/java/org/springframework/boot/convert/PeriodToStringConverter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/convert/PeriodToStringConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-present the original author or authors.
+ * Copyright 2012-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/web/graphql/runtimewiring/GreetingController.java
+++ b/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/web/graphql/runtimewiring/GreetingController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-present the original author or authors.
+ * Copyright 2012-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/testcontainers/AbstractMongoContainerConnectionDetailsFactory.java
+++ b/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/testcontainers/AbstractMongoContainerConnectionDetailsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2025 the original author or authors.
+ * Copyright 2012-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/testcontainers/MongoDbAtlasLocalContainerConnectionDetailsFactory.java
+++ b/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/testcontainers/MongoDbAtlasLocalContainerConnectionDetailsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2025 the original author or authors.
+ * Copyright 2012-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR changes to use "2012-present" for copyright headers as they seem to have been introduced accidentally in d49b37a6b5b53de13df3ebcb325a5625d41f4eb3.