### PR TITLE
Fix Docker multi-architecture image platform handling in buildpack operations

### DIFF
--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/Builder.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/Builder.java
@@ -355,7 +355,7 @@ public class Builder {
 		@Override
 		public void exportImageLayers(ImageReference reference, IOBiConsumer<String, TarArchive> exports)
 				throws IOException {
-			Builder.this.docker.image().exportLayers(reference, exports);
+			Builder.this.docker.image().exportLayers(reference, this.imageFetcher.defaultPlatform, exports);
 		}
 
 	}

--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/DockerApi.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/DockerApi.java
@@ -311,9 +311,24 @@ public class DockerApi {
 		 */
 		public void exportLayers(ImageReference reference, IOBiConsumer<String, TarArchive> exports)
 				throws IOException {
+			exportLayers(reference, null, exports);
+		}
+
+		/**
+		 * Export the layers of an image as {@link TarArchive TarArchives}.
+		 * @param reference the reference to export
+		 * @param platform the platform (os/architecture/variant) of the image to export
+		 * @param exports a consumer to receive the layers (contents can only be accessed
+		 * during the callback)
+		 * @throws IOException on IO error
+		 */
+		public void exportLayers(ImageReference reference, @Nullable ImagePlatform platform,
+				IOBiConsumer<String, TarArchive> exports) throws IOException {
 			Assert.notNull(reference, "'reference' must not be null");
 			Assert.notNull(exports, "'exports' must not be null");
-			URI uri = buildUrl("/images/" + reference + "/get");
+			URI uri = (platform != null)
+					? buildUrl(PLATFORM_API_VERSION, "/images/" + reference + "/get", "platform", platform)
+					: buildUrl("/images/" + reference + "/get");
 			try (Response response = http().get(uri)) {
 				try (ExportedImageTar exportedImageTar = new ExportedImageTar(reference, response.getContent())) {
 					exportedImageTar.exportLayers(exports);

--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/DockerApi.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/DockerApi.java
@@ -239,7 +239,9 @@ public class DockerApi {
 						listener.onUpdate(event);
 					});
 				}
-				return inspect((platform != null) ? PLATFORM_API_VERSION : API_VERSION, reference);
+				String digest = digestCapture.getDigest();
+				ImageReference inspectReference = (digest != null) ? reference.withDigest(digest) : reference;
+				return inspect((platform != null) ? PLATFORM_API_VERSION : API_VERSION, inspectReference);
 			}
 			finally {
 				listener.onFinish();
@@ -562,6 +564,10 @@ public class DockerApi {
 				Assert.state(this.digest == null || this.digest.equals(digest), "Different digests IDs provided");
 				this.digest = digest;
 			}
+		}
+
+		private @Nullable String getDigest() {
+			return this.digest;
 		}
 
 	}

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/DockerApiTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/DockerApiTests.java
@@ -448,6 +448,38 @@ class DockerApiTests {
 		}
 
 		@Test
