### PR TITLE
Document spring.test.* configuration properties

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -7,10 +7,47 @@
       "defaultValue": "any"
     },
     {
+      "name": "spring.test.jsontesters.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether auto-configuration for JSON testers is enabled."
+    },
+    {
+      "name": "spring.test.mockmvc.webclient.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether auto-configuration for MockMvc WebClient integration is enabled.",
+      "defaultValue": true
+    },
+    {
+      "name": "spring.test.mockmvc.webdriver.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether auto-configuration for MockMvc WebDriver integration is enabled.",
+      "defaultValue": true
+    },
+    {
       "name": "spring.test.observability.auto-configure",
       "type": "java.lang.Boolean",
       "description": "Whether observability should be auto-configured in tests.",
       "defaultValue": false
+    },
+    {
+      "name": "spring.test.webclient.mockrestserviceserver.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether auto-configuration for MockRestServiceServer is enabled."
+    },
+    {
+      "name": "spring.test.webclient.register-rest-template",
+      "type": "java.lang.Boolean",
+      "description": "Whether a RestTemplate bean should be registered for use in tests."
+    },
+    {
+      "name": "spring.test.webservice.client.mockserver.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether auto-configuration for MockWebServiceServer is enabled."
+    },
+    {
+      "name": "spring.test.webservice.client.register-web-service-template",
+      "type": "java.lang.Boolean",
+      "description": "Whether a WebServiceTemplate bean should be registered for use in tests."
     },
     {
       "name": "spring.test.webtestclient.timeout",


### PR DESCRIPTION
Document spring.test.* configuration properties

Add documentation for seven previously undocumented `spring.test.*` properties used in test auto-configuration.

## Problem
These properties are referenced in various test auto-configuration classes but were not documented in configuration metadata, making them:
- Undiscoverable in IDEs (no autocomplete)
- Missing from official documentation
- Unknown to developers

## Changes
Added metadata entries to `additional-spring-configuration-metadata.json` for:

| Property | Auto-Configuration | Default |
|----------|-------------------|---------|
| `spring.test.jsontesters.enabled` | JsonTestersAutoConfiguration | - |
| `spring.test.mockmvc.webclient.enabled` | MockMvcWebClientAutoConfiguration | `true` |
| `spring.test.mockmvc.webdriver.enabled` | MockMvcWebDriverAutoConfiguration | `true` |
| `spring.test.webclient.mockrestserviceserver.enabled` | MockRestServiceServerAutoConfiguration | - |
| `spring.test.webclient.register-rest-template` | WebClientRestTemplateAutoConfiguration | - |
| `spring.test.webservice.client.mockserver.enabled` | MockWebServiceServerAutoConfiguration | - |
| `spring.test.webservice.client.register-web-service-template` | WebServiceClientTemplateAutoConfiguration | - |

All entries follow alphabetical ordering as per Spring Boot conventions.

## Testing
- ✅ Metadata format validation passed
- ✅ JSON syntax validation passed
- ✅ Property ordering verified

Closes gh-47236