### PR TITLE
Clarify Javadoc of Customizer interfaces about overriding behavior

### DIFF
--- a/module/spring-boot-activemq/src/main/java/org/springframework/boot/activemq/autoconfigure/ActiveMQConnectionFactoryCustomizer.java
+++ b/module/spring-boot-activemq/src/main/java/org/springframework/boot/activemq/autoconfigure/ActiveMQConnectionFactoryCustomizer.java
@@ -20,7 +20,7 @@ import org.apache.activemq.ActiveMQConnectionFactory;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the
- * {@link ActiveMQConnectionFactory} whilst retaining default auto-configuration.
+ * {@link ActiveMQConnectionFactory} to fine-tune its auto-configuration.
  *
  * @author Stephane Nicoll
  * @since 4.0.0

--- a/module/spring-boot-batch/src/main/java/org/springframework/boot/batch/autoconfigure/BatchConversionServiceCustomizer.java
+++ b/module/spring-boot-batch/src/main/java/org/springframework/boot/batch/autoconfigure/BatchConversionServiceCustomizer.java
@@ -20,8 +20,8 @@ import org.springframework.core.convert.support.ConfigurableConversionService;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the
- * {@link ConfigurableConversionService} that is used by the batch infrastructure while
- * retaining its default auto-configuration.
+ * {@link ConfigurableConversionService} that is used by the batch infrastructure
+ * to fine-tune its auto-configuration.
  *
  * @author Claudio Nave
  * @since 4.0.0

--- a/module/spring-boot-cassandra/src/main/java/org/springframework/boot/cassandra/autoconfigure/CqlSessionBuilderCustomizer.java
+++ b/module/spring-boot-cassandra/src/main/java/org/springframework/boot/cassandra/autoconfigure/CqlSessionBuilderCustomizer.java
@@ -21,8 +21,8 @@ import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the
- * {@link CqlSession} through a {@link CqlSessionBuilder} whilst retaining default
- * auto-configuration.
+ * {@link CqlSession} through a {@link CqlSessionBuilder} to fine-tune
+ * its auto-configuration.
  *
  * @author Stephane Nicoll
  * @since 4.0.0

--- a/module/spring-boot-cassandra/src/main/java/org/springframework/boot/cassandra/autoconfigure/DriverConfigLoaderBuilderCustomizer.java
+++ b/module/spring-boot-cassandra/src/main/java/org/springframework/boot/cassandra/autoconfigure/DriverConfigLoaderBuilderCustomizer.java
@@ -21,8 +21,8 @@ import com.datastax.oss.driver.api.core.config.ProgrammaticDriverConfigLoaderBui
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the
- * {@link DriverConfigLoader} through a {@link DriverConfigLoaderBuilderCustomizer} whilst
- * retaining default auto-configuration.
+ * {@link DriverConfigLoader} through a {@link DriverConfigLoaderBuilderCustomizer}
+ * to fine-tune its auto-configuration.
  *
  * @author Stephane Nicoll
  * @since 4.0.0

