### PR TITLE
Clarify TestPropertySource location multi-document limitations

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/external-config.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/external-config.adoc
@@ -46,6 +46,9 @@ See xref:features/external-config.adoc#features.external-config.typesafe-configu
 
 NOTE: If your application runs in a servlet container or application server, then JNDI properties (in `java:comp/env`) or servlet context initialization parameters can be used instead of, or as well as, environment variables or system properties.
 
+NOTE: javadoc:org.springframework.test.context.TestPropertySource[format=annotation] `locations` attribute does not support multi-document files.
+
+
 To provide a concrete example, suppose you develop a javadoc:org.springframework.stereotype.Component[format=annotation] that uses a `name` property, as shown in the following example:
 
 include-code::MyBean[]


### PR DESCRIPTION
The following issue https://github.com/spring-projects/spring-boot/issues/33434#issuecomment-3357386503 as well as linked ones, for example https://github.com/spring-projects/spring-boot/pull/42603#issuecomment-2423166515,  shows it is widely believed that TestPropertySource supports multi-document files.

Worth be fair.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
