### PR TITLE
Upgrade to Commons Lang3 3.18.0 (fix CVE-2025-48924)

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -242,7 +242,7 @@ bom {
 			releaseNotes("https://commons.apache.org/proper/commons-dbcp/changes-report.html#a{version}")
 		}
 	}
-	library("Commons Lang3", "3.17.0") {
+	library("Commons Lang3", "3.18.0") {
 		group("org.apache.commons") {
 			modules = [
 				"commons-lang3"


### PR DESCRIPTION
The semi-automated process does not seem to cover Commons Lang versions for the 3.5.x branch.