### PR TITLE
Add AWS ECS to cloud platforms

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/cloud/CloudPlatform.java
@@ -164,6 +164,20 @@ public enum CloudPlatform {
 			return this.azureEnvVariables.stream().allMatch(environment::containsProperty);
 		}
 
+	},
+
+	/**
+	 * Amazon Web Services (AWS) Elastic Container Service (ECS) platform.
+	 * @since 4.0.0
+	 */
+	AWS_ECS {
+
+		@Override
+		public boolean isDetected(Environment environment) {
+			String awsExecutionEnv = environment.getProperty("AWS_EXECUTION_ENV");
+			return (awsExecutionEnv != null) && awsExecutionEnv.startsWith("AWS_ECS");
+		}
+
 	};
 
 	private static final String PROPERTY_NAME = "spring.main.cloud-platform";

--- a/core/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/cloud/CloudPlatformTests.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.MockConfigurationPropertySource;
@@ -200,6 +202,24 @@ class CloudPlatformTests {
 		envVars.put("WEBSITE_SITE_NAME", "---");
 		envVars.put("WEBSITE_INSTANCE_ID", "1234");
 		envVars.put("WEBSITE_RESOURCE_GROUP", "test");
+		Environment environment = getEnvironmentWithEnvVariables(envVars);
+		CloudPlatform platform = CloudPlatform.getActive(environment);
+		assertThat(platform).isNull();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "AWS_ECS_FARGATE", "AWS_ECS_EC2" })
+	void getActiveWhenHasAwsExecutionEnvEcsShouldReturnAwsEcs(String awsExecutionEnv) {
+		Map<String, Object> envVars = Map.of("AWS_EXECUTION_ENV", awsExecutionEnv);
+		Environment environment = getEnvironmentWithEnvVariables(envVars);
+		CloudPlatform platform = CloudPlatform.getActive(environment);
+		assertThat(platform).isNotNull().isEqualTo(CloudPlatform.AWS_ECS);
+		assertThat(platform.isActive(environment)).isTrue();
+	}
+
+	@Test
+	void getActiveWhenHasAwsExecutionEnvLambdaShouldNotReturnAwsEcs() {
+		Map<String, Object> envVars = Map.of("AWS_EXECUTION_ENV", "AWS_Lambda_java8");
 		Environment environment = getEnvironmentWithEnvVariables(envVars);
 		CloudPlatform platform = CloudPlatform.getActive(environment);
 		assertThat(platform).isNull();


### PR DESCRIPTION
This commit adds support for detecting AWS ECS to `CloudPlatform`. The detection is based on presence of `AWS_EXECUTION_ENV` environment variable with value starting with `AWS_ECS`.

Related resources:
- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-environment-variables.html
- https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html