### PR TITLE
Auto-configuration samples in spring-boot-docs should be final as well

### DIFF
--- a/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/developingautoconfiguration/conditionannotations/beanconditions/MyAutoConfiguration.java
+++ b/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/developingautoconfiguration/conditionannotations/beanconditions/MyAutoConfiguration.java
@@ -21,11 +21,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 
 @AutoConfiguration
-public class MyAutoConfiguration {
+public final class MyAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public SomeService someService() {
+	SomeService someService() {
 		return new SomeService();
 	}
 

--- a/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/developingautoconfiguration/conditionannotations/classconditions/MyAutoConfiguration.java
+++ b/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/developingautoconfiguration/conditionannotations/classconditions/MyAutoConfiguration.java
@@ -24,7 +24,7 @@ import org.springframework.context.annotation.Configuration;
 
 @AutoConfiguration
 // Some conditions ...
-public class MyAutoConfiguration {
+public final class MyAutoConfiguration {
 
 	// Auto-configured beans ...
 

--- a/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/developingautoconfiguration/testing/MyServiceAutoConfiguration.java
+++ b/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/features/developingautoconfiguration/testing/MyServiceAutoConfiguration.java
@@ -27,11 +27,11 @@ import org.springframework.context.annotation.Bean;
 @AutoConfiguration
 @ConditionalOnClass(MyService.class)
 @EnableConfigurationProperties(UserProperties.class)
-public class MyServiceAutoConfiguration {
+public final class MyServiceAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public MyService userService(UserProperties properties) {
+	MyService userService(UserProperties properties) {
 		return new MyService(properties.getName());
 	}
 


### PR DESCRIPTION
The `checkArchitectureMain` task from the `spring-boot-docs` fails as follows:

```
% ./gradlew clean :documentation:spring-boot-docs:checkArchitectureMain
...
> Task :documentation:spring-boot-docs:checkArchitectureMain FAILED
...
```

And `failure-report.txt` contains the following:

```
Architecture Violation [Priority: MEDIUM] - Rule 'classes that are annotated with @AutoConfiguration should be public and should have modifier FINAL' was violated (3 times):
Class <org.springframework.boot.docs.features.developingautoconfiguration.conditionannotations.beanconditions.MyAutoConfiguration> does not have modifier FINAL in (MyAutoConfiguration.java:0)
Class <org.springframework.boot.docs.features.developingautoconfiguration.conditionannotations.classconditions.MyAutoConfiguration> does not have modifier FINAL in (MyAutoConfiguration.java:0)
Class <org.springframework.boot.docs.features.developingautoconfiguration.testing.MyServiceAutoConfiguration> does not have modifier FINAL in (MyServiceAutoConfiguration.java:0)
Architecture Violation [Priority: MEDIUM] - Rule 'members that are declared in classes that are annotated with @AutoConfiguration and aren't default constructors and aren't constants and don't override public methods should not be public' was violated (2 times):
Method <org.springframework.boot.docs.features.developingautoconfiguration.conditionannotations.beanconditions.MyAutoConfiguration.someService()> has modifier PUBLIC in (MyAutoConfiguration.java:29)
Method <org.springframework.boot.docs.features.developingautoconfiguration.testing.MyServiceAutoConfiguration.userService(org.springframework.boot.docs.features.developingautoconfiguration.testing.MyServiceAutoConfiguration$UserProperties)> has modifier PUBLIC in (MyServiceAutoConfiguration.java:35)
```