### PR TITLE
Update Gradle examples to work with both the Groovy DSL and the Kotlin DSL

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/logging.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/logging.adoc
@@ -159,7 +159,7 @@ To do so, declare a dependency on the Log4j 2 starter and tell Gradle that any o
 [source,gradle]
 ----
 dependencies {
-	implementation "org.springframework.boot:spring-boot-starter-log4j2"
+	implementation("org.springframework.boot:spring-boot-starter-log4j2")
 	modules {
 		module("org.springframework.boot:spring-boot-starter-logging") {
 			replacedBy("org.springframework.boot:spring-boot-starter-log4j2", "Use Log4j2 instead of Logback")

--- a/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/nosql.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/nosql.adoc
@@ -38,10 +38,10 @@ The following example shows how to accomplish this in Gradle:
 [source,gradle]
 ----
 dependencies {
-	implementation('org.springframework.boot:spring-boot-starter-data-redis') {
+	implementation("org.springframework.boot:spring-boot-starter-data-redis") {
 	    exclude group: 'io.lettuce', module: 'lettuce-core'
 	}
-	implementation 'redis.clients:jedis'
+	implementation("redis.clients:jedis")
 	// ...
 }
 ----

--- a/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/webserver.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/webserver.adoc
@@ -45,8 +45,8 @@ The following Gradle example configures the necessary dependencies and a {url-gr
 [source,gradle]
 ----
 dependencies {
-	implementation "org.springframework.boot:spring-boot-starter-tomcat"
-	implementation "org.springframework.boot:spring-boot-starter-webflux"
+	implementation("org.springframework.boot:spring-boot-starter-tomcat")
+	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	modules {
 		module("org.springframework.boot:spring-boot-starter-reactor-netty") {
 			replacedBy("org.springframework.boot:spring-boot-starter-tomcat", "Use Tomcat instead of Reactor Netty")

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/enabling.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/enabling.adoc
@@ -27,6 +27,6 @@ For Gradle, use the following declaration:
 [source,gradle]
 ----
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation("org.springframework.boot:spring-boot-starter-actuator")
 }
 ----

--- a/documentation/spring-boot-docs/src/docs/antora/modules/tutorial/pages/first-application/index.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/tutorial/pages/first-application/index.adoc
@@ -261,7 +261,7 @@ To add the necessary dependencies, edit your `build.gradle` and add the `spring-
 [source,gradle]
 ----
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation("org.springframework.boot:spring-boot-starter-web")
 }
 ----
 

--- a/module/spring-boot-actuator/README.adoc
+++ b/module/spring-boot-actuator/README.adoc
@@ -30,7 +30,7 @@ For Gradle, use the following declaration:
 [source]
 ----
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation("org.springframework.boot:spring-boot-starter-actuator")
 }
 ----
 


### PR DESCRIPTION
Make it friendly for Gradle’s Kotlin DSL as possible.