### PR TITLE
Configure global observation registry

### DIFF
--- a/module/spring-boot-micrometer-observation/src/main/java/org/springframework/boot/micrometer/observation/autoconfigure/ObservationAutoConfiguration.java
+++ b/module/spring-boot-micrometer-observation/src/main/java/org/springframework/boot/micrometer/observation/autoconfigure/ObservationAutoConfiguration.java
@@ -52,13 +52,14 @@ public final class ObservationAutoConfiguration {
 
 	@Bean
 	static ObservationRegistryPostProcessor observationRegistryPostProcessor(
+			ObjectProvider<ObservationProperties> properties,
 			ObjectProvider<ObservationRegistryCustomizer<?>> observationRegistryCustomizers,
 			ObjectProvider<ObservationPredicate> observationPredicates,
 			ObjectProvider<GlobalObservationConvention<?>> observationConventions,
 			ObjectProvider<ObservationHandler<?>> observationHandlers,
 			ObjectProvider<ObservationHandlerGroup> observationHandlerGroups,
 			ObjectProvider<ObservationFilter> observationFilters) {
-		return new ObservationRegistryPostProcessor(observationRegistryCustomizers, observationPredicates,
+		return new ObservationRegistryPostProcessor(properties, observationRegistryCustomizers, observationPredicates,
 				observationConventions, observationHandlers, observationHandlerGroups, observationFilters);
 	}
 

--- a/module/spring-boot-micrometer-observation/src/main/java/org/springframework/boot/micrometer/observation/autoconfigure/ObservationProperties.java
+++ b/module/spring-boot-micrometer-observation/src/main/java/org/springframework/boot/micrometer/observation/autoconfigure/ObservationProperties.java
@@ -32,6 +32,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("management.observations")
 public class ObservationProperties {
 
+	/**
+	 * Whether auto-configured ObservationRegistry implementations should be bound to the global
+	 * static registry on Observations. For testing, set this to 'false' to maximize test
+	 * independence.
+	 */
+	private boolean useGlobalRegistry = true;
+
 	private final Http http = new Http();
 
 	/**
@@ -46,6 +53,14 @@ public class ObservationProperties {
 	private Map<String, Boolean> enable = new LinkedHashMap<>();
 
 	private final LongTaskTimer longTaskTimer = new LongTaskTimer();
+
+	public boolean isUseGlobalRegistry() {
+		return this.useGlobalRegistry;
+	}
+
+	public void setUseGlobalRegistry(boolean useGlobalRegistry) {
+		this.useGlobalRegistry = useGlobalRegistry;
+	}
 
 	public Map<String, Boolean> getEnable() {
 		return this.enable;


### PR DESCRIPTION
This change configures the global observation registry.

[Same as is done for the metric registry](https://github.com/spring-projects/spring-boot/blob/main/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/MeterRegistryPostProcessor.java), but for the observation registry.
