### PR TITLE
Avoid error in OAuth2ClientPropertiesMapper when CommonOAuth2Provider is not available

### DIFF
--- a/module/spring-boot-security-oauth2-client/src/main/java/org/springframework/boot/security/oauth2/client/autoconfigure/OAuth2ClientPropertiesMapper.java
+++ b/module/spring-boot-security-oauth2-client/src/main/java/org/springframework/boot/security/oauth2/client/autoconfigure/OAuth2ClientPropertiesMapper.java
@@ -32,6 +32,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.core.AuthenticationMethod;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -45,6 +46,12 @@ import org.springframework.util.StringUtils;
  * @since 4.0.0
  */
 public final class OAuth2ClientPropertiesMapper {
+	private static final boolean SPRING_SECURITY_CONFIG_PRESENT;
+                                                                                          
+	static {
+		ClassLoader loader = OAuth2ClientPropertiesMapper.class.getClassLoader();
+		SPRING_SECURITY_CONFIG_PRESENT = ClassUtils.isPresent("org.springframework.security.config.oauth2.client.CommonOAuth2Provider", loader);
+	}
 
 	private final OAuth2ClientProperties properties;
 
@@ -137,6 +144,10 @@ public final class OAuth2ClientPropertiesMapper {
 	}
 
 	private static @Nullable CommonOAuth2Provider getCommonProvider(String providerId) {
+		if (!SPRING_SECURITY_CONFIG_PRESENT) {
+			return null;
+		}
+		
 		try {
 			return ApplicationConversionService.getSharedInstance().convert(providerId, CommonOAuth2Provider.class);
 		}


### PR DESCRIPTION
This commit prevents `NoClassDefFoundError` when `CommonOAuth2Provider` is not present on classpath. This module does not declare explicit dependency on `spring-security-config` but was using `CommonOAuth2Provider` without guard statement.