### PR TITLE
Provide explicit order for Neo4j observation customizer

### DIFF
--- a/module/spring-boot-neo4j/src/main/java/org/springframework/boot/neo4j/autoconfigure/observation/Neo4jObservationAutoConfiguration.java
+++ b/module/spring-boot-neo4j/src/main/java/org/springframework/boot/neo4j/autoconfigure/observation/Neo4jObservationAutoConfiguration.java
@@ -27,6 +27,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.neo4j.autoconfigure.ConfigBuilderCustomizer;
 import org.springframework.boot.neo4j.autoconfigure.Neo4jAutoConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 
 /**
  * Auto-configuration for Neo4j observability.
@@ -42,6 +44,7 @@ public final class Neo4jObservationAutoConfiguration {
 
 	@Bean
 	@ConditionalOnBean(ObservationRegistry.class)
+	@Order(Ordered.HIGHEST_PRECEDENCE)
 	ConfigBuilderCustomizer neo4jObservationCustomizer(ObservationRegistry registry) {
 		return (builder) -> builder.withObservationProvider(MicrometerObservationProvider.builder(registry).build());
 	}


### PR DESCRIPTION
At present, the `neo4jObservationCustomizer` has an effective `Ordered.LOWEST_PRECEDENCE`, meaning that it goes last in `Neo4jAutoConfiguration`:
```java
configBuilderCustomizers.orderedStream().toList()
...
customizers.forEach((customizer) -> customizer.customize(builder));
```

This update sets its order to `Ordered.HIGHEST_PRECEDENCE`, meaning that a user-defined `ConfigBuilderCustomizer` can effectively override it.

As an example, this is useful when user wants to customize `MicrometerObservationProvider` as it actually has some optional properties that may be useful. Here is an example:
```java
@Bean
ConfigBuilderCustomizer observationCustomizer(ObservationRegistry observationRegistry) {
    return configBuilder -> {
        var observationProvider = MicrometerObservationProvider.builder(observationRegistry)
                .alwaysIncludeQuery(true)
                .includeQueryParameters(true)
                .includeUrlScheme(true)
                .includeUrlTemplate(true)
                .requestHeaderPredicate(name -> true)
                .responseHeaderPredicate(name -> true)
                .build();
        configBuilder.withObservationProvider(observationProvider);
    };
}
```
