### PR TITLE
Experimental: runtime usage report + /actuator/bootusage endpoint

### DIFF
--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/BeanOriginTrackingPostProcessor.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/BeanOriginTrackingPostProcessor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.usage;
+
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+/**
+ * Simple {@link BeanPostProcessor} capturing bean class -> code source locations.
+ * This is intentionally lightweight; it ignores infrastructure beans.
+ */
+/**
+ * Experimental – captures bean -> code source (jar/location) mapping for enrichment.
+ */
+public class BeanOriginTrackingPostProcessor implements BeanPostProcessor {
+
+    private final Map<String, String> beanOrigins = new ConcurrentHashMap<>();
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        Class<?> type = bean.getClass();
+        if (type.getName().startsWith("org.springframework.")) {
+            return bean; // skip core Spring infrastructure for clarity
+        }
+        String location = findLocation(type);
+        if (location != null) {
+            this.beanOrigins.put(beanName, location);
+        }
+        return bean;
+    }
+
+    private String findLocation(Class<?> type) {
+        try {
+            ProtectionDomain pd = type.getProtectionDomain();
+            if (pd == null) {
+                return null;
+            }
+            CodeSource cs = pd.getCodeSource();
+            if (cs == null) {
+                return null;
+            }
+            URL url = cs.getLocation();
+            return (url != null ? url.toString() : null);
+        }
+        catch (Throwable ex) {
+            return null;
+        }
+    }
+
+    public Map<String, String> getBeanOrigins() {
+        return Collections.unmodifiableMap(this.beanOrigins);
+    }
+}

--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/StarterUsageAnalyzer.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/StarterUsageAnalyzer.java
@@ -1,0 +1,135 @@
+package org.springframework.boot.autoconfigure.usage;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Heuristic starter usage analyzer (experimental).
+ */
+class StarterUsageAnalyzer {
+
+    private static final Pattern STARTER_PATTERN = Pattern.compile("spring-boot-starter-.*");
+
+    private final Map<String, StarterInfo> starters = new ConcurrentHashMap<>();
+
+    private static final Set<String> PROTECTED_STARTERS = Set.of(
+            "spring-boot-starter",
+            "spring-boot-starter-logging",
+            "spring-boot-starter-json"
+    );
+
+    private final Map<String, String> keywordToAutoConfigToken;
+
+    StarterUsageAnalyzer() {
+        Map<String, String> map = new HashMap<>();
+        map.put("web", "WebMvc");
+        map.put("webflux", "WebFlux");
+        map.put("actuator", "Actuator");
+        map.put("data-jpa", "Jpa");
+        map.put("data-jdbc", "Jdbc");
+        map.put("data-redis", "Redis");
+        map.put("data-mongodb", "Mongo");
+        map.put("data-cassandra", "Cassandra");
+        map.put("security", "SecurityAutoConfiguration");
+        map.put("oauth2-client", "OAuth2Client");
+        map.put("oauth2-resource-server", "OAuth2ResourceServer");
+        map.put("oauth2-authorization-server", "AuthorizationServer");
+        map.put("graphql", "GraphQl");
+        map.put("kafka", "Kafka");
+        map.put("amqp", "Rabbit");
+        map.put("batch", "Batch");
+        map.put("integration", "IntegrationAutoConfiguration");
+        map.put("mail", "MailSender");
+        map.put("thymeleaf", "Thymeleaf");
+        map.put("mustache", "Mustache");
+        map.put("freemarker", "FreeMarker");
+        map.put("quartz", "Quartz");
+        map.put("rsocket", "RSocket");
+        this.keywordToAutoConfigToken = Collections.unmodifiableMap(map);
+    }
+
+    void scanClasspath() {
+        String cp = System.getProperty("java.class.path", "");
+        if (cp.isEmpty()) return;
+        String[] entries = cp.split(java.io.File.pathSeparator);
+        for (String entry : entries) {
+            if (entry.endsWith(".jar")) {
+                try (JarFile jar = new JarFile(entry)) {
+                    JarEntry pomProps = findPomProperties(jar);
+                    if (pomProps != null) {
+                        Properties props = new Properties();
+                        try (InputStream is = jar.getInputStream(pomProps)) { props.load(is); }
+                        String artifactId = props.getProperty("artifactId");
+                        if (artifactId != null && STARTER_PATTERN.matcher(artifactId).matches()
+                                && !"spring-boot-starter".equals(artifactId)) {
+                            String groupId = props.getProperty("groupId", "");
+                            String version = props.getProperty("version", "");
+                            starters.putIfAbsent(artifactId, new StarterInfo(groupId + ":" + artifactId + ":" + version));
+                        }
+                    }
+                } catch (Exception ignored) { }
+            }
+        }
+    }
+
+    private JarEntry findPomProperties(JarFile jar) {
+        return jar.stream().filter(e -> e.getName().startsWith("META-INF/maven/") && e.getName().endsWith("/pom.properties")).findFirst().orElse(null);
+    }
+
+    StarterUsageResult classify(List<String> appliedAutoConfigurations) {
+        if (starters.isEmpty()) {
+            scanClasspath();
+        }
+        Set<String> applied = new HashSet<>(appliedAutoConfigurations);
+        starters.forEach((starter, info) -> {
+            String keyword = starter.substring("spring-boot-starter-".length());
+            String token = keywordToAutoConfigToken.get(keyword);
+            boolean used;
+            if (token != null) {
+                used = applied.stream().anyMatch(ac -> ac.contains(token));
+            } else {
+                used = applied.stream().anyMatch(ac -> simpleName(ac).toLowerCase().contains(keyword.replace("-", "")));
+            }
+            info.used = used;
+        });
+        List<String> declared = starters.keySet().stream().sorted().collect(Collectors.toList());
+        List<String> used = starters.entrySet().stream().filter(en -> en.getValue().used).map(Map.Entry::getKey).sorted().collect(Collectors.toList());
+        List<String> unused = starters.entrySet().stream()
+                .filter(en -> !en.getValue().used && !PROTECTED_STARTERS.contains(en.getKey()))
+                .map(Map.Entry::getKey)
+                .sorted()
+                .collect(Collectors.toList());
+        return new StarterUsageResult(declared, used, unused);
+    }
+
+    private String simpleName(String fqcn) {
+        int dot = fqcn.lastIndexOf('.');
+        return dot > -1 ? fqcn.substring(dot + 1) : fqcn;
+    }
+
+    private static class StarterInfo {
+        final String coordinate;
+        boolean used;
+        StarterInfo(String coordinate) { this.coordinate = coordinate; }
+    }
+
+    static class StarterUsageResult {
+        final List<String> declaredStarters;
+        final List<String> usedStarters;
+        final List<String> unusedStarters;
+        StarterUsageResult(List<String> d, List<String> u, List<String> un) {
+            this.declaredStarters = d; this.usedStarters = u; this.unusedStarters = un;
+        }
+    }
+}

