### PR TITLE
Kotlin samples for configuration metadata are in the wrong package

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/appendix/configurationmetadata/annotationprocessor/automaticmetadatageneration/MyMessagingProperties.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/appendix/configurationmetadata/annotationprocessor/automaticmetadatageneration/MyMessagingProperties.kt
@@ -14,25 +14,20 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.docs.configurationmetadata.annotationprocessor.automaticmetadatageneration
+package org.springframework.boot.docs.appendix.configurationmetadata.annotationprocessor.automaticmetadatageneration
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import java.util.Arrays
 
-@ConfigurationProperties(prefix = "my.server")
-class MyServerProperties(
+@ConfigurationProperties(prefix = "my.messaging")
+class MyMessagingProperties(
 
-	/**
-	 * Name of the server.
-	 */
-	var name: String,
+	val addresses: List<String> = ArrayList(Arrays.asList("a", "b")),
 
-	/**
-	 * IP address to listen to.
-	 */
-	var ip: String = "127.0.0.1",
+	var containerType: ContainerType = ContainerType.SIMPLE) {
 
-	/**
-	 * Port to listen to.
-	 */
-	var port: Int = 9797)
+	enum class ContainerType {
+		SIMPLE, DIRECT
+	}
+}
 

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/appendix/configurationmetadata/annotationprocessor/automaticmetadatageneration/MyServerProperties.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/appendix/configurationmetadata/annotationprocessor/automaticmetadatageneration/MyServerProperties.kt
@@ -14,17 +14,25 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.docs.configurationmetadata.format.property
+package org.springframework.boot.docs.appendix.configurationmetadata.annotationprocessor.automaticmetadatageneration
 
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.DeprecatedConfigurationProperty
 
-@ConfigurationProperties("my.app")
-class MyProperties(val name: String?) {
+@ConfigurationProperties(prefix = "my.server")
+class MyServerProperties(
 
-	var target: String? = null
-		@Deprecated("") @DeprecatedConfigurationProperty(replacement = "my.app.name") get
-		@Deprecated("") set
+	/**
+	 * Name of the server.
+	 */
+	var name: String,
 
-}
+	/**
+	 * IP address to listen to.
+	 */
+	var ip: String = "127.0.0.1",
+
+	/**
+	 * Port to listen to.
+	 */
+	var port: Int = 9797)
 

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/appendix/configurationmetadata/annotationprocessor/automaticmetadatageneration/nestedproperties/MyServerProperties.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/appendix/configurationmetadata/annotationprocessor/automaticmetadatageneration/nestedproperties/MyServerProperties.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.docs.configurationmetadata.annotationprocessor.automaticmetadatageneration.nestedproperties
+package org.springframework.boot.docs.appendix.configurationmetadata.annotationprocessor.automaticmetadatageneration.nestedproperties
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/appendix/configurationmetadata/format/property/MyProperties.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/appendix/configurationmetadata/format/property/MyProperties.kt
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.docs.configurationmetadata.manualhints.valuehint
+package org.springframework.boot.docs.appendix.configurationmetadata.format.property
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty
 
-@ConfigurationProperties("my")
-class MyProperties(val contexts: Map<String, Int>)
+@ConfigurationProperties("my.app")
+class MyProperties(val name: String?) {
+
+	var target: String? = null
+		@Deprecated("") @DeprecatedConfigurationProperty(replacement = "my.app.name") get
+		@Deprecated("") set
+
+}
 

--- a/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/appendix/configurationmetadata/manualhints/valuehint/MyProperties.kt
+++ b/spring-boot-project/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/appendix/configurationmetadata/manualhints/valuehint/MyProperties.kt
@@ -14,20 +14,10 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.docs.configurationmetadata.annotationprocessor.automaticmetadatageneration
+package org.springframework.boot.docs.appendix.configurationmetadata.manualhints.valuehint
 
 import org.springframework.boot.context.properties.ConfigurationProperties
-import java.util.Arrays
 
-@ConfigurationProperties(prefix = "my.messaging")
-class MyMessagingProperties(
-
-	val addresses: List<String> = ArrayList(Arrays.asList("a", "b")),
-
-	var containerType: ContainerType = ContainerType.SIMPLE) {
-
-	enum class ContainerType {
-		SIMPLE, DIRECT
-	}
-}
+@ConfigurationProperties("my")
+class MyProperties(val contexts: Map<String, Int>)
 


### PR DESCRIPTION
Reorganize several Kotlin documentation files by moving them into new package paths under `org.springframework.boot.docs.appendix` so they are in line with the Java examples