### PR TITLE
Missing metadata when using @Name with a constructor-bound property

### DIFF
--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptorResolver.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptorResolver.java
@@ -88,11 +88,12 @@ class PropertyDescriptorResolver {
 	private PropertyDescriptor extracted(TypeElement declaringElement, TypeElementMembers members,
 			VariableElement parameter) {
 		String name = getPropertyName(parameter);
+		String parameterName = parameter.getSimpleName().toString();
 		TypeMirror type = parameter.asType();
-		ExecutableElement getter = members.getPublicGetter(name, type);
-		ExecutableElement setter = members.getPublicSetter(name, type);
-		VariableElement field = members.getFields().get(name);
-		RecordComponentElement recordComponent = members.getRecordComponents().get(name);
+		ExecutableElement getter = members.getPublicGetter(parameterName, type);
+		ExecutableElement setter = members.getPublicSetter(parameterName, type);
+		VariableElement field = members.getFields().get(parameterName);
+		RecordComponentElement recordComponent = members.getRecordComponents().get(parameterName);
 		SourceMetadata sourceMetadata = this.environment.resolveSourceMetadata(field, getter);
 		PropertyDescriptor propertyDescriptor = (recordComponent != null)
 				? new RecordParameterPropertyDescriptor(name, type, parameter, declaringElement, getter,

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -301,6 +301,9 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 			.fromSource(type)
 			.withDeprecation("some-reason", null, null));
 		assertThat(metadata).has(Metadata.withProperty("deprecated-record.bravo", String.class).fromSource(type));
+		assertThat(metadata).has(Metadata.withProperty("deprecated-record.named.charlie", String.class)
+			.fromSource(type)
+			.withDeprecation("another-reason", null, null));
 	}
 
 	@Test
@@ -605,6 +608,8 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 			.withDescription("description without space after asterisk"));
 		assertThat(metadata).has(Metadata.withProperty("record.descriptions.some-byte", Byte.class)
 			.withDescription("last description in Javadoc"));
+		assertThat(metadata).has(Metadata.withProperty("record.descriptions.named.record.component", String.class)
+			.withDescription("description of a named component"));
 	}
 
 	@Test

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/record/ExampleRecord.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/record/ExampleRecord.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.configurationsample.record;
 
+import org.springframework.boot.configurationsample.Name;
+
 // @formatter:off
 
 /**
@@ -26,12 +28,21 @@ package org.springframework.boot.configurationsample.record;
  * @param someInteger description with @param and @ pitfalls
  * @param someBoolean description with extra spaces
  * @param someLong description without space after asterisk
+ * @param namedComponent description of a named component
  * @param someByte last description in Javadoc
  * @since 1.0.0
  * @author Pavel Anisimov
  */
 @org.springframework.boot.configurationsample.ConfigurationProperties("record.descriptions")