--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/UsageAnalysisAutoConfiguration.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/UsageAnalysisAutoConfiguration.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.usage;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.jar.JarFile;
+import java.util.Properties;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.file.Paths;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionEvaluationReport;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.usage.UsagePolicy;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Auto-configuration that, when enabled, produces a runtime usage report describing
+ * applied & skipped auto-configurations and bean origins. This is an experimental
+ * first phase implementation; output format may evolve.
+ */
+@AutoConfiguration
+@EnableConfigurationProperties(UsageReportProperties.class)
+@ConditionalOnProperty(prefix = "spring.boot.usage.report", name = "enabled", havingValue = "true")
+public class UsageAnalysisAutoConfiguration {
+
+    @Bean
+    static BeanOriginTrackingPostProcessor beanOriginTrackingPostProcessor() {
+        return new BeanOriginTrackingPostProcessor();
+    }
+
+    @Bean
+    UsageReportService usageReportService(UsageReportProperties props, ObjectProvider<UsageReportCustomizer> customizers,
+            ObjectProvider<UsagePolicy> policies) {
+        return new UsageReportService(props, customizers, policies);
+    }
+
+    @Bean
+    ApplicationListener<ApplicationReadyEvent> usageReportListener(UsageReportProperties props,
+            BeanOriginTrackingPostProcessor origins, UsageReportService service) {
+        return event -> {
+            try {
+                writeReport(event, props, origins, service);
+            }
+            catch (Exception ex) {
+                if (props.isFailOnError()) {
+                    throw new IllegalStateException("Failed to write usage report", ex);
+                }
+                // If policies require failure and violation occurred, rethrow regardless of failOnError
+                if (props.getPolicies().isFailOnViolation()) {
+                    throw new IllegalStateException("Policy violation prevented startup", ex);
+                }
+            }
+        };
+    }
+
+    private void writeReport(ApplicationReadyEvent event, UsageReportProperties props,
+            BeanOriginTrackingPostProcessor origins, UsageReportService service) throws IOException {
+        Path dir = props.getOutputDir();
+        Files.createDirectories(dir);
+        ConditionEvaluationReport report = ConditionEvaluationReport.get(event.getApplicationContext().getBeanFactory());
+    String json = buildJson(report, origins.getBeanOrigins(), props, service);
+        Files.writeString(dir.resolve("usage-report.json"), json, StandardCharsets.UTF_8);
+        if (props.isMarkdownSummary()) {
+            Files.writeString(dir.resolve("usage-summary.md"), buildMarkdown(report, origins.getBeanOrigins()),
+                    StandardCharsets.UTF_8);
+        }
+    }
+
+    private String buildJson(ConditionEvaluationReport report, Map<String, String> beanOrigins, UsageReportProperties props, UsageReportService service) {
+        Map<String, Object> structured = service.currentStructuredReport(report, beanOrigins, false);
+        UsageReportGenerator generator = new UsageReportGenerator();
+        UsageReportGenerator.UsageReport usage = generator.build(report, beanOrigins, props); // for failOnUnused check
+        StringBuilder sb = new StringBuilder();
+        sb.append('{');
+        boolean first = true;
+        for (Map.Entry<String, Object> e : structured.entrySet()) {
+            if (!first) sb.append(',');
+            first = false;
+            sb.append('\n').append("  \"").append(escape(e.getKey())).append("\": ").append(render(e.getValue(), 1));
+        }
+        sb.append('\n').append('}');
+    if (props.isFailOnUnused() && !usage.starterUsage().unusedStarters.isEmpty()) {
+            throw new IllegalStateException("Unused starters detected: " + usage.starterUsage().unusedStarters);
+        }
+        // Fail on policy violations if requested
+        if (props.getPolicies().isFailOnViolation()) {
+            Object policies = structured.get("policies");
+            if (policies instanceof Map<?,?> m) {
+                Object violations = m.get("violations");
+                if (violations instanceof java.util.Collection<?> col && !col.isEmpty()) {
+                    throw new IllegalStateException("Policy violations detected: " + col);
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    private String render(Object value, int indent) {
+        if (value == null) return "null";
+        if (value instanceof String s) {
+            return '"' + escape(s) + '"';
+        }
+        if (value instanceof Number || value instanceof Boolean) {
+            return value.toString();
+        }
+        if (value instanceof List<?> list) {
+            StringBuilder sb = new StringBuilder("[");
+            boolean first = true;
+            for (Object o : list) {
+                if (!first) sb.append(',');
+                first = false;
+                sb.append('\n').append("  ".repeat(indent + 1)).append(render(o, indent + 1));
+            }
+            if (!list.isEmpty()) sb.append('\n').append("  ".repeat(indent));
+            return sb.append(']').toString();
+        }
+        if (value instanceof Map<?,?> map) {
+            StringBuilder sb = new StringBuilder("{");
+            boolean first = true;
+            for (Map.Entry<?,?> en : map.entrySet()) {
+                if (!first) sb.append(',');
+                first = false;
+                sb.append('\n').append("  ".repeat(indent + 1)).append('"').append(escape(en.getKey().toString())).append("\": ").append(render(en.getValue(), indent + 1));
+            }
+            if (!map.isEmpty()) sb.append('\n').append("  ".repeat(indent));
+            return sb.append('}').toString();
+        }
+        return '"' + escape(value.toString()) + '"';
+    }
+
+    private String buildMarkdown(ConditionEvaluationReport report, Map<String, String> beanOrigins) {
+        StringBuilder md = new StringBuilder();
+        md.append("# Spring Boot Usage Report (Experimental)\n\n");
+        md.append("Generated: ").append(Instant.now()).append("\n\n");
+        md.append("## Applied Auto-Configurations\n\n");
+        List<String> applied = new ArrayList<>(report.getConditionAndOutcomesBySource().keySet());
+        applied.sort(String::compareTo);
+        for (String name : applied) {
+            md.append("- ").append(name).append('\n');
+        }
+        md.append("\n## Bean Origins (non-Spring framework)\n\n");
+        beanOrigins.entrySet().stream()
+                .sorted(Comparator.comparing(Map.Entry::getKey))
+                .forEach(e -> md.append("- `").append(e.getKey()).append("` -> ")
+                        .append(shorten(e.getValue())).append('\n'));
+        return md.toString();
+    }
+
+    private String escape(String v) {
+        return v.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private String limit(String s, int max) {
+        if (s.length() <= max) return s;
+        return s.substring(0, max - 3) + "...";
+    }
+
+    private String shorten(String loc) {
+        int bang = loc.indexOf('!');
+        if (bang > 0) {
+            return loc.substring(0, bang);
+        }
+        return loc;
+    }
+}

--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/UsagePolicy.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/UsagePolicy.java
@@ -1,0 +1,22 @@
+package org.springframework.boot.autoconfigure.usage;
+
+import java.util.List;
+
+/**
+ * Experimental SPI allowing custom policy evaluation against the structured usage report.
+ * Implementations should be cheap and side-effect free.
+ */
+public interface UsagePolicy {
+
+    /**
+     * Evaluate the report and return a result. Never return null.
+     */
+    PolicyResult evaluate(java.util.Map<String,Object> structured, UsageReportProperties properties);
+
+    /**
+     * Simple record containing policy warnings and violations.
+     */
+    record PolicyResult(List<String> warnings, List<String> violations) {
+        public static PolicyResult empty() { return new PolicyResult(List.of(), List.of()); }
+    }
+}

--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/UsageReportCustomizer.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/UsageReportCustomizer.java
@@ -1,0 +1,15 @@
+package org.springframework.boot.autoconfigure.usage;
+
+import java.util.Map;
+
+/**
+ * Callback interface that can customize the structured usage report before it is
+ * cached or returned by the actuator endpoint. Implementations can add or mutate
+ * entries in the provided {@code structured} map.
+ * <p>Experimental API – may evolve.</p>
+ */
+@FunctionalInterface
+public interface UsageReportCustomizer {
+
+    void customize(Map<String, Object> structured, UsageReportProperties properties);
+}

--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/UsageReportGenerator.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/UsageReportGenerator.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.usage;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.springframework.boot.autoconfigure.condition.ConditionEvaluationReport;
+
+/**
+ * Builds a structured usage report map (schemaVersion 1).
+ */
+/**
+ * Internal support class building the structured usage report map (schemaVersion=1).
+ * Kept package-private; output format is experimental.
+ */
+class UsageReportGenerator {
+
+    static final String SCHEMA_VERSION = "1";
+
+    UsageReportGenerator() {
+    }
+
+    UsageReport build(ConditionEvaluationReport report, Map<String, String> beanOrigins, UsageReportProperties props) {
+        List<String> applied = new ArrayList<>();
+        List<String> skipped = new ArrayList<>();
+        report.getConditionAndOutcomesBySource().forEach((name, outcomes) -> {
+            if (outcomes.isFullMatch()) {
+                applied.add(name);
+            }
+            else {
+                skipped.add(name);
+            }
+        });
+        applied.sort(String::compareTo);
+        skipped.sort(String::compareTo);
+        StarterUsageAnalyzer analyzer = new StarterUsageAnalyzer();
+        StarterUsageAnalyzer.StarterUsageResult usage = analyzer.classify(applied);
+        return new UsageReport(applied, skipped, usage, beanOrigins);
+    }
+
+    record UsageReport(List<String> applied, List<String> skipped, StarterUsageAnalyzer.StarterUsageResult starterUsage,
+            Map<String, String> beanOrigins) {
+    }
+
+    Map<String, Object> toStructuredMap(UsageReport r, boolean includeSkippedDetails, boolean failOnUnused) {
+        Map<String, Object> root = new LinkedHashMap<>();
+        root.put("schemaVersion", SCHEMA_VERSION);
+        root.put("timestamp", Instant.now().toString());
+        root.put("appliedAutoConfigurations", r.applied());
+        if (includeSkippedDetails) {
+            // For now just provide the names list; detailed reasons already in file builder
+            root.put("skippedAutoConfigurations", r.skipped());
+        }
+        root.put("declaredStarters", r.starterUsage().declaredStarters);
+        root.put("usedStarters", r.starterUsage().usedStarters);
+        root.put("unusedStarters", r.starterUsage().unusedStarters);
+        if (failOnUnused && !r.starterUsage().unusedStarters.isEmpty()) {
+            root.put("unusedStarterFailure", Boolean.TRUE);
+        }
+        Map<String, Object> suggestions = new LinkedHashMap<>();
+        suggestions.put("removeStarters", r.starterUsage().unusedStarters);
+        root.put("suggestions", suggestions);
+        Map<String, Object> origins = new TreeMap<>();
+        r.beanOrigins().forEach((bean, loc) -> {
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("location", loc);
+            origins.put(bean, entry);
+        });
+        root.put("beanOrigins", origins);
+        root.put("appliedCount", r.applied().size());
+        root.put("skippedCount", r.skipped().size());
+        root.put("beanCount", r.beanOrigins().size());
+        return root;
+    }
+}

--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/UsageReportProperties.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/UsageReportProperties.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.usage;
+
+import java.nio.file.Path;
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * Configuration properties for the experimental usage (dependency & auto-config) report.
+ * <p>Enable with {@code spring.boot.usage.report.enabled=true} to generate a JSON &
+ * plain-text summary of applied and skipped auto-configurations plus bean -> artifact
+ * origin mapping.
+ *
+ * @author Generated
+ * @since 3.x
+ */
+@ConfigurationProperties("spring.boot.usage.report")
+public class UsageReportProperties {
+
+    /**
+     * Enable generation of a runtime usage report (experimental).
+     */
+    private boolean enabled = false;
+
+    /**
+     * Output directory for report artifacts. Relative paths are resolved against the
+     * working directory.
+     */
+    private Path outputDir = Path.of("build", "boot-usage");
+
+    /**
+     * Write a Markdown summary alongside the JSON report.
+     */
+    private boolean markdownSummary = true;
+
+    /**
+     * Include skipped auto-configuration details (conditions & reasons) in JSON.
+     */
+    private boolean includeSkippedDetails = true;
+
+    /**
+     * Mark application as failed if unused starters (future phase) are detected.
+     */
+    private boolean failOnUnused = false;
+
+    /**
+     * Fail application startup if report writing fails.
+     */
+    private boolean failOnError = false;
+
+    /**
+     * Cache TTL for generated report served via endpoint (0 disables caching).
+     */
+    private Duration cacheTtl = Duration.ofMinutes(5);
+
+    /**
+     * Include bean origin details in the report (may reveal artifact coordinates); disable
+     * to reduce potentially sensitive information.
+     */
+    private boolean includeOrigins = true;
+
+    /**
+     * Include a basic confidence score map for suggestions.
+     */
+    private boolean includeConfidence = true;
+
+    /**
+     * Attempt a lightweight heuristic to list potentially unused jars on the classpath.
+     * (Experimental, may produce false positives.)
+     */
+    private boolean detectUnusedJars = false;
+
+    /**
+     * Policy evaluation configuration.
+     */
+    private final Policies policies = new Policies();
+
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Path getOutputDir() {
+        return this.outputDir;
+    }
+
+    public void setOutputDir(Path outputDir) {
+        this.outputDir = outputDir;
+    }
+
+    public boolean isMarkdownSummary() {
+        return this.markdownSummary;
+    }
+
+    public void setMarkdownSummary(boolean markdownSummary) {
+        this.markdownSummary = markdownSummary;
+    }
+
+    public boolean isFailOnError() {
+        return this.failOnError;
+    }
+
+    public void setFailOnError(boolean failOnError) {
+        this.failOnError = failOnError;
+    }
+
+    public boolean isIncludeSkippedDetails() {
+        return this.includeSkippedDetails;
+    }
+
+    public void setIncludeSkippedDetails(boolean includeSkippedDetails) {
+        this.includeSkippedDetails = includeSkippedDetails;
+    }
+
+    public boolean isFailOnUnused() {
+        return this.failOnUnused;
+    }
+
+    public void setFailOnUnused(boolean failOnUnused) {
+        this.failOnUnused = failOnUnused;
+    }
+
+    public Duration getCacheTtl() {
+        return this.cacheTtl;
+    }
+
+    public void setCacheTtl(Duration cacheTtl) {
+        this.cacheTtl = cacheTtl;
+    }
+
+    public boolean isIncludeOrigins() {
+        return this.includeOrigins;
+    }
+
+    public void setIncludeOrigins(boolean includeOrigins) {
+        this.includeOrigins = includeOrigins;
+    }
+
+    public boolean isIncludeConfidence() {
+        return this.includeConfidence;
+    }
+
+    public void setIncludeConfidence(boolean includeConfidence) {
+        this.includeConfidence = includeConfidence;
+    }
+
+    public boolean isDetectUnusedJars() {
+        return this.detectUnusedJars;
+    }
+
+    public void setDetectUnusedJars(boolean detectUnusedJars) {
+        this.detectUnusedJars = detectUnusedJars;
+    }
+
+    public Policies getPolicies() {
+        return this.policies;
+    }
+
+    /**
+     * Nested properties related to policy evaluation.
+     */
+    public static class Policies {
+        /**
+         * Fail application startup if any policy violation is reported.
+         */
+        private boolean failOnViolation = false;
+
+        public boolean isFailOnViolation() {
+            return this.failOnViolation;
+        }
+
+        public void setFailOnViolation(boolean failOnViolation) {
+            this.failOnViolation = failOnViolation;
+        }
+    }
+}

--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/UsageReportService.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/usage/UsageReportService.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.usage;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.ObjectProvider;
+
+import org.springframework.boot.autoconfigure.condition.ConditionEvaluationReport;
+
+/**
+ * Central service to build and (optionally) cache the usage report.
+ */
+/**
+ * Experimental API – subject to change. Service that assembles and optionally caches
+ * the structured usage report exposed via the actuator endpoint.
+ */
+public class UsageReportService {
+
+    private final UsageReportProperties properties;
+
+    private final UsageReportGenerator generator = new UsageReportGenerator();
+
+    private final ObjectProvider<UsageReportCustomizer> customizers;
+    private final ObjectProvider<UsagePolicy> policies;
+
+    private volatile Cached cached;
+
+    public UsageReportService(UsageReportProperties properties) {
+        this(properties, null, null);
+    }
+
+    public UsageReportService(UsageReportProperties properties, ObjectProvider<UsageReportCustomizer> customizers,
+            ObjectProvider<UsagePolicy> policies) {
+        this.properties = properties;
+        this.customizers = customizers;
+        this.policies = policies;
+    }
+
+    public synchronized Map<String, Object> currentStructuredReport(ConditionEvaluationReport report, Map<String, String> beanOrigins, boolean force) {
+        Duration ttl = this.properties.getCacheTtl();
+        Instant now = Instant.now();
+        if (!force && ttl != null && !ttl.isZero()) {
+            Cached c = this.cached;
+            if (c != null && now.isBefore(c.expiresAt) && c.report != null) {
+                return c.report;
+            }
+        }
+        UsageReportGenerator.UsageReport usage = this.generator.build(report, beanOrigins, this.properties);
+        Map<String, Object> structured = this.generator.toStructuredMap(usage, this.properties.isIncludeSkippedDetails(), this.properties.isFailOnUnused());
+        if (this.properties.isIncludeOrigins()) {
+            enrichCoordinatesAndSuggestions(structured, beanOrigins);
+        } else {
+            structured.remove("beanOrigins");
+            @SuppressWarnings("unchecked") Map<String,Object> suggestions = (Map<String,Object>) structured.get("suggestions");
+            if (suggestions != null) {
+                Object featuresObj = suggestions.get("schemaFeatures");
+                java.util.List<String> features = new java.util.ArrayList<>();
+                if (featuresObj instanceof Iterable<?> it) {
+                    for (Object o : it) {
+                        if (o instanceof String s && !s.equals("bean-origins") && !s.equals("coordinates")) {
+                            features.add(s);
+                        }
+                    }
+                }
+                if (features.isEmpty()) {
+                    features.add("starter-usage");
+                    features.add("suggestions-basic");
+                }
+                suggestions.put("schemaFeatures", features);
+            }
+        }
+        // Features that do not require origins
+        applyConfidence(structured);
+        detectUnusedJars(structured, beanOrigins);
+    if (this.customizers != null) {
+            this.customizers.orderedStream().forEach(c -> {
+                try { c.customize(structured, this.properties); } catch (RuntimeException ignored) {}
+            });
+        }
+    evaluatePolicies(structured);
+        if (ttl != null && !ttl.isZero()) {
+            this.cached = new Cached(structured, now.plus(ttl));
+        }
+        return structured;
+    }
+
+    private void enrichCoordinatesAndSuggestions(Map<String, Object> structured, Map<String, String> beanOrigins) {
+        @SuppressWarnings("unchecked") Map<String, Object> origins = (Map<String, Object>) structured.get("beanOrigins");
+        Map<String, String> coordCache = new HashMap<>();
+        origins.forEach((bean, value) -> {
+            @SuppressWarnings("unchecked") Map<String, Object> entry = (Map<String, Object>) value;
+            String loc = (String) entry.get("location");
+            String coord = coordinateFor(loc, coordCache);
+            if (coord != null) {
+                entry.put("coordinate", coord);
+            }
+            if (loc != null) {
+                entry.put("sanitizedLocation", sanitizeLocation(loc));
+            }
+        });
+        // Add enriched suggestions (removeDependencies with coordinates if possible)
+        @SuppressWarnings("unchecked") Map<String, Object> suggestions = (Map<String, Object>) structured.get("suggestions");
+        if (suggestions != null) {
+            Object removeStarters = suggestions.get("removeStarters");
+            if (removeStarters instanceof Iterable<?> it) {
+                java.util.List<String> removeDependencies = new java.util.ArrayList<>();
+                for (Object starter : it) {
+                    if (starter instanceof String s) {
+                        // Heuristic: transform org.springframework.boot:spring-boot-starter-foo
+                        // to same coordinate unless bean origins surfaced a more specific coordinate.
+                        removeDependencies.add(s);
+                    }
+                }
+                suggestions.put("removeDependencies", removeDependencies);
+            }
+            suggestions.putIfAbsent("schemaFeatures", java.util.List.of("starter-usage","bean-origins","suggestions-basic","coordinates"));
+        }
+    }
+
+    private void applyConfidence(Map<String,Object> structured) {
+        if (!this.properties.isIncludeConfidence()) return;
+        @SuppressWarnings("unchecked") Map<String,Object> suggestions = (Map<String,Object>) structured.get("suggestions");
+        if (suggestions == null) return;
+        java.util.Map<String,Number> confidence = new java.util.LinkedHashMap<>();
+        Object removeStarters = suggestions.get("removeStarters");
+        if (removeStarters instanceof java.util.Collection<?> col) {
+            confidence.put("removeStarters", col.isEmpty() ? 0.0 : 0.9);
+        }
+        Object removeDeps = suggestions.get("removeDependencies");
+        if (removeDeps instanceof java.util.Collection<?> col) {
+            confidence.put("removeDependencies", col.isEmpty() ? 0.0 : 0.9);
+        }
+        if (!confidence.isEmpty()) {
+            suggestions.put("confidence", confidence);
+            @SuppressWarnings("unchecked") java.util.List<String> features = (java.util.List<String>) suggestions.get("schemaFeatures");
+            if (features != null && !features.contains("suggestions-confidence")) {
+                java.util.List<String> updated = new java.util.ArrayList<>(features);
+                updated.add("suggestions-confidence");
+                suggestions.put("schemaFeatures", updated);
+            }
+        }
+    }
+
+    private void detectUnusedJars(Map<String,Object> structured, Map<String,String> beanOrigins) {
+        if (!this.properties.isDetectUnusedJars()) return;
+        @SuppressWarnings("unchecked") Map<String,Object> suggestions = (Map<String,Object>) structured.get("suggestions");
+        if (suggestions == null) return;
+        java.util.Set<String> usedSanitized = new java.util.HashSet<>();
+        Object originsObj = structured.get("beanOrigins");
+        if (originsObj instanceof Map<?,?> originsMap) {
+            for (Object v : originsMap.values()) {
+                if (v instanceof Map<?,?> m) {
+                    Object sanitized = m.get("sanitizedLocation");
+                    if (sanitized instanceof String s) usedSanitized.add(s);
+                }
+            }
+        }
+        java.util.List<String> candidates = new java.util.ArrayList<>();
+        String cp = System.getProperty("java.class.path", "");
+        java.util.Set<String> excludePrefixes = java.util.Set.of("spring-boot-", "spring-core-", "spring-beans-", "jackson-", "micrometer-", "reactor-", "logback-", "slf4j-");
+        for (String entry : cp.split(java.io.File.pathSeparator)) {
+            if (!entry.endsWith(".jar")) continue;
+            String name = entry.substring(entry.lastIndexOf(java.io.File.separatorChar) + 1);
+            if (usedSanitized.contains(name)) continue;
+            String lower = name.toLowerCase(java.util.Locale.ROOT);
+            if (lower.contains("test") || lower.contains("junit") || lower.contains("assertj")) continue; // skip obvious test jars
+            boolean excludedByPrefix = excludePrefixes.stream().anyMatch(lower::startsWith);
+            if (excludedByPrefix) continue; // Common core libs usually always needed; heuristic noise reduction
+            if (candidates.size() < 20) {
+                candidates.add(name);
+            } else {
+                break;
+            }
+        }
+        suggestions.put("unusedJars", candidates);
+        @SuppressWarnings("unchecked") java.util.List<String> features = (java.util.List<String>) suggestions.get("schemaFeatures");
+        if (features != null && !features.contains("unused-jars")) {
+            java.util.List<String> updated = new java.util.ArrayList<>(features);
+            updated.add("unused-jars");
+            suggestions.put("schemaFeatures", updated);
+        }
+    }
+
+    private String sanitizeLocation(String loc) {
+        // Strip local absolute paths, retain jar file name only.
+        int bang = loc.indexOf('!');
+        String base = (bang > 0 ? loc.substring(0, bang) : loc);
+        if (base.startsWith("file:")) {
+            base = base.substring(5);
+        }
+        int slash = Math.max(base.lastIndexOf('/'), base.lastIndexOf('\\'));
+        if (slash >= 0 && slash < base.length() - 1) {
+            return base.substring(slash + 1);
+        }
+        return base;
+    }
+
+    private String coordinateFor(String location, Map<String, String> cache) {
+        if (location == null) return null;
+        return cache.computeIfAbsent(location, UsageReportService::resolveCoordinateFromLocation);
+    }
+
+    private static String resolveCoordinateFromLocation(String location) {
+        try {
+            if (!location.startsWith("file:")) {
+                return null;
+            }
+            String path = location.substring("file:".length());
+            if (path.endsWith("/")) {
+                return null; // directory (likely exploded classes) – skip
+            }
+            java.nio.file.Path p = java.nio.file.Paths.get(java.net.URLDecoder.decode(path, java.nio.charset.StandardCharsets.UTF_8));
+            if (!java.nio.file.Files.isRegularFile(p)) return null;
+            try (java.util.jar.JarFile jar = new java.util.jar.JarFile(p.toFile())) {
+                return jar.stream()
+                        .filter(e -> e.getName().startsWith("META-INF/maven/") && e.getName().endsWith("/pom.properties"))
+                        .findFirst()
+                        .map(entry -> {
+                            try {
+                                java.util.Properties props = new java.util.Properties();
+                                props.load(jar.getInputStream(entry));
+                                String g = props.getProperty("groupId");
+                                String a = props.getProperty("artifactId");
+                                String v = props.getProperty("version");
+                                if (g != null && a != null && v != null) {
+                                    return g + ":" + a + ":" + v;
+                                }
+                            } catch (Exception ignored) {}
+                            return null;
+                        }).orElse(null);
+            }
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    private record Cached(Map<String, Object> report, Instant expiresAt) {
+    }
+
+    private void evaluatePolicies(Map<String,Object> structured) {
+        if (this.policies == null) return;
+        java.util.List<String> warnings = new java.util.ArrayList<>();
+        java.util.List<String> violations = new java.util.ArrayList<>();
+        this.policies.orderedStream().forEach(p -> {
+            try {
+                UsagePolicy.PolicyResult result = p.evaluate(structured, this.properties);
+                if (result != null) {
+                    if (result.warnings() != null) warnings.addAll(result.warnings());
+                    if (result.violations() != null) violations.addAll(result.violations());
+                }
+            } catch (RuntimeException ignored) {}
+        });
+        if (!warnings.isEmpty() || !violations.isEmpty()) {
+            java.util.Map<String,Object> policies = new java.util.LinkedHashMap<>();
+            if (!warnings.isEmpty()) policies.put("warnings", warnings);
+            if (!violations.isEmpty()) policies.put("violations", violations);
+            structured.put("policies", policies);
+            @SuppressWarnings("unchecked") Map<String,Object> suggestions = (Map<String,Object>) structured.get("suggestions");
+            if (suggestions != null) {
+                Object featuresObj = suggestions.get("schemaFeatures");
+                java.util.List<String> features = new java.util.ArrayList<>();
+                if (featuresObj instanceof Iterable<?> it) {
+                    for (Object o : it) { if (o instanceof String s) features.add(s); }
+                }
+                if (!features.contains("policies-basic")) {
+                    features.add("policies-basic");
+                    suggestions.put("schemaFeatures", features);
+                }
+            }
+        }
+    }
+}

--- a/core/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -252,12 +252,23 @@
         "level": "error"
       }
     },
-    {
+  {
       "name": "spring.threads.virtual.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to use virtual threads.",
       "defaultValue": false
-    }
+  },
+  {"name":"spring.boot.usage.report.enabled","type":"java.lang.Boolean","description":"Enable generation of the experimental runtime usage report.","defaultValue":false},
+  {"name":"spring.boot.usage.report.output-dir","type":"java.lang.String","description":"Output directory for usage-report.json and usage-summary.md.","defaultValue":"build/boot-usage"},
+  {"name":"spring.boot.usage.report.markdown-summary","type":"java.lang.Boolean","description":"Write a Markdown summary alongside the JSON report.","defaultValue":true},
+  {"name":"spring.boot.usage.report.include-skipped-details","type":"java.lang.Boolean","description":"Include skipped auto-configuration reason details in JSON.","defaultValue":true},
+  {"name":"spring.boot.usage.report.fail-on-unused","type":"java.lang.Boolean","description":"Fail application startup when unused starters are detected.","defaultValue":false},
+  {"name":"spring.boot.usage.report.fail-on-error","type":"java.lang.Boolean","description":"Fail application startup if writing the usage report fails.","defaultValue":false}
+  ,{"name":"spring.boot.usage.report.cache-ttl","type":"java.time.Duration","description":"Cache TTL for the generated usage report served via the actuator endpoint (0 disables caching).","defaultValue":"PT5M"}
+  ,{"name":"spring.boot.usage.report.include-origins","type":"java.lang.Boolean","description":"Include bean origin details in the usage report (may reveal artifact coordinates). Disable to reduce potentially sensitive information.","defaultValue":true}
+  ,{"name":"spring.boot.usage.report.include-confidence","type":"java.lang.Boolean","description":"Include a basic confidence score map for dependency usage suggestions.","defaultValue":true}
+  ,{"name":"spring.boot.usage.report.detect-unused-jars","type":"java.lang.Boolean","description":"Attempt a lightweight heuristic to list potentially unused jars on the classpath (experimental; may produce false positives).","defaultValue":false}
+  ,{"name":"spring.boot.usage.report.policies.fail-on-violation","type":"java.lang.Boolean","description":"Fail application startup if any usage policy reports a violation.","defaultValue":false}
   ],
   "hints": [
     {

--- a/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/usage/UsageAnalysisAutoConfigurationFailOnUnusedTests.java
+++ b/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/usage/UsageAnalysisAutoConfigurationFailOnUnusedTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ */
+package org.springframework.boot.autoconfigure.usage;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UsageAnalysisAutoConfigurationFailOnUnusedTests {
+
+    @Test
+    void failOnUnusedTriggersOnlyWhenUnusedPresent() throws Exception {
+        Path out = Path.of("build", "boot-usage");
+        try (ConfigurableApplicationContext context = new SpringApplicationBuilder(Sample.class)
+                .web(WebApplicationType.NONE)
+                .properties(
+                        "spring.boot.usage.report.enabled=true",
+                        "spring.boot.usage.report.fail-on-unused=true",
+                        "spring.main.banner-mode=off"
+                )
+                .run()) {
+            Path report = out.resolve("usage-report.json");
+            assertThat(Files.exists(report)).isTrue();
+            String json = Files.readString(report);
+            if (json.contains("\"unusedStarters\": [\n    \"")) {
+                // If there are any unused starters listed, unusedStarterFailure flag must be set
+                assertThat(json).contains("unusedStarterFailure");
+            }
+        }
+    }
+
+    @Test
+    void suggestionsSectionPresent() throws Exception {
+        Path out = Path.of("build", "boot-usage");
+        try (ConfigurableApplicationContext context = new SpringApplicationBuilder(Sample.class)
+                .web(WebApplicationType.NONE)
+                .properties(
+                        "spring.boot.usage.report.enabled=true",
+                        "spring.main.banner-mode=off"
+                )
+                .run()) {
+            Path report = out.resolve("usage-report.json");
+            assertThat(Files.exists(report)).isTrue();
+            String json = Files.readString(report);
+            assertThat(json).contains("\"suggestions\"");
+            assertThat(json).contains("removeStarters");
+        }
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    static class Sample { }
+}

--- a/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/usage/UsageAnalysisAutoConfigurationTests.java
+++ b/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/usage/UsageAnalysisAutoConfigurationTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.autoconfigure.usage;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link UsageAnalysisAutoConfiguration}.
+ */
+class UsageAnalysisAutoConfigurationTests {
+
+    @Test
+    void generatesJsonReportWhenEnabled() throws Exception {
+        Path out = Path.of("build", "boot-usage");
+        try (ConfigurableApplicationContext context = new SpringApplicationBuilder(Sample.class)
+                .web(WebApplicationType.NONE)
+                .properties(
+                        "spring.boot.usage.report.enabled=true",
+                        "spring.main.banner-mode=off")
+                .run()) {
+            Path report = out.resolve("usage-report.json");
+            assertThat(Files.exists(report)).isTrue();
+            String json = Files.readString(report);
+            assertThat(json).contains("appliedAutoConfigurations");
+            assertThat(json).contains("beanOrigins");
+            assertThat(json).contains("declaredStarters");
+            assertThat(json).contains("usedStarters");
+            assertThat(json).contains("unusedStarters");
+        }
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    static class Sample { }
+}

--- a/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/usage/UsagePolicyFailOnViolationTests.java
+++ b/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/usage/UsagePolicyFailOnViolationTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.autoconfigure.usage;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.SpringApplication;
+import java.time.Duration;
+
+class UsagePolicyFailOnViolationTests {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    ConfigurationPropertiesAutoConfiguration.class,
+                    PropertyPlaceholderAutoConfiguration.class,
+                    UsageAnalysisAutoConfiguration.class,
+                    PolicyConfig.class))
+            .withPropertyValues(
+                    "spring.boot.usage.report.enabled=true",
+                    "spring.boot.usage.report.policies.fail-on-violation=true");
+
+    @Test
+    void contextFailsOnViolation() {
+        this.runner.run(context -> {
+        assertThatThrownBy(() -> context.publishEvent(new ApplicationReadyEvent(new SpringApplication(), new String[0], context, Duration.ZERO)))
+            .hasMessageContaining("Policy violation prevented startup");
+        });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class PolicyConfig {
+        @Bean
+        UsagePolicy samplePolicy() {
+            return (structured, props) -> new UsagePolicy.PolicyResult(List.of(), List.of("Always fail policy"));
+        }
+    }
+}

--- a/documentation/spring-boot-actuator-docs/src/docs/antora/modules/api/examples/bootusage-schema-v1.json
+++ b/documentation/spring-boot-actuator-docs/src/docs/antora/modules/api/examples/bootusage-schema-v1.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/spring/bootusage-schema-v1.json",
+  "title": "Spring Boot Usage Report",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["schemaVersion", "timestamp", "starters", "autoConfiguration", "suggestions"],
+  "properties": {
+    "schemaVersion": {"type": "integer", "const": 1},
+    "timestamp": {"type": "integer", "description": "Epoch milliseconds when the report was generated."},
+    "starters": {
+      "type": "object",
+      "required": ["declared", "used", "unused"],
+      "properties": {
+        "declared": {"type": "array", "items": {"type": "string"}},
+        "used": {"type": "array", "items": {"type": "string"}},
+        "unused": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "autoConfiguration": {
+      "type": "object",
+      "properties": {
+        "appliedCount": {"type": "integer"},
+        "skippedCount": {"type": "integer"}
+      }
+    },
+    "suggestions": {
+      "type": "object",
+      "properties": {
+        "removeStarters": {"type": "array", "items": {"type": "string"}},
+        "removeDependencies": {"type": "array", "items": {"type": "string"}},
+        "confidence": {"type": "object", "additionalProperties": {"type": "number"}},
+        "unusedJars": {"type": "array", "items": {"type": "string"}},
+        "schemaFeatures": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "policies": {
+      "type": "object",
+      "properties": {
+        "warnings": {"type": "array", "items": {"type": "string"}},
+        "violations": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "beanOrigins": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "location": {"type": "string"},
+          "sanitizedLocation": {"type": "string"},
+          "coordinate": {"type": "string"}
+        }
+      }
+    }
+  }
+}

--- a/documentation/spring-boot-actuator-docs/src/docs/antora/modules/api/pages/rest/actuator/bootusage.adoc
+++ b/documentation/spring-boot-actuator-docs/src/docs/antora/modules/api/pages/rest/actuator/bootusage.adoc
@@ -1,0 +1,166 @@
+= bootusage
+
+The `bootusage` endpoint exposes an experimental structured report describing runtime usage of Spring Boot auto-configuration and starter dependencies.
+
+[NOTE]
+====
+This endpoint is experimental; its schema may evolve between minor releases. It is disabled by default and must be explicitly enabled.
+====
+
+== Enabling
+
+Add the following property:
+
+[source,properties]
+----
+spring.boot.usage.report.enabled=true
+----
+
+Then expose the endpoint (if you use the web actuator exposure include list):
+
+[source,properties]
+----
+management.endpoints.web.exposure.include=bootusage
+----
+
+You can disable the endpoint independently (defaults to enabled when the usage report feature is on):
+
+[source,properties]
+----
+management.endpoint.bootusage.enabled=false
+----
+
+== Operations
+
+|===
+|HTTP Method|Path|Description
+|GET|/actuator/bootusage|Returns the current (possibly cached) usage report.
+|GET|/actuator/bootusage?force=true|Forces regeneration bypassing the cache.
+|===
+
+== Payload (Schema Version 1)
+
+The response is a JSON object containing (fields may expand in the future):
+
+[source,json]
+----
+{
+  "schemaVersion": 1,
+  "timestamp": 1730000000000,
+  "starters": {
+    "declared": [ "spring-boot-starter-web", "spring-boot-starter-actuator" ],
+    "used": [ "spring-boot-starter-web", "spring-boot-starter-actuator" ],
+    "unused": []
+  },
+  "autoConfiguration": {
+    "appliedCount": 123,
+    "skippedCount": 45
+  },
+  "suggestions": {
+    "removeStarters": [],
+    "removeDependencies": [],
+    "confidence": { "removeStarters": 0.9, "removeDependencies": 0.9 },
+    "unusedJars": [ "example-unused.jar" ]
+  },
+  "policies": {
+    "warnings": ["Example warning"],
+    "violations": ["Example violation"]
+  },
+  "beanOrigins": {
+    "myService": "com.example:demo:1.0.0",
+    "objectMapper": "com.fasterxml.jackson.core:jackson-databind"
+  }
+}
+----
+
+Field notes:
+
+- schemaVersion: Integer for compatibility negotiation.
+- timestamp: Milliseconds since epoch when the report (or cached copy) was produced.
+- starters: High-level starter dependency usage classification; `unused` suggests removal candidates.
+- autoConfiguration: Counts of applied and skipped auto-configurations (details may be extended later).
+- suggestions: Machine-generated advisory actions (list may grow; treat as hints, not directives).
+  - confidence: Basic confidence scores for certain suggestion lists (experimental heuristic).
+  - unusedJars: Experimental heuristic list of jars on the classpath not linked to any bean origin.
+  - policies: Policy evaluation output with warnings and violations.
+- beanOrigins: Mapping of bean names to inferred coordinates or code source locations (sanitized).
+
+=== Schema Features
+
+The `suggestions.schemaFeatures` array advertises feature flags present in the payload to enable forward-compatible clients:
+
+[cols="1,3"]
+|===
+|Feature|Meaning
+|starter-usage|Starter dependency usage classification (declared/used/unused)
+|bean-origins|`beanOrigins` section included
+|coordinates|Dependency coordinates inferred for bean origins where possible
+|suggestions-basic|Basic suggestions (e.g. removeStarters)
+|suggestions-confidence|Confidence score map present
+|unused-jars|Heuristic `unusedJars` list present
+|policies-basic|Policy evaluation results included
+|===
+
+JSON schema (informative) is available in the distribution sources at: `examples/bootusage-schema-v1.json`.
+
+=== Extension SPIs (Experimental)
+
+You can extend or govern the report via two experimental SPIs:
+
+* `UsageReportCustomizer` – mutate the structured `Map<String,Object>` after it is assembled, before caching.
+* `UsagePolicy` – evaluate the structured map and return warnings/violations; with `spring.boot.usage.report.policies.fail-on-violation=true` any violation fails startup.
+
+Register beans of these types in your application context; ordering follows standard Spring bean ordering semantics.
+
+=== Property Summary
+
+[source,properties]
+----
+spring.boot.usage.report.enabled=false
+spring.boot.usage.report.output-dir=build/boot-usage
+spring.boot.usage.report.markdown-summary=true
+spring.boot.usage.report.include-skipped-details=true
+spring.boot.usage.report.fail-on-unused=false
+spring.boot.usage.report.fail-on-error=false
+spring.boot.usage.report.cache-ttl=5m
+spring.boot.usage.report.include-origins=true
+spring.boot.usage.report.include-confidence=true
+spring.boot.usage.report.detect-unused-jars=false
+spring.boot.usage.report.policies.fail-on-violation=false
+----
+
+== Caching & Forcing Refresh
+
+Responses are cached for the duration specified by `spring.boot.usage.report.cache-ttl` (default `5m`). Supplying the `force=true` query parameter skips the cache and regenerates the report.
+
+== Failure Modes
+
+If `spring.boot.usage.report.fail-on-error=true`, any failure to write the on-disk report at application start will fail the application.
+If `spring.boot.usage.report.fail-on-unused=true` and unused starters are detected, startup fails (future expansion may refine this behavior).
+
+== Security Considerations
+
+The report may reveal dependency coordinates and bean names. Evaluate sensitivity before exposing it in production. You can:
+
+* Restrict exposure using standard actuator security.
+* Disable or minimize emission of potentially sensitive fields:
+
+[source,properties]
+----
+spring.boot.usage.report.include-origins=false   # removes beanOrigins & coordinates
+spring.boot.usage.report.include-confidence=false
+spring.boot.usage.report.detect-unused-jars=false
+spring.boot.usage.report.policies.fail-on-violation=true
+----
+
+== Evolution Roadmap (Informative)
+
+Future schema additions under consideration:
+
+- Confidence scores for suggestions.
+- Size / initialization time impact estimates.
+- Unused transitive dependency insights.
+- Policy-driven warnings (organization rules).
+ - Rich unused jar analysis (current heuristic is simplistic).
+
+Treat unknown fields as ignorable for forward compatibility.

--- a/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/usage/UsageEndpointAutoConfiguration.java
+++ b/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/usage/UsageEndpointAutoConfiguration.java
@@ -1,0 +1,30 @@
+package org.springframework.boot.actuate.autoconfigure.usage;
+
+import org.springframework.boot.actuate.usage.UsageEndpoint;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.usage.UsageReportProperties;
+import org.springframework.boot.autoconfigure.usage.UsageReportService;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configuration for the bootusage actuator endpoint.
+ */
+import org.springframework.boot.autoconfigure.usage.UsageAnalysisAutoConfiguration;
+
+@AutoConfiguration(after = UsageAnalysisAutoConfiguration.class)
+@ConditionalOnClass(UsageEndpoint.class)
+@ConditionalOnProperty(prefix = "spring.boot.usage.report", name = "enabled", havingValue = "true")
+@ConditionalOnAvailableEndpoint(UsageEndpoint.class)
+public final class UsageEndpointAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    UsageEndpoint usageEndpoint(ConfigurableApplicationContext context, UsageReportProperties props, UsageReportService service) {
+        return new UsageEndpoint(context, props, service);
+    }
+}

--- a/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/usage/UsageEndpoint.java
+++ b/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/usage/UsageEndpoint.java
@@ -1,0 +1,48 @@
+package org.springframework.boot.actuate.usage;
+
+import java.util.Map;
+
+import org.springframework.boot.actuate.endpoint.OperationResponseBody;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.autoconfigure.condition.ConditionEvaluationReport;
+import org.springframework.boot.autoconfigure.usage.BeanOriginTrackingPostProcessor;
+import org.springframework.boot.autoconfigure.usage.UsageReportProperties;
+import org.springframework.boot.autoconfigure.usage.UsageReportService;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.util.Assert;
+
+/**
+ * Actuator endpoint that exposes the structured Spring Boot usage report (experimental).
+ */
+/**
+ * Experimental actuator endpoint exposing the structured runtime usage report.
+ */
+@Endpoint(id = "bootusage")
+public class UsageEndpoint {
+
+    private final ConfigurableApplicationContext context;
+    private final UsageReportProperties properties;
+    private final UsageReportService service;
+    
+    public UsageEndpoint(ConfigurableApplicationContext context, UsageReportProperties properties, UsageReportService service) {
+        Assert.notNull(context, "context must not be null");
+        this.context = context;
+        this.properties = properties;
+        this.service = service;
+    }
+
+    @ReadOperation
+    public Map<String, Object> usage(Boolean force) {
+        boolean forceRefresh = (force != null && force);
+        if (!this.properties.isEnabled()) {
+            return OperationResponseBody.of(Map.of("enabled", Boolean.FALSE));
+        }
+        ConditionEvaluationReport report = ConditionEvaluationReport.get(this.context.getBeanFactory());
+        Map<String, String> origins = this.context.getBeansOfType(BeanOriginTrackingPostProcessor.class)
+                .values().stream().findFirst().map(BeanOriginTrackingPostProcessor::getBeanOrigins)
+                .orElseGet(Map::of);
+        Map<String, Object> structured = this.service.currentStructuredReport(report, origins, forceRefresh);
+        return OperationResponseBody.of(structured);
+    }
+}

--- a/module/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/module/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -100,6 +100,12 @@
       ]
     },
     {
+      "name": "management.endpoint.bootusage.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable the bootusage endpoint.",
+      "defaultValue": true
+    },
+    {
       "name": "management.health.defaults.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to enable default health indicators.",

--- a/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/usage/UsageAnalysisAutoConfigurationActivationTests.java
+++ b/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/usage/UsageAnalysisAutoConfigurationActivationTests.java
@@ -1,0 +1,37 @@
+package org.springframework.boot.actuate.autoconfigure.usage;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.usage.UsageAnalysisAutoConfiguration;
+import org.springframework.boot.autoconfigure.usage.UsageReportService;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UsageAnalysisAutoConfigurationActivationTests {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    ConfigurationPropertiesAutoConfiguration.class,
+                    PropertyPlaceholderAutoConfiguration.class,
+                    UsageAnalysisAutoConfiguration.class))
+            .withPropertyValues("spring.boot.usage.report.enabled=true");
+
+    @Test
+    void serviceBeanCreatedWhenEnabledPropertyTrue() {
+        this.runner.run(ctx -> assertThat(ctx).hasSingleBean(UsageReportService.class));
+    }
+
+    @Test
+    void serviceBeanAbsentWhenPropertyMissing() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        ConfigurationPropertiesAutoConfiguration.class,
+                        PropertyPlaceholderAutoConfiguration.class,
+                        UsageAnalysisAutoConfiguration.class))
+                .run(ctx -> assertThat(ctx).doesNotHaveBean(UsageReportService.class));
+    }
+}

--- a/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/usage/UsageEndpointAutoConfigurationTests.java
+++ b/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/usage/UsageEndpointAutoConfigurationTests.java
@@ -1,0 +1,71 @@
+package org.springframework.boot.actuate.autoconfigure.usage;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.usage.UsageEndpoint;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.autoconfigure.usage.UsageAnalysisAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.jackson.JacksonEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UsageEndpointAutoConfigurationTests {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(
+                ConfigurationPropertiesAutoConfiguration.class,
+                PropertyPlaceholderAutoConfiguration.class,
+                EndpointAutoConfiguration.class,
+                JacksonEndpointAutoConfiguration.class,
+                WebEndpointAutoConfiguration.class,
+                ManagementContextAutoConfiguration.class,
+                UsageAnalysisAutoConfiguration.class,
+                UsageEndpointAutoConfiguration.class))
+            .withPropertyValues(
+                    "spring.boot.usage.report.enabled=true",
+                    "management.endpoint.bootusage.enabled=true",
+                    "management.endpoints.web.exposure.include=bootusage");
+
+    @Test
+    void disabledPropertyDoesNotCreateEndpoint() {
+    new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(
+            ConfigurationPropertiesAutoConfiguration.class,
+            PropertyPlaceholderAutoConfiguration.class,
+            EndpointAutoConfiguration.class,
+            JacksonEndpointAutoConfiguration.class,
+                    WebEndpointAutoConfiguration.class,
+                    ManagementContextAutoConfiguration.class,
+            UsageAnalysisAutoConfiguration.class,
+            UsageEndpointAutoConfiguration.class))
+            .withPropertyValues("management.endpoints.web.exposure.include=bootusage","management.endpoint.bootusage.enabled=true")
+            .run((context) -> assertThat(context).doesNotHaveBean(UsageEndpoint.class));
+    }
+
+    @Test
+    void enabledCreatesEndpoint() {
+        this.contextRunner.run((context) -> {
+            boolean endpoint = context.containsBean("usageEndpoint");
+            boolean service = context.getBeansOfType(org.springframework.boot.autoconfigure.usage.UsageReportService.class).size() == 1;
+            if (!endpoint) {
+                org.springframework.boot.autoconfigure.condition.ConditionEvaluationReport report = org.springframework.boot.autoconfigure.condition.ConditionEvaluationReport.get(context.getBeanFactory());
+                System.out.println("=== Diagnostics: UsageEndpointAutoConfiguration (FULL) ===");
+                System.out.println("servicePresent=" + service);
+                System.out.println("properties.enabled=" + context.getEnvironment().getProperty("spring.boot.usage.report.enabled"));
+                if (report != null) {
+                    report.getConditionAndOutcomesBySource().forEach((k,v) -> {
+                        System.out.println(k + " matched=" + v.isFullMatch());
+                        v.forEach(outcome -> System.out.println("  - " + outcome));
+                    });
+                }
+            }
+            assertThat(endpoint).as("UsageEndpoint bean should be present").isTrue();
+        });
+    }
+}

