### PR TITLE
maven-plugin aot test mojo: process aot when tests are built but not run

### DIFF
--- a/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/ProcessTestAotMojo.java
+++ b/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/ProcessTestAotMojo.java
@@ -124,7 +124,7 @@ public class ProcessTestAotMojo extends AbstractAotMojo {
 			getLog().debug("process-test-aot goal could not be applied to pom project.");
 			return;
 		}
-		if (Boolean.getBoolean("skipTests") || Boolean.getBoolean("maven.test.skip")) {
+		if (Boolean.getBoolean("maven.test.skip")) {
 			getLog().info("Skipping AOT test processing since tests are skipped");
 			return;
 		}


### PR DESCRIPTION
Currently, it is not possible to build the tests AOT processing without running them. Maven Surefire provides two different configuration switches:

* `skipTests` builds, but does not run, tests
* `maven.test.skip` neither builds nor runs tests

Right now the spring boot aot processing will skip aot in both cases. However, there's reasons to build but not run tests: in particular, this breaks reproducible builds because the main run (with tests built and run) has the aot classes built, but then the reproducer run (build tests but skip running them) does not, leading to different test jars.

In the case where tests are built but not run, we should still do AOT processing, since that is part of producing the full test jar.

We'd very much appreciate a backport to 3.5.x if possible
