### PR TITLE
Refactor AbstractAotMojo args initialization

### DIFF
--- a/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractAotMojo.java
+++ b/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractAotMojo.java
@@ -149,8 +149,7 @@ public abstract class AbstractAotMojo extends AbstractDependencyFilterMojo {
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 		try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null)) {
 			JavaCompilerPluginConfiguration compilerConfiguration = new JavaCompilerPluginConfiguration(this.project);
-			List<String> args = new ArrayList<>();
-			args.addAll(ClassPath.of(classPath).args(false));
+			List<String> args = new ArrayList<>(ClassPath.of(classPath).args(false));
 			args.add("-d");
 			args.add(outputDirectory.toPath().toAbsolutePath().toString());
 			String releaseVersion = compilerConfiguration.getReleaseVersion();


### PR DESCRIPTION
Simplify args list creation by using constructor instead of creating an empty list and adding elements with `addAll`.
Behavior remains unchanged and all existing tests have passed successfully.

**Before**

```java
List<String> args = new ArrayList<>();
args.addAll(ClassPath.of(classPath).args(false));
```

**After**

```java
List<String> args = new ArrayList<>(ClassPath.of(classPath).args(false));
```

**Notes**

* Verified that the change does not affect runtime behavior.
* All tests have been executed and passed.