--- a/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/usage/UsageEndpointCachingTests.java
+++ b/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/usage/UsageEndpointCachingTests.java
@@ -1,0 +1,49 @@
+package org.springframework.boot.actuate.usage;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.jackson.JacksonEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.usage.UsageEndpointAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.usage.UsageAnalysisAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UsageEndpointCachingTests {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    ConfigurationPropertiesAutoConfiguration.class,
+                    PropertyPlaceholderAutoConfiguration.class,
+                    EndpointAutoConfiguration.class,
+                    JacksonEndpointAutoConfiguration.class,
+                    WebEndpointAutoConfiguration.class,
+                    ManagementContextAutoConfiguration.class,
+                    UsageAnalysisAutoConfiguration.class,
+                    UsageEndpointAutoConfiguration.class))
+            .withPropertyValues(
+                    "spring.boot.usage.report.enabled=true",
+                    "spring.boot.usage.report.cache-ttl=5m",
+                    "management.endpoints.web.exposure.include=bootusage");
+
+    @Test
+    void forceBypassesCache() {
+        this.runner.run(ctx -> {
+            UsageEndpoint endpoint = ctx.getBean(UsageEndpoint.class);
+            Map<String,Object> first = endpoint.usage(null);
+            Map<String,Object> second = endpoint.usage(null);
+            assertThat(first.get("timestamp")).isEqualTo(second.get("timestamp"));
+            Map<String,Object> forced = endpoint.usage(Boolean.TRUE);
+            assertThat(forced.get("timestamp")).isNotEqualTo(first.get("timestamp"));
+        });
+    }
+}

