### PR TITLE
Support Redis static master-replica auto-configuration

### DIFF
--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/JedisConnectionConfiguration.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/JedisConnectionConfiguration.java
@@ -38,6 +38,7 @@ import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.RedisStaticMasterReplicaConfiguration;
 import org.springframework.data.redis.connection.jedis.JedisClientConfiguration;
 import org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisClientConfigurationBuilder;
 import org.springframework.data.redis.connection.jedis.JedisClientConfiguration.JedisSslClientConfigurationBuilder;
@@ -55,6 +56,7 @@ import org.springframework.util.StringUtils;
  * @author Andy Wilkinson
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author Yong-Hyun Kim
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass({ GenericObjectPool.class, JedisConnection.class, Jedis.class })
@@ -64,10 +66,12 @@ class JedisConnectionConfiguration extends RedisConnectionConfiguration {
 
 	JedisConnectionConfiguration(RedisProperties properties,
 			ObjectProvider<RedisStandaloneConfiguration> standaloneConfigurationProvider,
-			ObjectProvider<RedisSentinelConfiguration> sentinelConfiguration,
-			ObjectProvider<RedisClusterConfiguration> clusterConfiguration, RedisConnectionDetails connectionDetails) {
-		super(properties, connectionDetails, standaloneConfigurationProvider, sentinelConfiguration,
-				clusterConfiguration);
+			ObjectProvider<RedisSentinelConfiguration> sentinelConfigurationProvider,
+			ObjectProvider<RedisClusterConfiguration> clusterConfigurationProvider,
+			ObjectProvider<RedisStaticMasterReplicaConfiguration> staticMasterReplicaConfigurationProvider,
+			RedisConnectionDetails connectionDetails) {
+		super(properties, connectionDetails, standaloneConfigurationProvider, sentinelConfigurationProvider,
+				clusterConfigurationProvider, staticMasterReplicaConfigurationProvider);
 	}
 
 	@Bean
@@ -103,6 +107,7 @@ class JedisConnectionConfiguration extends RedisConnectionConfiguration {
 				Assert.state(sentinelConfig != null, "'sentinelConfig' must not be null");
 				yield new JedisConnectionFactory(sentinelConfig, clientConfiguration);
 			}
+			case STATIC_MASTER_REPLICA -> throw new IllegalStateException("Static master-replica mode is not supported by Jedis");
 		};
 	}
 

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/LettuceConnectionConfiguration.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/LettuceConnectionConfiguration.java
@@ -49,6 +49,7 @@ import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisSentinelConfiguration;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.RedisStaticMasterReplicaConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -64,6 +65,7 @@ import org.springframework.util.StringUtils;
  * @author Moritz Halbritter
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author Yong-Hyun Kim
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(RedisClient.class)
@@ -74,9 +76,10 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 			ObjectProvider<RedisStandaloneConfiguration> standaloneConfigurationProvider,
 			ObjectProvider<RedisSentinelConfiguration> sentinelConfigurationProvider,
 			ObjectProvider<RedisClusterConfiguration> clusterConfigurationProvider,
+			ObjectProvider<RedisStaticMasterReplicaConfiguration> staticMasterReplicaConfigurationProvider,
 			RedisConnectionDetails connectionDetails) {
 		super(properties, connectionDetails, standaloneConfigurationProvider, sentinelConfigurationProvider,
-				clusterConfigurationProvider);
+				clusterConfigurationProvider, staticMasterReplicaConfigurationProvider);
 	}
 
 	@Bean(destroyMethod = "shutdown")
@@ -131,6 +134,12 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 				RedisSentinelConfiguration sentinelConfig = getSentinelConfig();
 				Assert.state(sentinelConfig != null, "'sentinelConfig' must not be null");
 				yield new LettuceConnectionFactory(sentinelConfig, clientConfiguration);
+			}
+			case STATIC_MASTER_REPLICA -> {
+				RedisStaticMasterReplicaConfiguration staticMasterReplicaConfiguration = getStaticMasterReplicaConfiguration();
+				Assert.state(staticMasterReplicaConfiguration != null,
+						"'staticMasterReplicaConfiguration' must not be null");
+				yield new LettuceConnectionFactory(staticMasterReplicaConfiguration, clientConfiguration);
 			}
 		};
 	}

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/PropertiesRedisConnectionDetails.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/PropertiesRedisConnectionDetails.java
@@ -35,6 +35,7 @@ import org.springframework.util.StringUtils;
  * @author Scott Frederick
  * @author Yanming Zhou
  * @author Phillip Webb
