### PR TITLE
Hazelcast health indicator reports the wrong status when Hazelcast has shut down due to an out-of-memory error

### DIFF
--- a/module/spring-boot-hazelcast/src/main/java/org/springframework/boot/hazelcast/health/HazelcastHealthIndicator.java
+++ b/module/spring-boot-hazelcast/src/main/java/org/springframework/boot/hazelcast/health/HazelcastHealthIndicator.java
@@ -28,6 +28,7 @@ import org.springframework.util.Assert;
  *
  * @author Dmytro Nosan
  * @author Stephane Nicoll
+ * @author Tommy Karlsson
  * @since 4.0.0
  */
 public class HazelcastHealthIndicator extends AbstractHealthIndicator {
@@ -42,6 +43,10 @@ public class HazelcastHealthIndicator extends AbstractHealthIndicator {
 
 	@Override
 	protected void doHealthCheck(Health.Builder builder) {
+		if (!this.hazelcast.getLifecycleService().isRunning()) {
+			builder.down();
+			return;
+		}
 		this.hazelcast.executeTransaction((context) -> {
 			String uuid = this.hazelcast.getLocalEndpoint().getUuid().toString();
 			builder.up().withDetail("name", this.hazelcast.getName()).withDetail("uuid", uuid);


### PR DESCRIPTION
This is needed because when the default Out-Of-Memory handler in Hazelcast detects a OOM error, and terminates Hazelcast, it does so on the _node_ but not via the Hazelcast lifecycle manager - and the results is that it is still possible to successfully execute transactions in Hazelcast after this termination. The health indicator should not report UP after Hazelcast has detected an OOM and terminated itself.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
