### PR TITLE
Polish tests in buildSrc

### DIFF
--- a/buildSrc/src/test/java/org/springframework/boot/build/ConventionsPluginTests.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/ConventionsPluginTests.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for {@link ConventionsPlugin}.
  *
  * @author Christoph Dreis
+ * @author Yanming Zhou
  */
 class ConventionsPluginTests {
 
@@ -77,7 +78,9 @@ class ConventionsPluginTests {
 			out.println("    id 'org.springframework.boot.conventions'");
 			out.println("}");
 			out.println("version = '1.2.3'");
-			out.println("sourceCompatibility = '17'");
+			out.println("java {");
+			out.println("    sourceCompatibility = '17'");
+			out.println("}");
 			out.println("description 'Test project for manifest customization'");
 			out.println("jar.archiveFileName = 'test.jar'");
 		}
@@ -107,7 +110,9 @@ class ConventionsPluginTests {
 			out.println("    id 'org.springframework.boot.conventions'");
 			out.println("}");
 			out.println("version = '1.2.3'");
-			out.println("sourceCompatibility = '17'");
+			out.println("java {");
+			out.println("    sourceCompatibility = '17'");
+			out.println("}");
 			out.println("description 'Test'");
 		}
 		runGradle("assemble");
@@ -136,7 +141,9 @@ class ConventionsPluginTests {
 			out.println("    id 'org.springframework.boot.conventions'");
 			out.println("}");
 			out.println("version = '1.2.3'");
-			out.println("sourceCompatibility = '17'");
+			out.println("java {");
+			out.println("    sourceCompatibility = '17'");
+			out.println("}");
 			out.println("description 'Test'");
 		}
 		runGradle("assemble");

--- a/buildSrc/src/test/java/org/springframework/boot/build/testing/TestFailuresPluginIntegrationTests.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/testing/TestFailuresPluginIntegrationTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integrations tests for {@link TestFailuresPlugin}.
  *
  * @author Andy Wilkinson
+ * @author Yanming Zhou
  */
 class TestFailuresPluginIntegrationTests {
 
@@ -166,6 +167,7 @@ class TestFailuresPluginIntegrationTests {
 			writer.println("dependencies {");
 			writer.println("	testImplementation 'org.junit.jupiter:junit-jupiter:5.6.0'");
 			writer.println("	testImplementation 'org.assertj:assertj-core:3.11.1'");
+			writer.println("	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'");
 			writer.println("}");
 			writer.println();
 			writer.println("test {");


### PR DESCRIPTION
`gradle :buildSrc:test` is passed with Gradle 9 now.

Fix:
```
Could not set unknown property 'sourceCompatibility' for root project 'junit-5112049806825616538' of type org.gradle.api.Project.
```
and
```
Failed to load JUnit Platform.  Please ensure that the JUnit Platform is available on the test runtime classpath.
```