### PR TITLE
Remove unnecessary stream opening in BootZipCopyAction

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootZipCopyAction.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootZipCopyAction.java
@@ -348,11 +348,8 @@ class BootZipCopyAction implements CopyAction {
 
 		private void writeJarModeLibrary(String location, JarModeLibrary library) throws IOException {
 			String name = location + library.getName();
-			writeEntry(name, ZipEntryContentWriter.fromInputStream(library.openStream()), false, (entry) -> {
-				try (InputStream in = library.openStream()) {
-					prepareStoredEntry(library.openStream(), false, entry);
-				}
-			});
+			writeEntry(name, ZipEntryContentWriter.fromInputStream(library.openStream()), false,
+					(entry) -> prepareStoredEntry(library.openStream(), false, entry));
 			if (BootZipCopyAction.this.layerResolver != null) {
 				Layer layer = BootZipCopyAction.this.layerResolver.getLayer(library);
 				this.layerIndex.add(layer, name);


### PR DESCRIPTION
Issue #47883

BootZipCopyAction was calling library.openStream() an unnecessary extra time when packaging a stored library. 

This was caused by a redundant try-with-resources block that wrapped the call to prepareStoredEntry. As noted in the issue, this block is unnecessary as prepareStoredEntry closes the stream it is given.

This change removes the redundant block to avoid the unnecessary stream opening.