### PR TITLE
The 'spring.mongodb.representation.uuid' property cannot be bound

### DIFF
--- a/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoProperties.java
+++ b/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoProperties.java
@@ -218,8 +218,8 @@ public class MongoProperties {
 			return this.uuid;
 		}
 
-		public void setUuidRepresentation(UuidRepresentation uuidRepresentation) {
-			this.uuid = uuidRepresentation;
+		public void setUuid(UuidRepresentation uuid) {
+			this.uuid = uuid;
 		}
 
 	}


### PR DESCRIPTION
This PR fixes the setter for the `MongoProperties.Representation.uuid` as it seems to be a typo.

See gh-47052