### PR TITLE
Disable LiveReload server by default

### DIFF
--- a/documentation/spring-boot-docs/build.gradle
+++ b/documentation/spring-boot-docs/build.gradle
@@ -320,7 +320,7 @@ tasks.register("documentDevtoolsPropertyDefaults", org.springframework.boot.buil
 tasks.register("runRemoteSpringApplicationExample", org.springframework.boot.build.docs.ApplicationRunner) {
 	classpath = configurations.remoteSpringApplicationExample
 	mainClass = "org.springframework.boot.devtools.RemoteSpringApplication"
-	args = ["https://myapp.example.com", "--spring.devtools.remote.secret=secret", "--spring.devtools.livereload.port=0"]
+	args = ["https://myapp.example.com", "--spring.devtools.remote.secret=secret", "--spring.devtools.livereload.enabled=true", "--spring.devtools.livereload.port=0"]
 	output = layout.buildDirectory.file("example-output/remote-spring-application.txt")
 	expectedLogging = "Started RemoteSpringApplication in "
 	applicationJar = "/Users/myuser/.m2/repository/org/springframework/boot/spring-boot-devtools/${project.version}/spring-boot-devtools-${project.version}.jar"

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/using/devtools.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/using/devtools.adoc
@@ -287,7 +287,7 @@ The `spring-boot-devtools` module includes an embedded LiveReload server that ca
 LiveReload browser extensions are freely available for Chrome, Firefox and Safari.
 You can find these extensions by searching 'LiveReload' in the marketplace or store of your chosen browser.
 
-If you do not want to start the LiveReload server when your application runs, you can set the configprop:spring.devtools.livereload.enabled[] property to `false`.
+If you want to start the LiveReload server when your application runs, you can set the configprop:spring.devtools.livereload.enabled[] property to `true`.
 
 NOTE: You can only run one LiveReload server at a time.
 Before starting your application, ensure that no other LiveReload servers are running.

--- a/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
+++ b/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.java
@@ -193,7 +193,7 @@ public class DevToolsProperties {
 		/**
 		 * Whether to enable a livereload.com-compatible server.
 		 */
-		private boolean enabled = true;
+		private boolean enabled = false;
 
 		/**
 		 * Server port.

--- a/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
+++ b/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfiguration.java
@@ -70,7 +70,7 @@ public final class LocalDevToolsAutoConfiguration {
 	 * Local LiveReload configuration.
 	 */
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnBooleanProperty(name = "spring.devtools.livereload.enabled", matchIfMissing = true)
+	@ConditionalOnBooleanProperty(name = "spring.devtools.livereload.enabled")
 	static class LiveReloadConfiguration {
 
 		@Bean

--- a/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/remote/client/RemoteClientConfiguration.java
+++ b/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/remote/client/RemoteClientConfiguration.java
@@ -131,7 +131,7 @@ public class RemoteClientConfiguration implements InitializingBean {
 	 * LiveReload configuration.
 	 */
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnBooleanProperty(name = "spring.devtools.livereload.enabled", matchIfMissing = true)
+	@ConditionalOnBooleanProperty(name = "spring.devtools.livereload.enabled")
 	static class LiveReloadConfiguration {
 
 		private final DevToolsProperties properties;

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
@@ -112,15 +112,10 @@ class LocalDevToolsAutoConfigurationTests {
 	}
 
 	@Test
-	void liveReloadServer() throws Exception {
-		this.context = getContext(() -> initializeAndRun(Config.class));
-		LiveReloadServer server = this.context.getBean(LiveReloadServer.class);
-		assertThat(server.isStarted()).isTrue();
-	}
-
-	@Test
 	void liveReloadTriggeredOnContextRefresh() throws Exception {
-		this.context = getContext(() -> initializeAndRun(ConfigWithMockLiveReload.class));
+		Map<String, Object> properties = new HashMap<>();
+		properties.put("spring.devtools.livereload.enabled", true);
+		this.context = getContext(() -> initializeAndRun(ConfigWithMockLiveReload.class, properties));
 		LiveReloadServer server = this.context.getBean(LiveReloadServer.class);
 		reset(server);
 		this.context.publishEvent(new ContextRefreshedEvent(this.context));
@@ -129,7 +124,9 @@ class LocalDevToolsAutoConfigurationTests {
 
 	@Test
 	void liveReloadTriggeredOnClassPathChangeWithoutRestart() throws Exception {
-		this.context = getContext(() -> initializeAndRun(ConfigWithMockLiveReload.class));
+		Map<String, Object> properties = new HashMap<>();
+		properties.put("spring.devtools.livereload.enabled", true);
+		this.context = getContext(() -> initializeAndRun(ConfigWithMockLiveReload.class, properties));
 		LiveReloadServer server = this.context.getBean(LiveReloadServer.class);
 		reset(server);
 		ClassPathChangedEvent event = new ClassPathChangedEvent(this.context, Collections.emptySet(), false);
@@ -139,7 +136,9 @@ class LocalDevToolsAutoConfigurationTests {
 
 	@Test
 	void liveReloadNotTriggeredOnClassPathChangeWithRestart() throws Exception {
-		this.context = getContext(() -> initializeAndRun(ConfigWithMockLiveReload.class));
+		Map<String, Object> properties = new HashMap<>();
+		properties.put("spring.devtools.livereload.enabled", true);
+		this.context = getContext(() -> initializeAndRun(ConfigWithMockLiveReload.class, properties));
 		LiveReloadServer server = this.context.getBean(LiveReloadServer.class);
 		reset(server);
 		ClassPathChangedEvent event = new ClassPathChangedEvent(this.context, Collections.emptySet(), true);
@@ -148,10 +147,8 @@ class LocalDevToolsAutoConfigurationTests {
 	}
 
 	@Test
-	void liveReloadDisabled() throws Exception {
-		Map<String, Object> properties = new HashMap<>();
-		properties.put("spring.devtools.livereload.enabled", false);
-		this.context = getContext(() -> initializeAndRun(Config.class, properties));
+	void liveReloadDisabledByDefault() throws Exception {
+		this.context = getContext(() -> initializeAndRun(Config.class));
 		assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
 			.isThrownBy(() -> this.context.getBean(OptionalLiveReloadServer.class));
 	}

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/client/RemoteClientConfigurationTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/client/RemoteClientConfigurationTests.java
@@ -102,8 +102,8 @@ class RemoteClientConfigurationTests {
 	}
 
 	@Test
-	void liveReloadOnClassPathChanged() throws Exception {
-		configure();
+	void liveReloadOnClassPathChanged() {
+		configure("spring.devtools.livereload.enabled:true");
 		Set<ChangedFiles> changeSet = new HashSet<>();
 		ClassPathChangedEvent event = new ClassPathChangedEvent(this, changeSet, false);
 		this.clientContext.publishEvent(event);
@@ -112,8 +112,8 @@ class RemoteClientConfigurationTests {
 	}
 
 	@Test
-	void liveReloadDisabled() {
-		configure("spring.devtools.livereload.enabled:false");
+	void liveReloadDisabledByDefault() {
+		configure();
 		assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
 			.isThrownBy(() -> this.context.getBean(OptionalLiveReloadServer.class));
 	}


### PR DESCRIPTION
This commit changes the default value of configuration property `spring.devtools.livereload.enabled` to `false`.

---

This is related to #43697 where flipping the default has been discussed as one of the things that could help move that PR forward (see https://github.com/spring-projects/spring-boot/pull/43697#issuecomment-2814286731 specifically).