### PR TITLE
Exclude infrastructure beans from lazy init early

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/LazyInitializationBeanFactoryPostProcessor.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/LazyInitializationBeanFactoryPostProcessor.java
@@ -80,6 +80,9 @@ public final class LazyInitializationBeanFactoryPostProcessor implements BeanFac
 		if (lazyInit != null) {
 			return;
 		}
+		if (beanDefinition.getRole() == BeanDefinition.ROLE_INFRASTRUCTURE) {
+			return;
+		}
 		Class<?> beanType = getBeanType(beanFactory, beanName);
 		if (!isExcluded(filters, beanName, beanDefinition, beanType)) {
 			beanDefinition.setLazyInit(true);


### PR DESCRIPTION
ROLE_INFRASTRUCTURE bean added early return logic prior to bean type interpretation(getType) to be excluded from lazy-init in any case.
I think the code can eliminate the room for the infrastructure bean to accidentally turn into Lazy-init=true even when the beanType is null or the type inference is limited.