### PR TITLE
Add support for @ObservationKeyValue

### DIFF
--- a/module/spring-boot-micrometer-observation/src/main/java/org/springframework/boot/micrometer/observation/autoconfigure/ObservationAutoConfiguration.java
+++ b/module/spring-boot-micrometer-observation/src/main/java/org/springframework/boot/micrometer/observation/autoconfigure/ObservationAutoConfiguration.java
@@ -22,9 +22,11 @@ import io.micrometer.observation.ObservationFilter;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationPredicate;
 import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.aop.ObservationKeyValueAnnotationHandler;
 import io.micrometer.observation.aop.ObservedAspect;
 import org.aspectj.weaver.Advice;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -87,8 +89,18 @@ public final class ObservationAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		ObservedAspect observedAspect(ObservationRegistry observationRegistry) {
-			return new ObservedAspect(observationRegistry);
+		ObservedAspect observedAspect(ObservationRegistry observationRegistry,
+				ObjectProvider<ObservationKeyValueAnnotationHandler> observationKeyValueAnnotationHandler) {
+			ObservedAspect observedAspect = new ObservedAspect(observationRegistry);
+			observationKeyValueAnnotationHandler.ifAvailable(observedAspect::setObservationKeyValueAnnotationHandler);
+			return observedAspect;
+		}
+
+		@Bean
+		@ConditionalOnMissingBean
+		ObservationKeyValueAnnotationHandler observationKeyValueAnnotationHandler(BeanFactory beanFactory,
+				ValueExpressionResolver valueExpressionResolver) {
+			return new ObservationKeyValueAnnotationHandler(beanFactory::getBean, (ignored) -> valueExpressionResolver);
 		}
 
 	}


### PR DESCRIPTION
In Micrometer `1.16.0-RC1` we added capabilities for `@Observed` methods to add metadata based on method parameters and result using `@ObservationKeyValue` (similar to `@MeterTag` for `@Timed` and `@Counted`).

See https://github.com/micrometer-metrics/micrometer/issues/4030