### PR TITLE
Rename test annotations with Test prefix in Configuration Processor

### DIFF
--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -521,7 +521,7 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 	@Test
 	void recordProperties() {
 		String source = """
-				@org.springframework.boot.configurationsample.ConfigurationProperties("implicit")
+				@org.springframework.boot.configurationsample.TestConfigurationProperties("implicit")
 				public record ExampleRecord(String someString, Integer someInteger) {
 				}
 				""";
@@ -533,10 +533,10 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 	@Test
 	void recordPropertiesWithDefaultValues() {
 		String source = """
-				@org.springframework.boot.configurationsample.ConfigurationProperties("record.defaults")
+				@org.springframework.boot.configurationsample.TestConfigurationProperties("record.defaults")
 				public record ExampleRecord(
-					@org.springframework.boot.configurationsample.DefaultValue("An1s9n") String someString,
-					@org.springframework.boot.configurationsample.DefaultValue("594") Integer someInteger) {
+					@org.springframework.boot.configurationsample.TestDefaultValue("An1s9n") String someString,
+					@org.springframework.boot.configurationsample.TestDefaultValue("594") Integer someInteger) {
 				}
 				""";
 		ConfigurationMetadata metadata = compile(source);
@@ -549,9 +549,9 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 	@Test
 	void multiConstructorRecordProperties() {
 		String source = """
-				@org.springframework.boot.configurationsample.ConfigurationProperties("multi")
+				@org.springframework.boot.configurationsample.TestConfigurationProperties("multi")
 				public record ExampleRecord(String someString, Integer someInteger) {
-					@org.springframework.boot.configurationsample.ConstructorBinding
+					@org.springframework.boot.configurationsample.TestConstructorBinding
 					public ExampleRecord(String someString) {
 						this(someString, 42);
 					}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/TestProject.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/TestProject.java
@@ -29,8 +29,8 @@ import org.springframework.boot.configurationprocessor.metadata.ConfigurationMet
 import org.springframework.boot.configurationprocessor.metadata.JsonMarshaller;
 import org.springframework.boot.configurationprocessor.test.CompiledMetadataReader;
 import org.springframework.boot.configurationprocessor.test.TestConfigurationMetadataAnnotationProcessor;
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
 import org.springframework.core.test.tools.ResourceFile;
 import org.springframework.core.test.tools.SourceFile;
 import org.springframework.core.test.tools.SourceFiles;
@@ -50,8 +50,8 @@ import org.springframework.util.FileCopyUtils;
  */
 public class TestProject {
 
-	private static final Class<?>[] ALWAYS_INCLUDE = { ConfigurationProperties.class,
-			NestedConfigurationProperty.class };
+	private static final Class<?>[] ALWAYS_INCLUDE = { TestConfigurationProperties.class,
+			TestNestedConfigurationProperty.class };
 
 	private SourceFiles sources;
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/test/TestConfigurationMetadataAnnotationProcessor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/test/TestConfigurationMetadataAnnotationProcessor.java
@@ -47,35 +47,35 @@ import org.springframework.boot.configurationprocessor.ConfigurationMetadataAnno
 @SupportedSourceVersion(SourceVersion.RELEASE_6)
 public class TestConfigurationMetadataAnnotationProcessor extends ConfigurationMetadataAnnotationProcessor {
 
-	public static final String CONFIGURATION_PROPERTIES_ANNOTATION = "org.springframework.boot.configurationsample.ConfigurationProperties";
+	public static final String CONFIGURATION_PROPERTIES_ANNOTATION = "org.springframework.boot.configurationsample.TestConfigurationProperties";
 
-	public static final String CONFIGURATION_PROPERTIES_SOURCE_ANNOTATION = "org.springframework.boot.configurationsample.ConfigurationPropertiesSource";
+	public static final String CONFIGURATION_PROPERTIES_SOURCE_ANNOTATION = "org.springframework.boot.configurationsample.TestConfigurationPropertiesSource";
 
-	public static final String NESTED_CONFIGURATION_PROPERTY_ANNOTATION = "org.springframework.boot.configurationsample.NestedConfigurationProperty";
+	public static final String NESTED_CONFIGURATION_PROPERTY_ANNOTATION = "org.springframework.boot.configurationsample.TestNestedConfigurationProperty";
 
-	public static final String DEPRECATED_CONFIGURATION_PROPERTY_ANNOTATION = "org.springframework.boot.configurationsample.DeprecatedConfigurationProperty";
+	public static final String DEPRECATED_CONFIGURATION_PROPERTY_ANNOTATION = "org.springframework.boot.configurationsample.TestDeprecatedConfigurationProperty";
 
-	public static final String CONSTRUCTOR_BINDING_ANNOTATION = "org.springframework.boot.configurationsample.ConstructorBinding";
+	public static final String CONSTRUCTOR_BINDING_ANNOTATION = "org.springframework.boot.configurationsample.TestConstructorBinding";
 
-	public static final String AUTOWIRED_ANNOTATION = "org.springframework.boot.configurationsample.Autowired";
+	public static final String AUTOWIRED_ANNOTATION = "org.springframework.boot.configurationsample.TestAutowired";
 
-	public static final String DEFAULT_VALUE_ANNOTATION = "org.springframework.boot.configurationsample.DefaultValue";
+	public static final String DEFAULT_VALUE_ANNOTATION = "org.springframework.boot.configurationsample.TestDefaultValue";
 
-	public static final String CONTROLLER_ENDPOINT_ANNOTATION = "org.springframework.boot.configurationsample.ControllerEndpoint";
+	public static final String CONTROLLER_ENDPOINT_ANNOTATION = "org.springframework.boot.configurationsample.TestControllerEndpoint";
 
-	public static final String ENDPOINT_ANNOTATION = "org.springframework.boot.configurationsample.Endpoint";
+	public static final String ENDPOINT_ANNOTATION = "org.springframework.boot.configurationsample.TestEndpoint";
 
-	public static final String JMX_ENDPOINT_ANNOTATION = "org.springframework.boot.configurationsample.JmxEndpoint";
+	public static final String JMX_ENDPOINT_ANNOTATION = "org.springframework.boot.configurationsample.TestJmxEndpoint";
 
-	public static final String REST_CONTROLLER_ENDPOINT_ANNOTATION = "org.springframework.boot.configurationsample.RestControllerEndpoint";
+	public static final String REST_CONTROLLER_ENDPOINT_ANNOTATION = "org.springframework.boot.configurationsample.TestRestControllerEndpoint";
 
-	public static final String SERVLET_ENDPOINT_ANNOTATION = "org.springframework.boot.configurationsample.ServletEndpoint";
+	public static final String SERVLET_ENDPOINT_ANNOTATION = "org.springframework.boot.configurationsample.TestServletEndpoint";
 
-	public static final String WEB_ENDPOINT_ANNOTATION = "org.springframework.boot.configurationsample.WebEndpoint";
+	public static final String WEB_ENDPOINT_ANNOTATION = "org.springframework.boot.configurationsample.TestWebEndpoint";
 
-	public static final String READ_OPERATION_ANNOTATION = "org.springframework.boot.configurationsample.ReadOperation";
+	public static final String READ_OPERATION_ANNOTATION = "org.springframework.boot.configurationsample.TestReadOperation";
 
-	public static final String NAME_ANNOTATION = "org.springframework.boot.configurationsample.Name";
+	public static final String NAME_ANNOTATION = "org.springframework.boot.configurationsample.TestName";
 
 	public static final String ENDPOINT_ACCESS_ENUM = "org.springframework.boot.configurationsample.Access";
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestAutowired.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestAutowired.java
@@ -23,18 +23,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Alternative to Spring Boot's {@code @WebEndpoint} for testing (removes the need for a
- * dependency on the real annotation).
+ * Alternative to Spring Framework's {@code @Autowired} for testing (removes the need for
+ * a dependency on the real annotation).
  *
- * @author Andy Wilkinson
+ * @author Madhura Bhave
  */
-@Target(ElementType.TYPE)
+@Target({ ElementType.TYPE, ElementType.CONSTRUCTOR })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface WebEndpoint {
-
-	String id() default "";
-
-	Access defaultAccess() default Access.UNRESTRICTED;
+public @interface TestAutowired {
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestConfigurationProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestConfigurationProperties.java
@@ -23,16 +23,19 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Alternative to Spring Boot's {@code @Name} for testing (removes the need for a
- * dependency on the real annotation).
+ * Alternative to Spring Boot's {@code @ConfigurationProperties} for testing (removes the
+ * need for a dependency on the real annotation).
  *
+ * @author Stephane Nicoll
  * @author Phillip Webb
  */
-@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface Name {
+public @interface TestConfigurationProperties {
 
-	String value();
+	String value() default "";
+
+	String prefix() default "";
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestConfigurationPropertiesSource.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestConfigurationPropertiesSource.java
@@ -23,37 +23,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that a getter in a {@link ConfigurationProperties @ConfigurationProperties}
- * object is deprecated. This annotation has no bearing on the actual binding processes,
- * but it is used by the {@code spring-boot-configuration-processor} to add deprecation
- * meta-data.
- * <p>
- * This annotation <strong>must</strong> be used on the getter of the deprecated element.
+ * Alternative to Spring Boot's {@code @ConfigurationProperties} for testing (removes the
+ * need for a dependency on the real annotation).
  *
- * @author Phillip Webb
- * @since 1.3.0
+ * @author Stephane Nicoll
  */
-@Target(ElementType.METHOD)
+@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface DeprecatedConfigurationProperty {
-
-	/**
-	 * The reason for the deprecation.
-	 * @return the deprecation reason
-	 */
-	String reason() default "";
-
-	/**
-	 * The field that should be used instead (if any).
-	 * @return the replacement field
-	 */
-	String replacement() default "";
-
-	/**
-	 * The version in which the property became deprecated.
-	 * @return the version
-	 */
-	String since() default "";
+public @interface TestConfigurationPropertiesSource {
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestConstructorBinding.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestConstructorBinding.java
@@ -23,14 +23,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Alternative to Spring Boot's {@code @ConfigurationProperties} for testing (removes the
- * need for a dependency on the real annotation).
+ * Alternative to Spring Boot's {@code @ConstructorBinding} for testing (removes the need
+ * for a dependency on the real annotation).
  *
  * @author Stephane Nicoll
  */
-@Target(ElementType.TYPE)
+@Target({ ElementType.CONSTRUCTOR, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface ConfigurationPropertiesSource {
+public @interface TestConstructorBinding {
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestControllerEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestControllerEndpoint.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface ControllerEndpoint {
+public @interface TestControllerEndpoint {
 
 	String id() default "";
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestDefaultValue.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestDefaultValue.java
@@ -23,18 +23,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Alternative to Spring Boot's {@code @ServletEndpoint} for testing (removes the need for
- * a dependency on the real annotation).
+ * Alternative to Spring Boot's {@code @DefaultValue} for testing (removes the need for a
+ * dependency on the real annotation).
  *
- * @author Andy Wilkinson
+ * @author Stephane Nicoll
+ * @author Pavel Anisimov
  */
-@Target(ElementType.TYPE)
+@Target({ ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface ServletEndpoint {
+public @interface TestDefaultValue {
 
-	String id() default "";
-
-	Access defaultAccess() default Access.UNRESTRICTED;
+	String[] value() default {};
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestDeprecatedConfigurationProperty.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestDeprecatedConfigurationProperty.java
@@ -23,14 +23,37 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Alternative to Spring Framework's {@code @Autowired} for testing (removes the need for
- * a dependency on the real annotation).
+ * Indicates that a getter in a {@link TestConfigurationProperties @ConfigurationProperties}
+ * object is deprecated. This annotation has no bearing on the actual binding processes,
+ * but it is used by the {@code spring-boot-configuration-processor} to add deprecation
+ * meta-data.
+ * <p>
+ * This annotation <strong>must</strong> be used on the getter of the deprecated element.
  *
- * @author Madhura Bhave
+ * @author Phillip Webb
+ * @since 1.3.0
  */
-@Target({ ElementType.TYPE, ElementType.CONSTRUCTOR })
+@Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface Autowired {
+public @interface TestDeprecatedConfigurationProperty {
+
+	/**
+	 * The reason for the deprecation.
+	 * @return the deprecation reason
+	 */
+	String reason() default "";
+
+	/**
+	 * The field that should be used instead (if any).
+	 * @return the replacement field
+	 */
+	String replacement() default "";
+
+	/**
+	 * The version in which the property became deprecated.
+	 * @return the version
+	 */
+	String since() default "";
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestEndpoint.java
@@ -23,14 +23,18 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Alternative to Spring Boot's {@code @ConstructorBinding} for testing (removes the need
- * for a dependency on the real annotation).
+ * Alternative to Spring Boot's {@code @Endpoint} for testing (removes the need for a
+ * dependency on the real annotation).
  *
  * @author Stephane Nicoll
  */
-@Target({ ElementType.CONSTRUCTOR, ElementType.ANNOTATION_TYPE })
+@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface ConstructorBinding {
+public @interface TestEndpoint {
+
+	String id() default "";
+
+	Access defaultAccess() default Access.UNRESTRICTED;
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestJmxEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestJmxEndpoint.java
@@ -23,16 +23,18 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Alternative to Spring Boot's {@code @ReadOperation} for testing (removes the need for a
+ * Alternative to Spring Boot's {@code @JmxEndpoint} for testing (removes the need for a
  * dependency on the real annotation).
  *
- * @author Stephane Nicoll
+ * @author Andy Wilkinson
  */
-@Target(ElementType.METHOD)
+@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface ReadOperation {
+public @interface TestJmxEndpoint {
 
-	String[] produces() default {};
+	String id() default "";
+
+	Access defaultAccess() default Access.UNRESTRICTED;
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestName.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestName.java
@@ -23,18 +23,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Alternative to Spring Boot's {@code @RestControllerEndpoint} for testing (removes the
- * need for a dependency on the real annotation).
+ * Alternative to Spring Boot's {@code @Name} for testing (removes the need for a
+ * dependency on the real annotation).
  *
- * @author Andy Wilkinson
+ * @author Phillip Webb
  */
-@Target(ElementType.TYPE)
+@Target({ ElementType.PARAMETER, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface RestControllerEndpoint {
+public @interface TestName {
 
-	String id() default "";
-
-	Access defaultAccess() default Access.UNRESTRICTED;
+	String value();
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestNestedConfigurationProperty.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestNestedConfigurationProperty.java
@@ -23,18 +23,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Alternative to Spring Boot's {@code @JmxEndpoint} for testing (removes the need for a
- * dependency on the real annotation).
+ * Alternative to Spring Boot's {@code @NestedConfigurationProperty} for testing (removes
+ * the need for a dependency on the real annotation).
  *
- * @author Andy Wilkinson
+ * @author Stephane Nicoll
+ * @author Phillip Webb
+ * @since 1.2.0
  */
-@Target(ElementType.TYPE)
+@Target({ ElementType.FIELD, ElementType.RECORD_COMPONENT, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface JmxEndpoint {
-
-	String id() default "";
-
-	Access defaultAccess() default Access.UNRESTRICTED;
+public @interface TestNestedConfigurationProperty {
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestReadOperation.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestReadOperation.java
@@ -23,17 +23,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Alternative to Spring Boot's {@code @DefaultValue} for testing (removes the need for a
+ * Alternative to Spring Boot's {@code @ReadOperation} for testing (removes the need for a
  * dependency on the real annotation).
  *
  * @author Stephane Nicoll
- * @author Pavel Anisimov
  */
-@Target({ ElementType.PARAMETER })
+@Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface DefaultValue {
+public @interface TestReadOperation {
 
-	String[] value() default {};
+	String[] produces() default {};
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestRestControllerEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestRestControllerEndpoint.java
@@ -23,16 +23,18 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Alternative to Spring Boot's {@code @NestedConfigurationProperty} for testing (removes
- * the need for a dependency on the real annotation).
+ * Alternative to Spring Boot's {@code @RestControllerEndpoint} for testing (removes the
+ * need for a dependency on the real annotation).
  *
- * @author Stephane Nicoll
- * @author Phillip Webb
- * @since 1.2.0
+ * @author Andy Wilkinson
  */
-@Target({ ElementType.FIELD, ElementType.RECORD_COMPONENT, ElementType.METHOD })
+@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface NestedConfigurationProperty {
+public @interface TestRestControllerEndpoint {
+
+	String id() default "";
+
+	Access defaultAccess() default Access.UNRESTRICTED;
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestServletEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestServletEndpoint.java
@@ -23,19 +23,18 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Alternative to Spring Boot's {@code @ConfigurationProperties} for testing (removes the
- * need for a dependency on the real annotation).
+ * Alternative to Spring Boot's {@code @ServletEndpoint} for testing (removes the need for
+ * a dependency on the real annotation).
  *
- * @author Stephane Nicoll
- * @author Phillip Webb
+ * @author Andy Wilkinson
  */
-@Target({ ElementType.TYPE, ElementType.METHOD })
+@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface ConfigurationProperties {
+public @interface TestServletEndpoint {
 
-	String value() default "";
+	String id() default "";
 
-	String prefix() default "";
+	Access defaultAccess() default Access.UNRESTRICTED;
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestWebEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/TestWebEndpoint.java
@@ -23,15 +23,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Alternative to Spring Boot's {@code @Endpoint} for testing (removes the need for a
+ * Alternative to Spring Boot's {@code @WebEndpoint} for testing (removes the need for a
  * dependency on the real annotation).
  *
- * @author Stephane Nicoll
+ * @author Andy Wilkinson
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface Endpoint {
+public @interface TestWebEndpoint {
 
 	String id() default "";
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/deprecation/Dbcp2Configuration.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/deprecation/Dbcp2Configuration.java
@@ -18,7 +18,7 @@ package org.springframework.boot.configurationsample.deprecation;
 
 import org.apache.commons.dbcp2.BasicDataSource;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Test configuration for DBCP2 {@link BasicDataSource}.
@@ -27,7 +27,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  */
 public class Dbcp2Configuration {
 
-	@ConfigurationProperties("spring.datasource.dbcp2")
+	@TestConfigurationProperties("spring.datasource.dbcp2")
 	BasicDataSource basicDataSource() {
 		return new BasicDataSource();
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/CamelCaseEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/CamelCaseEndpoint.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.endpoint;
 
-import org.springframework.boot.configurationsample.Endpoint;
+import org.springframework.boot.configurationsample.TestEndpoint;
 
 /**
  * An endpoint with an upper camel case id.
  *
  * @author Stephane Nicoll
  */
-@Endpoint(id = "PascalCase")
+@TestEndpoint(id = "PascalCase")
 public class CamelCaseEndpoint {
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/CustomPropertiesEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/CustomPropertiesEndpoint.java
@@ -16,22 +16,22 @@
 
 package org.springframework.boot.configurationsample.endpoint;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.Endpoint;
-import org.springframework.boot.configurationsample.ReadOperation;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestEndpoint;
+import org.springframework.boot.configurationsample.TestReadOperation;
 
 /**
  * An endpoint with additional custom properties.
  *
  * @author Stephane Nicoll
  */
-@Endpoint(id = "customprops")
-@ConfigurationProperties("management.endpoint.customprops")
+@TestEndpoint(id = "customprops")
+@TestConfigurationProperties("management.endpoint.customprops")
 public class CustomPropertiesEndpoint {
 
 	private String name = "test";
 
-	@ReadOperation
+	@TestReadOperation
 	public String getName() {
 		return this.name;
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/EnabledEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/EnabledEndpoint.java
@@ -16,22 +16,22 @@
 
 package org.springframework.boot.configurationsample.endpoint;
 
-import org.springframework.boot.configurationsample.Endpoint;
-import org.springframework.boot.configurationsample.ReadOperation;
+import org.springframework.boot.configurationsample.TestEndpoint;
+import org.springframework.boot.configurationsample.TestReadOperation;
 
 /**
  * An endpoint that is enabled unless configured explicitly.
  *
  * @author Stephane Nicoll
  */
-@Endpoint(id = "enabled")
+@TestEndpoint(id = "enabled")
 public class EnabledEndpoint {
 
 	public String someMethod() {
 		return "not a read operation";
 	}
 
-	@ReadOperation
+	@TestReadOperation
 	public String retrieve(String parameter, Integer anotherParameter) {
 		return "not a main read operation";
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/NoAccessEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/NoAccessEndpoint.java
@@ -17,14 +17,14 @@
 package org.springframework.boot.configurationsample.endpoint;
 
 import org.springframework.boot.configurationsample.Access;
-import org.springframework.boot.configurationsample.Endpoint;
+import org.springframework.boot.configurationsample.TestEndpoint;
 
 /**
  * An endpoint with no permitted access unless configured explicitly.
  *
  * @author Andy Wilkinson
  */
-@Endpoint(id = "noaccess", defaultAccess = Access.NONE)
+@TestEndpoint(id = "noaccess", defaultAccess = Access.NONE)
 public class NoAccessEndpoint {
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/NullableParameterEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/NullableParameterEndpoint.java
@@ -18,18 +18,18 @@ package org.springframework.boot.configurationsample.endpoint;
 
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.boot.configurationsample.Endpoint;
-import org.springframework.boot.configurationsample.ReadOperation;
+import org.springframework.boot.configurationsample.TestEndpoint;
+import org.springframework.boot.configurationsample.TestReadOperation;
 
 /**
  * An endpoint that uses {@code Nullable} to signal an optional parameter.
  *
  * @author Wonyong Hwang
  */
-@Endpoint(id = "nullable")
+@TestEndpoint(id = "nullable")
 public class NullableParameterEndpoint {
 
-	@ReadOperation
+	@TestReadOperation
 	public String invoke(@Nullable String parameter) {
 		return "test with " + parameter;
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/ReadOnlyAccessEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/ReadOnlyAccessEndpoint.java
@@ -17,14 +17,14 @@
 package org.springframework.boot.configurationsample.endpoint;
 
 import org.springframework.boot.configurationsample.Access;
-import org.springframework.boot.configurationsample.Endpoint;
+import org.springframework.boot.configurationsample.TestEndpoint;
 
 /**
  * An endpoint with read-only access unless configured explicitly.
  *
  * @author Andy Wilkinson
  */
-@Endpoint(id = "readonlyaccess", defaultAccess = Access.READ_ONLY)
+@TestEndpoint(id = "readonlyaccess", defaultAccess = Access.READ_ONLY)
 public class ReadOnlyAccessEndpoint {
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/SimpleEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/SimpleEndpoint.java
@@ -16,18 +16,18 @@
 
 package org.springframework.boot.configurationsample.endpoint;
 
-import org.springframework.boot.configurationsample.Endpoint;
-import org.springframework.boot.configurationsample.ReadOperation;
+import org.springframework.boot.configurationsample.TestEndpoint;
+import org.springframework.boot.configurationsample.TestReadOperation;
 
 /**
  * A simple endpoint with no default override.
  *
  * @author Stephane Nicoll
  */
-@Endpoint(id = "simple")
+@TestEndpoint(id = "simple")
 public class SimpleEndpoint {
 
-	@ReadOperation
+	@TestReadOperation
 	public String invoke() {
 		return "test";
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/SimpleEndpoint2.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/SimpleEndpoint2.java
@@ -16,18 +16,18 @@
 
 package org.springframework.boot.configurationsample.endpoint;
 
-import org.springframework.boot.configurationsample.Endpoint;
-import org.springframework.boot.configurationsample.ReadOperation;
+import org.springframework.boot.configurationsample.TestEndpoint;
+import org.springframework.boot.configurationsample.TestReadOperation;
 
 /**
  * A simple endpoint with no default override, with the same id as {@link SimpleEndpoint}.
  *
  * @author Moritz Halbritter
  */
-@Endpoint(id = "simple")
+@TestEndpoint(id = "simple")
 public class SimpleEndpoint2 {
 
-	@ReadOperation
+	@TestReadOperation
 	public String invoke() {
 		return "test";
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/SimpleEndpoint3.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/SimpleEndpoint3.java
@@ -17,8 +17,8 @@
 package org.springframework.boot.configurationsample.endpoint;
 
 import org.springframework.boot.configurationsample.Access;
-import org.springframework.boot.configurationsample.Endpoint;
-import org.springframework.boot.configurationsample.ReadOperation;
+import org.springframework.boot.configurationsample.TestEndpoint;
+import org.springframework.boot.configurationsample.TestReadOperation;
 
 /**
  * A simple endpoint with no default override, with the same id as {@link SimpleEndpoint},
@@ -26,10 +26,10 @@ import org.springframework.boot.configurationsample.ReadOperation;
  *
  * @author Moritz Halbritter
  */
-@Endpoint(id = "simple", defaultAccess = Access.NONE)
+@TestEndpoint(id = "simple", defaultAccess = Access.NONE)
 public class SimpleEndpoint3 {
 
-	@ReadOperation
+	@TestReadOperation
 	public String invoke() {
 		return "test";
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/SpecificEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/SpecificEndpoint.java
@@ -19,8 +19,8 @@ package org.springframework.boot.configurationsample.endpoint;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.boot.configurationsample.Access;
-import org.springframework.boot.configurationsample.ReadOperation;
-import org.springframework.boot.configurationsample.WebEndpoint;
+import org.springframework.boot.configurationsample.TestReadOperation;
+import org.springframework.boot.configurationsample.TestWebEndpoint;
 
 /**
  * A meta-annotated endpoint. Also with a package private read operation that has an
@@ -28,10 +28,10 @@ import org.springframework.boot.configurationsample.WebEndpoint;
  *
  * @author Stephane Nicoll
  */
-@WebEndpoint(id = "specific", defaultAccess = Access.READ_ONLY)
+@TestWebEndpoint(id = "specific", defaultAccess = Access.READ_ONLY)
 public class SpecificEndpoint {
 
-	@ReadOperation
+	@TestReadOperation
 	String invoke(@Nullable String param) {
 		return "test";
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/UnrestrictedAccessEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/UnrestrictedAccessEndpoint.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.endpoint;
 
-import org.springframework.boot.configurationsample.Endpoint;
+import org.springframework.boot.configurationsample.TestEndpoint;
 
 /**
  * An endpoint with unrestricted access unless configured explicitly.
  *
  * @author Andy Wilkinson
  */
-@Endpoint(id = "unrestrictedaccess")
+@TestEndpoint(id = "unrestrictedaccess")
 public class UnrestrictedAccessEndpoint {
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/incremental/IncrementalEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/incremental/IncrementalEndpoint.java
@@ -18,18 +18,18 @@ package org.springframework.boot.configurationsample.endpoint.incremental;
 
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.boot.configurationsample.Endpoint;
-import org.springframework.boot.configurationsample.ReadOperation;
+import org.springframework.boot.configurationsample.TestEndpoint;
+import org.springframework.boot.configurationsample.TestReadOperation;
 
 /**
  * An endpoint that is enabled by default.
  *
  * @author Stephane Nicoll
  */
-@Endpoint(id = "incremental")
+@TestEndpoint(id = "incremental")
 public class IncrementalEndpoint {
 
-	@ReadOperation
+	@TestReadOperation
 	public String invoke(@Nullable String param) {
 		return "test";
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/incremental/IncrementalSpecificEndpoint.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/endpoint/incremental/IncrementalSpecificEndpoint.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.endpoint.incremental;
 
-import org.springframework.boot.configurationsample.JmxEndpoint;
+import org.springframework.boot.configurationsample.TestJmxEndpoint;
 
 /**
  * A meta-annotated endpoint.
@@ -24,7 +24,7 @@ import org.springframework.boot.configurationsample.JmxEndpoint;
  * @author Stephane Nicoll
  * @author Andy Wilkinson
  */
-@JmxEndpoint(id = "incremental")
+@TestJmxEndpoint(id = "incremental")
 public class IncrementalSpecificEndpoint {
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/fieldvalues/FieldValues.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/fieldvalues/FieldValues.java
@@ -22,7 +22,7 @@ import java.time.Duration;
 import java.time.Period;
 import java.time.temporal.ChronoUnit;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 import org.springframework.util.MimeType;
 import org.springframework.util.unit.DataSize;
 
@@ -33,7 +33,7 @@ import org.springframework.util.unit.DataSize;
  * @author Stephane Nicoll
  */
 @SuppressWarnings("unused")
-@ConfigurationProperties
+@TestConfigurationProperties
 public class FieldValues {
 
 	private static final String STRING_CONST = "c";

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ComplexGenericProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ComplexGenericProperties.java
@@ -16,18 +16,18 @@
 
 package org.springframework.boot.configurationsample.generic;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
 
 /**
  * More advanced generic setup.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("generic")
+@TestConfigurationProperties("generic")
 public class ComplexGenericProperties {
 
-	@NestedConfigurationProperty
+	@TestNestedConfigurationProperty
 	private final UpperBoundGenericPojo<Test> test = new UpperBoundGenericPojo<>();
 
 	public UpperBoundGenericPojo<Test> getTest() {

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ConcreteBuilderProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/ConcreteBuilderProperties.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.generic;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Builder pattern with a resolved generic
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("builder")
+@TestConfigurationProperties("builder")
 public class ConcreteBuilderProperties extends GenericBuilderProperties<ConcreteBuilderProperties> {
 
 	private String description;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/GenericConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/GenericConfig.java
@@ -19,8 +19,8 @@ package org.springframework.boot.configurationsample.generic;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
 
 /**
  * Demonstrate that only relevant generics are stored in the metadata.
@@ -28,7 +28,7 @@ import org.springframework.boot.configurationsample.NestedConfigurationProperty;
  * @param <T> the type of the config
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("generic")
+@TestConfigurationProperties("generic")
 public class GenericConfig<T> {
 
 	private final Foo foo = new Foo();
@@ -41,7 +41,7 @@ public class GenericConfig<T> {
 
 		private String name;
 
-		@NestedConfigurationProperty
+		@TestNestedConfigurationProperty
 		private final Bar<String> bar = new Bar<>();
 
 		private final Map<String, Bar<Integer>> stringToBar = new HashMap<>();
@@ -74,7 +74,7 @@ public class GenericConfig<T> {
 
 		private String name;
 
-		@NestedConfigurationProperty
+		@TestNestedConfigurationProperty
 		private final Biz<String> biz = new Biz<>();
 
 		public String getName() {

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/SimpleGenericProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/SimpleGenericProperties.java
@@ -18,14 +18,14 @@ package org.springframework.boot.configurationsample.generic;
 
 import java.time.Duration;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Simple properties with resolved generic information.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("generic")
+@TestConfigurationProperties("generic")
 public class SimpleGenericProperties extends AbstractIntermediateGenericProperties<Duration> {
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/UnresolvedGenericProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/UnresolvedGenericProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.generic;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Properties with unresolved generic information.
@@ -25,7 +25,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  * @param <C> mapping value type
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("generic")
+@TestConfigurationProperties("generic")
 public class UnresolvedGenericProperties<B extends Number, C> extends AbstractGenericProperties<String, B, C> {
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/WildcardConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/generic/WildcardConfig.java
@@ -19,14 +19,14 @@ package org.springframework.boot.configurationsample.generic;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Demonstrate properties with a wildcard type.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("wildcard")
+@TestConfigurationProperties("wildcard")
 public class WildcardConfig {
 
 	private Map<String, ? extends Number> stringToNumber;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/DeducedImmutableClassProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/DeducedImmutableClassProperties.java
@@ -16,20 +16,20 @@
 
 package org.springframework.boot.configurationsample.immutable;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.DefaultValue;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestDefaultValue;
 
 /**
  * Inner properties, in immutable format.
  *
  * @author Phillip Webb
  */
-@ConfigurationProperties("test")
+@TestConfigurationProperties("test")
 public class DeducedImmutableClassProperties {
 
 	private final Nested nested;
 
-	public DeducedImmutableClassProperties(@DefaultValue Nested nested) {
+	public DeducedImmutableClassProperties(@TestDefaultValue Nested nested) {
 		this.nested = nested;
 	}
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/ImmutableCollectionProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/ImmutableCollectionProperties.java
@@ -19,7 +19,7 @@ package org.springframework.boot.configurationsample.immutable;
 import java.time.Duration;
 import java.util.List;
 
-import org.springframework.boot.configurationsample.DefaultValue;
+import org.springframework.boot.configurationsample.TestDefaultValue;
 
 /**
  * Simple immutable properties with collections types and defaults.
@@ -35,8 +35,8 @@ public class ImmutableCollectionProperties {
 
 	private final List<Duration> durations;
 
-	public ImmutableCollectionProperties(List<String> names, @DefaultValue({ "true", "false" }) List<Boolean> flags,
-			@DefaultValue({ "10s", "1m", "1h" }) List<Duration> durations) {
+	public ImmutableCollectionProperties(List<String> names, @TestDefaultValue({ "true", "false" }) List<Boolean> flags,
+			@TestDefaultValue({ "10s", "1m", "1h" }) List<Duration> durations) {
 		this.names = names;
 		this.flags = flags;
 		this.durations = durations;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/ImmutableDeducedConstructorBindingProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/ImmutableDeducedConstructorBindingProperties.java
@@ -16,13 +16,13 @@
 
 package org.springframework.boot.configurationsample.immutable;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.DefaultValue;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestDefaultValue;
 
 /**
  * @author Madhura Bhave
  */
-@ConfigurationProperties("immutable")
+@TestConfigurationProperties("immutable")
 public class ImmutableDeducedConstructorBindingProperties {
 
 	/**
@@ -35,7 +35,7 @@ public class ImmutableDeducedConstructorBindingProperties {
 	 */
 	private final boolean flag;
 
-	public ImmutableDeducedConstructorBindingProperties(@DefaultValue("boot") String theName, boolean flag) {
+	public ImmutableDeducedConstructorBindingProperties(@TestDefaultValue("boot") String theName, boolean flag) {
 		this.theName = theName;
 		this.flag = flag;
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/ImmutableInnerClassProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/ImmutableInnerClassProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.immutable;
 
-import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
 import org.springframework.boot.configurationsample.specific.SimplePojo;
 
 /**
@@ -30,7 +30,7 @@ public class ImmutableInnerClassProperties {
 
 	private Foo second;
 
-	@NestedConfigurationProperty
+	@TestNestedConfigurationProperty
 	private final SimplePojo third;
 
 	private final Fourth fourth;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/ImmutableMultiConstructorProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/ImmutableMultiConstructorProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.immutable;
 
-import org.springframework.boot.configurationsample.ConstructorBinding;
+import org.springframework.boot.configurationsample.TestConstructorBinding;
 
 /**
  * Simple immutable properties with several constructors.
@@ -37,7 +37,7 @@ public class ImmutableMultiConstructorProperties {
 		this(name, null);
 	}
 
-	@ConstructorBinding
+	@TestConstructorBinding
 	public ImmutableMultiConstructorProperties(String name, String description) {
 		this.name = name;
 		this.description = description;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/ImmutablePrimitiveWithDefaultsProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/ImmutablePrimitiveWithDefaultsProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.immutable;
 
-import org.springframework.boot.configurationsample.DefaultValue;
+import org.springframework.boot.configurationsample.TestDefaultValue;
 
 /**
  * Simple immutable properties with primitive types and defaults.
@@ -42,10 +42,10 @@ public class ImmutablePrimitiveWithDefaultsProperties {
 
 	private final double ratio;
 
-	public ImmutablePrimitiveWithDefaultsProperties(@DefaultValue("true") boolean flag, @DefaultValue("120") byte octet,
-			@DefaultValue("a") char letter, @DefaultValue("1000") short number, @DefaultValue("42") int counter,
-			@DefaultValue("2000") long value, @DefaultValue("0.5") float percentage,
-			@DefaultValue("42.42") double ratio) {
+	public ImmutablePrimitiveWithDefaultsProperties(@TestDefaultValue("true") boolean flag, @TestDefaultValue("120") byte octet,
+			@TestDefaultValue("a") char letter, @TestDefaultValue("1000") short number, @TestDefaultValue("42") int counter,
+			@TestDefaultValue("2000") long value, @TestDefaultValue("0.5") float percentage,
+			@TestDefaultValue("42.42") double ratio) {
 		this.flag = flag;
 		this.octet = octet;
 		this.letter = letter;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/ImmutablePrimitiveWrapperWithDefaultsProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/ImmutablePrimitiveWrapperWithDefaultsProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.immutable;
 
-import org.springframework.boot.configurationsample.DefaultValue;
+import org.springframework.boot.configurationsample.TestDefaultValue;
 
 /**
  * Simple immutable properties with primitive wrapper types and defaults.
@@ -42,10 +42,10 @@ public class ImmutablePrimitiveWrapperWithDefaultsProperties {
 
 	private final Double ratio;
 
-	public ImmutablePrimitiveWrapperWithDefaultsProperties(@DefaultValue("true") Boolean flag,
-			@DefaultValue("120") Byte octet, @DefaultValue("a") Character letter, @DefaultValue("1000") Short number,
-			@DefaultValue("42") Integer counter, @DefaultValue("2000") Long value,
-			@DefaultValue("0.5") Float percentage, @DefaultValue("42.42") Double ratio) {
+	public ImmutablePrimitiveWrapperWithDefaultsProperties(@TestDefaultValue("true") Boolean flag,
+			@TestDefaultValue("120") Byte octet, @TestDefaultValue("a") Character letter, @TestDefaultValue("1000") Short number,
+			@TestDefaultValue("42") Integer counter, @TestDefaultValue("2000") Long value,
+			@TestDefaultValue("0.5") Float percentage, @TestDefaultValue("42.42") Double ratio) {
 		this.flag = flag;
 		this.octet = octet;
 		this.letter = letter;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/ImmutableSimpleProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/immutable/ImmutableSimpleProperties.java
@@ -18,16 +18,16 @@ package org.springframework.boot.configurationsample.immutable;
 
 import java.util.Comparator;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.ConstructorBinding;
-import org.springframework.boot.configurationsample.DefaultValue;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConstructorBinding;
+import org.springframework.boot.configurationsample.TestDefaultValue;
 
 /**
  * Simple properties, in immutable format.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("immutable")
+@TestConfigurationProperties("immutable")
 public class ImmutableSimpleProperties {
 
 	/**
@@ -48,8 +48,8 @@ public class ImmutableSimpleProperties {
 	@SuppressWarnings("unused")
 	private final Long counter;
 
-	@ConstructorBinding
-	public ImmutableSimpleProperties(@DefaultValue("boot") String theName, boolean flag, Comparator<?> comparator,
+	@TestConstructorBinding
+	public ImmutableSimpleProperties(@TestDefaultValue("boot") String theName, boolean flag, Comparator<?> comparator,
 			Long counter) {
 		this.theName = theName;
 		this.flag = flag;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/incremental/BarProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/incremental/BarProperties.java
@@ -16,9 +16,9 @@
 
 package org.springframework.boot.configurationsample.incremental;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
-@ConfigurationProperties("bar")
+@TestConfigurationProperties("bar")
 public class BarProperties {
 
 	private String name;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/incremental/FooProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/incremental/FooProperties.java
@@ -16,9 +16,9 @@
 
 package org.springframework.boot.configurationsample.incremental;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
-@ConfigurationProperties("foo")
+@TestConfigurationProperties("foo")
 public class FooProperties {
 
 	private String name;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/incremental/RenamedBarProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/incremental/RenamedBarProperties.java
@@ -16,9 +16,9 @@
 
 package org.springframework.boot.configurationsample.incremental;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
-@ConfigurationProperties("bar")
+@TestConfigurationProperties("bar")
 public class RenamedBarProperties {
 
 	private String name;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/inheritance/ChildPropertiesConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/inheritance/ChildPropertiesConfig.java
@@ -16,11 +16,11 @@
 
 package org.springframework.boot.configurationsample.inheritance;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 public class ChildPropertiesConfig {
 
-	@ConfigurationProperties("inheritance")
+	@TestConfigurationProperties("inheritance")
 	public ChildProperties childConfig() {
 		return new ChildProperties();
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/inheritance/OverrideChildPropertiesConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/inheritance/OverrideChildPropertiesConfig.java
@@ -16,11 +16,11 @@
 
 package org.springframework.boot.configurationsample.inheritance;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 public class OverrideChildPropertiesConfig {
 
-	@ConfigurationProperties("inheritance")
+	@TestConfigurationProperties("inheritance")
 	public OverrideChildProperties overrideChildProperties() {
 		return new OverrideChildProperties();
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokAccessLevelOverwriteDataProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokAccessLevelOverwriteDataProperties.java
@@ -21,7 +21,7 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Configuration properties using Lombok @Data on element level and overwriting behaviour
@@ -30,7 +30,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  * @author Jonas Keßler
  */
 @Data
-@ConfigurationProperties("accesslevel.overwrite.data")
+@TestConfigurationProperties("accesslevel.overwrite.data")
 @SuppressWarnings("unused")
 public class LombokAccessLevelOverwriteDataProperties {
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokAccessLevelOverwriteDefaultProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokAccessLevelOverwriteDefaultProperties.java
@@ -20,7 +20,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Configuration properties using lombok @Getter and @Setter without explicitly defining
@@ -30,7 +30,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  */
 @Getter
 @Setter
-@ConfigurationProperties("accesslevel.overwrite.default")
+@TestConfigurationProperties("accesslevel.overwrite.default")
 public class LombokAccessLevelOverwriteDefaultProperties {
 
 	@SuppressWarnings("unused")

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokAccessLevelOverwriteExplicitProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokAccessLevelOverwriteExplicitProperties.java
@@ -20,7 +20,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Configuration properties using lombok @Getter and @Setter with explicitly defining
@@ -30,7 +30,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  */
 @Getter(AccessLevel.PUBLIC)
 @Setter(AccessLevel.PUBLIC)
-@ConfigurationProperties("accesslevel.overwrite.explicit")
+@TestConfigurationProperties("accesslevel.overwrite.explicit")
 @SuppressWarnings("unused")
 public class LombokAccessLevelOverwriteExplicitProperties {
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokAccessLevelProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokAccessLevelProperties.java
@@ -20,14 +20,14 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Configuration properties without lombok annotations at element level.
  *
  * @author Jonas Keßler
  */
-@ConfigurationProperties("accesslevel")
+@TestConfigurationProperties("accesslevel")
 public class LombokAccessLevelProperties {
 
 	@Getter(AccessLevel.PUBLIC)

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokDefaultValueProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokDefaultValueProperties.java
@@ -18,7 +18,7 @@ package org.springframework.boot.configurationsample.lombok;
 
 import lombok.Data;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Configuration properties with default values.
@@ -26,7 +26,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  * @author Stephane Nicoll
  */
 @Data
-@ConfigurationProperties("default")
+@TestConfigurationProperties("default")
 @SuppressWarnings("unused")
 public class LombokDefaultValueProperties {
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokDeprecatedProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokDeprecatedProperties.java
@@ -19,7 +19,7 @@ package org.springframework.boot.configurationsample.lombok;
 import lombok.Getter;
 import lombok.Setter;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Deprecated configuration properties.
@@ -29,7 +29,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  */
 @Getter
 @Setter
-@ConfigurationProperties("deprecated")
+@TestConfigurationProperties("deprecated")
 @Deprecated
 @SuppressWarnings("unused")
 public class LombokDeprecatedProperties {

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokDeprecatedSingleProperty.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokDeprecatedSingleProperty.java
@@ -18,7 +18,7 @@ package org.springframework.boot.configurationsample.lombok;
 
 import lombok.Data;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Configuration properties with a single deprecated element.
@@ -26,7 +26,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  * @author Stephane Nicoll
  */
 @Data
-@ConfigurationProperties("singledeprecated")
+@TestConfigurationProperties("singledeprecated")
 @SuppressWarnings("unused")
 public class LombokDeprecatedSingleProperty {
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokExplicitProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokExplicitProperties.java
@@ -22,14 +22,14 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Configuration properties using lombok @Getter/@Setter at field level.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("explicit")
+@TestConfigurationProperties("explicit")
 public class LombokExplicitProperties {
 
 	@Getter

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokInnerClassProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokInnerClassProperties.java
@@ -18,8 +18,8 @@ package org.springframework.boot.configurationsample.lombok;
 
 import lombok.Data;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
 
 /**
  * Demonstrate the auto-detection of inner config classes using Lombok.
@@ -27,7 +27,7 @@ import org.springframework.boot.configurationsample.NestedConfigurationProperty;
  * @author Stephane Nicoll
  */
 @Data
-@ConfigurationProperties("config")
+@TestConfigurationProperties("config")
 @SuppressWarnings("unused")
 public class LombokInnerClassProperties {
 
@@ -35,7 +35,7 @@ public class LombokInnerClassProperties {
 
 	private Foo second = new Foo();
 
-	@NestedConfigurationProperty
+	@TestNestedConfigurationProperty
 	private final SimpleLombokPojo third = new SimpleLombokPojo();
 
 	private Fourth fourth;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokInnerClassWithGetterProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokInnerClassWithGetterProperties.java
@@ -18,10 +18,10 @@ package org.springframework.boot.configurationsample.lombok;
 
 import lombok.Data;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 @Data
-@ConfigurationProperties("config")
+@TestConfigurationProperties("config")
 @SuppressWarnings("unused")
 public class LombokInnerClassWithGetterProperties {
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokSimpleDataProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokSimpleDataProperties.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import lombok.Data;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Configuration properties using lombok @Data.
@@ -29,7 +29,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  * @author Stephane Nicoll
  */
 @Data
-@ConfigurationProperties("data")
+@TestConfigurationProperties("data")
 @SuppressWarnings("unused")
 public class LombokSimpleDataProperties {
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokSimpleProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokSimpleProperties.java
@@ -22,7 +22,7 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Configuration properties using lombok @Getter/@Setter at class level.
@@ -31,7 +31,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  */
 @Getter
 @Setter
-@ConfigurationProperties("simple")
+@TestConfigurationProperties("simple")
 @SuppressWarnings("unused")
 public class LombokSimpleProperties {
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokSimpleValueProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokSimpleValueProperties.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import lombok.Value;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Configuration properties using Lombok {@code @Value}.
@@ -29,7 +29,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  * @author Mark Jeffrey
  */
 @Value
-@ConfigurationProperties("value")
+@TestConfigurationProperties("value")
 @SuppressWarnings("unused")
 public class LombokSimpleValueProperties {
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/DeprecatedClassMethodConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/DeprecatedClassMethodConfig.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.method;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Sample for testing method configuration with deprecated class.
@@ -27,7 +27,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
 @Deprecated
 public class DeprecatedClassMethodConfig {
 
-	@ConfigurationProperties("foo")
+	@TestConfigurationProperties("foo")
 	public Foo foo() {
 		return new Foo();
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/DeprecatedMethodConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/DeprecatedMethodConfig.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.method;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Sample for testing deprecated method configuration.
@@ -25,7 +25,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  */
 public class DeprecatedMethodConfig {
 
-	@ConfigurationProperties("foo")
+	@TestConfigurationProperties("foo")
 	@Deprecated
 	public Foo foo() {
 		return new Foo();

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/EmptyTypeMethodConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/EmptyTypeMethodConfig.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.method;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Sample for testing method configuration.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("something")
+@TestConfigurationProperties("something")
 public class EmptyTypeMethodConfig {
 
 	private String name;
@@ -36,7 +36,7 @@ public class EmptyTypeMethodConfig {
 		this.name = name;
 	}
 
-	@ConfigurationProperties("something")
+	@TestConfigurationProperties("something")
 	public Foo foo() {
 		return new Foo();
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/InvalidMethodConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/InvalidMethodConfig.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.method;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Sample for testing invalid method configuration.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("something")
+@TestConfigurationProperties("something")
 public class InvalidMethodConfig {
 
 	private String name;
@@ -36,7 +36,7 @@ public class InvalidMethodConfig {
 		this.name = name;
 	}
 
-	@ConfigurationProperties("invalid")
+	@TestConfigurationProperties("invalid")
 	InvalidMethodConfig foo() {
 		return new InvalidMethodConfig();
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/MethodAndClassConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/MethodAndClassConfig.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.method;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Sample for testing mixed method and class configuration.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("conflict")
+@TestConfigurationProperties("conflict")
 public class MethodAndClassConfig {
 
 	private String value;
@@ -36,7 +36,7 @@ public class MethodAndClassConfig {
 		this.value = value;
 	}
 
-	@ConfigurationProperties("conflict")
+	@TestConfigurationProperties("conflict")
 	public Foo foo() {
 		return new Foo();
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/NestedPropertiesMethod.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/NestedPropertiesMethod.java
@@ -16,10 +16,10 @@
 
 package org.springframework.boot.configurationsample.method;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
 
-@ConfigurationProperties("method-nested")
+@TestConfigurationProperties("method-nested")
 public class NestedPropertiesMethod {
 
 	private String myProperty;
@@ -36,7 +36,7 @@ public class NestedPropertiesMethod {
 		this.myProperty = myProperty;
 	}
 
-	@NestedConfigurationProperty
+	@TestNestedConfigurationProperty
 	public NestedProperty getNested() {
 		return this.nested;
 	}
@@ -59,7 +59,7 @@ public class NestedPropertiesMethod {
 			this.myInnerProperty = myInnerProperty;
 		}
 
-		@NestedConfigurationProperty
+		@TestNestedConfigurationProperty
 		public NestedProperty getNested() {
 			return this.nested;
 		}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/PackagePrivateMethodConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/PackagePrivateMethodConfig.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.method;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Sample for testing package-private method configuration.
@@ -25,7 +25,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  */
 public class PackagePrivateMethodConfig {
 
-	@ConfigurationProperties("foo")
+	@TestConfigurationProperties("foo")
 	Foo foo() {
 		return new Foo();
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/PrivateMethodConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/PrivateMethodConfig.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.method;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Sample for testing private method configuration.
@@ -25,7 +25,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  */
 public class PrivateMethodConfig {
 
-	@ConfigurationProperties("foo")
+	@TestConfigurationProperties("foo")
 	private Foo foo() {
 		return new Foo();
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/ProtectedMethodConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/ProtectedMethodConfig.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.method;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Sample for testing protected method configuration.
@@ -25,7 +25,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  */
 public class ProtectedMethodConfig {
 
-	@ConfigurationProperties("foo")
+	@TestConfigurationProperties("foo")
 	protected Foo foo() {
 		return new Foo();
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/PublicMethodConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/PublicMethodConfig.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.method;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Sample for testing public method configuration.
@@ -25,7 +25,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  */
 public class PublicMethodConfig {
 
-	@ConfigurationProperties("foo")
+	@TestConfigurationProperties("foo")
 	public Foo foo() {
 		return new Foo();
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/SingleConstructorMethodConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/method/SingleConstructorMethodConfig.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.method;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Sample for testing method configuration that uses a constructor that should not be
@@ -27,7 +27,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
 @SuppressWarnings("unused")
 public class SingleConstructorMethodConfig {
 
-	@ConfigurationProperties("foo")
+	@TestConfigurationProperties("foo")
 	public Foo foo() {
 		return new Foo(new Object());
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/name/ConstructorParameterNameAnnotationProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/name/ConstructorParameterNameAnnotationProperties.java
@@ -16,9 +16,9 @@
 
 package org.springframework.boot.configurationsample.name;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.DefaultValue;
-import org.springframework.boot.configurationsample.Name;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestDefaultValue;
+import org.springframework.boot.configurationsample.TestName;
 
 /**
  * Constructor properties making use of {@code @Name}.
@@ -26,7 +26,7 @@ import org.springframework.boot.configurationsample.Name;
  * @author Phillip Webb
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("named")
+@TestConfigurationProperties("named")
 public class ConstructorParameterNameAnnotationProperties {
 
 	/**
@@ -39,8 +39,8 @@ public class ConstructorParameterNameAnnotationProperties {
 	 */
 	private final boolean defaultValue;
 
-	public ConstructorParameterNameAnnotationProperties(@Name("import") String imports,
-			@Name("default") @DefaultValue("true") boolean defaultValue) {
+	public ConstructorParameterNameAnnotationProperties(@TestName("import") String imports,
+			@TestName("default") @TestDefaultValue("true") boolean defaultValue) {
 		this.imports = imports;
 		this.defaultValue = defaultValue;
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/name/JavaBeanNameAnnotationProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/name/JavaBeanNameAnnotationProperties.java
@@ -16,8 +16,8 @@
 
 package org.springframework.boot.configurationsample.name;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.Name;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestName;
 
 /**
  * Java bean properties making use of {@code @Name}.
@@ -25,19 +25,19 @@ import org.springframework.boot.configurationsample.Name;
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("named")
+@TestConfigurationProperties("named")
 public class JavaBeanNameAnnotationProperties {
 
 	/**
 	 * Imports to apply.
 	 */
-	@Name("import")
+	@TestName("import")
 	private String imports;
 
 	/**
 	 * Whether default mode is enabled.
 	 */
-	@Name("default")
+	@TestName("default")
 	private boolean defaultValue = true;
 
 	public String getImports() {

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/name/LombokNameAnnotationProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/name/LombokNameAnnotationProperties.java
@@ -19,8 +19,8 @@ package org.springframework.boot.configurationsample.name;
 import lombok.Getter;
 import lombok.Setter;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.Name;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestName;
 
 /**
  * Lombok properties making use of {@code @Name}.
@@ -29,19 +29,19 @@ import org.springframework.boot.configurationsample.Name;
  */
 @Getter
 @Setter
-@ConfigurationProperties("named")
+@TestConfigurationProperties("named")
 public class LombokNameAnnotationProperties {
 
 	/**
 	 * Imports to apply.
 	 */
-	@Name("import")
+	@TestName("import")
 	private String imports;
 
 	/**
 	 * Whether default mode is enabled.
 	 */
-	@Name("default")
+	@TestName("default")
 	private boolean defaultValue = true;
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/name/RecordComponentNameAnnotationProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/name/RecordComponentNameAnnotationProperties.java
@@ -16,9 +16,9 @@
 
 package org.springframework.boot.configurationsample.name;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.DefaultValue;
-import org.springframework.boot.configurationsample.Name;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestDefaultValue;
+import org.springframework.boot.configurationsample.TestName;
 
 /**
  * Record properties making use of {@code @Name}.
@@ -28,8 +28,8 @@ import org.springframework.boot.configurationsample.Name;
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("named")
-public record RecordComponentNameAnnotationProperties(@Name("import") String imports,
-		@Name("default") @DefaultValue("true") boolean defaultValue) {
+@TestConfigurationProperties("named")
+public record RecordComponentNameAnnotationProperties(@TestName("import") String imports,
+		@TestName("default") @TestDefaultValue("true") boolean defaultValue) {
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/record/ExampleRecord.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/record/ExampleRecord.java
@@ -16,7 +16,8 @@
 
 package org.springframework.boot.configurationsample.record;
 
-import org.springframework.boot.configurationsample.Name;
+import org.springframework.boot.configurationsample.TestName;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Example Record Javadoc sample
@@ -30,7 +31,7 @@ import org.springframework.boot.configurationsample.Name;
  * @since 1.0.0
  * @author Pavel Anisimov
  */
-@org.springframework.boot.configurationsample.ConfigurationProperties("record.descriptions")
+@TestConfigurationProperties("record.descriptions")
 public record ExampleRecord(String someString, Integer someInteger, Boolean someBoolean, Long someLong,
-		@Name("named.record.component") String namedComponent, Byte someByte) {
+							@TestName("named.record.component") String namedComponent, Byte someByte) {
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/record/NestedPropertiesRecord.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/record/NestedPropertiesRecord.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.record;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
 
-@ConfigurationProperties("record-nested")
-public record NestedPropertiesRecord(String myProperty, @NestedConfigurationProperty NestedRecord nested,
+@TestConfigurationProperties("record-nested")
+public record NestedPropertiesRecord(String myProperty, @TestNestedConfigurationProperty NestedRecord nested,
 		InnerPropertiesRecord inner) {
 
-	public record InnerPropertiesRecord(String myInnerProperty, @NestedConfigurationProperty NestedRecord nested) {
+	public record InnerPropertiesRecord(String myInnerProperty, @TestNestedConfigurationProperty NestedRecord nested) {
 	}
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/record/RecordWithGetter.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/record/RecordWithGetter.java
@@ -16,9 +16,9 @@
 
 package org.springframework.boot.configurationsample.record;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
-@ConfigurationProperties("record-with-getter")
+@TestConfigurationProperties("record-with-getter")
 public record RecordWithGetter(String alpha) {
 
 	public String getBravo() {

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/recursive/RecursiveProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/recursive/RecursiveProperties.java
@@ -16,9 +16,9 @@
 
 package org.springframework.boot.configurationsample.recursive;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
-@ConfigurationProperties("prefix")
+@TestConfigurationProperties("prefix")
 public class RecursiveProperties {
 
 	private RecursiveProperties recursive;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/AutowiredProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/AutowiredProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.simple;
 
-import org.springframework.boot.configurationsample.Autowired;
+import org.springframework.boot.configurationsample.TestAutowired;
 
 /**
  * Properties with autowired constructor.
@@ -30,7 +30,7 @@ public class AutowiredProperties {
 	 */
 	private String theName;
 
-	@Autowired
+	@TestAutowired
 	public AutowiredProperties(String theName) {
 		this.theName = theName;
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/ClassWithNestedProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/ClassWithNestedProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.simple;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Class with nested configuration properties.
@@ -39,7 +39,7 @@ public class ClassWithNestedProperties {
 
 	}
 
-	@ConfigurationProperties("nestedChildProps")
+	@TestConfigurationProperties("nestedChildProps")
 	public static class NestedChildClass extends NestedParentClass {
 
 		private int childClassProperty = 20;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/DeprecatedFieldSingleProperty.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/DeprecatedFieldSingleProperty.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.simple;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Configuration properties with a single deprecated element.
  *
  * @author Andy Wilkinson
  */
-@ConfigurationProperties("singlefielddeprecated")
+@TestConfigurationProperties("singlefielddeprecated")
 public class DeprecatedFieldSingleProperty {
 
 	@Deprecated

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/DeprecatedProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/DeprecatedProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.simple;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Deprecated configuration properties.
@@ -25,7 +25,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  * @deprecated deprecated
  */
 @Deprecated
-@ConfigurationProperties("deprecated")
+@TestConfigurationProperties("deprecated")
 public class DeprecatedProperties {
 
 	private String name;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/DeprecatedRecord.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/DeprecatedRecord.java
@@ -16,9 +16,9 @@
 
 package org.springframework.boot.configurationsample.simple;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.DeprecatedConfigurationProperty;
-import org.springframework.boot.configurationsample.Name;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestDeprecatedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestName;
 
 /**
  * Configuration properties as record with deprecated property.
@@ -28,17 +28,17 @@ import org.springframework.boot.configurationsample.Name;
  * @param charlie charlie property, named, deprecated
  * @author Moritz Halbritter
  */
-@ConfigurationProperties("deprecated-record")
-public record DeprecatedRecord(String alpha, String bravo, @Name("named.charlie") String charlie) {
+@TestConfigurationProperties("deprecated-record")
+public record DeprecatedRecord(String alpha, String bravo, @TestName("named.charlie") String charlie) {
 
 	@Deprecated
-	@DeprecatedConfigurationProperty(reason = "some-reason")
+	@TestDeprecatedConfigurationProperty(reason = "some-reason")
 	public String alpha() {
 		return this.alpha;
 	}
 
 	@Deprecated
-	@DeprecatedConfigurationProperty(reason = "another-reason")
+	@TestDeprecatedConfigurationProperty(reason = "another-reason")
 	public String charlie() {
 		return this.charlie;
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/DeprecatedSingleProperty.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/DeprecatedSingleProperty.java
@@ -16,21 +16,21 @@
 
 package org.springframework.boot.configurationsample.simple;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.DeprecatedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestDeprecatedConfigurationProperty;
 
 /**
  * Configuration properties with a single deprecated element.
  *
  * @author Phillip Webb
  */
-@ConfigurationProperties("singledeprecated")
+@TestConfigurationProperties("singledeprecated")
 public class DeprecatedSingleProperty {
 
 	private String newName;
 
 	@Deprecated
-	@DeprecatedConfigurationProperty(reason = "renamed", replacement = "singledeprecated.new-name", since = "1.2.3")
+	@TestDeprecatedConfigurationProperty(reason = "renamed", replacement = "singledeprecated.new-name", since = "1.2.3")
 	public String getName() {
 		return getNewName();
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/DescriptionProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/DescriptionProperties.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.simple;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Configuration properties with various description styles.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("description")
+@TestConfigurationProperties("description")
 public class DescriptionProperties {
 
 	/**

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/HierarchicalProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/HierarchicalProperties.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.simple;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Configuration properties with inherited values.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("hierarchical")
+@TestConfigurationProperties("hierarchical")
 public class HierarchicalProperties extends HierarchicalPropertiesParent {
 
 	/**

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/IgnoredProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/IgnoredProperties.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.simple;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Configuration properties where some of them are being ignored.
  *
  * @author Moritz Halbritter
  */
-@ConfigurationProperties("ignored")
+@TestConfigurationProperties("ignored")
 public class IgnoredProperties {
 
 	private String prop1;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/InnerClassWithPrivateConstructor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/InnerClassWithPrivateConstructor.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.simple;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Nested properties with a private constructor.
  *
  * @author Phillip Webb
  */
-@ConfigurationProperties("config")
+@TestConfigurationProperties("config")
 public class InnerClassWithPrivateConstructor {
 
 	private Nested nested = new Nested("whatever");

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/SimpleArrayProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/SimpleArrayProperties.java
@@ -18,14 +18,14 @@ package org.springframework.boot.configurationsample.simple;
 
 import java.util.Map;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Properties with array.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("array")
+@TestConfigurationProperties("array")
 public class SimpleArrayProperties {
 
 	private int[] primitive;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/SimpleCollectionProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/SimpleCollectionProperties.java
@@ -23,14 +23,14 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Properties with collections.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("collection")
+@TestConfigurationProperties("collection")
 public class SimpleCollectionProperties {
 
 	private Map<Integer, String> integersToNames;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/SimplePrefixValueProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/SimplePrefixValueProperties.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.simple;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Properties with a simple prefix.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("simple")
+@TestConfigurationProperties("simple")
 public class SimplePrefixValueProperties {
 
 	private String name;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/SimpleProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/SimpleProperties.java
@@ -19,14 +19,14 @@ package org.springframework.boot.configurationsample.simple;
 import java.beans.FeatureDescriptor;
 import java.util.Comparator;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Simple properties.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("simple")
+@TestConfigurationProperties("simple")
 public class SimpleProperties {
 
 	/**

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/SimpleTypeProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/simple/SimpleTypeProperties.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.simple;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Expose simple types to make sure these are detected properly.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("simple.type")
+@TestConfigurationProperties("simple.type")
 public class SimpleTypeProperties {
 
 	private String myString;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/ConcreteProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/ConcreteProperties.java
@@ -16,9 +16,9 @@
 
 package org.springframework.boot.configurationsample.source;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
-@ConfigurationProperties("example")
+@TestConfigurationProperties("example")
 public class ConcreteProperties extends BaseSource {
 
 	/**

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/ConcreteSourceAnnotated.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/ConcreteSourceAnnotated.java
@@ -16,13 +16,13 @@
 
 package org.springframework.boot.configurationsample.source;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
 
-@ConfigurationProperties("example")
+@TestConfigurationProperties("example")
 public class ConcreteSourceAnnotated {
 
-	@NestedConfigurationProperty
+	@TestNestedConfigurationProperty
 	private final ConcreteSource nested = new ConcreteSource();
 
 	public ConcreteSource getNested() {

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/ConventionSourceAnnotated.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/ConventionSourceAnnotated.java
@@ -16,13 +16,13 @@
 
 package org.springframework.boot.configurationsample.source;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
 
-@ConfigurationProperties(prefix = "example")
+@TestConfigurationProperties(prefix = "example")
 public class ConventionSourceAnnotated {
 
-	@NestedConfigurationProperty
+	@TestNestedConfigurationProperty
 	private final ConventionSource nested = new ConventionSource();
 
 	public ConventionSource getNested() {

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/ImmutableSourceAnnotated.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/ImmutableSourceAnnotated.java
@@ -16,13 +16,13 @@
 
 package org.springframework.boot.configurationsample.source;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
 
-@ConfigurationProperties("example")
+@TestConfigurationProperties("example")
 public class ImmutableSourceAnnotated {
 
-	@NestedConfigurationProperty
+	@TestNestedConfigurationProperty
 	private final ImmutableSource nested;
 
 	public ImmutableSourceAnnotated(ImmutableSource nested) {

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/LombokSourceAnnotated.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/LombokSourceAnnotated.java
@@ -18,14 +18,14 @@ package org.springframework.boot.configurationsample.source;
 
 import lombok.Getter;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
 
 @Getter
-@ConfigurationProperties("example")
+@TestConfigurationProperties("example")
 public class LombokSourceAnnotated {
 
-	@NestedConfigurationProperty
+	@TestNestedConfigurationProperty
 	private final LombokSource nested = new LombokSource();
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/ParentWithHintProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/ParentWithHintProperties.java
@@ -16,9 +16,9 @@
 
 package org.springframework.boot.configurationsample.source;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
-@ConfigurationProperties("example")
+@TestConfigurationProperties("example")
 public class ParentWithHintProperties extends SimpleSource {
 
 	/**

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/RecordSourceAnnotated.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/RecordSourceAnnotated.java
@@ -16,10 +16,10 @@
 
 package org.springframework.boot.configurationsample.source;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
 
-@ConfigurationProperties("example")
-public record RecordSourceAnnotated(@NestedConfigurationProperty RecordSource nested) {
+@TestConfigurationProperties("example")
+public record RecordSourceAnnotated(@TestNestedConfigurationProperty RecordSource nested) {
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/SimpleSourceAnnotated.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/SimpleSourceAnnotated.java
@@ -16,13 +16,13 @@
 
 package org.springframework.boot.configurationsample.source;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
 
-@ConfigurationProperties("example")
+@TestConfigurationProperties("example")
 public class SimpleSourceAnnotated {
 
-	@NestedConfigurationProperty
+	@TestNestedConfigurationProperty
 	private final SimpleSource nested = new SimpleSource();
 
 	public SimpleSource getNested() {

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/generation/AbstractPropertiesSource.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/generation/AbstractPropertiesSource.java
@@ -16,9 +16,9 @@
 
 package org.springframework.boot.configurationsample.source.generation;
 
-import org.springframework.boot.configurationsample.ConfigurationPropertiesSource;
+import org.springframework.boot.configurationsample.TestConfigurationPropertiesSource;
 
-@ConfigurationPropertiesSource
+@TestConfigurationPropertiesSource
 public abstract class AbstractPropertiesSource {
 
 	/**

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/generation/ConfigurationPropertySourcesContainer.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/generation/ConfigurationPropertySourcesContainer.java
@@ -16,11 +16,11 @@
 
 package org.springframework.boot.configurationsample.source.generation;
 
-import org.springframework.boot.configurationsample.ConfigurationPropertiesSource;
+import org.springframework.boot.configurationsample.TestConfigurationPropertiesSource;
 
 public class ConfigurationPropertySourcesContainer {
 
-	@ConfigurationPropertiesSource
+	@TestConfigurationPropertiesSource
 	public static class First {
 
 		/**
@@ -38,7 +38,7 @@ public class ConfigurationPropertySourcesContainer {
 
 	}
 
-	@ConfigurationPropertiesSource
+	@TestConfigurationPropertiesSource
 	public static class Second {
 
 		/**

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/generation/ImmutablePropertiesSource.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/generation/ImmutablePropertiesSource.java
@@ -16,10 +16,10 @@
 
 package org.springframework.boot.configurationsample.source.generation;
 
-import org.springframework.boot.configurationsample.ConfigurationPropertiesSource;
-import org.springframework.boot.configurationsample.DefaultValue;
+import org.springframework.boot.configurationsample.TestConfigurationPropertiesSource;
+import org.springframework.boot.configurationsample.TestDefaultValue;
 
-@ConfigurationPropertiesSource
+@TestConfigurationPropertiesSource
 public class ImmutablePropertiesSource {
 
 	/**
@@ -34,7 +34,7 @@ public class ImmutablePropertiesSource {
 	@SuppressWarnings("unused")
 	private final boolean enabled;
 
-	public ImmutablePropertiesSource(@DefaultValue("boot") String name, boolean enabled) {
+	public ImmutablePropertiesSource(@TestDefaultValue("boot") String name, boolean enabled) {
 		this.name = name;
 		this.enabled = enabled;
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/generation/LombokPropertiesSource.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/generation/LombokPropertiesSource.java
@@ -19,11 +19,11 @@ package org.springframework.boot.configurationsample.source.generation;
 import lombok.Getter;
 import lombok.Setter;
 
-import org.springframework.boot.configurationsample.ConfigurationPropertiesSource;
+import org.springframework.boot.configurationsample.TestConfigurationPropertiesSource;
 
 @Getter
 @Setter
-@ConfigurationPropertiesSource
+@TestConfigurationPropertiesSource
 public class LombokPropertiesSource {
 
 	/**

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/generation/NestedPropertiesSource.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/generation/NestedPropertiesSource.java
@@ -16,9 +16,9 @@
 
 package org.springframework.boot.configurationsample.source.generation;
 
-import org.springframework.boot.configurationsample.ConfigurationPropertiesSource;
+import org.springframework.boot.configurationsample.TestConfigurationPropertiesSource;
 
-@ConfigurationPropertiesSource
+@TestConfigurationPropertiesSource
 public class NestedPropertiesSource {
 
 	/**

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/generation/RecordPropertiesSources.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/generation/RecordPropertiesSources.java
@@ -16,8 +16,8 @@
 
 package org.springframework.boot.configurationsample.source.generation;
 
-import org.springframework.boot.configurationsample.ConfigurationPropertiesSource;
-import org.springframework.boot.configurationsample.DefaultValue;
+import org.springframework.boot.configurationsample.TestConfigurationPropertiesSource;
+import org.springframework.boot.configurationsample.TestDefaultValue;
 
 /**
  * Sample record properties source.
@@ -26,6 +26,6 @@ import org.springframework.boot.configurationsample.DefaultValue;
  * @param enabled Whether it is enabled.
  * @author Stephane Nicoll
  */
-@ConfigurationPropertiesSource
-public record RecordPropertiesSources(@DefaultValue("boot") String name, boolean enabled) {
+@TestConfigurationPropertiesSource
+public record RecordPropertiesSources(@TestDefaultValue("boot") String name, boolean enabled) {
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/generation/SimplePropertiesSource.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/source/generation/SimplePropertiesSource.java
@@ -16,9 +16,9 @@
 
 package org.springframework.boot.configurationsample.source.generation;
 
-import org.springframework.boot.configurationsample.ConfigurationPropertiesSource;
+import org.springframework.boot.configurationsample.TestConfigurationPropertiesSource;
 
-@ConfigurationPropertiesSource
+@TestConfigurationPropertiesSource
 public class SimplePropertiesSource {
 
 	/**

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/AnnotatedGetter.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/AnnotatedGetter.java
@@ -18,7 +18,7 @@ package org.springframework.boot.configurationsample.specific;
 
 import jakarta.validation.constraints.NotEmpty;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * An annotated getter with {@code NotEmpty} that triggers a different class type in the
@@ -26,7 +26,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("specific")
+@TestConfigurationProperties("specific")
 public class AnnotatedGetter {
 
 	private String name;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/BoxingPojo.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/BoxingPojo.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Demonstrate the use of boxing/unboxing. Even if the type does not strictly match, it
@@ -24,7 +24,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("boxing")
+@TestConfigurationProperties("boxing")
 public class BoxingPojo {
 
 	private boolean flag;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/BuilderPojo.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/BuilderPojo.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Sample with builder style setters.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("builder")
+@TestConfigurationProperties("builder")
 public class BuilderPojo {
 
 	private String name;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/DeprecatedLessPreciseTypePojo.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/DeprecatedLessPreciseTypePojo.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Demonstrate that deprecating accessor with not the same type is not taken into account
@@ -24,7 +24,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("not.deprecated")
+@TestConfigurationProperties("not.deprecated")
 public class DeprecatedLessPreciseTypePojo {
 
 	private boolean flag;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/DeprecatedUnrelatedMethodPojo.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/DeprecatedUnrelatedMethodPojo.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Demonstrate that an unrelated setter is not taken into account to detect the deprecated
@@ -24,7 +24,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("not.deprecated")
+@TestConfigurationProperties("not.deprecated")
 public class DeprecatedUnrelatedMethodPojo {
 
 	private Integer counter;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/DoubleRegistrationProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/DoubleRegistrationProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Test that the same type can be registered several times if the prefix is different.
@@ -25,12 +25,12 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  */
 public class DoubleRegistrationProperties {
 
-	@ConfigurationProperties("one")
+	@TestConfigurationProperties("one")
 	public SimplePojo one() {
 		return new SimplePojo();
 	}
 
-	@ConfigurationProperties("two")
+	@TestConfigurationProperties("two")
 	public SimplePojo two() {
 		return new SimplePojo();
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/EmptyDefaultValueProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/EmptyDefaultValueProperties.java
@@ -16,22 +16,22 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.ConstructorBinding;
-import org.springframework.boot.configurationsample.DefaultValue;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConstructorBinding;
+import org.springframework.boot.configurationsample.TestDefaultValue;
 
 /**
  * Demonstrates that an empty default value on a property leads to no default value.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("test")
+@TestConfigurationProperties("test")
 public class EmptyDefaultValueProperties {
 
 	private final String name;
 
-	@ConstructorBinding
-	public EmptyDefaultValueProperties(@DefaultValue String name) {
+	@TestConstructorBinding
+	public EmptyDefaultValueProperties(@TestDefaultValue String name) {
 		this.name = name;
 	}
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/EnumValuesPojo.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/EnumValuesPojo.java
@@ -19,14 +19,14 @@ package org.springframework.boot.configurationsample.specific;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Sample config for enum and default values.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("test")
+@TestConfigurationProperties("test")
 public class EnumValuesPojo {
 
 	private ChronoUnit seconds = ChronoUnit.SECONDS;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/ExcludedTypesPojo.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/ExcludedTypesPojo.java
@@ -21,7 +21,7 @@ import java.io.Writer;
 
 import javax.sql.DataSource;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Sample config with types that should not be added to the meta-data as we have no way to
@@ -29,7 +29,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("excluded")
+@TestConfigurationProperties("excluded")
 public class ExcludedTypesPojo {
 
 	private String name;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InnerClassAnnotatedGetterConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InnerClassAnnotatedGetterConfig.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Demonstrate that a method that exposes a root group within an annotated class is
@@ -24,7 +24,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("specific")
+@TestConfigurationProperties("specific")
 public class InnerClassAnnotatedGetterConfig {
 
 	private String value;
@@ -37,7 +37,7 @@ public class InnerClassAnnotatedGetterConfig {
 		this.value = value;
 	}
 
-	@ConfigurationProperties("foo")
+	@TestConfigurationProperties("foo")
 	public Foo getFoo() {
 		return new Foo();
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InnerClassHierarchicalProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InnerClassHierarchicalProperties.java
@@ -16,16 +16,16 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
 
 /**
  * Demonstrate inner classes end up in metadata regardless of position in hierarchy and
- * without the use of {@link NestedConfigurationProperty @NestedConfigurationProperty}.
+ * without the use of {@link TestNestedConfigurationProperty @NestedConfigurationProperty}.
  *
  * @author Madhura Bhave
  */
-@ConfigurationProperties("config")
+@TestConfigurationProperties("config")
 public class InnerClassHierarchicalProperties {
 
 	private Foo foo;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InnerClassProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InnerClassProperties.java
@@ -16,22 +16,22 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.NestedConfigurationProperty;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
 
 /**
  * Demonstrate the auto-detection of inner config classes.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("config")
+@TestConfigurationProperties("config")
 public class InnerClassProperties {
 
 	private final Foo first = new Foo();
 
 	private Foo second = new Foo();
 
-	@NestedConfigurationProperty
+	@TestNestedConfigurationProperty
 	private final SimplePojo third = new SimplePojo();
 
 	private Fourth fourth;
@@ -62,7 +62,7 @@ public class InnerClassProperties {
 		this.fourth = fourth;
 	}
 
-	@NestedConfigurationProperty
+	@TestNestedConfigurationProperty
 	public DeprecatedSimplePojo getFifth() {
 		return this.fifth;
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InnerClassRootConfig.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InnerClassRootConfig.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Sample with a simple inner class config.
@@ -25,7 +25,7 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  */
 public class InnerClassRootConfig {
 
-	@ConfigurationProperties("config")
+	@TestConfigurationProperties("config")
 	public static class Config {
 
 		private String name;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InvalidAccessorProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InvalidAccessorProperties.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Demonstrates that invalid accessors are ignored.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("config")
+@TestConfigurationProperties("config")
 public class InvalidAccessorProperties {
 
 	private String name;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InvalidDefaultValueCharacterProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InvalidDefaultValueCharacterProperties.java
@@ -16,22 +16,22 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.ConstructorBinding;
-import org.springframework.boot.configurationsample.DefaultValue;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConstructorBinding;
+import org.springframework.boot.configurationsample.TestDefaultValue;
 
 /**
  * Demonstrates that an invalid default character value leads to a compilation failure.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("test")
+@TestConfigurationProperties("test")
 public class InvalidDefaultValueCharacterProperties {
 
 	private final char letter;
 
-	@ConstructorBinding
-	public InvalidDefaultValueCharacterProperties(@DefaultValue("bad") char letter) {
+	@TestConstructorBinding
+	public InvalidDefaultValueCharacterProperties(@TestDefaultValue("bad") char letter) {
 		this.letter = letter;
 	}
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InvalidDefaultValueFloatingPointProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InvalidDefaultValueFloatingPointProperties.java
@@ -16,8 +16,8 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.DefaultValue;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestDefaultValue;
 
 /**
  * Demonstrates that an invalid default floating point value leads to a compilation
@@ -25,12 +25,12 @@ import org.springframework.boot.configurationsample.DefaultValue;
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("test")
+@TestConfigurationProperties("test")
 public class InvalidDefaultValueFloatingPointProperties {
 
 	private final Double ratio;
 
-	public InvalidDefaultValueFloatingPointProperties(@DefaultValue("55.55.33") Double ratio) {
+	public InvalidDefaultValueFloatingPointProperties(@TestDefaultValue("55.55.33") Double ratio) {
 		this.ratio = ratio;
 	}
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InvalidDefaultValueNumberProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InvalidDefaultValueNumberProperties.java
@@ -16,20 +16,20 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
-import org.springframework.boot.configurationsample.DefaultValue;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestDefaultValue;
 
 /**
  * Demonstrates that an invalid default number value leads to a compilation failure.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("test")
+@TestConfigurationProperties("test")
 public class InvalidDefaultValueNumberProperties {
 
 	private final int counter;
 
-	public InvalidDefaultValueNumberProperties(@DefaultValue("invalid") int counter) {
+	public InvalidDefaultValueNumberProperties(@TestDefaultValue("invalid") int counter) {
 		this.counter = counter;
 	}
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InvalidDoubleRegistrationProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/InvalidDoubleRegistrationProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * Test that compilation fails if the same type is registered twice with the same prefix.
@@ -25,12 +25,12 @@ import org.springframework.boot.configurationsample.ConfigurationProperties;
  */
 public class InvalidDoubleRegistrationProperties {
 
-	@ConfigurationProperties("foo")
+	@TestConfigurationProperties("foo")
 	public Foo foo() {
 		return new Foo();
 	}
 
-	@ConfigurationProperties("foo")
+	@TestConfigurationProperties("foo")
 	public static class Foo {
 
 		private String name;

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/SimpleConflictingProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/SimpleConflictingProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 import org.springframework.boot.configurationsample.simple.SimpleProperties;
 
 /**
@@ -24,7 +24,7 @@ import org.springframework.boot.configurationsample.simple.SimpleProperties;
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("simple")
+@TestConfigurationProperties("simple")
 public class SimpleConflictingProperties {
 
 	private String flag = "hello";

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/StaticAccessor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/StaticAccessor.java
@@ -16,14 +16,14 @@
 
 package org.springframework.boot.configurationsample.specific;
 
-import org.springframework.boot.configurationsample.ConfigurationProperties;
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
 
 /**
  * A property that is exposed by static accessors.
  *
  * @author Stephane Nicoll
  */
-@ConfigurationProperties("specific")
+@TestConfigurationProperties("specific")
 public class StaticAccessor {
 
 	private static String name;


### PR DESCRIPTION
Completed #47468 

This PR refactors all annotations used in the tests of the Configuration Processor by adding a `Test` prefix to their names. All usages of the original annotations in test classes have been updated accordingly.

Example:
-` @Autowired `→ `@TestAutowired`
- `@ConfigurationProperties` →` @TestConfigurationProperties`

And similarly for other annotations used in tests.