### PR TITLE
Use Elasticsearch 9.2's elasticsearch-rest5-client in spring-boot-elasticsearch

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/data/nosql.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/data/nosql.adoc
@@ -314,7 +314,8 @@ Spring Boot provides a dedicated starter, `spring-boot-starter-data-elasticsearc
 === Connecting to Elasticsearch Using REST clients
 
 Elasticsearch ships two different REST clients that you can use to query a cluster: the https://www.elastic.co/docs/reference/elasticsearch/clients/java/transport/rest5-client/[low-level client] and the https://www.elastic.co/docs/reference/elasticsearch/clients/java[Java API client].
-Both clients are provided by the `co.elastic.clients:elasticsearch-java` module.
+The Java API client is provided by the `co.elastic.clients:elasticsearch-java` module and
+the low-level client is provided by the `co.elastic.clients:elasticsearch-rest5-client` module.
 Additionally, Spring Boot provides support for a reactive client from the `org.springframework.data:spring-data-elasticsearch` module.
 By default, the clients will target `http://localhost:9200`.
 You can use `spring.elasticsearch.*` properties to further tune how the clients are configured, as shown in the following example:
@@ -334,7 +335,7 @@ spring:
 [[data.nosql.elasticsearch.connecting-using-rest.restclient]]
 ==== Connecting to Elasticsearch Using Rest5Client
 
-If you have `co.elastic.clients:elasticsearch-java` on the classpath, Spring Boot will auto-configure and register a javadoc:co.elastic.clients.transport.rest5_client.low_level.Rest5Client[] bean.
+If you have `co.elastic.clients:elasticsearch-rest5-client` on the classpath, Spring Boot will auto-configure and register a javadoc:co.elastic.clients.transport.rest5_client.low_level.Rest5Client[] bean.
 In addition to the properties described previously, to fine-tune the javadoc:co.elastic.clients.transport.rest5_client.low_level.Rest5Client[] you can register an arbitrary number of beans that implement javadoc:org.springframework.boot.elasticsearch.autoconfigure.Rest5ClientBuilderCustomizer[] for more advanced customizations.
 To take full control over the client's configuration, define a javadoc:co.elastic.clients.transport.rest5_client.low_level.Rest5ClientBuilder[] bean.
 

--- a/module/spring-boot-elasticsearch/build.gradle
+++ b/module/spring-boot-elasticsearch/build.gradle
@@ -27,7 +27,7 @@ description = "Spring Boot Elasticsearch"
 
 dependencies {
 	api(project(":core:spring-boot"))
-	api("co.elastic.clients:elasticsearch-java")
+	api("co.elastic.clients:elasticsearch-rest5-client")
 
 	optional(project(":core:spring-boot-autoconfigure"))
 	optional(project(":core:spring-boot-docker-compose"))
@@ -35,6 +35,9 @@ dependencies {
 	optional(project(":module:spring-boot-health"))
 	optional(project(":module:spring-boot-jsonb"))
 	optional(project(":module:spring-boot-reactor"))
+	optional("co.elastic.clients:elasticsearch-java") {
+		exclude group: "commons-logging", module: "commons-logging"
+	}
 
 	optional("com.fasterxml.jackson.core:jackson-databind")
 	optional("jakarta.json.bind:jakarta.json.bind-api")

--- a/platform/spring-boot-dependencies/build.gradle
+++ b/platform/spring-boot-dependencies/build.gradle
@@ -367,7 +367,8 @@ bom {
 		}
 		group("co.elastic.clients") {
 			modules = [
-				"elasticsearch-java"
+				"elasticsearch-java",
+				"elasticsearch-rest5-client"
 			]
 		}
 		links {


### PR DESCRIPTION
Seems like that since the integration to use the new Elasticsearch `Rest5Client` was done in #46061 and from version 9.2.0 Elasticsearch is now also delivering a dedicated [`co.elastic.clients:elasticsearch-rest5-client`](https://central.sonatype.com/artifact/co.elastic.clients/elasticsearch-rest5-client).

With this PR I am adding that client to the managed dependencies and I have made the Java client [`co.elastic.clients:elasticsearch-java`](https://central.sonatype.com/artifact/co.elastic.clients/elasticsearch-java) an optional dependency.

I believe that this is similar to how it was in Spring Boot 3 and similar to 4.0.0-M1.