### PR TITLE
Enable virtualThreadMetrics bean on if virtual threads are enabled

### DIFF
--- a/module/spring-boot-metrics/src/main/java/org/springframework/boot/metrics/autoconfigure/jvm/JvmMetricsAutoConfiguration.java
+++ b/module/spring-boot-metrics/src/main/java/org/springframework/boot/metrics/autoconfigure/jvm/JvmMetricsAutoConfiguration.java
@@ -36,8 +36,10 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnThreading;
 import org.springframework.boot.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.metrics.autoconfigure.MetricsAutoConfiguration;
+import org.springframework.boot.thread.Threading;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.util.ClassUtils;
@@ -102,6 +104,7 @@ public final class JvmMetricsAutoConfiguration {
 	@ConditionalOnClass(name = VIRTUAL_THREAD_METRICS_CLASS)
 	@ConditionalOnMissingBean(type = VIRTUAL_THREAD_METRICS_CLASS)
 	@ImportRuntimeHints(VirtualThreadMetricsRuntimeHintsRegistrar.class)
+	@ConditionalOnThreading(Threading.VIRTUAL)
 	MeterBinder virtualThreadMetrics() throws ClassNotFoundException {
 		Class<?> virtualThreadMetricsClass = ClassUtils.forName(VIRTUAL_THREAD_METRICS_CLASS,
 				getClass().getClassLoader());

--- a/module/spring-boot-metrics/src/test/java/org/springframework/boot/metrics/autoconfigure/jvm/JvmMetricsAutoConfigurationTests.java
+++ b/module/spring-boot-metrics/src/test/java/org/springframework/boot/metrics/autoconfigure/jvm/JvmMetricsAutoConfigurationTests.java
@@ -108,9 +108,17 @@ class JvmMetricsAutoConfigurationTests {
 
 	@Test
 	@EnabledForJreRange(min = JRE.JAVA_21)
-	void autoConfiguresJvmMetricsWithVirtualThreadsMetrics() {
+	void doesntAutoConfigureJvmMetricsWithVirtualThreadsMetricsIfVirtualThreadsAreDisabled() {
 		this.contextRunner.run(assertMetricsBeans()
-			.andThen((context) -> assertThat(context).hasSingleBean(getVirtualThreadMetricsClass())));
+			.andThen((context) -> assertThat(context).doesNotHaveBean(getVirtualThreadMetricsClass())));
+	}
+
+	@Test
+	@EnabledForJreRange(min = JRE.JAVA_21)
+	void autoConfiguresJvmMetricsWithVirtualThreadsMetricsIfVirtualThreadsAreEnabled() {
+		this.contextRunner.withPropertyValues("spring.threads.virtual.enabled=true")
+			.run(assertMetricsBeans()
+				.andThen((context) -> assertThat(context).hasSingleBean(getVirtualThreadMetricsClass())));
 	}
 
 	@Test


### PR DESCRIPTION
Currently `VirtualThreadMetrics` from micrometer don't work in a native image. Despite that it was tested in https://github.com/spring-projects/spring-boot/pull/43852, the PR https://github.com/micrometer-metrics/micrometer/pull/6104 broke it due to the fact that native images don't have `jdk.management.VirtualThreadSchedulerMXBean`.
I'd like to fix it in micrometer, but in the meantime I'd like to propose not to configure the bean if virtual threads aren't enabled. Without them the bean seems redundant.

What do you think?