### PR TITLE
Align method descriptions for SslOptions getCiphers and getEnabledProtocols with '@returns'

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/ssl/SslOptions.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/ssl/SslOptions.java
@@ -32,6 +32,7 @@ import org.springframework.core.style.ToStringCreator;
  * Configuration options that should be applied when establishing an SSL connection.
  *
  * @author Scott Frederick
+ * @author Jeonghun Kang
  * @since 3.1.0
  * @see SslBundle#getOptions()
  */
@@ -51,7 +52,7 @@ public interface SslOptions {
 	}
 
 	/**
-	 * Return the ciphers that can be used or an empty set. The cipher names in this set
+	 * Return the ciphers that can be used or null. The cipher names in this set
 	 * should be compatible with those supported by
 	 * {@link SSLEngine#getSupportedCipherSuites()}.
 	 * @return the ciphers that can be used or {@code null}
@@ -59,7 +60,7 @@ public interface SslOptions {
 	String @Nullable [] getCiphers();
 
 	/**
-	 * Return the protocols that should be enabled or an empty set. The protocols names in
+	 * Return the protocols that should be enabled or null. The protocols names in
 	 * this set should be compatible with those supported by
 	 * {@link SSLEngine#getSupportedProtocols()}.
 	 * @return the protocols to enable or {@code null}


### PR DESCRIPTION
### Description

This pull request aligns the Javadoc description of `SslOptions.getCiphers()` and `SslOptions.getEnabledProtocols()` with their `@return` tags.

Currently, the method descriptions state that they return an "empty set," while the `@return` tag correctly specifies that they return `null`. This change resolves the discrepancy by updating the description to explicitly state that the methods return `null` when no options are specified, which is consistent with the current implementation.

**Before:**
- `Return the ciphers that can be used or an empty set.`
- `Return the protocols that should be enabled or an empty set.`

**After:**
- `Return the ciphers that can be used or null.`
- `Return the protocols that should be enabled or null.`

ref. [issue 46660](https://github.com/spring-projects/spring-boot/issues/46660) 