### PR TITLE
Fix typos in jQuery and validation scripts

### DIFF
--- a/smoke-test/spring-boot-smoke-test-web-groovy-templates/src/main/resources/static/js/jquery-1.7.2.js
+++ b/smoke-test/spring-boot-smoke-test-web-groovy-templates/src/main/resources/static/js/jquery-1.7.2.js
@@ -2338,7 +2338,7 @@ jQuery.fn.extend({
           classNames = value.split( rspace );
 
         while ( (className = classNames[ i++ ]) ) {
-          // check each className given, space seperated list
+          // check each className given, space separated list
           state = isBool ? state : !self.hasClass( className );
           self[ state ? "addClass" : "removeClass" ]( className );
         }
@@ -8249,7 +8249,7 @@ if ( jQuery.support.ajax ) {
               xml;
 
             // Firefox throws exceptions when accessing properties
-            // of an xhr when a network error occured
+            // of an xhr when a network error occurred
             // https://helpful.knobs-dials.com/index.php/Component_returned_failure_code:_0x80040111_(NS_ERROR_NOT_AVAILABLE)
             try {
 

--- a/smoke-test/spring-boot-smoke-test-web-groovy-templates/src/main/resources/static/js/jquery.validate.js
+++ b/smoke-test/spring-boot-smoke-test-web-groovy-templates/src/main/resources/static/js/jquery.validate.js
@@ -105,7 +105,7 @@ $.extend($.fn, {
       return valid;
     }
   },
-  // attributes: space seperated list of attributes to retrieve and remove
+  // attributes: space separated list of attributes to retrieve and remove
   removeAttrs: function(attributes) {
     var result = {},
       $element = this;
@@ -550,7 +550,7 @@ $.extend($.validator, {
           }
         } catch(e) {
           if ( this.settings.debug && window.console ) {
-            console.log("exception occured when checking element " + element.id + ", check the '" + rule.method + "' method", e);
+            console.log("exception occurred when checking element " + element.id + ", check the '" + rule.method + "' method", e);
           }
           throw e;
         }


### PR DESCRIPTION
Correct 'seperated' to 'separated' and 'occured' to 'occurred' in comments and log messages within jquery-1.7.2.js and jquery.validate.js to improve clarity.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