--- a/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/usage/UsageEndpointConfidenceToggleTests.java
+++ b/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/usage/UsageEndpointConfidenceToggleTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.actuate.usage;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.jackson.JacksonEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.usage.UsageEndpointAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.usage.UsageAnalysisAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UsageEndpointConfidenceToggleTests {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    ConfigurationPropertiesAutoConfiguration.class,
+                    PropertyPlaceholderAutoConfiguration.class,
+                    EndpointAutoConfiguration.class,
+                    JacksonEndpointAutoConfiguration.class,
+                    WebEndpointAutoConfiguration.class,
+                    ManagementContextAutoConfiguration.class,
+                    UsageAnalysisAutoConfiguration.class,
+                    UsageEndpointAutoConfiguration.class))
+            .withPropertyValues(
+                    "spring.boot.usage.report.enabled=true",
+                    "spring.boot.usage.report.include-confidence=false",
+                    "management.endpoints.web.exposure.include=bootusage");
+
+    @Test
+    void confidenceOmittedWhenDisabled() {
+        this.runner.run(ctx -> {
+            UsageEndpoint endpoint = ctx.getBean(UsageEndpoint.class);
+            Map<String,Object> body = endpoint.usage(null);
+            assertThat(body).doesNotContainKey("suggestionConfidence");
+        });
+    }
+}

