### PR TITLE
Use isNoop() instead of Observation.NOOP

### DIFF
--- a/module/spring-boot-micrometer-observation/src/test/java/org/springframework/boot/micrometer/observation/autoconfigure/ObservationAutoConfigurationTests.java
+++ b/module/spring-boot-micrometer-observation/src/test/java/org/springframework/boot/micrometer/observation/autoconfigure/ObservationAutoConfigurationTests.java
@@ -99,11 +99,11 @@ class ObservationAutoConfigurationTests {
 			ObservationRegistry observationRegistry = context.getBean(ObservationRegistry.class);
 			// This is allowed by ObservationPredicates.customPredicate
 			Observation observation = Observation.start("observation1", observationRegistry);
-			assertThat(observation).isNotEqualTo(Observation.NOOP);
+			assertThat(observation.isNoop()).isFalse();
 			observation.stop();
 			// This isn't allowed by ObservationPredicates.customPredicate
 			observation = Observation.start("observation2", observationRegistry);
-			assertThat(observation).isEqualTo(Observation.NOOP);
+			assertThat(observation.isNoop()).isTrue();
 			observation.stop();
 		});
 	}
@@ -150,7 +150,7 @@ class ObservationAutoConfigurationTests {
 		this.contextRunner.run((context) -> {
 			ObservationRegistry observationRegistry = context.getBean(ObservationRegistry.class);
 			Observation observation = Observation.start("spring.security.filterchains", observationRegistry);
-			assertThat(observation).isNotEqualTo(Observation.NOOP);
+			assertThat(observation.isNoop()).isFalse();
 			observation.stop();
 		});
 	}
@@ -160,7 +160,7 @@ class ObservationAutoConfigurationTests {
 		this.contextRunner.withPropertyValues("management.observations.enable.spring.security=false").run((context) -> {
 			ObservationRegistry observationRegistry = context.getBean(ObservationRegistry.class);
 			Observation observation = Observation.start("spring.security.filterchains", observationRegistry);
-			assertThat(observation).isEqualTo(Observation.NOOP);
+			assertThat(observation.isNoop()).isTrue();
 			observation.stop();
 		});
 	}


### PR DESCRIPTION
TL;DR: this is a polishing PR as long as https://github.com/micrometer-metrics/micrometer/pull/6700 is not merged (`1.16.0`). If that will happen, tests will break without this change.

Details:
The Micrometer team is considering some improvements in the Observation API which involves changing the behavior of `Observation.NOOP`: https://github.com/micrometer-metrics/micrometer/pull/6700
`Observation.NOOP` is not truly no-op right now, it does context propagation, we are trying to make it truly no-op in the PR above. The non-truly no-op version will still be used in certain scenarios (see `NoopButScopeHandlingObservation`). `observation.isNoop()` should be used for checking if an Observation is no-op or not instead of `Observation.NOOP`.