### PR TITLE
Add an ArchRule to ensure that the return type of a @Bean method is not private

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitecturePlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitecturePlugin.java
@@ -49,6 +49,7 @@ public class ArchitecturePlugin implements Plugin<Project> {
 			TaskProvider<ArchitectureCheck> checkPackageTangles = project.getTasks()
 				.register("checkArchitecture" + StringUtils.capitalize(sourceSet.getName()), ArchitectureCheck.class,
 						(task) -> {
+							task.getSourceSet().set(sourceSet.getName());
 							task.getCompileClasspath().from(sourceSet.getCompileClasspath());
 							task.setClasses(sourceSet.getOutput().getClassesDirs());
 							task.getResourcesDirectory().set(sourceSet.getOutput().getResourcesDir());

--- a/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureRules.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureRules.java
@@ -33,6 +33,7 @@ import com.tngtech.archunit.core.domain.JavaCall;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClass.Predicates;
 import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.domain.JavaParameter;
 import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.properties.CanBeAnnotated;
@@ -91,6 +92,20 @@ final class ArchitectureRules {
 		rules.add(enumSourceShouldNotSpecifyOnlyATypeThatIsTheSameAsMethodParameterType());
 		rules.add(allConfigurationPropertiesBindingBeanMethodsShouldBeStatic());
 		return List.copyOf(rules);
+	}
+
+	static ArchRule allBeanMethodsShouldReturnNonPrivateType() {
+		return methodsThatAreAnnotatedWith("org.springframework.context.annotation.Bean").should(check(
+				"not return types declared with the %s modifier, as such types are incompatible with Spring AOT processing"
+					.formatted(JavaModifier.PRIVATE),
+				(method, events) -> {
+					JavaClass returnType = method.getRawReturnType();
+					if (returnType.getModifiers().contains(JavaModifier.PRIVATE)) {
+						addViolation(events, method, "%s returns %s which is declared as %s".formatted(
+								method.getDescription(), returnType.getDescription(), returnType.getModifiers()));
+					}
+				}))
+			.allowEmptyShould(true);
 	}
 
 	private static ArchRule allPackagesShouldBeFreeOfTangles() {

--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/beans/privatebean/PrivateBean.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/beans/privatebean/PrivateBean.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.build.architecture.beans.privatebean;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+class PrivateBean {
+
+	@Bean
+	static MyBean myBean() {
+		return new MyBean();
+	}
+
+	private static final class MyBean {
+
+	}
+
+}

--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/beans/regular/RegularBean.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/beans/regular/RegularBean.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.build.architecture.beans.regular;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+class RegularBean {
+
+	@Bean
+	static PackagePrivate packagePrivateBean() {
+		return new PackagePrivate();
+	}
+
+	@Bean
+	static Protected protectedBean() {
+		return new Protected();
+	}
+
+	@Bean
+	static Public publicBean() {
+		return new Public();
+	}
+
+	static final class PackagePrivate {
+
+	}
+
+	protected static final class Protected {
+
+	}
+
+	public static final class Public {
+
+	}
+
+}


### PR DESCRIPTION
See #46688 