### PR TITLE
Fix handling of default values for arithmetic expressions in configuration metadata

### DIFF
--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/fieldvalues/javac/JavaCompilerFieldValuesParser.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/fieldvalues/javac/JavaCompilerFieldValuesParser.java
@@ -209,7 +209,7 @@ public class JavaCompilerFieldValuesParser implements FieldValuesParser {
 				}
 				return null;
 			}
-			return defaultValue;
+			return null;
 		}
 
 		private Object getFactoryValue(ExpressionTree expression, Object factoryValue) {

--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/JsonConverter.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/metadata/JsonConverter.java
@@ -167,6 +167,9 @@ class JsonConverter {
 	}
 
 	private void putDefaultValue(JSONObject jsonObject, Object value) throws Exception {
+		if (value == null) {
+			return;
+		}
 		Object defaultValue = extractItemValue(value);
 		jsonObject.put("defaultValue", defaultValue);
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -31,6 +31,7 @@ import org.springframework.boot.configurationprocessor.metadata.ItemMetadata;
 import org.springframework.boot.configurationprocessor.metadata.Metadata;
 import org.springframework.boot.configurationprocessor.test.CompiledMetadataReader;
 import org.springframework.boot.configurationprocessor.test.TestConfigurationMetadataAnnotationProcessor;
+import org.springframework.boot.configurationsample.arithmetic.ArithmeticExpressionProperties;
 import org.springframework.boot.configurationsample.deprecation.Dbcp2Configuration;
 import org.springframework.boot.configurationsample.method.NestedPropertiesMethod;
 import org.springframework.boot.configurationsample.record.ExampleRecord;
@@ -118,6 +119,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Pavel Anisimov
  * @author Scott Frederick
  * @author Moritz Halbritter
+ * @author Hyeon Jae Kim
  */
 class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGenerationTests {
 
@@ -625,6 +627,21 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 		assertThat(metadata).has(Metadata.withProperty("ignored.prop2", String.class));
 		assertThat(metadata).doesNotHave(Metadata.withProperty("ignored.prop3", String.class));
 		assertThat(metadata.getIgnored()).containsExactly(ItemIgnore.forProperty("ignored.prop3"));
+	}
+
+	@Test
+	void arithmeticExpressionPropertiesShouldOmitUnknownDefaultValues(){
+		ConfigurationMetadata metadata = compile(ArithmeticExpressionProperties.class);
+		assertThat(metadata).has(Metadata.withProperty("arithmetic.calculated", Integer.class)
+			.fromSource(ArithmeticExpressionProperties.class));
+		assertThat(metadata).has(Metadata.withProperty("arithmetic.literal", Integer.class)
+			.fromSource(ArithmeticExpressionProperties.class)
+			.withDefaultValue(100));
+		assertThat(metadata).has(Metadata.withProperty("arithmetic.simple-flag", Boolean.class)
+			.fromSource(ArithmeticExpressionProperties.class)
+			.withDefaultValue(true));
+		assertThat(metadata).has(Metadata.withProperty("arithmetic.complex-flag", Boolean.class)
+			.fromSource(ArithmeticExpressionProperties.class));
 	}
 
 	@Nested

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/arithmetic/ArithmeticExpressionProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/arithmetic/ArithmeticExpressionProperties.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.configurationsample.arithmetic;
+
+import org.springframework.boot.configurationsample.ConfigurationProperties;
+
+/**
+ * Configuration properties with arithmetic expressions to test metadata generation for
+ * values that cannot be inferred at compile time. Used to verify that primitive types
+ * with unknown default values omit the defaultValue field in the generated metadata.
+ *
+ * @author Hyeon Jae Kim
+ */
+@ConfigurationProperties(prefix = "arithmetic")
+public class ArithmeticExpressionProperties {
+
+	/**
+	 * A value calculated using arithmetic expression that cannot be inferred.
+	 */
+	private int calculated = 10 * 10;
+
+	/**
+	 * A literal value that can be inferred.
+	 */
+	private int literal = 100;
+
+	/**
+	 * A boolean expression that cannot be inferred.
+	 */
+	private boolean complexFlag = !false;
+
+	/**
+	 * A simple boolean literal.
+	 */
+	private boolean simpleFlag = true;
+
+	public int getCalculated() {
+		return this.calculated;
+	}
+
+	public void setCalculated(int calculated) {
+		this.calculated = calculated;
+	}
+
+	public int getLiteral() {
+		return this.literal;
+	}
+
+	public void setLiteral(int literal) {
+		this.literal = literal;
+	}
+
+	public boolean isComplexFlag() {
+		return this.complexFlag;
+	}
+
+	public void setComplexFlag(boolean complexFlag) {
+		this.complexFlag = complexFlag;
+	}
+
+	public boolean isSimpleFlag() {
+		return this.simpleFlag;
+	}
+
+	public void setSimpleFlag(boolean simpleFlag) {
+		this.simpleFlag = simpleFlag;
+	}
+
+}


### PR DESCRIPTION
### Change Summary

Improve configuration metadata annotation processor to omit unknown default values in arithmetic expressions.

As arithmetic expressions are not considered literals by the processor, their default values should not be recorded in the generated metadata. This change updates the processor to properly omit such values and adds tests to verify the behavior.

Open to suggestions or corrections!

### Related Issue
#46509