### PR TITLE
Rename ScheduledTasksObservabilityAutoConfiguration to ScheduledTasksObservationAutoConfiguration

### DIFF
--- a/module/spring-boot-micrometer-observation/src/main/java/org/springframework/boot/micrometer/observation/autoconfigure/ScheduledTasksObservationAutoConfiguration.java
+++ b/module/spring-boot-micrometer-observation/src/main/java/org/springframework/boot/micrometer/observation/autoconfigure/ScheduledTasksObservationAutoConfiguration.java
@@ -37,7 +37,7 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 @AutoConfiguration(after = ObservationAutoConfiguration.class)
 @ConditionalOnBean(ObservationRegistry.class)
 @ConditionalOnClass(ThreadPoolTaskScheduler.class)
-public final class ScheduledTasksObservabilityAutoConfiguration {
+public final class ScheduledTasksObservationAutoConfiguration {
 
 	@Bean
 	ObservabilitySchedulingConfigurer observabilitySchedulingConfigurer(ObservationRegistry observationRegistry) {

--- a/module/spring-boot-micrometer-observation/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/module/spring-boot-micrometer-observation/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,2 @@
 org.springframework.boot.micrometer.observation.autoconfigure.ObservationAutoConfiguration
-org.springframework.boot.micrometer.observation.autoconfigure.ScheduledTasksObservabilityAutoConfiguration
+org.springframework.boot.micrometer.observation.autoconfigure.ScheduledTasksObservationAutoConfiguration

--- a/module/spring-boot-micrometer-observation/src/test/java/org/springframework/boot/micrometer/observation/autoconfigure/ScheduledTasksObservationAutoConfigurationTests.java
+++ b/module/spring-boot-micrometer-observation/src/test/java/org/springframework/boot/micrometer/observation/autoconfigure/ScheduledTasksObservationAutoConfigurationTests.java
@@ -20,21 +20,21 @@ import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.micrometer.observation.autoconfigure.ScheduledTasksObservabilityAutoConfiguration.ObservabilitySchedulingConfigurer;
+import org.springframework.boot.micrometer.observation.autoconfigure.ScheduledTasksObservationAutoConfiguration.ObservabilitySchedulingConfigurer;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link ScheduledTasksObservabilityAutoConfiguration}.
+ * Tests for {@link ScheduledTasksObservationAutoConfiguration}.
  *
  * @author Moritz Halbritter
  */
-class ScheduledTasksObservabilityAutoConfigurationTests {
+class ScheduledTasksObservationAutoConfigurationTests {
 
 	private final ApplicationContextRunner runner = new ApplicationContextRunner().withConfiguration(AutoConfigurations
-		.of(ObservationAutoConfiguration.class, ScheduledTasksObservabilityAutoConfiguration.class));
+		.of(ObservationAutoConfiguration.class, ScheduledTasksObservationAutoConfiguration.class));
 
 	@Test
 	void shouldProvideObservabilitySchedulingConfigurer() {


### PR DESCRIPTION
ScheduledTasksObservabilityAutoConfiguration Renamed to ScheduledTasksObservationAutoConfiguration to align naming

Related to #46993

### Notes
This is my first contribution to Spring Boot (and to open source in general).  
If I missed any conventions or best practices, please let me know. I’ll be happy to adjust. 🙏
