### PR TITLE
Upgrade to Commons Lang3 3.19.0

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -236,7 +236,7 @@ bom {
 			releaseNotes("https://commons.apache.org/proper/commons-dbcp/changes-report.html#a{version}")
 		}
 	}
-	library("Commons Lang3", "3.17.0") {
+	library("Commons Lang3", "3.19.0") {
 		group("org.apache.commons") {
 			modules = [
 				"commons-lang3"


### PR DESCRIPTION
Upgrade to Commons Lang3 [3.19.0](https://commons.apache.org/proper/commons-lang/changes.html#a3.19.0)