### PR TITLE
Fix: Include child contexts in auto-configuration conditions report

### DIFF
--- a/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/condition/ConditionsReportEndpoint.java
+++ b/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/condition/ConditionsReportEndpoint.java
@@ -18,6 +18,7 @@ package org.springframework.boot.actuate.autoconfigure.condition;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,12 +65,35 @@ public class ConditionsReportEndpoint {
 	@ReadOperation
 	public ConditionsDescriptor conditions() {
 		Map<String, ContextConditionsDescriptor> contextConditionEvaluations = new HashMap<>();
-		ConfigurableApplicationContext target = this.context;
-		while (target != null) {
-			contextConditionEvaluations.put(target.getId(), new ContextConditionsDescriptor(target));
-			target = getConfigurableParent(target);
+		List<ConfigurableApplicationContext> allContexts = collectAllContexts(this.context);
+		for (ConfigurableApplicationContext ctx : allContexts) {
+			String ctxId = ctx.getId();
+			if (ctxId != null) {
+				contextConditionEvaluations.put(ctxId, new ContextConditionsDescriptor(ctx));
+			}
 		}
 		return new ConditionsDescriptor(contextConditionEvaluations);
+	}
+
+	List<ConfigurableApplicationContext> collectAllContexts(ConfigurableApplicationContext rootContext) {
+		List<ConfigurableApplicationContext> contexts = new ArrayList<>();
+		Set<String> seenIds = new HashSet<>();
+		ConfigurableApplicationContext current = rootContext;
+
+		while (current != null && current.getId() != null && seenIds.add(current.getId())) {
+			contexts.add(current);
+			current = getConfigurableParent(current);
+		}
+
+		Map<String, ConfigurableApplicationContext> found = rootContext
+			.getBeansOfType(ConfigurableApplicationContext.class, false, false);
+		for (ConfigurableApplicationContext ctx : found.values()) {
+			String ctxId = ctx.getId();
+			if (ctxId != null && seenIds.add(ctxId)) {
+				contexts.add(ctx);
+			}
+		}
+		return contexts;
 	}
 
 	private @Nullable ConfigurableApplicationContext getConfigurableParent(ConfigurableApplicationContext context) {


### PR DESCRIPTION
Previously, ConditionsReportEndpoint only traversed the parent ApplicationContext hierarchy, which caused conditions from child contexts (e.g. the Actuator's management context) to be missing from the report.

This commit updates the context collection logic to:
- Traverse both parent and child ApplicationContexts
- Use seenIds to avoid duplicate or cyclic references
- Ensure child contexts (like Actuator context) are now included in the conditions evaluation report

Closes gh-6698

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
