### PR TITLE
Homebrew formula for the CLI should use libexec

### DIFF
--- a/cli/spring-boot-cli/src/main/homebrew/spring-boot.rb
+++ b/cli/spring-boot-cli/src/main/homebrew/spring-boot.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class SpringBoot < Formula
   homepage 'https://spring.io/projects/spring-boot'
-  url 'https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-cli/3.5.6/spring-boot-cli-3.5.6-bin.tar.gz'
-  version '3.5.6'
-  sha256 '3ac9314100c474ddad1c4ae04a85404383817d6f748820980e26ccbe55393bbe'
+  url '${repo}/org/springframework/boot/spring-boot-cli/${version}/spring-boot-cli-${version}-bin.tar.gz'
+  version '${version}'
+  sha256 '${hash}'
   head 'https://github.com/spring-projects/spring-boot.git', :branch => "main"
 
   def install


### PR DESCRIPTION
Fixes #46866

*Summary*
This PR updates the spring-boot Homebrew formula to install JARs under libexec instead of lib.
This change follows Homebrew best practices to avoid conflicts between packages when HOMEBREW_DEVELOPER=true is enabled.

*Changes*
- Updated the formula to install all JARs into libexec.
- Wrapped the spring binary with write_env_script to ensure correct runtime paths.
- Verified shell completion installation for Bash and Zsh.

*Verification*
Tested locally with:
`HOMEBREW_DEVELOPER=true brew install --build-from-source spring-boot`

Result: No warnings when running with HOMEBREW_DEVELOPER=true, and the CLI works as expected.

*Before change*
<img width="1282" height="426" alt="Captura de tela de 2025-10-18 20-01-45" src="https://github.com/user-attachments/assets/e83ab8ca-ab99-409f-ae6a-835a5cbfeb12" />

*After change*
<img width="1277" height="274" alt="Captura de tela de 2025-10-18 19-59-41" src="https://github.com/user-attachments/assets/ed3b38fe-64be-4bb3-bb17-00f5bad436c9" />



