### PR TITLE
Avoid Stream API in performance critical tracing code

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/CompositePropagationFactory.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/CompositePropagationFactory.java
@@ -19,7 +19,6 @@ package org.springframework.boot.actuate.autoconfigure.tracing;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import brave.propagation.B3Propagation;
@@ -76,11 +75,19 @@ class CompositePropagationFactory extends Propagation.Factory {
 
 	@Override
 	public TraceContext decorate(TraceContext context) {
-		return Stream.concat(this.injectors.stream(), this.extractors.stream())
-			.map((factory) -> factory.decorate(context))
-			.filter((decorated) -> decorated != context)
-			.findFirst()
-			.orElse(context);
+		for (Propagation.Factory factory : this.injectors.factories) {
+			TraceContext decorated = factory.decorate(context);
+			if (decorated != context) {
+				return decorated;
+			}
+		}
+		for (Propagation.Factory factory : this.extractors.factories) {
+			TraceContext decorated = factory.decorate(context);
+			if (decorated != context) {
+				return decorated;
+			}
+		}
+		return context;
 	}
 
 	/**
@@ -179,11 +186,21 @@ class CompositePropagationFactory extends Propagation.Factory {
 		}
 
 		boolean requires128BitTraceId() {
-			return stream().anyMatch(Propagation.Factory::requires128BitTraceId);
+			for (Propagation.Factory factory : this.factories) {
+				if (factory.requires128BitTraceId()) {
+					return true;
+				}
+			}
+			return false;
 		}
 
 		boolean supportsJoin() {
-			return stream().allMatch(Propagation.Factory::supportsJoin);
+			for (Propagation.Factory factory : this.factories) {
+				if (!factory.supportsJoin()) {
+					return false;
+				}
+			}
+			return true;
 		}
 
 		List<Propagation<String>> get() {
@@ -224,19 +241,24 @@ class CompositePropagationFactory extends Propagation.Factory {
 
 		@Override
 		public <R> TraceContext.Injector<R> injector(Setter<R, String> setter) {
-			return (traceContext, request) -> this.injectors.stream()
-				.map((propagation) -> propagation.injector(setter))
-				.forEach((injector) -> injector.inject(traceContext, request));
+			return (traceContext, request) -> {
+				for (Propagation<String> propagation : this.injectors) {
+					propagation.injector(setter).inject(traceContext, request);
+				}
+			};
 		}
 
 		@Override
 		public <R> TraceContext.Extractor<R> extractor(Getter<R, String> getter) {
-			return (request) -> this.extractors.stream()
-				.map((propagation) -> propagation.extractor(getter))
-				.map((extractor) -> extractor.extract(request))
-				.filter(Predicate.not(TraceContextOrSamplingFlags.EMPTY::equals))
-				.findFirst()
-				.orElse(TraceContextOrSamplingFlags.EMPTY);
+			return (request) -> {
+				for (Propagation<String> propagation : this.extractors) {
+					TraceContextOrSamplingFlags extracted = propagation.extractor(getter).extract(request);
+					if (!TraceContextOrSamplingFlags.EMPTY.equals(extracted)) {
+						return extracted;
+					}
+				}
+				return TraceContextOrSamplingFlags.EMPTY;
+			};
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/CompositeTextMapPropagator.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/CompositeTextMapPropagator.java
@@ -106,11 +106,14 @@ class CompositeTextMapPropagator implements TextMapPropagator {
 		if (getter == null) {
 			return context;
 		}
-		Context result = this.extractors.stream()
-			.map((extractor) -> extractor.extract(context, carrier, getter))
-			.filter((extracted) -> extracted != context)
-			.findFirst()
-			.orElse(context);
+		Context result = context;
+		for (TextMapPropagator extractor : this.extractors) {
+			Context extracted = extractor.extract(context, carrier, getter);
+			if (extracted != context) {
+				result = extracted;
+				break;
+			}
+		}
 		if (this.baggagePropagator != null) {
 			result = this.baggagePropagator.extract(result, carrier, getter);
 		}


### PR DESCRIPTION
Injection or extraction of the tracing context happens on each request. For example, on each call with an HTTP client or handled by a Controller that's instrumented. The Stream API used here was showing up on CPU profiling under heavy load. With these changes, the CPU profiling looks better while maintaining the same behavior as before.

Before (Stream API highlighted)
<img width="1512" height="552" alt="image" src="https://github.com/user-attachments/assets/e384ae06-9631-4817-a283-1bb098b57172" />

After
<img width="1512" height="386" alt="image" src="https://github.com/user-attachments/assets/ec71ecfb-48d2-43cd-8512-640f966048e3" />
