### PR TITLE
Remove redundant suppressions from Checkstyle configuration

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -69,7 +69,6 @@
 	<suppress files="StringSequence" checks="SpringMethodVisibility" message="isEmpty"/>
 	<suppress files="ValidatorPropertiesWithDefaultValues\.java" checks="SpringMethodVisibility" />
 	<suppress files="DeprecatedElasticsearchRestClientProperties\.java" checks="SpringMethodVisibility" />
-	<suppress files="DeprecatedElasticsearchRestClientProperties\.java" checks="SpringMethodVisibility" />
 	<suppress files="DeprecatedReactiveElasticsearchRestClientProperties\.java" checks="SpringMethodVisibility" />
 	<suppress files="DevToolsTestApplication\.java" checks="SpringMethodVisibility" />
 	<suppress files="DevToolsR2dbcAutoConfigurationTests" checks="HideUtilityClassConstructor" />


### PR DESCRIPTION
This PR removes a duplicate suppression entry for
`DeprecatedElasticsearchRestClientProperties` in the Checkstyle configuration.