--- a/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/usage/UsageEndpointCustomizationTests.java
+++ b/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/usage/UsageEndpointCustomizationTests.java
@@ -1,0 +1,65 @@
+package org.springframework.boot.actuate.usage;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.jackson.JacksonEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.usage.UsageEndpointAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.usage.UsageAnalysisAutoConfiguration;
+import org.springframework.boot.autoconfigure.usage.UsageReportCustomizer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UsageEndpointCustomizationTests {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    ConfigurationPropertiesAutoConfiguration.class,
+                    PropertyPlaceholderAutoConfiguration.class,
+                    EndpointAutoConfiguration.class,
+                    JacksonEndpointAutoConfiguration.class,
+                    WebEndpointAutoConfiguration.class,
+                    ManagementContextAutoConfiguration.class,
+                    UsageAnalysisAutoConfiguration.class,
+                    UsageEndpointAutoConfiguration.class,
+                    CustomizerConfig.class))
+            .withPropertyValues(
+                    "spring.boot.usage.report.enabled=true",
+                    "spring.boot.usage.report.cache-ttl=0",
+                    "spring.boot.usage.report.include-origins=false",
+                    "spring.boot.usage.report.detect-unused-jars=true",
+                    "management.endpoints.web.exposure.include=bootusage");
+
+    @Test
+    void customizerInvokedAndFeaturesPresent() {
+        this.runner.run(ctx -> {
+            UsageEndpoint ep = ctx.getBean(UsageEndpoint.class);
+            @SuppressWarnings("unchecked") Map<String,Object> body = ep.usage(Boolean.TRUE);
+            System.out.println("Customization full body=" + body);
+            assertThat(body.get("customized")).isEqualTo(Boolean.TRUE);
+            @SuppressWarnings("unchecked") Map<String,Object> suggestions = (Map<String,Object>) body.get("suggestions");
+            assertThat(suggestions).isNotNull();
+            @SuppressWarnings("unchecked") Map<String,Object> confidence = (Map<String,Object>) suggestions.get("confidence");
+            assertThat(confidence).isNotNull();
+            assertThat(suggestions).containsKey("unusedJars");
+        });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CustomizerConfig {
+        @Bean
+        UsageReportCustomizer markerCustomizer() {
+            return (structured, props) -> structured.put("customized", Boolean.TRUE);
+        }
+    }
+}

