### PR TITLE
Flyway Ignore Migration Patterns setting can't be set to an empty string

### DIFF
--- a/module/spring-boot-flyway/src/main/java/org/springframework/boot/flyway/autoconfigure/FlywayAutoConfiguration.java
+++ b/module/spring-boot-flyway/src/main/java/org/springframework/boot/flyway/autoconfigure/FlywayAutoConfiguration.java
@@ -320,7 +320,6 @@ public final class FlywayAutoConfiguration {
 			map.from(properties.getSkipExecutingMigrations())
 				.to((skipExecutingMigrations) -> configuration.skipExecutingMigrations(skipExecutingMigrations));
 			map.from(properties.getIgnoreMigrationPatterns())
-				.whenNot(List::isEmpty)
 				.to((ignoreMigrationPatterns) -> configuration
 					.ignoreMigrationPatterns(ignoreMigrationPatterns.toArray(new String[0])));
 			map.from(properties.getDetectEncoding())

--- a/module/spring-boot-flyway/src/main/java/org/springframework/boot/flyway/autoconfigure/FlywayProperties.java
+++ b/module/spring-boot-flyway/src/main/java/org/springframework/boot/flyway/autoconfigure/FlywayProperties.java
@@ -323,7 +323,7 @@ public class FlywayProperties {
 	/**
 	 * List of patterns that identify migrations to ignore when performing validation.
 	 */
-	private @Nullable List<String> ignoreMigrationPatterns;
+	private List<String> ignoreMigrationPatterns = Collections.singletonList("*:future");
 
 	/**
 	 * Whether to attempt to automatically detect SQL migration file encoding.
@@ -757,11 +757,11 @@ public class FlywayProperties {
 		this.skipExecutingMigrations = skipExecutingMigrations;
 	}
 
-	public @Nullable List<String> getIgnoreMigrationPatterns() {
+	public List<String> getIgnoreMigrationPatterns() {
 		return this.ignoreMigrationPatterns;
 	}
 
-	public void setIgnoreMigrationPatterns(@Nullable List<String> ignoreMigrationPatterns) {
+	public void setIgnoreMigrationPatterns(List<String> ignoreMigrationPatterns) {
 		this.ignoreMigrationPatterns = ignoreMigrationPatterns;
 	}
 

--- a/module/spring-boot-flyway/src/test/java/org/springframework/boot/flyway/autoconfigure/FlywayAutoConfigurationTests.java
+++ b/module/spring-boot-flyway/src/test/java/org/springframework/boot/flyway/autoconfigure/FlywayAutoConfigurationTests.java
@@ -897,6 +897,14 @@ class FlywayAutoConfigurationTests {
 				.containsExactly(ValidatePattern.fromPattern("*:missing")));
 	}
 
+	@Test
+	void ignoreMigrationPatternsIsEmpty() {
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+			.withPropertyValues("spring.flyway.ignore-migration-patterns=")
+			.run((context) -> assertThat(context.getBean(Flyway.class).getConfiguration().getIgnoreMigrationPatterns())
+				.isEmpty());
+	}
+
 	private ContextConsumer<AssertableApplicationContext> validateFlywayTeamsPropertyOnly(String propertyName) {
 		return (context) -> {
 			assertThat(context).hasFailed();

--- a/module/spring-boot-flyway/src/test/java/org/springframework/boot/flyway/autoconfigure/FlywayAutoConfigurationTests.java
+++ b/module/spring-boot-flyway/src/test/java/org/springframework/boot/flyway/autoconfigure/FlywayAutoConfigurationTests.java
@@ -898,7 +898,14 @@ class FlywayAutoConfigurationTests {
 	}
 
 	@Test
-	void ignoreMigrationPatternsIsEmpty() {
+	void ignoreMigrationPatternsUsesDefaultValuesWhenNotSet() {
+		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
+			.run((context) -> assertThat(context.getBean(Flyway.class).getConfiguration().getIgnoreMigrationPatterns())
+				.containsExactly(new FluentConfiguration().getIgnoreMigrationPatterns()));
+	}
+
+	@Test
+	void ignoreMigrationPatternsWhenEmpty() {
 		this.contextRunner.withUserConfiguration(EmbeddedDataSourceConfiguration.class)
 			.withPropertyValues("spring.flyway.ignore-migration-patterns=")
 			.run((context) -> assertThat(context.getBean(Flyway.class).getConfiguration().getIgnoreMigrationPatterns())

--- a/module/spring-boot-flyway/src/test/java/org/springframework/boot/flyway/autoconfigure/FlywayPropertiesTests.java
+++ b/module/spring-boot-flyway/src/test/java/org/springframework/boot/flyway/autoconfigure/FlywayPropertiesTests.java
@@ -30,6 +30,7 @@ import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.configuration.ClassicConfiguration;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.flywaydb.core.api.pattern.ValidatePattern;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.BeanWrapper;
@@ -95,8 +96,8 @@ class FlywayPropertiesTests {
 		assertThat(properties.getScriptPlaceholderSuffix()).isEqualTo(configuration.getScriptPlaceholderSuffix());
 		assertThat(properties.isExecuteInTransaction()).isEqualTo(configuration.isExecuteInTransaction());
 		assertThat(properties.getCommunityDbSupportEnabled()).isNull();
-		assertThat(configuration.getIgnoreMigrationPatterns()).extracting(Object::toString)
-			.isEqualTo(properties.getIgnoreMigrationPatterns());
+		assertThat(properties.getIgnoreMigrationPatterns().stream().map(ValidatePattern::fromPattern))
+			.containsExactly(configuration.getIgnoreMigrationPatterns());
 	}
 
 	@Test

--- a/module/spring-boot-flyway/src/test/java/org/springframework/boot/flyway/autoconfigure/FlywayPropertiesTests.java
+++ b/module/spring-boot-flyway/src/test/java/org/springframework/boot/flyway/autoconfigure/FlywayPropertiesTests.java
@@ -30,6 +30,7 @@ import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.configuration.ClassicConfiguration;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.flywaydb.core.api.pattern.ValidatePattern;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.BeanWrapper;
@@ -95,6 +96,8 @@ class FlywayPropertiesTests {
 		assertThat(properties.getScriptPlaceholderSuffix()).isEqualTo(configuration.getScriptPlaceholderSuffix());
 		assertThat(properties.isExecuteInTransaction()).isEqualTo(configuration.isExecuteInTransaction());
 		assertThat(properties.getCommunityDbSupportEnabled()).isNull();
+		assertThat(configuration.getIgnoreMigrationPatterns()).extracting(Object::toString)
+			.isEqualTo(properties.getIgnoreMigrationPatterns());
 	}
 
 	@Test

--- a/module/spring-boot-flyway/src/test/java/org/springframework/boot/flyway/autoconfigure/FlywayPropertiesTests.java
+++ b/module/spring-boot-flyway/src/test/java/org/springframework/boot/flyway/autoconfigure/FlywayPropertiesTests.java
@@ -30,7 +30,6 @@ import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.configuration.ClassicConfiguration;
 import org.flywaydb.core.api.configuration.Configuration;
 import org.flywaydb.core.api.configuration.FluentConfiguration;
-import org.flywaydb.core.api.pattern.ValidatePattern;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.BeanWrapper;


### PR DESCRIPTION
This PR resolves issue #46969.
### Summary

Allows `spring.flyway.ignore-migration-patterns` to be set to an empty string to align with Flyway's documented behavior for unsetting default migration patterns.

### Changes

- In `FlywayAutoConfiguration`, removed the condition that prevented an empty list from being passed to Flyway's `ignoreMigrationPatterns` configuration.
- This change ensures that setting `spring.flyway.ignore-migration-patterns=` in application properties works as expected.

### Testing

The existing test `ignoreMigrationPatternsIsEmpty` in `FlywayAutoConfigurationTests` was used to verify the fix.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
