### PR TITLE
Missing property for Spring Authorization Server's PAR endpoint

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerProperties.java
@@ -32,6 +32,7 @@ import org.springframework.util.StringUtils;
  * OAuth 2.0 Authorization Server properties.
  *
  * @author Steve Riesenberg
+ * @author Florian Lemaire
  * @since 3.1.0
  */
 @ConfigurationProperties("spring.security.oauth2.authorizationserver")
@@ -145,6 +146,11 @@ public class OAuth2AuthorizationServerProperties implements InitializingBean {
 		private String tokenIntrospectionUri = "/oauth2/introspect";
 
 		/**
+		 * Authorization Server's OAuth 2.0 Pushed Authorization Request Endpoint.
+		 */
+		private String pushedAuthorizationRequestUri = "/oauth2/par";
+
+		/**
 		 * OpenID Connect 1.0 endpoints.
 		 */
 		@NestedConfigurationProperty
@@ -204,6 +210,14 @@ public class OAuth2AuthorizationServerProperties implements InitializingBean {
 
 		public void setTokenIntrospectionUri(String tokenIntrospectionUri) {
 			this.tokenIntrospectionUri = tokenIntrospectionUri;
+		}
+
+		public String getPushedAuthorizationRequestUri() {
+			return this.pushedAuthorizationRequestUri;
+		}
+
+		public void setPushedAuthorizationRequestUri(String pushedAuthorizationRequestUri) {
+			this.pushedAuthorizationRequestUri = pushedAuthorizationRequestUri;
 		}
 
 		public OidcEndpoint getOidc() {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerPropertiesMapper.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerPropertiesMapper.java
@@ -38,6 +38,7 @@ import org.springframework.security.oauth2.server.authorization.settings.TokenSe
  * Maps {@link OAuth2AuthorizationServerProperties} to Authorization Server types.
  *
  * @author Steve Riesenberg
+ * @author Florian Lemaire
  */
 final class OAuth2AuthorizationServerPropertiesMapper {
 
@@ -61,6 +62,7 @@ final class OAuth2AuthorizationServerPropertiesMapper {
 		map.from(endpoint::getJwkSetUri).to(builder::jwkSetEndpoint);
 		map.from(endpoint::getTokenRevocationUri).to(builder::tokenRevocationEndpoint);
 		map.from(endpoint::getTokenIntrospectionUri).to(builder::tokenIntrospectionEndpoint);
+		map.from(endpoint::getPushedAuthorizationRequestUri).to(builder::pushedAuthorizationRequestEndpoint);
 		map.from(oidc::getLogoutUri).to(builder::oidcLogoutEndpoint);
 		map.from(oidc::getClientRegistrationUri).to(builder::oidcClientRegistrationEndpoint);
 		map.from(oidc::getUserInfoUri).to(builder::oidcUserInfoEndpoint);

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerAutoConfigurationTests.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Steve Riesenberg
  * @author Madhura Bhave
+ * @author Florian Lemaire
  */
 class OAuth2AuthorizationServerAutoConfigurationTests {
 
@@ -133,6 +134,7 @@ class OAuth2AuthorizationServerAutoConfigurationTests {
 					PROPERTIES_PREFIX + ".endpoint.token-uri=/token", PROPERTIES_PREFIX + ".endpoint.jwk-set-uri=/jwks",
 					PROPERTIES_PREFIX + ".endpoint.token-revocation-uri=/revoke",
 					PROPERTIES_PREFIX + ".endpoint.token-introspection-uri=/introspect",
+					PROPERTIES_PREFIX + ".endpoint.pushed-authorization-request-uri=/par",
 					PROPERTIES_PREFIX + ".endpoint.oidc.logout-uri=/logout",
 					PROPERTIES_PREFIX + ".endpoint.oidc.client-registration-uri=/register",
 					PROPERTIES_PREFIX + ".endpoint.oidc.user-info-uri=/user")
@@ -146,6 +148,7 @@ class OAuth2AuthorizationServerAutoConfigurationTests {
 				assertThat(settings.getJwkSetEndpoint()).isEqualTo("/jwks");
 				assertThat(settings.getTokenRevocationEndpoint()).isEqualTo("/revoke");
 				assertThat(settings.getTokenIntrospectionEndpoint()).isEqualTo("/introspect");
+				assertThat(settings.getPushedAuthorizationRequestEndpoint()).isEqualTo("/par");
 				assertThat(settings.getOidcLogoutEndpoint()).isEqualTo("/logout");
 				assertThat(settings.getOidcClientRegistrationEndpoint()).isEqualTo("/register");
 				assertThat(settings.getOidcUserInfoEndpoint()).isEqualTo("/user");

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerPropertiesMapperTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerPropertiesMapperTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link OAuth2AuthorizationServerPropertiesMapper}.
  *
  * @author Steve Riesenberg
+ * @author Florian Lemaire
  */
 class OAuth2AuthorizationServerPropertiesMapperTests {
 
@@ -107,6 +108,7 @@ class OAuth2AuthorizationServerPropertiesMapperTests {
 		endpoints.setJwkSetUri("/jwks");
 		endpoints.setTokenRevocationUri("/revoke");
 		endpoints.setTokenIntrospectionUri("/introspect");
+		endpoints.setPushedAuthorizationRequestUri("/par");
 		OAuth2AuthorizationServerProperties.OidcEndpoint oidc = endpoints.getOidc();
 		oidc.setLogoutUri("/logout");
 		oidc.setClientRegistrationUri("/register");
@@ -121,6 +123,7 @@ class OAuth2AuthorizationServerPropertiesMapperTests {
 		assertThat(settings.getJwkSetEndpoint()).isEqualTo("/jwks");
 		assertThat(settings.getTokenRevocationEndpoint()).isEqualTo("/revoke");
 		assertThat(settings.getTokenIntrospectionEndpoint()).isEqualTo("/introspect");
+		assertThat(settings.getPushedAuthorizationRequestEndpoint()).isEqualTo("/par");
 		assertThat(settings.getOidcLogoutEndpoint()).isEqualTo("/logout");
 		assertThat(settings.getOidcClientRegistrationEndpoint()).isEqualTo("/register");
 		assertThat(settings.getOidcUserInfoEndpoint()).isEqualTo("/user");
@@ -137,6 +140,7 @@ class OAuth2AuthorizationServerPropertiesMapperTests {
 		endpoints.setJwkSetUri("/jwks");
 		endpoints.setTokenRevocationUri("/revoke");
 		endpoints.setTokenIntrospectionUri("/introspect");
+		endpoints.setPushedAuthorizationRequestUri("/par");
 		OAuth2AuthorizationServerProperties.OidcEndpoint oidc = endpoints.getOidc();
 		oidc.setLogoutUri("/logout");
 		oidc.setClientRegistrationUri("/register");
@@ -151,6 +155,7 @@ class OAuth2AuthorizationServerPropertiesMapperTests {
 		assertThat(settings.getJwkSetEndpoint()).isEqualTo("/jwks");
 		assertThat(settings.getTokenRevocationEndpoint()).isEqualTo("/revoke");
 		assertThat(settings.getTokenIntrospectionEndpoint()).isEqualTo("/introspect");
+		assertThat(settings.getPushedAuthorizationRequestEndpoint()).isEqualTo("/par");
 		assertThat(settings.getOidcLogoutEndpoint()).isEqualTo("/logout");
 		assertThat(settings.getOidcClientRegistrationEndpoint()).isEqualTo("/register");
 		assertThat(settings.getOidcUserInfoEndpoint()).isEqualTo("/user");

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerPropertiesTests.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * Tests for {@link OAuth2AuthorizationServerProperties}.
  *
  * @author Steve Riesenberg
+ * @author Florian Lemaire
  */
 class OAuth2AuthorizationServerPropertiesTests {
 
@@ -85,6 +86,7 @@ class OAuth2AuthorizationServerPropertiesTests {
 		assertThat(properties.getJwkSetUri()).isEqualTo(defaults.getJwkSetEndpoint());
 		assertThat(properties.getTokenRevocationUri()).isEqualTo(defaults.getTokenRevocationEndpoint());
 		assertThat(properties.getTokenIntrospectionUri()).isEqualTo(defaults.getTokenIntrospectionEndpoint());
+		assertThat(properties.getPushedAuthorizationRequestUri()).isEqualTo(defaults.getPushedAuthorizationRequestEndpoint());
 		OAuth2AuthorizationServerProperties.OidcEndpoint oidc = properties.getOidc();
 		assertThat(oidc.getLogoutUri()).isEqualTo(defaults.getOidcLogoutEndpoint());
 		assertThat(oidc.getClientRegistrationUri()).isEqualTo(defaults.getOidcClientRegistrationEndpoint());

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-oauth2-authorization-server/src/main/resources/application.yml
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-oauth2-authorization-server/src/main/resources/application.yml
@@ -9,6 +9,7 @@ spring:
           jwk-set-uri: /jwks
           token-revocation-uri: /revoke
           token-introspection-uri: /introspect
+          pushed-authorization-request-uri: /par
           oidc:
             logout-uri: /logout
             client-registration-uri: /register

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-oauth2-authorization-server/src/test/java/smoketest/oauth2/server/SampleOAuth2AuthorizationServerApplicationTests.java
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-oauth2-authorization-server/src/test/java/smoketest/oauth2/server/SampleOAuth2AuthorizationServerApplicationTests.java
@@ -70,6 +70,7 @@ class SampleOAuth2AuthorizationServerApplicationTests {
 		assertThat(config.getTokenRevocationEndpoint()).hasToString("https://provider.com/revoke");
 		assertThat(config.getEndSessionEndpoint()).hasToString("https://provider.com/logout");
 		assertThat(config.getTokenIntrospectionEndpoint()).hasToString("https://provider.com/introspect");
+		assertThat(config.getPushedAuthorizationRequestEndpoint()).hasToString("https://provider.com/par");
 		assertThat(config.getUserInfoEndpoint()).hasToString("https://provider.com/user");
 		// OIDC Client Registration is disabled by default
 		assertThat(config.getClientRegistrationEndpoint()).isNull();
@@ -88,6 +89,7 @@ class SampleOAuth2AuthorizationServerApplicationTests {
 		assertThat(config.getJwkSetUrl()).hasToString("https://provider.com/jwks");
 		assertThat(config.getTokenRevocationEndpoint()).hasToString("https://provider.com/revoke");
 		assertThat(config.getTokenIntrospectionEndpoint()).hasToString("https://provider.com/introspect");
+		assertThat(config.getPushedAuthorizationRequestEndpoint()).hasToString("https://provider.com/par");
 		// OIDC Client Registration is disabled by default
 		assertThat(config.getClientRegistrationEndpoint()).isNull();
 	}


### PR DESCRIPTION
This PR addresses gh-46486 by introducing a new configuration property:
`spring.security.oauth2.authorizationserver.endpoint.pushed-authorization-request-uri`.

This allows customizing the path of the Pushed Authorization Request (PAR) endpoint,
which was previously hardcoded.

The default remains `/oauth2/par`, and the value can now be overridden via configuration.

Closes gh-46486

Signed-off-by: Florian Lemaire <florian.lemaire.gis@gmail.com>