+ * @author Yong-Hyun Kim
  */
 class PropertiesRedisConnectionDetails implements RedisConnectionDetails {
 
@@ -90,6 +91,12 @@ class PropertiesRedisConnectionDetails implements RedisConnectionDetails {
 	public @Nullable Cluster getCluster() {
 		RedisProperties.Cluster cluster = this.properties.getCluster();
 		return (cluster != null) ? new PropertiesCluster(cluster) : null;
+	}
+
+	@Override
+	public @Nullable StaticMasterReplica getStaticMasterReplica() {
+		RedisProperties.StaticMasterReplica staticMasterReplica = this.properties.getStaticMasterReplica();
+		return (staticMasterReplica != null) ? new PropertiesStaticMasterReplica(getStandalone().getDatabase(), staticMasterReplica) : null;
 	}
 
 	private @Nullable RedisUrl getRedisUrl() {
@@ -172,6 +179,37 @@ class PropertiesRedisConnectionDetails implements RedisConnectionDetails {
 		@Override
 		public @Nullable String getPassword() {
 			return this.properties.getPassword();
+		}
+
+		@Override
+		public @Nullable SslBundle getSslBundle() {
+			return PropertiesRedisConnectionDetails.this.getSslBundle();
+		}
+
+	}
+
+	/**
+	 * {@link StaticMasterReplica} implementation backed by properties.
+	 */
+	private class PropertiesStaticMasterReplica implements StaticMasterReplica {
+
+		private final int database;
+
+		private final RedisProperties.StaticMasterReplica properties;
+
+		PropertiesStaticMasterReplica(int database, RedisProperties.StaticMasterReplica properties) {
+			this.database = database;
+			this.properties = properties;
+		}
+
+		@Override
+		public int getDatabase() {
+			return this.database;
+		}
+
+		@Override
+		public List<Node> getNodes() {
+			return asNodes(this.properties.getNodes());
 		}
 
 		@Override

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/RedisConnectionDetails.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/RedisConnectionDetails.java
@@ -29,6 +29,7 @@ import org.springframework.util.Assert;
  *
  * @author Moritz Halbritter
  * @author Andy Wilkinson
+ * @author Yong-Hyun Kim
  * @since 4.0.0
  */
 public interface RedisConnectionDetails extends ConnectionDetails {
@@ -50,8 +51,8 @@ public interface RedisConnectionDetails extends ConnectionDetails {
 	}
 
 	/**
-	 * Redis standalone configuration. Mutually exclusive with {@link #getSentinel()} and
-	 * {@link #getCluster()}.
+	 * Redis standalone configuration. Mutually exclusive with {@link #getSentinel()},
+	 * {@link #getCluster()} and {@link #getStaticMasterReplica()}.
 	 * @return the Redis standalone configuration
 	 */
 	default @Nullable Standalone getStandalone() {
@@ -59,8 +60,8 @@ public interface RedisConnectionDetails extends ConnectionDetails {
 	}
 
 	/**
-	 * Redis sentinel configuration. Mutually exclusive with {@link #getStandalone()} and
-	 * {@link #getCluster()}.
+	 * Redis sentinel configuration. Mutually exclusive with {@link #getStandalone()},
+	 * {@link #getCluster()} and {@link #getStaticMasterReplica()}.
 	 * @return the Redis sentinel configuration
 	 */
 	default @Nullable Sentinel getSentinel() {
@@ -68,11 +69,20 @@ public interface RedisConnectionDetails extends ConnectionDetails {
 	}
 
 	/**
-	 * Redis cluster configuration. Mutually exclusive with {@link #getStandalone()} and
-	 * {@link #getSentinel()}.
+	 * Redis cluster configuration. Mutually exclusive with {@link #getStandalone()},
+	 * {@link #getSentinel()} and {@link #getStaticMasterReplica()}.
 	 * @return the Redis cluster configuration
 	 */
 	default @Nullable Cluster getCluster() {
+		return null;
+	}
+
+	/**
+	 * Redis static Master / Replica configuration. Mutually exclusive with {@link #getStandalone()},
+	 * {@link #getSentinel()} and {@link #getCluster()}.
+	 * @return the Redis static Master / Replica configuration
+	 */
+	default @Nullable StaticMasterReplica getStaticMasterReplica() {
 		return null;
 	}
 
@@ -245,7 +255,39 @@ public interface RedisConnectionDetails extends ConnectionDetails {
 	}
 
 	/**
-	 * A node in a sentinel or cluster configuration.
+	 * Redis static Master / Replica configuration.
+	 */
+	interface StaticMasterReplica {
+
+		/**
+		 * Database index used by the connection factory.
+		 * @return the database index used by the connection factory
+		 */
+		default int getDatabase() {
+			return 0;
+		}
+
+		/**
+		 * List of Master and Replica nodes for the static configuration. This represents
+		 * the nodes to be used in a static Master/Replica setup and is required to have
+		 * at least one entry. The first node does not need to be the master, as the actual
+		 * roles are determined by querying each node's ROLE command.
+		 * @return the list of nodes for Master/Replica configuration
+		 */
+		List<Node> getNodes();
+
+		/**
+		 * SSL bundle to use.
+		 * @return the SSL bundle to use
+		 */
+		default @Nullable SslBundle getSslBundle() {
+			return null;
+		}
+
+	}
+
+	/**
+	 * A node in a sentinel, cluster or static master-replica configuration.
 	 *
 	 * @param host the hostname of the node
 	 * @param port the port of the node

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/RedisProperties.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/RedisProperties.java
@@ -34,6 +34,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Stephane Nicoll
  * @author Scott Frederick
  * @author Yanming Zhou
+ * @author Yong-Hyun Kim
  * @since 4.0.0
  */
 @ConfigurationProperties("spring.data.redis")
@@ -93,6 +94,8 @@ public class RedisProperties {
 	private @Nullable Sentinel sentinel;
 
 	private @Nullable Cluster cluster;
+
+	private @Nullable StaticMasterReplica staticMasterReplica;
 
 	private final Ssl ssl = new Ssl();
 
@@ -198,6 +201,14 @@ public class RedisProperties {
 
 	public void setCluster(@Nullable Cluster cluster) {
 		this.cluster = cluster;
+	}
+
+	public @Nullable StaticMasterReplica getStaticMasterReplica() {
+		return this.staticMasterReplica;
+	}
+
+	public void setStaticMasterReplica(@Nullable StaticMasterReplica staticMasterReplica) {
+		this.staticMasterReplica = staticMasterReplica;
 	}
 
 	public Jedis getJedis() {
@@ -409,6 +420,27 @@ public class RedisProperties {
 
 		public void setPassword(@Nullable String password) {
 			this.password = password;
+		}
+
+	}
+
+	/**
+	 * Redis static master-replica properties.
+	 */
+	public static class StaticMasterReplica {
+
+		/**
+		 * List of "host:port" pairs regardless of role as the actual roles are determined
+		 * by querying each node's ROLE command.
+		 */
+		private @Nullable List<String> nodes;
+
+		public @Nullable List<String> getNodes() {
+			return this.nodes;
+		}
+
+		public void setNodes(@Nullable List<String> nodes) {
+			this.nodes = nodes;
 		}
 
 	}

--- a/module/spring-boot-data-redis/src/test/java/org/springframework/boot/data/redis/autoconfigure/PropertiesRedisConnectionDetailsTests.java
+++ b/module/spring-boot-data-redis/src/test/java/org/springframework/boot/data/redis/autoconfigure/PropertiesRedisConnectionDetailsTests.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Scott Frederick
  * @author Moritz Halbritter
+ * @author Yong-Hyun Kim
  */
 class PropertiesRedisConnectionDetailsTests {
 
@@ -161,6 +162,19 @@ class PropertiesRedisConnectionDetailsTests {
 	}
 
 	@Test
+	void staticMasterReplicaIsConfigured() {
+		RedisProperties.StaticMasterReplica staticMasterReplica = new RedisProperties.StaticMasterReplica();
+		staticMasterReplica.setNodes(List.of("localhost:1111", "127.0.0.1:2222", "[::1]:3333"));
+		this.properties.setStaticMasterReplica(staticMasterReplica);
+		this.properties.setDatabase(5);
+		PropertiesRedisConnectionDetails connectionDetails = new PropertiesRedisConnectionDetails(this.properties,
+				null);
+		assertThat(connectionDetails.getStaticMasterReplica().getNodes()).containsExactly(new Node("localhost", 1111),
+				new Node("127.0.0.1", 2222), new Node("[::1]", 3333));
+		assertThat(connectionDetails.getStaticMasterReplica().getDatabase()).isEqualTo(5);
+	}
+
+	@Test
 	void sentinelDatabaseIsConfiguredFromUrl() {
 		RedisProperties.Sentinel sentinel = new RedisProperties.Sentinel();
 		sentinel.setNodes(List.of("localhost:1111", "127.0.0.1:2222", "[::1]:3333"));
@@ -170,6 +184,18 @@ class PropertiesRedisConnectionDetailsTests {
 		PropertiesRedisConnectionDetails connectionDetails = new PropertiesRedisConnectionDetails(this.properties,
 				null);
 		assertThat(connectionDetails.getSentinel().getDatabase()).isEqualTo(9999);
+	}
+
+	@Test
+	void staticMasterReplicaDatabaseIsConfiguredFromUrl() {
+		RedisProperties.StaticMasterReplica staticMasterReplica = new RedisProperties.StaticMasterReplica();
+		staticMasterReplica.setNodes(List.of("localhost:1111", "127.0.0.1:2222", "[::1]:3333"));
+		this.properties.setStaticMasterReplica(staticMasterReplica);
+		this.properties.setUrl("redis://example.com:1234/9999");
+		this.properties.setDatabase(5);
+		PropertiesRedisConnectionDetails connectionDetails = new PropertiesRedisConnectionDetails(this.properties,
+				null);
+		assertThat(connectionDetails.getStaticMasterReplica().getDatabase()).isEqualTo(9999);
 	}
 
 	@Test

--- a/module/spring-boot-data-redis/src/test/java/org/springframework/boot/data/redis/autoconfigure/RedisAutoConfigurationJedisTests.java
+++ b/module/spring-boot-data-redis/src/test/java/org/springframework/boot/data/redis/autoconfigure/RedisAutoConfigurationJedisTests.java
@@ -49,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Andy Wilkinson
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author Yong-Hyun Kim
  */
 @ClassPathExclusions("lettuce-core-*.jar")
 class RedisAutoConfigurationJedisTests {
@@ -242,6 +243,14 @@ class RedisAutoConfigurationJedisTests {
 	@Test
 	void testRedisConfigurationWithCluster() {
 		this.contextRunner.withPropertyValues("spring.data.redis.cluster.nodes=127.0.0.1:27379,127.0.0.1:27380")
+			.withUserConfiguration(JedisConnectionFactoryCaptorConfiguration.class)
+			.run((context) -> assertThat(JedisConnectionFactoryCaptor.connectionFactory.isRedisClusterAware())
+				.isTrue());
+	}
+
+	@Test
+	void testRedisConfigurationWithStaticMasterReplica() {
+		this.contextRunner.withPropertyValues("spring.data.redis.static-master-replica.nodes=127.0.0.1:27379,127.0.0.1:27380")
 			.withUserConfiguration(JedisConnectionFactoryCaptorConfiguration.class)
 			.run((context) -> assertThat(JedisConnectionFactoryCaptor.connectionFactory.isRedisClusterAware())
 				.isTrue());


### PR DESCRIPTION
Hi.

I'd like to suggest support for Redis static Master/Replica auto-configuration.
This auto-configuration makes `LettuceConnectionFactory` use [RedisStaticMasterReplicaConfiguration](https://docs.spring.io/spring-data/redis/reference/api/java/org/springframework/data/redis/connection/RedisStaticMasterReplicaConfiguration.html), e.g. AWS ElastiCache with Replicas.
I know it's cautious since Jedis doesn't support for static master-replica connection in Jedis, while Lettuce does.

Please feel free to review this suggestion and share your thoughts.