### PR TITLE
Update H2 library version to 2.3.240

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -517,7 +517,7 @@ bom {
 			releaseNotes("https://github.com/google/gson/releases/tag/gson-parent-{version}")
 		}
 	}
-	library("H2", "2.3.232") {
+	library("H2", "2.3.240") {
 		group("com.h2database") {
 			modules = [
 				"h2"


### PR DESCRIPTION
2.3.232 has CVEs, see: https://central.sonatype.com/artifact/com.h2database/h2/versions

> Dependency Upgrades

> Please do not open a pull request for a straightforward dependency upgrade (one that
> only updates the version property). We have a semi-automated process for such upgrades
> that we prefer to use. However, if the upgrade is more involved (such as requiring
> changes for removed or deprecated API) your pull request is most welcome.

oops! I just read that, oh well, my PR is ready, I leave it open in case your automation takes time!