-public record ExampleRecord(String someString, Integer someInteger, Boolean someBoolean, Long someLong, Byte someByte) {
+public record ExampleRecord(
+				String someString,
+				Integer someInteger,
+				Boolean someBoolean,
+				Long someLong,
+				@Name("named.record.component")
+				String namedComponent,
+				Byte someByte
+		) {
 }
 
 //@formatter:on

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/DeprecatedRecord.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/DeprecatedRecord.java
@@ -18,16 +18,18 @@ package org.springframework.boot.configurationsample.simple;
 
 import org.springframework.boot.configurationsample.ConfigurationProperties;
 import org.springframework.boot.configurationsample.DeprecatedConfigurationProperty;
+import org.springframework.boot.configurationsample.Name;
 
 /**
  * Configuration properties as record with deprecated property.
  *
  * @param alpha alpha property, deprecated
  * @param bravo bravo property
+ * @param charlie charlie property, named, deprecated
  * @author Moritz Halbritter
  */
 @ConfigurationProperties("deprecated-record")
-public record DeprecatedRecord(String alpha, String bravo) {
+public record DeprecatedRecord(String alpha, String bravo, @Name("named.charlie") String charlie) {
 
 	@Deprecated
 	@DeprecatedConfigurationProperty(reason = "some-reason")
@@ -35,4 +37,9 @@ public record DeprecatedRecord(String alpha, String bravo) {
 		return this.alpha;
 	}
 
+	@Deprecated
+	@DeprecatedConfigurationProperty(reason = "another-reason")
+	public String charlie() {
+		return this.charlie;
+	}
 }


### PR DESCRIPTION
Hello,

I'd like to suggest a fix for a bug that I've found while using `@Name` annotation with [Type-safe Configuration Properties](https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config.typesafe-configuration-properties).

### Problem description

When `@Name` annotation is used, the metadata items extracted from executable elements (like description and deprecation data) are missing. The following example demonstrates it:

Let's say we have record like this:
```
/**
 * @param namedPropertyExample this should be in the metadata description.
 */
@ConfigurationProperties(prefix = "example.properties")
public record ExampleProperties(
        @Deprecated
        @DeprecatedConfigurationProperty(reason = "Some reason")
        String namedPropertyExample) {}
```
Then it's generated metadata is:
```
{
  "groups": [
    {
      "name": "example.properties",
      "type": "org.some.example.ExampleProperties",
      "sourceType": "org.some.example.ExampleProperties"
    }
  ],
  "properties": [
    {
      "name": "example.properties.named-property-example",
      "type": "java.lang.String",
      "description": "this should be in the metadata description.",
      "sourceType": "org.some.example.ExampleProperties",
      "deprecated": true,
      "deprecation": {
        "reason": "Some reason"
      }
    }
  ],
  "hints": [],
  "ignored": {
    "properties": []
  }
}
``` 
But if `@Name` annotation is added:
```
/**
 * @param namedPropertyExample this should be in the metadata description.
 */
@ConfigurationProperties(prefix = "example.properties")
public record ExampleProperties(
        @Name("named.property")
        @Deprecated
        @DeprecatedConfigurationProperty(reason = "Some reason")
        String namedPropertyExample) {}
```
the metadata misses several attributes:
```
{
  "groups": [
    {
      "name": "example.properties",
      "type": "org.some.example.ExampleProperties",
      "sourceType": "org.some.example.ExampleProperties"
    }
  ],
  "properties": [
    {
      "name": "example.properties.named.property",
      "type": "java.lang.String",
      "sourceType": "org.some.example.ExampleProperties"
    }
  ],
  "hints": [],
  "ignored": {
    "properties": []
  }
}
```

### Root cause and the fix descriptions

The root cause is the using `Name#value` for locating executable elements in `org.springframework.boot.configurationprocessor.PropertyDescriptorResolver#extracted`:
```
		String name = getPropertyName(parameter);
		TypeMirror type = parameter.asType();
		ExecutableElement getter = members.getPublicGetter(name, type);
		ExecutableElement setter = members.getPublicSetter(name, type);
		VariableElement field = members.getFields().get(name);
		RecordComponentElement recordComponent = members.getRecordComponents().get(name);

...

	private String getPropertyName(VariableElement parameter) {
		return getPropertyName(parameter, parameter.getSimpleName().toString());
	}

	private String getPropertyName(VariableElement parameter, String fallback) {
		AnnotationMirror nameAnnotation = this.environment.getNameAnnotation(parameter);
		if (nameAnnotation != null) {
			return this.environment.getAnnotationElementStringValue(nameAnnotation, "value");
		}
		return fallback;
	}
```
For the example above it means searching record component with name `named.property`. I'd like to suggest using parameter name for locating the executable elements:
```
		String parameterName = parameter.getSimpleName().toString();
		TypeMirror type = parameter.asType();
		ExecutableElement getter = members.getPublicGetter(parameterName, type);
		ExecutableElement setter = members.getPublicSetter(parameterName, type);
		VariableElement field = members.getFields().get(parameterName);
		RecordComponentElement recordComponent = members.getRecordComponents().get(parameterName);
``` 