+		void exportLayersWithPlatformExportsLayerTars() throws Exception {
+			ImageReference reference = ImageReference.of("docker.io/paketobuildpacks/builder:base");
+			ImagePlatform platform = ImagePlatform.of("linux/amd64");
+			URI exportUri = new URI(
+					PLATFORM_IMAGES_URL + "/docker.io/paketobuildpacks/builder:base/get?platform=linux%2Famd64");
+			given(DockerApiTests.this.http.head(eq(new URI(PING_URL))))
+				.willReturn(responseWithHeaders(new BasicHeader(DockerApi.API_VERSION_HEADER_NAME, "1.41")));
+			given(DockerApiTests.this.http.get(exportUri)).willReturn(responseOf("export.tar"));
+			MultiValueMap<String, String> contents = new LinkedMultiValueMap<>();
+			this.api.exportLayers(reference, platform, (name, archive) -> {
+				ByteArrayOutputStream out = new ByteArrayOutputStream();
+				archive.writeTo(out);
+				try (TarArchiveInputStream in = new TarArchiveInputStream(
+						new ByteArrayInputStream(out.toByteArray()))) {
+					TarArchiveEntry entry = in.getNextEntry();
+					while (entry != null) {
+						contents.add(name, entry.getName());
+						entry = in.getNextEntry();
+					}
+				}
+			});
+			assertThat(contents).hasSize(3)
+				.containsKeys("70bb7a3115f3d5c01099852112c7e05bf593789e510468edb06b6a9a11fa3b73/layer.tar",
+						"74a9a50ece13c025cf10e9110d9ddc86c995079c34e2a22a28d1a3d523222c6e/layer.tar",
+						"a69532b5b92bb891fbd9fa1a6b3af9087ea7050255f59ba61a796f8555ecd783/layer.tar");
+			assertThat(contents.get("70bb7a3115f3d5c01099852112c7e05bf593789e510468edb06b6a9a11fa3b73/layer.tar"))
+				.containsExactly("/cnb/order.toml");
+			assertThat(contents.get("74a9a50ece13c025cf10e9110d9ddc86c995079c34e2a22a28d1a3d523222c6e/layer.tar"))
+				.containsExactly("/cnb/stack.toml");
+		}
+
+		@Test
 		void tagWhenReferenceIsNullThrowsException() {
 			ImageReference tag = ImageReference.of("localhost:5000/ubuntu");
 			assertThatIllegalArgumentException().isThrownBy(() -> this.api.tag(null, tag))

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/DockerApiTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/DockerApiTests.java
@@ -207,7 +207,8 @@ class DockerApiTests {
 		void pullPullsImageAndProducesEvents() throws Exception {
 			ImageReference reference = ImageReference.of("docker.io/paketobuildpacks/builder:base");
 			URI createUri = new URI(IMAGES_URL + "/create?fromImage=docker.io%2Fpaketobuildpacks%2Fbuilder%3Abase");
-			URI imageUri = new URI(IMAGES_URL + "/docker.io/paketobuildpacks/builder:base/json");
+			URI imageUri = new URI(IMAGES_URL
+					+ "/docker.io/paketobuildpacks/builder@sha256:4acb6bfd6c4f0cabaf7f3690e444afe51f1c7de54d51da7e63fac709c56f1c30/json");
 			given(http().post(eq(createUri), isNull())).willReturn(responseOf("pull-stream.json"));
 			given(http().get(imageUri)).willReturn(responseOf("type/image.json"));
 			Image image = this.api.pull(reference, null, this.pullListener);
@@ -222,7 +223,8 @@ class DockerApiTests {
 		void pullWithRegistryAuthPullsImageAndProducesEvents() throws Exception {
 			ImageReference reference = ImageReference.of("docker.io/paketobuildpacks/builder:base");
 			URI createUri = new URI(IMAGES_URL + "/create?fromImage=docker.io%2Fpaketobuildpacks%2Fbuilder%3Abase");
-			URI imageUri = new URI(IMAGES_URL + "/docker.io/paketobuildpacks/builder:base/json");
+			URI imageUri = new URI(IMAGES_URL
+					+ "/docker.io/paketobuildpacks/builder@sha256:4acb6bfd6c4f0cabaf7f3690e444afe51f1c7de54d51da7e63fac709c56f1c30/json");
 			given(http().post(eq(createUri), eq("auth token"))).willReturn(responseOf("pull-stream.json"));
 			given(http().get(imageUri)).willReturn(responseOf("type/image.json"));
 			Image image = this.api.pull(reference, null, this.pullListener, "auth token");
@@ -239,7 +241,8 @@ class DockerApiTests {
 			ImagePlatform platform = ImagePlatform.of("linux/arm64/v1");
 			URI createUri = new URI(PLATFORM_IMAGES_URL
 					+ "/create?fromImage=gcr.io%2Fpaketo-buildpacks%2Fbuilder%3Abase&platform=linux%2Farm64%2Fv1");
-			URI imageUri = new URI(PLATFORM_IMAGES_URL + "/gcr.io/paketo-buildpacks/builder:base/json");
+			URI imageUri = new URI(PLATFORM_IMAGES_URL
+					+ "/gcr.io/paketo-buildpacks/builder@sha256:4acb6bfd6c4f0cabaf7f3690e444afe51f1c7de54d51da7e63fac709c56f1c30/json");
 			given(http().head(eq(new URI(PING_URL))))
 				.willReturn(responseWithHeaders(new BasicHeader(DockerApi.API_VERSION_HEADER_NAME, "1.41")));
 			given(http().post(eq(createUri), isNull())).willReturn(responseOf("pull-stream.json"));


### PR DESCRIPTION
## Summary

This PR fixes Docker platform handling issues that occur when building images with specific platforms on ARM64 Macs, particularly when targeting AMD64 platforms. The changes ensure that platform information is properly respected throughout the buildpack layer export and multi-architecture image inspection processes.

###  Related Issues

  - #46665: New arm64 macbooks fail to bootBuildImage due to incorrect platform image
  - #46674: Image building may fail when specifying a platform if an image has already been built with a different platform
 
##  Issue Description

  Two related issues were affecting users building container images with Spring Boot's buildpack integration:

  1. Issue #46665: ARM64 Mac users failed to build AMD64 platform images due to incorrect platform handling in Docker API calls. When buildpacks needed to be downloaded from Docker Hub, the docker save command didn't include platform information, causing Docker daemon to default to the host platform (ARM64) instead of the requested platform (AMD64).
  2. Issue #46674: Image platform mismatch errors occurred when building images with different platforms consecutively. Users experienced failures with the message "Image platform mismatch detected" when switching between platforms without clearing Docker's cache.

 ### Root Cause

  The issues stemmed from incomplete platform information propagation in the Docker API implementation:
  - During buildpack layer export, platform information wasn't passed to the docker save command
  - Multi-architecture image inspection didn't properly respect the pulled digest, leading to platform conflicts

 ## Changes Made

 ### 1. Respect pulled digest when inspecting multi-arch images

  - File: buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/Builder.java
  - Change: Modified image inspection logic to use the actual pulled digest instead of the manifest tag
  - Impact: Prevents platform mismatch errors when working with multi-architecture images

 ### 2. Respect image platform when exporting buildpack layers

  - File: buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/DockerApi.java
  - Change: Enhanced Docker save operations to include platform information
  - Impact: Ensures correct platform handling during buildpack layer export

##  Compatibility

  - Backward Compatible: These changes don't affect existing functionality for users not specifying custom platforms
  - Docker Version: Compatible with Docker versions that support multi-platform operations
  - Platform Support: Improves cross-platform building capabilities on ARM64 and AMD64 hosts