### PR TITLE
Update managed dependency version override examples in documentation

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/examples/using/different-versions-pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/examples/using/different-versions-pom.xml
@@ -6,7 +6,7 @@
 	<!-- tag::different-versions[] -->
 	<properties>
 		<slf4j.version>1.7.30</slf4j.version>
-		<spring-data-releasetrain.version>Moore-SR6</spring-data-releasetrain.version>
+		<spring-data-bom.version>2024.1.10</spring-data-bom.version>
 	</properties>
 	<!-- end::different-versions[] -->
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/examples/using/no-starter-parent-override-dependencies-pom.xml
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/examples/using/no-starter-parent-override-dependencies-pom.xml
@@ -24,8 +24,8 @@
 			<!-- Override Spring Data release train provided by Spring Boot -->
 			<dependency>
 				<groupId>org.springframework.data</groupId>
-				<artifactId>spring-data-releasetrain</artifactId>
-				<version>2020.0.0-SR1</version>
+				<artifactId>spring-data-bom</artifactId>
+				<version>2024.1.10</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/pages/using.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/pages/using.adoc
@@ -67,6 +67,9 @@ include::example$using/different-versions-pom.xml[tags=different-versions]
 
 Browse the xref:appendix:dependency-versions/properties.adoc[Dependency Versions Properties] section in the Spring Boot reference for a complete list of dependency version properties.
 
+WARNING: Each Spring Boot release is designed and tested against a specific set of third-party dependencies.
+Overriding versions may cause compatibility issues and should be done with care.
+
 
 
 [[using.import]]


### PR DESCRIPTION
The examples for overriding a managed dependency version with Maven were using an outdated version property `spring-data-releasetrain`. This commit updates the example to use a valid property `spring-data-bom`. Keeping the versions in the example up-to-date will be difficult, but IMO it would be good if the property was a valid one. 

The version override warning from the [Gradle plugin docs](https://docs.spring.io/spring-boot/3.4/gradle-plugin/managing-dependencies.html#managing-dependencies.dependency-management-plugin.customizing) was also copied to the Maven docs.