--- a/module/spring-boot-couchbase/src/main/java/org/springframework/boot/couchbase/autoconfigure/ClusterEnvironmentBuilderCustomizer.java
+++ b/module/spring-boot-couchbase/src/main/java/org/springframework/boot/couchbase/autoconfigure/ClusterEnvironmentBuilderCustomizer.java
@@ -21,8 +21,8 @@ import com.couchbase.client.java.env.ClusterEnvironment.Builder;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the
- * {@link ClusterEnvironment} through a {@link Builder ClusterEnvironment.Builder} whilst
- * retaining default auto-configuration.
+ * {@link ClusterEnvironment} through a {@link Builder ClusterEnvironment.Builder}
+ * to fine-tune its auto-configuration.
  *
  * @author Stephane Nicoll
  * @since 4.0.0

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/ClientResourcesBuilderCustomizer.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/ClientResourcesBuilderCustomizer.java
@@ -21,8 +21,7 @@ import io.lettuce.core.resource.ClientResources.Builder;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the
- * {@link ClientResources} through a {@link Builder} whilst retaining default
- * auto-configuration.
+ * {@link ClientResources} through a {@link Builder} to fine-tune its auto-configuration.
  *
  * @author Stephane Nicoll
  * @since 4.0.0

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/JedisClientConfigurationBuilderCustomizer.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/JedisClientConfigurationBuilderCustomizer.java
@@ -22,8 +22,8 @@ import org.springframework.data.redis.connection.jedis.JedisClientConfiguration.
 /**
  * Callback interface that can be implemented by beans wishing to customize the
  * {@link JedisClientConfiguration} through a {@link JedisClientConfigurationBuilder
- * JedisClientConfiguration.JedisClientConfigurationBuilder} whilst retaining default
- * auto-configuration.
+ * JedisClientConfiguration.JedisClientConfigurationBuilder} to fine-tune
+ * its auto-configuration.
  *
  * @author Mark Paluch
  * @since 4.0.0

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/LettuceClientConfigurationBuilderCustomizer.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/LettuceClientConfigurationBuilderCustomizer.java
@@ -22,8 +22,8 @@ import org.springframework.data.redis.connection.lettuce.LettuceClientConfigurat
 /**
  * Callback interface that can be implemented by beans wishing to customize the
  * {@link LettuceClientConfiguration} through a {@link LettuceClientConfigurationBuilder
- * LettuceClientConfiguration.LettuceClientConfigurationBuilder} whilst retaining default
- * auto-configuration. To customize only the
+ * LettuceClientConfiguration.LettuceClientConfigurationBuilder} to fine-tune
+ * its auto-configuration. To customize only the
  * {@link LettuceClientConfiguration#getClientOptions() client options} of the
  * configuration, use {@link LettuceClientOptionsBuilderCustomizer} instead.
  *

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/LettuceClientOptionsBuilderCustomizer.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/LettuceClientOptionsBuilderCustomizer.java
@@ -24,7 +24,7 @@ import org.springframework.data.redis.connection.lettuce.LettuceClientConfigurat
 /**
  * Callback interface that can be implemented by beans wishing to customize the
  * {@link ClientOptions} of the {@link LettuceClientConfiguration} through a
- * {@link Builder} whilst retaining default auto-configuration. To customize the entire
+ * {@link Builder} to fine-tune its auto-configuration. To customize the entire
  * configuration, use {@link LettuceClientConfigurationBuilderCustomizer} instead.
  *
  * @author Soohyun Lim

--- a/module/spring-boot-elasticsearch/src/main/java/org/springframework/boot/elasticsearch/autoconfigure/Rest5ClientBuilderCustomizer.java
+++ b/module/spring-boot-elasticsearch/src/main/java/org/springframework/boot/elasticsearch/autoconfigure/Rest5ClientBuilderCustomizer.java
@@ -27,8 +27,8 @@ import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBu
 
 /**
  * Callback interface that can be implemented by beans wishing to further customize the
- * {@link Rest5Client} through a {@link Rest5ClientBuilder} whilst retaining default
- * auto-configuration.
+ * {@link Rest5Client} through a {@link Rest5ClientBuilder} to fine-tune
+ * its auto-configuration.
  *
  * @author Brian Clozel
  * @author Vedran Pavic

--- a/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/GraphQlSourceBuilderCustomizer.java
+++ b/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/GraphQlSourceBuilderCustomizer.java
@@ -21,7 +21,7 @@ import org.springframework.graphql.execution.GraphQlSource;
 /**
  * Callback interface that can be implemented by beans wishing to customize properties of
  * {@link org.springframework.graphql.execution.GraphQlSource.SchemaResourceBuilder
- * Builder} whilst retaining default auto-configuration.
+ * Builder} to fine-tune its auto-configuration.
  *
  * @author Rossen Stoyanchev
  * @since 4.0.0

--- a/module/spring-boot-gson/src/main/java/org/springframework/boot/gson/autoconfigure/GsonBuilderCustomizer.java
+++ b/module/spring-boot-gson/src/main/java/org/springframework/boot/gson/autoconfigure/GsonBuilderCustomizer.java
@@ -21,7 +21,7 @@ import com.google.gson.GsonBuilder;
 
 /**
  * Callback interface that can be implemented by beans wishing to further customize the
- * {@link Gson} through {@link GsonBuilder} retaining its default auto-configuration.
+ * {@link Gson} through {@link GsonBuilder} to fine-tune its auto-configuration.
  *
  * @author Ivan Golovko
  * @since 4.0.0

--- a/module/spring-boot-integration/src/main/java/org/springframework/boot/integration/autoconfigure/PollerMetadataCustomizer.java
+++ b/module/spring-boot-integration/src/main/java/org/springframework/boot/integration/autoconfigure/PollerMetadataCustomizer.java
@@ -20,7 +20,7 @@ import org.springframework.integration.scheduling.PollerMetadata;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the
- * {@link PollerMetadata} whilst retaining default auto-configuration.
+ * {@link PollerMetadata} to fine-tune its auto-configuration.
  *
  * @author Yanming Zhou
  * @since 4.0.0

--- a/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/Jackson2ObjectMapperBuilderCustomizer.java
+++ b/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/Jackson2ObjectMapperBuilderCustomizer.java
@@ -22,11 +22,8 @@ import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 /**
  * Callback interface that can be implemented by beans wishing to further customize the
- * {@link ObjectMapper} through {@link Jackson2ObjectMapperBuilder} retaining its default
- * auto-configuration.
- * Note: Depending on which methods of {@link Jackson2ObjectMapperBuilder} are used,
- * customizations may override or replace parts of the default auto-configuration
- * instead of merely adding to it.
+ * {@link ObjectMapper} through {@link Jackson2ObjectMapperBuilder} to fine-tune
+ * its auto-configuration.
  *
  * @author Grzegorz Poznachowski
  * @since 4.0.0

--- a/module/spring-boot-jooq/src/main/java/org/springframework/boot/jooq/autoconfigure/DefaultConfigurationCustomizer.java
+++ b/module/spring-boot-jooq/src/main/java/org/springframework/boot/jooq/autoconfigure/DefaultConfigurationCustomizer.java
@@ -20,7 +20,7 @@ import org.jooq.impl.DefaultConfiguration;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the
- * {@link DefaultConfiguration} whilst retaining default auto-configuration.
+ * {@link DefaultConfiguration} to fine-tune its auto-configuration.
  *
  * @author Stephane Nicoll
  * @since 4.0.0

--- a/module/spring-boot-micrometer-tracing/src/main/java/org/springframework/boot/micrometer/tracing/autoconfigure/otlp/OtlpGrpcSpanExporterBuilderCustomizer.java
+++ b/module/spring-boot-micrometer-tracing/src/main/java/org/springframework/boot/micrometer/tracing/autoconfigure/otlp/OtlpGrpcSpanExporterBuilderCustomizer.java
@@ -20,7 +20,7 @@ import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the
- * {@link OtlpGrpcSpanExporterBuilder} whilst retaining default auto-configuration.
+ * {@link OtlpGrpcSpanExporterBuilder} to fine-tune its auto-configuration.
  *
  * @author Dmytro Nosan
  * @since 4.0.0

--- a/module/spring-boot-micrometer-tracing/src/main/java/org/springframework/boot/micrometer/tracing/autoconfigure/otlp/OtlpHttpSpanExporterBuilderCustomizer.java
+++ b/module/spring-boot-micrometer-tracing/src/main/java/org/springframework/boot/micrometer/tracing/autoconfigure/otlp/OtlpHttpSpanExporterBuilderCustomizer.java
@@ -20,7 +20,7 @@ import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the
- * {@link OtlpHttpSpanExporterBuilder} whilst retaining default auto-configuration.
+ * {@link OtlpHttpSpanExporterBuilder} to fine-tune its auto-configuration.
  *
  * @author Dmytro Nosan
  * @since 4.0.0

--- a/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoClientSettingsBuilderCustomizer.java
+++ b/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoClientSettingsBuilderCustomizer.java
@@ -21,7 +21,7 @@ import com.mongodb.MongoClientSettings.Builder;
 /**
  * Callback interface that can be implemented by beans wishing to customize the
  * {@link com.mongodb.MongoClientSettings} through a {@link Builder
- * MongoClientSettings.Builder} whilst retaining default auto-configuration.
+ * MongoClientSettings.Builder} to fine-tune its auto-configuration.
  *
  * @author Mark Paluch
  * @since 4.0.0

--- a/module/spring-boot-neo4j/src/main/java/org/springframework/boot/neo4j/autoconfigure/ConfigBuilderCustomizer.java
+++ b/module/spring-boot-neo4j/src/main/java/org/springframework/boot/neo4j/autoconfigure/ConfigBuilderCustomizer.java
@@ -21,8 +21,7 @@ import org.neo4j.driver.Config.ConfigBuilder;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the
- * {@link Config} through a {@link ConfigBuilder} whilst retaining default
- * auto-configuration.
+ * {@link Config} through a {@link ConfigBuilder} to fine-tune its auto-configuration.
  *
  * @author Stephane Nicoll
  * @since 4.0.0

--- a/module/spring-boot-r2dbc/src/main/java/org/springframework/boot/r2dbc/autoconfigure/ConnectionFactoryOptionsBuilderCustomizer.java
+++ b/module/spring-boot-r2dbc/src/main/java/org/springframework/boot/r2dbc/autoconfigure/ConnectionFactoryOptionsBuilderCustomizer.java
@@ -21,8 +21,8 @@ import io.r2dbc.spi.ConnectionFactoryOptions.Builder;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize the
- * {@link ConnectionFactoryOptions} through a {@link Builder} whilst retaining default
- * auto-configuration.
+ * {@link ConnectionFactoryOptions} through a {@link Builder} to fine-tune
+ * its auto-configuration.
  *
  * @author Mark Paluch
  * @since 4.0.0

--- a/module/spring-boot-tx/src/main/java/org/springframework/boot/transaction/autoconfigure/TransactionManagerCustomizer.java
+++ b/module/spring-boot-tx/src/main/java/org/springframework/boot/transaction/autoconfigure/TransactionManagerCustomizer.java
@@ -20,8 +20,7 @@ import org.springframework.transaction.TransactionManager;
 
 /**
  * Callback interface that can be implemented by beans wishing to customize
- * {@link TransactionManager TransactionManagers} while retaining default
- * auto-configuration.
+ * {@link TransactionManager TransactionManagers} to fine-tune its auto-configuration.
  *
  * @param <T> the transaction manager type
  * @author Andy Wilkinson


### PR DESCRIPTION
### Motivation

To prevent misunderstandings and make the behavior of Jackson2ObjectMapperBuilder more transparent when used through `Jackson2ObjectMapperBuilderCustomizer`.

### Description

The existing Javadoc of `Jackson2ObjectMapperBuilderCustomizer` suggests that customizations retain the default auto-configuration while extending it. However, depending on which methods of `Jackson2ObjectMapperBuilder` are invoked, the default configuration may actually be overridden or replaced instead of merely extended.

This PR updates the Javadoc to explicitly note this possibility, so that developers are aware that certain builder methods (e.g., modules, dateFormat, propertyNamingStrategy) may discard or replace auto-configured settings.

### Changes

Added a clarification line in the Javadoc of `Jackson2ObjectMapperBuilderCustomizer` to indicate that some customizations may override or replace default auto-configuration.