--- a/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/usage/UsageEndpointOriginsToggleTests.java
+++ b/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/usage/UsageEndpointOriginsToggleTests.java
@@ -1,0 +1,46 @@
+package org.springframework.boot.actuate.usage;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.jackson.JacksonEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.usage.UsageEndpointAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.usage.UsageAnalysisAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UsageEndpointOriginsToggleTests {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    ConfigurationPropertiesAutoConfiguration.class,
+                    PropertyPlaceholderAutoConfiguration.class,
+                    EndpointAutoConfiguration.class,
+                    JacksonEndpointAutoConfiguration.class,
+                    WebEndpointAutoConfiguration.class,
+                    ManagementContextAutoConfiguration.class,
+                    UsageAnalysisAutoConfiguration.class,
+                    UsageEndpointAutoConfiguration.class))
+            .withPropertyValues(
+                    "spring.boot.usage.report.enabled=true",
+                    "spring.boot.usage.report.include-origins=false",
+                    "management.endpoints.web.exposure.include=bootusage");
+
+    @Test
+    void beanOriginsOmittedWhenDisabled() {
+        this.runner.run(ctx -> {
+            UsageEndpoint endpoint = ctx.getBean(UsageEndpoint.class);
+            @SuppressWarnings("unchecked") Map<String,Object> body = endpoint.usage(null);
+            System.out.println("UsageEndpointOriginsToggleTests body keys=" + body.keySet());
+            assertThat(body).doesNotContainKey("beanOrigins");
+        });
+    }
+}

