### PR TITLE
Share SpelExpressionParser in SpelValueExpressionResolver

### DIFF
--- a/module/spring-boot-observation/src/main/java/org/springframework/boot/observation/autoconfigure/SpelValueExpressionResolver.java
+++ b/module/spring-boot-observation/src/main/java/org/springframework/boot/observation/autoconfigure/SpelValueExpressionResolver.java
@@ -30,12 +30,13 @@ import org.springframework.expression.spel.support.SimpleEvaluationContext;
  */
 class SpelValueExpressionResolver implements ValueExpressionResolver {
 
+	private final ExpressionParser expressionParser = new SpelExpressionParser();
+
 	@Override
 	public String resolve(String expression, Object parameter) {
 		try {
 			SimpleEvaluationContext context = SimpleEvaluationContext.forReadOnlyDataBinding().build();
-			ExpressionParser expressionParser = new SpelExpressionParser();
-			Expression expressionToEvaluate = expressionParser.parseExpression(expression);
+			Expression expressionToEvaluate = this.expressionParser.parseExpression(expression);
 			return expressionToEvaluate.getValue(context, parameter, String.class);
 		}
 		catch (Exception ex) {


### PR DESCRIPTION
This PR changes to share a `SpelExpressionParser` instance in the `SpelValueExpressionResolver` as it seems to be okay to be shared.