### PR TITLE
Update AOTCache documentation to JEP 514

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/class-data-sharing.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/class-data-sharing.adoc
@@ -38,8 +38,8 @@ To use the AOT cache, you should first perform a training run on your applicatio
 ----
 $ java -Djarmode=tools -jar my-app.jar extract --destination application
 $ cd application
-$ java -XX:AOTMode=record -XX:AOTConfiguration=app.aotconf -Dspring.context.exit=onRefresh -jar my-app.jar
-$ java -XX:AOTMode=create -XX:AOTConfiguration=app.aotconf -XX:AOTCache=app.aot -jar my-app.jar
+$ java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh -jar my-app.jar
+$ java -XX:AOTCache=app.aot -jar my-app.jar
 ----
 
 This creates an `app.aot` cache file that can be reused as long as the application is not updated.

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/class-data-sharing.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/class-data-sharing.adoc
@@ -38,12 +38,18 @@ To use the AOT cache, you should first perform a training run on your applicatio
 ----
 $ java -Djarmode=tools -jar my-app.jar extract --destination application
 $ cd application
-$ java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh -jar my-app.jar
-$ java -XX:AOTCache=app.aot -jar my-app.jar
+----
+
+=== Java 24
+
+[source,shell]
+----
+$ java -XX:AOTMode=record -XX:AOTConfiguration=app.aotconf -Dspring.context.exit=onRefresh -jar my-app.jar
+$ java -XX:AOTMode=create -XX:AOTConfiguration=app.aotconf -XX:AOTCache=app.aot -jar my-app.jar
 ----
 
 This creates an `app.aot` cache file that can be reused as long as the application is not updated.
-The intermediate `app.aotconf` file is no longer needed and can be safely deleted.
+The intermediate `app.aotconf` file is required in Java 24.
 
 To use the cache file, you need to add an extra parameter when starting the application:
 
@@ -51,3 +57,15 @@ To use the cache file, you need to add an extra parameter when starting the appl
 ----
 $ java -XX:AOTCache=app.aot -jar my-app.jar
 ----
+
+=== Java 25 and later
+
+[source,shell]
+----
+$ java -Djarmode=tools -jar my-app.jar extract --destination application
+$ cd application
+$ java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh -jar my-app.jar
+$ java -XX:AOTCache=app.aot -jar my-app.jar
+----
+Here the intermediate `app.aotconf` file is no longer needed and can be safely deleted.
+

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/container-images/dockerfiles.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/container-images/dockerfiles.adoc
@@ -85,6 +85,7 @@ include::reference:partial$dockerfile[]
 # Execute the AOT cache training run
 RUN java -XX:AOTMode=record -XX:AOTConfiguration=app.aotconf -Dspring.context.exit=onRefresh -jar application.jar
 RUN java -XX:AOTMode=create -XX:AOTConfiguration=app.aotconf -XX:AOTCache=app.aot -jar application.jar && rm app.aotconf
+
 # Start the application jar with AOT cache enabled - this is not the uber jar used by the builder
 # This jar only contains application code and references to the extracted jar files
 # This layout is efficient to start up and AOT cache friendly


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

### Summary
Update Spring Boot documentation to reflect JEP 514 AOT Cache flags in Java 25.

### Changes Made
- Updated class-data-sharing.adoc: replaced old -XX:AOTMode/AOTConfiguration flags with -XX:AOTCacheOutput/-XX:AOTCache.
- Updated container-images/dockerfiles.adoc: updated Dockerfile examples to use the new AOTCache flags.

### Motivation
Old documentation used outdated JVM flags. This update ensures docs match the new standard and are clear for users.

### References
- Issue: #47274
- JEP 514: https://openjdk.org/jeps/514

