### PR TITLE
Allow EntityManagerFactoryBuilder to also add PersistenceUnitPostProcessor instances

### DIFF
--- a/module/spring-boot-jpa/src/main/java/org/springframework/boot/jpa/EntityManagerFactoryBuilder.java
+++ b/module/spring-boot-jpa/src/main/java/org/springframework/boot/jpa/EntityManagerFactoryBuilder.java
@@ -17,9 +17,12 @@
 package org.springframework.boot.jpa;
 
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -127,6 +130,24 @@ public class EntityManagerFactoryBuilder {
 	 */
 	public void setPersistenceUnitPostProcessors(PersistenceUnitPostProcessor... persistenceUnitPostProcessors) {
 		this.persistenceUnitPostProcessors = persistenceUnitPostProcessors;
+	}
+
+	/**
+	 * Add some {@linkplain PersistenceUnitPostProcessor persistence unit post processors}
+	 * to be applied to the PersistenceUnitInfo used for creating the
+	 * {@link LocalContainerEntityManagerFactoryBean}.
+	 * @param persistenceUnitPostProcessors the persistence unit post processors to use
+	 */
+	public void addPersistenceUnitPostProcessors(PersistenceUnitPostProcessor... persistenceUnitPostProcessors) {
+		if (this.persistenceUnitPostProcessors == null) {
+			this.persistenceUnitPostProcessors = persistenceUnitPostProcessors;
+			return;
+		}
+
+		var combined = new ArrayList<>(Arrays.asList(this.persistenceUnitPostProcessors));
+		combined.addAll(Arrays.asList(persistenceUnitPostProcessors));
+
+		this.persistenceUnitPostProcessors = combined.toArray(PersistenceUnitPostProcessor[]::new);
 	}
 
 	/**


### PR DESCRIPTION

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
The goal of this commit is to enable the EntityManagerFactoryBuilder to automatically detect and apply PersistenceUnitPostProcessor beans.
Currently, it is possible to use an EntityManagerFactoryBuilderCustomizer, but since there is no getter providing access to the already registered PersistenceUnitPostProcessor instances, using setPersistenceUnitPostProcessors may unintentionally remove existing ones.