--- a/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/usage/UsageEndpointPoliciesTests.java
+++ b/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/usage/UsageEndpointPoliciesTests.java
@@ -1,0 +1,67 @@
+package org.springframework.boot.actuate.usage;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.jackson.JacksonEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.usage.UsageEndpointAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.usage.UsageAnalysisAutoConfiguration;
+import org.springframework.boot.autoconfigure.usage.UsagePolicy;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UsageEndpointPoliciesTests {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    ConfigurationPropertiesAutoConfiguration.class,
+                    PropertyPlaceholderAutoConfiguration.class,
+                    EndpointAutoConfiguration.class,
+                    JacksonEndpointAutoConfiguration.class,
+                    WebEndpointAutoConfiguration.class,
+                    ManagementContextAutoConfiguration.class,
+                    UsageAnalysisAutoConfiguration.class,
+                    UsageEndpointAutoConfiguration.class,
+                    PolicyConfig.class))
+            .withPropertyValues(
+                    "spring.boot.usage.report.enabled=true",
+                    "spring.boot.usage.report.cache-ttl=0",
+                    "management.endpoints.web.exposure.include=bootusage");
+
+    @Test
+    void policyAddsViolation() {
+        this.runner.run(ctx -> {
+            UsageEndpoint ep = ctx.getBean(UsageEndpoint.class);
+            Map<String,Object> body = ep.usage(Boolean.TRUE);
+            @SuppressWarnings("unchecked") Map<String,Object> policies = (Map<String,Object>) body.get("policies");
+            assertThat(policies).isNotNull();
+            assertThat(policies.get("violations")).as("violations present").isInstanceOf(List.class);
+        });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class PolicyConfig {
+        @Bean
+        UsagePolicy samplePolicy() {
+            return (structured, props) -> {
+                @SuppressWarnings("unchecked") java.util.List<String> applied = (java.util.List<String>) structured.get("appliedAutoConfigurations");
+                boolean endpointAuto = applied.stream().anyMatch(s -> s.contains("EndpointAutoConfiguration"));
+                if (endpointAuto) {
+                    return new UsagePolicy.PolicyResult(List.of(), List.of("Disallow EndpointAutoConfiguration in sample policy"));
+                }
+                return UsagePolicy.PolicyResult.empty();
+            };
+        }
+    }
+}

