### PR TITLE
Configure devtools to set trace probability to 100% by default

### DIFF
--- a/module/spring-boot-micrometer-tracing/src/main/resources/META-INF/spring-devtools.properties
+++ b/module/spring-boot-micrometer-tracing/src/main/resources/META-INF/spring-devtools.properties
@@ -1,0 +1,1 @@
+defaults.management.tracing.sampling.probability=1.0


### PR DESCRIPTION
Developer will not miss any traces after this commit.