### PR TITLE
Move configuration property sections from buildSrc to spring-boot-docs

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/context/properties/DocumentConfigurationProperties.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/context/properties/DocumentConfigurationProperties.java
@@ -17,24 +17,27 @@
 package org.springframework.boot.build.context.properties;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Task;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
-import org.springframework.boot.build.context.properties.Snippet.Config;
-
 /**
- * {@link Task} used to document auto-configuration classes.
+ * {@link Task} used to document configuration properties.
  *
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Kim Tae Eun
  */
 public abstract class DocumentConfigurationProperties extends DefaultTask {
 
@@ -53,176 +56,131 @@ public abstract class DocumentConfigurationProperties extends DefaultTask {
 	@OutputDirectory
 	public abstract DirectoryProperty getOutputDir();
 
+	@Input
+	public abstract ListProperty<PropertySectionDefinition> getPropertySections();
+
 	@TaskAction
 	void documentConfigurationProperties() throws IOException {
 		Snippets snippets = new Snippets(this.configurationPropertyMetadata);
-		snippets.add("application-properties.core", "Core Properties", this::corePrefixes);
-		snippets.add("application-properties.cache", "Cache Properties", this::cachePrefixes);
-		snippets.add("application-properties.mail", "Mail Properties", this::mailPrefixes);
-		snippets.add("application-properties.json", "JSON Properties", this::jsonPrefixes);
-		snippets.add("application-properties.data", "Data Properties", this::dataPrefixes);
-		snippets.add("application-properties.transaction", "Transaction Properties", this::transactionPrefixes);
-		snippets.add("application-properties.data-migration", "Data Migration Properties", this::dataMigrationPrefixes);
-		snippets.add("application-properties.integration", "Integration Properties", this::integrationPrefixes);
-		snippets.add("application-properties.web", "Web Properties", this::webPrefixes);
-		snippets.add("application-properties.templating", "Templating Properties", this::templatePrefixes);
-		snippets.add("application-properties.server", "Server Properties", this::serverPrefixes);
-		snippets.add("application-properties.security", "Security Properties", this::securityPrefixes);
-		snippets.add("application-properties.rsocket", "RSocket Properties", this::rsocketPrefixes);
-		snippets.add("application-properties.actuator", "Actuator Properties", this::actuatorPrefixes);
-		snippets.add("application-properties.devtools", "Devtools Properties", this::devtoolsPrefixes);
-		snippets.add("application-properties.docker-compose", "Docker Compose Properties", this::dockerComposePrefixes);
-		snippets.add("application-properties.testcontainers", "Testcontainers Properties",
-				this::testcontainersPrefixes);
-		snippets.add("application-properties.testing", "Testing Properties", this::testingPrefixes);
+
+		List<PropertySectionDefinition> sections = getPropertySections().getOrElse(getDefaultPropertySections());
+		for (PropertySectionDefinition section : sections) {
+			snippets.add(section.getFileName(), section.getTitle(), (config) -> {
+				for (String prefix : section.getPrefixes()) {
+					if (section.getDescriptions().containsKey(prefix)) {
+						config.accept(prefix, section.getDescriptions().get(prefix));
+					}
+					else {
+						config.accept(prefix);
+					}
+				}
+			});
+		}
+
 		snippets.writeTo(getOutputDir().getAsFile().get().toPath());
 	}
 
-	private void corePrefixes(Config config) {
-		config.accept("debug");
-		config.accept("trace");
-		config.accept("logging");
-		config.accept("spring.aop");
-		config.accept("spring.application");
-		config.accept("spring.autoconfigure");
-		config.accept("spring.banner");
-		config.accept("spring.beaninfo");
-		config.accept("spring.config");
-		config.accept("spring.info");
-		config.accept("spring.jmx");
-		config.accept("spring.lifecycle");
-		config.accept("spring.main");
-		config.accept("spring.messages");
-		config.accept("spring.pid");
-		config.accept("spring.profiles");
-		config.accept("spring.quartz");
-		config.accept("spring.reactor");
-		config.accept("spring.ssl");
-		config.accept("spring.task");
-		config.accept("spring.threads");
-		config.accept("spring.validation");
-		config.accept("spring.mandatory-file-encoding");
-		config.accept("info");
-		config.accept("spring.output.ansi.enabled");
+	private List<PropertySectionDefinition> getDefaultPropertySections() {
+		return List.of(
+				new PropertySectionDefinition("application-properties.core", "Core Properties",
+						List.of("debug", "trace", "logging", "spring.aop", "spring.application", "spring.autoconfigure",
+								"spring.banner", "spring.beaninfo", "spring.config", "spring.info", "spring.jmx",
+								"spring.lifecycle", "spring.main", "spring.messages", "spring.pid", "spring.profiles",
+								"spring.quartz", "spring.reactor", "spring.ssl", "spring.task", "spring.threads",
+								"spring.validation", "spring.mandatory-file-encoding", "info",
+								"spring.output.ansi.enabled"),
+						Map.of()),
+				new PropertySectionDefinition("application-properties.cache", "Cache Properties",
+						List.of("spring.cache"), Map.of()),
+				new PropertySectionDefinition("application-properties.mail", "Mail Properties",
+						List.of("spring.mail", "spring.sendgrid"), Map.of()),
+				new PropertySectionDefinition("application-properties.json", "JSON Properties",
+						List.of("spring.jackson", "spring.gson"), Map.of()),
+				new PropertySectionDefinition("application-properties.data", "Data Properties",
+						List.of("spring.couchbase", "spring.cassandra", "spring.elasticsearch", "spring.h2",
+								"spring.influx", "spring.ldap", "spring.mongodb", "spring.neo4j", "spring.dao",
+								"spring.data", "spring.datasource", "spring.jooq", "spring.jdbc", "spring.jpa",
+								"spring.r2dbc", "spring.datasource.oracleucp", "spring.datasource.dbcp2",
+								"spring.datasource.tomcat", "spring.datasource.hikari"),
+						Map.of("spring.datasource.oracleucp",
+								"Oracle UCP specific settings bound to an instance of Oracle UCP's PoolDataSource",
+								"spring.datasource.dbcp2",
+								"Commons DBCP2 specific settings bound to an instance of DBCP2's BasicDataSource",
+								"spring.datasource.tomcat",
+								"Tomcat datasource specific settings bound to an instance of Tomcat JDBC's DataSource",
+								"spring.datasource.hikari",
+								"Hikari specific settings bound to an instance of Hikari's HikariDataSource")),
+				new PropertySectionDefinition("application-properties.transaction", "Transaction Properties",
+						List.of("spring.jta", "spring.transaction"), Map.of()),
+				new PropertySectionDefinition("application-properties.data-migration", "Data Migration Properties",
+						List.of("spring.flyway", "spring.liquibase", "spring.sql.init"), Map.of()),
+				new PropertySectionDefinition("application-properties.integration", "Integration Properties",
+						List.of("spring.activemq", "spring.artemis", "spring.batch", "spring.integration", "spring.jms",
+								"spring.kafka", "spring.pulsar", "spring.rabbitmq", "spring.hazelcast",
+								"spring.webservices"),
+						Map.of()),
+				new PropertySectionDefinition("application-properties.web", "Web Properties",
+						List.of("spring.graphql", "spring.hateoas", "spring.http", "spring.jersey", "spring.mvc",
+								"spring.netty", "spring.resources", "spring.servlet", "spring.session", "spring.web",
+								"spring.webflux"),
+						Map.of()),
+				new PropertySectionDefinition("application-properties.templating", "Templating Properties",
+						List.of("spring.freemarker", "spring.groovy", "spring.mustache", "spring.thymeleaf"), Map.of()),
+				new PropertySectionDefinition("application-properties.server", "Server Properties", List.of("server"),
+						Map.of()),
+				new PropertySectionDefinition("application-properties.security", "Security Properties",
+						List.of("spring.security"), Map.of()),
+				new PropertySectionDefinition("application-properties.rsocket", "RSocket Properties",
+						List.of("spring.rsocket"), Map.of()),
+				new PropertySectionDefinition("application-properties.actuator", "Actuator Properties",
+						List.of("management", "micrometer"), Map.of()),
+				new PropertySectionDefinition("application-properties.devtools", "Devtools Properties",
+						List.of("spring.devtools"), Map.of()),
+				new PropertySectionDefinition("application-properties.docker-compose", "Docker Compose Properties",
+						List.of("spring.docker.compose"), Map.of()),
+				new PropertySectionDefinition("application-properties.testcontainers", "Testcontainers Properties",
+						List.of("spring.testcontainers."), Map.of()),
+				new PropertySectionDefinition("application-properties.testing", "Testing Properties",
+						List.of("spring.test."), Map.of()));
 	}
 
-	private void cachePrefixes(Config config) {
-		config.accept("spring.cache");
-	}
+	/**
+	 * Configuration for a property section.
+	 */
+	public static class PropertySectionDefinition {
 
-	private void mailPrefixes(Config config) {
-		config.accept("spring.mail");
-		config.accept("spring.sendgrid");
-	}
+		private final String fileName;
 
-	private void jsonPrefixes(Config config) {
-		config.accept("spring.jackson");
-		config.accept("spring.gson");
-	}
+		private final String title;
 
-	private void dataPrefixes(Config config) {
-		config.accept("spring.couchbase");
-		config.accept("spring.cassandra");
-		config.accept("spring.elasticsearch");
-		config.accept("spring.h2");
-		config.accept("spring.influx");
-		config.accept("spring.ldap");
-		config.accept("spring.mongodb");
-		config.accept("spring.neo4j");
-		config.accept("spring.dao");
-		config.accept("spring.data");
-		config.accept("spring.datasource");
-		config.accept("spring.jooq");
-		config.accept("spring.jdbc");
-		config.accept("spring.jpa");
-		config.accept("spring.r2dbc");
-		config.accept("spring.datasource.oracleucp",
-				"Oracle UCP specific settings bound to an instance of Oracle UCP's PoolDataSource");
-		config.accept("spring.datasource.dbcp2",
-				"Commons DBCP2 specific settings bound to an instance of DBCP2's BasicDataSource");
-		config.accept("spring.datasource.tomcat",
-				"Tomcat datasource specific settings bound to an instance of Tomcat JDBC's DataSource");
-		config.accept("spring.datasource.hikari",
-				"Hikari specific settings bound to an instance of Hikari's HikariDataSource");
+		private final List<String> prefixes;
 
-	}
+		private final Map<String, String> descriptions;
 
-	private void transactionPrefixes(Config prefix) {
-		prefix.accept("spring.jta");
-		prefix.accept("spring.transaction");
-	}
+		public PropertySectionDefinition(String fileName, String title, List<String> prefixes,
+				Map<String, String> descriptions) {
+			this.fileName = fileName;
+			this.title = title;
+			this.prefixes = prefixes;
+			this.descriptions = descriptions;
+		}
 
-	private void dataMigrationPrefixes(Config prefix) {
-		prefix.accept("spring.flyway");
-		prefix.accept("spring.liquibase");
-		prefix.accept("spring.sql.init");
-	}
+		public String getFileName() {
+			return this.fileName;
+		}
 
-	private void integrationPrefixes(Config prefix) {
-		prefix.accept("spring.activemq");
-		prefix.accept("spring.artemis");
-		prefix.accept("spring.batch");
-		prefix.accept("spring.integration");
-		prefix.accept("spring.jms");
-		prefix.accept("spring.kafka");
-		prefix.accept("spring.pulsar");
-		prefix.accept("spring.rabbitmq");
-		prefix.accept("spring.hazelcast");
-		prefix.accept("spring.webservices");
-	}
+		public String getTitle() {
+			return this.title;
+		}
 
-	private void webPrefixes(Config prefix) {
-		prefix.accept("spring.graphql");
-		prefix.accept("spring.hateoas");
-		prefix.accept("spring.http");
-		prefix.accept("spring.jersey");
-		prefix.accept("spring.mvc");
-		prefix.accept("spring.netty");
-		prefix.accept("spring.resources");
-		prefix.accept("spring.servlet");
-		prefix.accept("spring.session");
-		prefix.accept("spring.web");
-		prefix.accept("spring.webflux");
-	}
+		public List<String> getPrefixes() {
+			return this.prefixes;
+		}
 
-	private void templatePrefixes(Config prefix) {
-		prefix.accept("spring.freemarker");
-		prefix.accept("spring.groovy");
-		prefix.accept("spring.mustache");
-		prefix.accept("spring.thymeleaf");
-	}
+		public Map<String, String> getDescriptions() {
+			return this.descriptions;
+		}
 
-	private void serverPrefixes(Config prefix) {
-		prefix.accept("server");
-	}
-
-	private void securityPrefixes(Config prefix) {
-		prefix.accept("spring.security");
-	}
-
-	private void rsocketPrefixes(Config prefix) {
-		prefix.accept("spring.rsocket");
-	}
-
-	private void actuatorPrefixes(Config prefix) {
-		prefix.accept("management");
-		prefix.accept("micrometer");
-	}
-
-	private void dockerComposePrefixes(Config prefix) {
-		prefix.accept("spring.docker.compose");
-	}
-
-	private void devtoolsPrefixes(Config prefix) {
-		prefix.accept("spring.devtools");
-	}
-
-	private void testingPrefixes(Config prefix) {
-		prefix.accept("spring.test.");
-	}
-
-	private void testcontainersPrefixes(Config prefix) {
-		prefix.accept("spring.testcontainers.");
 	}
 
 }

--- a/documentation/spring-boot-docs/build.gradle
+++ b/documentation/spring-boot-docs/build.gradle
@@ -295,6 +295,130 @@ def configurationPropertiesMetadataAggregate = aggregates.create("configurationP
 tasks.register("documentConfigurationProperties", org.springframework.boot.build.context.properties.DocumentConfigurationProperties) {
 	configurationPropertyMetadata = configurationPropertiesMetadataAggregate.files
 	outputDir = layout.buildDirectory.dir("generated/docs/application-properties")
+
+	// Configure property sections declaratively
+	propertySections.set([
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.core",
+			"Core Properties",
+			["debug", "trace", "logging", "spring.aop", "spring.application", "spring.autoconfigure",
+			 "spring.banner", "spring.beaninfo", "spring.config", "spring.info", "spring.jmx",
+			 "spring.lifecycle", "spring.main", "spring.messages", "spring.pid", "spring.profiles",
+			 "spring.quartz", "spring.reactor", "spring.ssl", "spring.task", "spring.threads",
+			 "spring.validation", "spring.mandatory-file-encoding", "info", "spring.output.ansi.enabled"],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.cache",
+			"Cache Properties",
+			["spring.cache"],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.mail",
+			"Mail Properties",
+			["spring.mail", "spring.sendgrid"],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.json",
+			"JSON Properties",
+			["spring.jackson", "spring.gson"],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.data",
+			"Data Properties",
+			["spring.couchbase", "spring.cassandra", "spring.elasticsearch", "spring.h2",
+			 "spring.influx", "spring.ldap", "spring.mongodb", "spring.neo4j", "spring.dao",
+			 "spring.data", "spring.datasource", "spring.jooq", "spring.jdbc", "spring.jpa", "spring.r2dbc",
+			 "spring.datasource.oracleucp", "spring.datasource.dbcp2", "spring.datasource.tomcat", "spring.datasource.hikari"],
+			["spring.datasource.oracleucp": "Oracle UCP specific settings bound to an instance of Oracle UCP's PoolDataSource",
+			 "spring.datasource.dbcp2": "Commons DBCP2 specific settings bound to an instance of DBCP2's BasicDataSource",
+			 "spring.datasource.tomcat": "Tomcat datasource specific settings bound to an instance of Tomcat JDBC's DataSource",
+			 "spring.datasource.hikari": "Hikari specific settings bound to an instance of Hikari's HikariDataSource"]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.transaction",
+			"Transaction Properties",
+			["spring.jta", "spring.transaction"],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.data-migration",
+			"Data Migration Properties",
+			["spring.flyway", "spring.liquibase", "spring.sql.init"],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.integration",
+			"Integration Properties",
+			["spring.activemq", "spring.artemis", "spring.batch", "spring.integration", "spring.jms",
+			 "spring.kafka", "spring.pulsar", "spring.rabbitmq", "spring.hazelcast", "spring.webservices"],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.web",
+			"Web Properties",
+			["spring.graphql", "spring.hateoas", "spring.http", "spring.jersey", "spring.mvc",
+			 "spring.netty", "spring.resources", "spring.servlet", "spring.session", "spring.web", "spring.webflux"],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.templating",
+			"Templating Properties",
+			["spring.freemarker", "spring.groovy", "spring.mustache", "spring.thymeleaf"],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.server",
+			"Server Properties",
+			["server"],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.security",
+			"Security Properties",
+			["spring.security"],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.rsocket",
+			"RSocket Properties",
+			["spring.rsocket"],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.actuator",
+			"Actuator Properties",
+			["management", "micrometer"],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.devtools",
+			"Devtools Properties",
+			["spring.devtools"],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.docker-compose",
+			"Docker Compose Properties",
+			["spring.docker.compose"],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.testcontainers",
+			"Testcontainers Properties",
+			["spring.testcontainers."],
+			[:]
+		),
+		new org.springframework.boot.build.context.properties.DocumentConfigurationProperties.PropertySectionDefinition(
+			"application-properties.testing",
+			"Testing Properties",
+			["spring.test."],
+			[:]
+		)
+	])
 }
 
 tasks.register("documentDevtoolsPropertyDefaults", org.springframework.boot.build.devtools.DocumentDevtoolsPropertyDefaults) {}


### PR DESCRIPTION
## Description

This pull request addresses issue #23972 by moving the configuration of property sections from the `buildSrc` module to the `spring-boot-docs` module's `build.gradle` script.

### Problem

The configuration property sections for the appendix were hardcoded in the `DocumentConfigurationProperties` task within the `buildSrc` module. This approach had a significant drawback: whenever changes were made to these sections, it would trigger a complete rebuild of the entire project due to how Gradle treats changes in the `buildSrc` directory.

### Solution

This PR refactors the approach by:

1. **Modifying `DocumentConfigurationProperties` class**: Added support for declarative configuration through a new `ListProperty<PropertySectionDefinition>` field that allows external configuration of property sections.

2. **Creating `PropertySectionDefinition` class**: A new data class that encapsulates section information including filename, title, prefixes, and descriptions.

3. **Moving configuration to `spring-boot-docs/build.gradle`**: The property sections are now declaratively configured in the `documentConfigurationProperties` task within the docs module's build script.

### Benefits

- **Improved build performance**: Changes to property sections no longer trigger full project rebuilds
- **Better maintainability**: Configuration is now declarative and easier to modify
- **Clearer separation of concerns**: Build logic stays in `buildSrc` while configuration moves to the appropriate module

### Changes Made

- Modified `buildSrc/src/main/java/org/springframework/boot/build/context/properties/DocumentConfigurationProperties.java` to support external configuration
- Updated `documentation/spring-boot-docs/build.gradle` to include declarative property section definitions

The implementation maintains backward compatibility by providing default sections when no external configuration is specified.
