### PR TITLE
 LiquibaseEndpoint always uses defaultSchema instead of liquibaseSchema

### DIFF
--- a/module/spring-boot-liquibase/src/main/java/org/springframework/boot/liquibase/endpoint/LiquibaseEndpoint.java
+++ b/module/spring-boot-liquibase/src/main/java/org/springframework/boot/liquibase/endpoint/LiquibaseEndpoint.java
@@ -44,6 +44,7 @@ import org.springframework.util.StringUtils;
  * {@link Endpoint @Endpoint} to expose liquibase info.
  *
  * @author Eddú Meléndez
+ * @author Nabil Fawwaz Elqayyim
  * @since 4.0.0
  */
 @Endpoint(id = "liquibase")
@@ -80,9 +81,12 @@ public class LiquibaseEndpoint {
 			Database database = null;
 			try {
 				database = factory.findCorrectDatabaseImplementation(connection);
-				String defaultSchema = liquibase.getDefaultSchema();
-				if (StringUtils.hasText(defaultSchema)) {
-					database.setDefaultSchemaName(defaultSchema);
+				String schemaToUse = liquibase.getLiquibaseSchema();
+				if (!StringUtils.hasText(schemaToUse)) { // Use liquibase-schema if set, otherwise fall back to default-schema
+					schemaToUse = liquibase.getDefaultSchema();
+				}
+				if (StringUtils.hasText(schemaToUse)) {
+					database.setDefaultSchemaName(schemaToUse);
 				}
 				database.setDatabaseChangeLogTableName(liquibase.getDatabaseChangeLogTable());
 				database.setDatabaseChangeLogLockTableName(liquibase.getDatabaseChangeLogLockTable());

--- a/module/spring-boot-liquibase/src/test/java/org/springframework/boot/liquibase/actuate/endpoint/LiquibaseEndpointTests.java
+++ b/module/spring-boot-liquibase/src/test/java/org/springframework/boot/liquibase/actuate/endpoint/LiquibaseEndpointTests.java
@@ -51,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  * @author Leo Li
+ * @author Nabil Fawwaz Elqayyim
  */
 @WithResource(name = "db/changelog/db.changelog-master.yaml", content = """
 		databaseChangeLog:
@@ -118,6 +119,21 @@ class LiquibaseEndpointTests {
 					.getLiquibaseBeans();
 				assertThat(liquibaseBeans.get("liquibase").getChangeSets()).hasSize(1);
 			});
+	}
+
+	@Test
+	@WithResource(name = "db/create-custom-schema.sql", content = "CREATE SCHEMA LIQUIBASE_SCHEMA;")
+	void invokeWithLiquibaseSchema() {
+		this.contextRunner.withUserConfiguration(Config.class, DataSourceWithSchemaConfiguration.class)
+				.withPropertyValues("spring.liquibase.liquibase-schema=LIQUIBASE_SCHEMA")
+				.run((context) -> {
+					Map<String, LiquibaseBeanDescriptor> liquibaseBeans = context.getBean(LiquibaseEndpoint.class)
+							.liquibaseBeans()
+							.getContexts()
+							.get(context.getId())
+							.getLiquibaseBeans();
+					assertThat(liquibaseBeans.get("liquibase").getChangeSets()).hasSize(1);
+				});
 	}
 
 	@Test


### PR DESCRIPTION
## 🚀 Overview

This PR fixes the `/actuator/liquibase` endpoint to respect the `spring.liquibase.liquibase-schema` property. Previously, the endpoint always used `default-schema`, even when `liquibase-schema` was configured.

---

## 🔥 Motivation

When application tables and Liquibase’s internal tables use separate schemas, the `/actuator/liquibase` endpoint ignores `liquibase-schema` and only reports changes from `default-schema`. This results in misleading output and prevents accurate monitoring of Liquibase change sets.

---

## 🔧 Changes

- Updated `LiquibaseEndpoint.createReport` to:
  - Use `liquibase.getLiquibaseSchema()` when configured.
  - Fall back to `liquibase.getDefaultSchema()` otherwise.
- Applied `database.setDefaultSchemaName(schemaToUse)` only when a schema is present.
- Added unit test `invokeWithLiquibaseSchema()` to verify correct behavior.

---

## ✅ Benefits

- `/actuator/liquibase` now produces accurate reports when `spring.liquibase.liquibase-schema` is configured.
- Supports schema separation between Liquibase internal tables and application domain tables.
- Backward compatible — existing setups that rely on `default-schema` remain unaffected.

---

## 🔖 Related Issue

Closes #47290