### PR TITLE
Fail with a useful error message if Gradle is run on JDK < 24

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -44,6 +44,11 @@ rootProject.name="spring-boot-build"
 enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
 
 settings.gradle.projectsLoaded {
+	ensureCompatibleJavaVersion -> {
+		if (!JavaVersion.current().isCompatibleWith(JavaVersion.toVersion(24))) {
+			throw new GradleException("Java 24 or newer is needed to compile. Java version used is ${JavaVersion.current().toString()}.")
+		}
+	}
 	develocity {
 		buildScan {
 			def toolchainVersion = settings.gradle.rootProject.findProperty('toolchainVersion')


### PR DESCRIPTION
If the JDK version used to compile the software is not compatible with Java 24, the build fails fast with a hint what has gone wrong. This check happens on the `projectsLoaded` hook.
Fix #46625

