### PR TITLE
Use inferred destroy method name where feasible

### DIFF
--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/LettuceConnectionConfiguration.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/LettuceConnectionConfiguration.java
@@ -79,7 +79,7 @@ class LettuceConnectionConfiguration extends RedisConnectionConfiguration {
 				clusterConfigurationProvider);
 	}
 
-	@Bean(destroyMethod = "shutdown")
+	@Bean
 	@ConditionalOnMissingBean(ClientResources.class)
 	DefaultClientResources lettuceClientResources(ObjectProvider<ClientResourcesBuilderCustomizer> customizers) {
 		DefaultClientResources.Builder builder = DefaultClientResources.builder();

--- a/module/spring-boot-flyway/src/test/java/org/springframework/boot/flyway/autoconfigure/FlywayAutoConfigurationTests.java
+++ b/module/spring-boot-flyway/src/test/java/org/springframework/boot/flyway/autoconfigure/FlywayAutoConfigurationTests.java
@@ -1163,7 +1163,7 @@ class FlywayAutoConfigurationTests {
 	@EnableConfigurationProperties(DataSourceProperties.class)
 	abstract static class AbstractUserH2DataSourceConfiguration {
 
-		@Bean(destroyMethod = "shutdown")
+		@Bean
 		EmbeddedDatabase dataSource(DataSourceProperties properties) throws SQLException {
 			EmbeddedDatabase database = new EmbeddedDatabaseBuilder().setType(EmbeddedDatabaseType.H2)
 				.setName(getDatabaseName(properties))

--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/EmbeddedDataSourceConfiguration.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/EmbeddedDataSourceConfiguration.java
@@ -46,7 +46,7 @@ public class EmbeddedDataSourceConfiguration implements BeanClassLoaderAware {
 		this.classLoader = classLoader;
 	}
 
-	@Bean(destroyMethod = "shutdown")
+	@Bean
 	public EmbeddedDatabase dataSource(DataSourceProperties properties) {
 		EmbeddedDatabaseType type = EmbeddedDatabaseConnection.get(this.classLoader).getType();
 		String databaseName = properties.determineDatabaseName();

--- a/module/spring-boot-liquibase/src/test/java/org/springframework/boot/liquibase/autoconfigure/LiquibaseAutoConfigurationTests.java
+++ b/module/spring-boot-liquibase/src/test/java/org/springframework/boot/liquibase/autoconfigure/LiquibaseAutoConfigurationTests.java
@@ -637,7 +637,7 @@ class LiquibaseAutoConfigurationTests {
 
 		private final String name = UUID.randomUUID().toString();
 
-		@Bean(destroyMethod = "shutdown")
+		@Bean
 		EmbeddedDatabase dataSource() throws SQLException {
 			EmbeddedDatabase database = new EmbeddedDatabaseBuilder().setType(EmbeddedDatabaseType.H2)
 				.setName(this.name)


### PR DESCRIPTION
See https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Bean.html#destroyMethod()

>> This 'destroy method inference' is currently limited to detecting only public, no-arg methods named 'close' or 'shutdown'.
