### PR TITLE
SpringLiquibaseCustomizer is exposed outside its defined visibility scope

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java
@@ -183,6 +183,7 @@ public class LiquibaseAutoConfiguration {
 	}
 
 	@ConditionalOnClass(Customizer.class)
+	@Configuration(proxyBeanMethods = false)
 	static class CustomizerConfiguration {
 
 		@Bean
@@ -260,7 +261,7 @@ public class LiquibaseAutoConfiguration {
 	}
 
 	@FunctionalInterface
-	private interface SpringLiquibaseCustomizer {
+	interface SpringLiquibaseCustomizer {
 
 		/**
 		 * Customize the given {@link SpringLiquibase} instance.


### PR DESCRIPTION
> /Users/dmytronosan/Downloads/liqutest/build/generated/aotSources/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration__BeanDefinitions.java:112: error: SpringLiquibaseCustomizer has private access in LiquibaseAutoConfiguration
    private static BeanInstanceSupplier<LiquibaseAutoConfiguration.SpringLiquibaseCustomizer> getSpringLiquibaseCustomizerInstanceSupplier(