### PR TITLE
Update Java version from 24 to 25 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           - os:
               name: Linux
             java:
-              version: 24
+              version: 25
           - os:
               name: ${{ github.repository == 'spring-projects/spring-boot-commercial' && 'Windows' }}
     steps:


### PR DESCRIPTION
Because the excluded version is incorrectly set, and the workflows test is failing for that. Fixed the version to be currently executed as per Java 25, for Linux.

It fixes the failing workflow run for ci.yml in the github/workflows folder.

