### PR TITLE
Exclude frames from stacktrace in structured json

### DIFF
--- a/core/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -303,6 +303,11 @@
       "description": "Mapping between member paths and an alternative name that should be used in structured logging JSON"
     },
     {
+      "name": "logging.structured.json.stacktrace.excluded-frames",
+      "type": "java.util.List<java.lang.String>",
+      "description": "List of patterns excluded from stacktrace, f.e. java.lang.reflect.Method."
+    },
+    {
       "name": "logging.structured.json.stacktrace.include-common-frames",
       "type": "java.lang.Boolean",
       "description": "Whether common frames should be included."

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/logging.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/logging.adoc
@@ -674,6 +674,9 @@ To do this, you can use one or more of the following properties:
 
 | configprop:logging.structured.json.stacktrace.include-hashes[]
 | If a hash of the stack trace should be included
+
+| configprop:logging.structured.json.stacktrace.exluded-frames[]
+| List of patterns excluded from stacktrace, f.e. `java.lang.reflect.Method`, `ByCGLIB`
 |===
 
 For example, the following will use root first stack traces, limit their length, and include hashes.


### PR DESCRIPTION
Allows declare by application properties which frames should be excluded from stacktrace.

For a long time it is widely known stacktrace contains frames from frameworks (haha) which are irrelevant for bug tracking and decrease readability.
For example this 13 years old article https://nurkiewicz.com/2012/03/filtering-irrelevant-stack-trace-lines.html is still valid.
More links can be found here: https://github.com/spring-projects/spring-boot/issues/43864#issuecomment-3368478060
And here https://github.com/spring-projects/spring-boot/issues/42486

Current printer implemented in Spring Boot has everything to filter out irrelevant frames. The only missing piece is configuring irrelevant frames.

This is PR is the icing on the cake.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
