### PR TITLE
Document spring.test.* configuration properties

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -7,6 +7,23 @@
       "defaultValue": "any"
     },
     {
+      "name": "spring.test.jsontesters.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether auto-configuration for JSON testers is enabled."
+    },
+    {
+      "name": "spring.test.mockmvc.webclient.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether auto-configuration for MockMvc WebClient integration is enabled.",
+      "defaultValue": true
+    },
+    {
+      "name": "spring.test.mockmvc.webdriver.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether auto-configuration for MockMvc WebDriver integration is enabled.",
+      "defaultValue": true
+    },
+    {
       "name": "spring.test.observability.auto-configure",
       "type": "java.lang.Boolean",
       "description": "Whether observability should be auto-configured in tests.",
@@ -17,6 +34,26 @@
       "type": "java.lang.Boolean",
       "description": "Whether the condition evaluation report should be printed when the ApplicationContext fails to start.",
       "defaultValue": true
+    },
+    {
+      "name": "spring.test.webclient.mockrestserviceserver.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether auto-configuration for MockRestServiceServer is enabled."
+    },
+    {
+      "name": "spring.test.webclient.register-rest-template",
+      "type": "java.lang.Boolean",
+      "description": "Whether a RestTemplate bean should be registered for use in tests."
+    },
+    {
+      "name": "spring.test.webservice.client.mockserver.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether auto-configuration for MockWebServiceServer is enabled."
+    },
+    {
+      "name": "spring.test.webservice.client.register-web-service-template",
+      "type": "java.lang.Boolean",
+      "description": "Whether a WebServiceTemplate bean should be registered for use in tests."
     },
     {
       "name": "spring.test.webtestclient.timeout",


### PR DESCRIPTION
Add documentation for seven previously undocumented `spring.test.*` properties used in test auto-configuration.

## Changes

Added metadata entries for the following properties in `additional-spring-configuration-metadata.json`:

- `spring.test.jsontesters.enabled` - Controls auto-configuration for JSON testers (JacksonTester, GsonTester, JsonbTester)
- `spring.test.mockmvc.webclient.enabled` - Controls MockMvc WebClient integration (default: true)
- `spring.test.mockmvc.webdriver.enabled` - Controls MockMvc WebDriver integration (default: true)
- `spring.test.webclient.mockrestserviceserver.enabled` - Controls MockRestServiceServer auto-configuration
- `spring.test.webclient.register-rest-template` - Controls RestTemplate bean registration for tests
- `spring.test.webservice.client.mockserver.enabled` - Controls MockWebServiceServer auto-configuration
- `spring.test.webservice.client.register-web-service-template` - Controls WebServiceTemplate bean registration for tests

These properties already exist in the codebase but were missing from the configuration metadata, making them undiscoverable in IDEs and documentation.

Closes gh-47236