### PR TITLE
Order auto-configured message converter beans at 0

### DIFF
--- a/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/GsonHttpMessageConvertersConfiguration.java
+++ b/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/GsonHttpMessageConvertersConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.converter.json.GsonHttpMessageConverter;
 import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 
@@ -47,6 +48,7 @@ class GsonHttpMessageConvertersConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
+		@Order(0)
 		GsonHttpMessageConverter gsonHttpMessageConverter(Gson gson) {
 			GsonHttpMessageConverter converter = new GsonHttpMessageConverter();
 			converter.setGson(gson);

--- a/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/HttpMessageConvertersAutoConfiguration.java
+++ b/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/HttpMessageConvertersAutoConfiguration.java
@@ -92,6 +92,7 @@ public final class HttpMessageConvertersAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
+		@Order(0)
 		StringHttpMessageConverter stringHttpMessageConverter(HttpMessageConvertersProperties properties) {
 			StringHttpMessageConverter converter = new StringHttpMessageConverter(
 					properties.getStringEncodingCharset());

--- a/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/Jackson2HttpMessageConvertersConfiguration.java
+++ b/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/Jackson2HttpMessageConvertersConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
@@ -50,6 +51,7 @@ class Jackson2HttpMessageConvertersConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
+		@Order(0)
 		org.springframework.http.converter.json.MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter(
 				ObjectMapper objectMapper) {
 			return new org.springframework.http.converter.json.MappingJackson2HttpMessageConverter(objectMapper);
@@ -64,6 +66,7 @@ class Jackson2HttpMessageConvertersConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
+		@Order(0)
 		public MappingJackson2XmlHttpMessageConverter mappingJackson2XmlHttpMessageConverter(
 				Jackson2ObjectMapperBuilder builder) {
 			return new MappingJackson2XmlHttpMessageConverter(builder.createXmlMapper(true).build());

--- a/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/JacksonHttpMessageConvertersConfiguration.java
+++ b/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/JacksonHttpMessageConvertersConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.http.converter.xml.JacksonXmlHttpMessageConverter;
 
@@ -47,6 +48,7 @@ class JacksonHttpMessageConvertersConfiguration {
 		@ConditionalOnMissingBean(
 				ignoredType = { "org.springframework.hateoas.server.mvc.TypeConstrainedJacksonJsonHttpMessageConverter",
 						"org.springframework.data.rest.webmvc.alps.AlpsJacksonJsonHttpMessageConverter" })
+		@Order(0)
 		JacksonJsonHttpMessageConverter jacksonJsonHttpMessageConverter(JsonMapper jsonMapper) {
 			return new JacksonJsonHttpMessageConverter(jsonMapper);
 		}
@@ -60,6 +62,7 @@ class JacksonHttpMessageConvertersConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
+		@Order(0)
 		public JacksonXmlHttpMessageConverter jacksonXmlHttpMessageConverter(XmlMapper xmlMapper) {
 			return new JacksonXmlHttpMessageConverter(xmlMapper);
 		}

--- a/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/JsonbHttpMessageConvertersConfiguration.java
+++ b/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/JsonbHttpMessageConvertersConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.converter.json.GsonHttpMessageConverter;
 import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.http.converter.json.JsonbHttpMessageConverter;
@@ -46,6 +47,7 @@ class JsonbHttpMessageConvertersConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
+		@Order(0)
 		JsonbHttpMessageConverter jsonbHttpMessageConverter(Jsonb jsonb) {
 			JsonbHttpMessageConverter converter = new JsonbHttpMessageConverter();
 			converter.setJsonb(jsonb);


### PR DESCRIPTION
This PR orders auto-configured message converter beans at 0 to allow users to reliably override them with custom converters.

Previously, auto-configured message converter beans were not explicitly ordered, making it difficult for users to override them with custom converters. By ordering them at 0, users can now reliably order their custom converters before or after the auto-configured ones.

This complements the earlier change that ordered the default customizers at 0, ensuring consistent ordering behavior for both customizers and converter beans.

Fixes #47798