--- a/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/usage/UsageEndpointSanitizedLocationTests.java
+++ b/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/usage/UsageEndpointSanitizedLocationTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.actuate.usage;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.jackson.JacksonEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.usage.UsageEndpointAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.usage.UsageAnalysisAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UsageEndpointSanitizedLocationTests {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    ConfigurationPropertiesAutoConfiguration.class,
+                    PropertyPlaceholderAutoConfiguration.class,
+                    EndpointAutoConfiguration.class,
+                    JacksonEndpointAutoConfiguration.class,
+                    WebEndpointAutoConfiguration.class,
+                    ManagementContextAutoConfiguration.class,
+                    UsageAnalysisAutoConfiguration.class,
+                    UsageEndpointAutoConfiguration.class))
+            .withPropertyValues(
+                    "spring.boot.usage.report.enabled=true",
+                    "spring.boot.usage.report.cache-ttl=0",
+                    "management.endpoints.web.exposure.include=bootusage");
+
+    @Test
+    void sanitizedLocationsContainNoAbsolutePaths() {
+        this.runner.run(ctx -> {
+            UsageEndpoint endpoint = ctx.getBean(UsageEndpoint.class);
+            Map<String,Object> body = endpoint.usage(Boolean.TRUE);
+            @SuppressWarnings("unchecked") Map<String,Object> origins = (Map<String,Object>) body.get("beanOrigins");
+            if (origins != null) {
+                origins.forEach((bean, val) -> {
+                    if (val instanceof Map<?,?> m) {
+                        Object sanitized = m.get("sanitizedLocation");
+                        if (sanitized instanceof String s) {
+                            assertThat(s).doesNotContain(":\\").doesNotContain("/\\");
+                            assertThat(s).doesNotContain("\\").doesNotContain("/");
+                        }
+                    }
+                });
+            }
+        });
+    }
+}

--- a/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/usage/UsageEndpointUnusedJarsToggleTests.java
+++ b/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/usage/UsageEndpointUnusedJarsToggleTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.actuate.usage;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.jackson.JacksonEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.usage.UsageEndpointAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.usage.UsageAnalysisAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UsageEndpointUnusedJarsToggleTests {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    ConfigurationPropertiesAutoConfiguration.class,
+                    PropertyPlaceholderAutoConfiguration.class,
+                    EndpointAutoConfiguration.class,
+                    JacksonEndpointAutoConfiguration.class,
+                    WebEndpointAutoConfiguration.class,
+                    ManagementContextAutoConfiguration.class,
+                    UsageAnalysisAutoConfiguration.class,
+                    UsageEndpointAutoConfiguration.class))
+            .withPropertyValues(
+                    "spring.boot.usage.report.enabled=true",
+                    "spring.boot.usage.report.detect-unused-jars=false",
+                    "management.endpoints.web.exposure.include=bootusage");
+
+    @Test
+    void unusedJarsOmittedWhenDisabled() {
+        this.runner.run(ctx -> {
+            UsageEndpoint endpoint = ctx.getBean(UsageEndpoint.class);
+            Map<String,Object> body = endpoint.usage(null);
+            assertThat(body).doesNotContainKey("unusedJars");
+        });
+    }
+}


### PR DESCRIPTION
## Summary
Adds an *experimental* runtime usage reporting feature that generates a structured JSON (and optional Markdown) report of auto‑configuration behavior, starter usage, bean origins, and policy outcomes. Exposes the report via a new Actuator endpoint: `/actuator/bootusage`.

## Motivation
Helps developers:
- See which auto‑configurations applied or were skipped.
- Identify declared vs actually used starters (and unused jars).
- Trace (sanitized) bean origin locations.
- Enforce custom usage policies (e.g., forbid certain starters) with optional fail-fast.
- Retrieve usage insights at runtime (cached endpoint) or as a persisted build artifact.

## Key Components
- Auto-config: `UsageAnalysisAutoConfiguration`
- Service & generation: `UsageReportService`, `UsageReportGenerator`, `StarterUsageAnalyzer`
- Post-processor: `BeanOriginTrackingPostProcessor`
- Endpoint: `UsageEndpoint` + `UsageEndpointAutoConfiguration`
- SPIs:
  - `UsageReportCustomizer` (augment structured report)
  - `UsagePolicy` (validate and optionally fail startup)
- JSON Schema: `bootusage-schema-v1.json`
- Documentation: `bootusage.adoc`
- Metadata: Added configuration property entries (core + actuator)

## Configuration Properties (prefix `spring.boot.usage.report.`)
- `enabled` (boolean) – master switch (default: false)
- `cache-ttl` (duration, ms by default) – endpoint cache TTL (0 = no cache)
- `include-origins` (boolean) – include sanitized bean origin paths
- `include-confidence` (boolean) – include heuristic confidence scoring
- `detect-unused-jars` (boolean) – list jars on classpath not contributing beans
- `markdown-summary` (boolean) – also emit a Markdown summary file
- `output-dir` (string) – output directory for persisted report (default: `build/boot-usage`)
- `policies.fail-on-violation` (boolean) – throw on first policy violation
(Actuator exposure still controlled by normal `management.*` settings.)

## Actuator Endpoint
- ID: `bootusage`
- GET `/actuator/bootusage`
  - Query parameter `force=true` bypasses cache.
- Structure includes:
  - `appliedAutoConfigurations`
  - `skippedAutoConfigurations` (with optional detail)
  - `starters` (`declared`, `used`, `unused`)
  - `suggestions` (confidence, unusedJars, future policy slots)
  - `beanOrigins` (when enabled)
  - `policies` (violations, if any)
  - `metadata` (generation timestamp, version)

## Policy & Customization SPIs
- Implement `UsagePolicy` to validate the generated report (return violations).
- Implement `UsageReportCustomizer` to mutate the structured map before exposure/persist.
- Both discovered through the application context (standard bean registration).

## Failure Semantics
- If `policies.fail-on-violation=true`, startup fails on first violation.
- If `detect-unused-jars=true` and (optionally) integrated policies deem unused jars unacceptable, it can contribute to violations.

## Persistence
- When `enabled=true`, a JSON report is written on `ApplicationReadyEvent`.
- Optional Markdown summary when `markdown-summary=true`.

## Security & Sanitization
- Bean origins are trimmed / sanitized to remove user-specific absolute paths.
- No class byte inspection; heuristics rely on configuration report and bean definitions.

## Backward Compatibility
- Disabled by default; no impact on existing applications unless explicitly enabled.
- No public API changes outside newly added classes and endpoint.

## Tests Added
- Activation / conditional creation
- Endpoint exposure & caching
- Customizer invocation
- Policy failure path
- Unused jars detection
- Bean origin sanitization

## Limitations / Future Work
- Heuristics for unused jars are best-effort; could be refined with class usage tracing.
- Policy SPI currently synchronous at startup (consider deferred evaluation).
- Potential integration with build tooling for aggregated multi-module analysis.

## How to Try
Enable and expose:
```
spring.boot.usage.report.enabled=true
management.endpoints.web.exposure.include=bootusage
management.endpoint.bootusage.enabled=true
```
Optional extras:
```
spring.boot.usage.report.include-origins=true
spring.boot.usage.report.detect-unused-jars=true
spring.boot.usage.report.policies.fail-on-violation=true
```

## Reviewer Checklist
- [ ] Feature is property-gated (default off)
- [ ] Endpoint only present when feature enabled
- [ ] Documentation and metadata entries present
- [ ] NullAway clean in touched code
- [ ] No regressions in unrelated modules (CI baseline)
- [ ] Experimental scope acceptable (naming + docs clarity)

## Notes
Snapshot dependency resolution flakiness may cause unrelated CI failures (infrastructure). Re-run if failures are only network/timeouts.
