### PR TITLE
BootstrapContext#getOrElseThrow has incorrect reference to IllegalStateException

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/bootstrap/BootstrapContext.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/bootstrap/BootstrapContext.java
@@ -79,7 +79,6 @@ public interface BootstrapContext {
 	 * @param exceptionSupplier the supplier which will return the exception to be thrown
 	 * @return the instance managed by the context, which may be {@code null}
 	 * @throws X if the type has not been registered
-	 * @throws IllegalStateException if the type has not been registered
 	 */
 	<T, X extends Throwable> @Nullable T getOrElseThrow(Class<T> type, Supplier<? extends X> exceptionSupplier)
 			throws X;


### PR DESCRIPTION
Fixes leftover from https://github.com/spring-projects/spring-boot/issues/47896