### PR TITLE
Add configuration property for Tomcat's static resource cache max size

### DIFF
--- a/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/autoconfigure/TomcatServerProperties.java
+++ b/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/autoconfigure/TomcatServerProperties.java
@@ -695,6 +695,11 @@ public class TomcatServerProperties {
 		private boolean allowCaching = true;
 
 		/**
+		 * Maximum size of the static resource cache.
+		 */
+		private @Nullable DataSize cacheMaxSize;
+
+		/**
 		 * Time-to-live of the static resource cache.
 		 */
 		private @Nullable Duration cacheTtl;
@@ -705,6 +710,14 @@ public class TomcatServerProperties {
 
 		public void setAllowCaching(boolean allowCaching) {
 			this.allowCaching = allowCaching;
+		}
+
+		public @Nullable DataSize getCacheMaxSize() {
+			return this.cacheMaxSize;
+		}
+
+		public void setCacheMaxSize(@Nullable DataSize cacheMaxSize) {
+			this.cacheMaxSize = cacheMaxSize;
 		}
 
 		public @Nullable Duration getCacheTtl() {

--- a/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/autoconfigure/TomcatWebServerFactoryCustomizer.java
+++ b/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/autoconfigure/TomcatWebServerFactoryCustomizer.java
@@ -384,6 +384,10 @@ public class TomcatWebServerFactoryCustomizer
 					long ttl = resource.getCacheTtl().toMillis();
 					context.getResources().setCacheTtl(ttl);
 				}
+				if (resource.getCacheMaxSize() != null) {
+					long cacheMaxSize = resource.getCacheMaxSize().toKilobytes();
+					context.getResources().setCacheMaxSize(cacheMaxSize);
+				}
 			}
 		}));
 	}

--- a/module/spring-boot-tomcat/src/test/java/org/springframework/boot/tomcat/autoconfigure/TomcatWebServerFactoryCustomizerTests.java
+++ b/module/spring-boot-tomcat/src/test/java/org/springframework/boot/tomcat/autoconfigure/TomcatWebServerFactoryCustomizerTests.java
@@ -333,6 +333,16 @@ class TomcatWebServerFactoryCustomizerTests {
 	}
 
 	@Test
+	void customStaticResourceCacheMaxSize() {
+		bind("server.tomcat.resource.cache-max-size=4096KB");
+		customizeAndRunServer((server) -> {
+			Tomcat tomcat = server.getTomcat();
+			Context context = (Context) tomcat.getHost().findChildren()[0];
+			assertThat(context.getResources().getCacheMaxSize()).isEqualTo(4096L);
+		});
+	}
+
+	@Test
 	void customStaticResourceCacheTtl() {
 		bind("server.tomcat.resource.cache-ttl=10000");
 		customizeAndRunServer((server) -> {


### PR DESCRIPTION
This change exposes the Tomcat static resources [maximum cache size](https://tomcat.apache.org/tomcat-11.0-doc/api/org/apache/catalina/WebResourceRoot.html#setCacheMaxSize(long)) as a server configuration property. This is an option we configure and would appreciate the option being exposed via a property