### PR TITLE
Use non-deprecated syntax to configure sourceCompatibility

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/tutorial/pages/first-application/index.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/tutorial/pages/first-application/index.adoc
@@ -180,7 +180,10 @@ apply plugin: 'io.spring.dependency-management'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
+
+java {
+	sourceCompatibility = '17'
+}
 
 repositories {
 	mavenCentral()


### PR DESCRIPTION
The `sourceCompatibility` property needs to be moved inside the java block for the configuration to take effect.