### PR TITLE
Fix code formatting in README.md and SpringRepositorySupport.groovy

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,7 +42,6 @@ public class Example {
 	public static void main(String[] args) {
 		SpringApplication.run(Example.class, args);
 	}
-
 }
 ----
 

--- a/buildSrc/SpringRepositorySupport.groovy
+++ b/buildSrc/SpringRepositorySupport.groovy
@@ -156,5 +156,4 @@ class SpringRepositoriesExtension {
 	static def addTo(repositories, version, buildType) {
 		repositories.extensions.create("spring", SpringRepositoriesExtension.class, repositories, version, buildType)
 	}
-
 }


### PR DESCRIPTION
Adjust unnecessary spacing, indentation, and line breaks in README.md and SpringRepositorySupport.groovy to follow standard Spring Boot and Groovy code conventions. This improves readability without changing any functional behavior.