### PR TITLE
Auto-configure SmileMapper.Builder and SmileMapper

### DIFF
--- a/module/spring-boot-jackson/build.gradle
+++ b/module/spring-boot-jackson/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	optional(project(":core:spring-boot-test-autoconfigure"))
 	optional("org.springframework:spring-web")
 	optional("tools.jackson.dataformat:jackson-dataformat-cbor")
+	optional("tools.jackson.dataformat:jackson-dataformat-smile")
 	optional("tools.jackson.dataformat:jackson-dataformat-xml")
 	optional("tools.jackson.module:jackson-module-jakarta-xmlbind-annotations")
 

--- a/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonSmileProperties.java
+++ b/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonSmileProperties.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jackson.autoconfigure;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import tools.jackson.dataformat.smile.SmileReadFeature;
+import tools.jackson.dataformat.smile.SmileWriteFeature;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties to configure Jackson's Smile support.
+ *
+ * @author Yanming Zhou
+ * @since 4.0.0
+ */
+@ConfigurationProperties("spring.jackson.smile")
+public class JacksonSmileProperties {
+
+	/**
+	 * Jackson on/off token reader features that are specific to Smile.
+	 */
+	private final Map<SmileReadFeature, Boolean> read = new EnumMap<>(SmileReadFeature.class);
+
+	/**
+	 * Jackson on/off token writer features that are specific to Smile.
+	 */
+	private final Map<SmileWriteFeature, Boolean> write = new EnumMap<>(SmileWriteFeature.class);
+
+	public Map<SmileReadFeature, Boolean> getRead() {
+		return this.read;
+	}
+
+	public Map<SmileWriteFeature, Boolean> getWrite() {
+		return this.write;
+	}
+
+}

--- a/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/SmileMapperBuilderCustomizer.java
+++ b/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/SmileMapperBuilderCustomizer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jackson.autoconfigure;
+
+import tools.jackson.dataformat.smile.SmileMapper;
+import tools.jackson.dataformat.smile.SmileMapper.Builder;
+
+/**
+ * Callback interface that can be implemented by beans wishing to further customize the
+ * {@link SmileMapper} through {@link Builder SmileMapper.Builder} to fine-tune its
+ * auto-configuration.
+ *
+ * @author Yanming Zhou
+ * @since 4.0.0
+ */
+@FunctionalInterface
+public interface SmileMapperBuilderCustomizer {
+
+	/**
+	 * Customize the SmileMapper.Builder.
+	 * @param smileMapperBuilder the builder to customize
+	 */
+	void customize(Builder smileMapperBuilder);
+
+}


### PR DESCRIPTION
Smile should be supported as same as CBOR, like Spring Framework's DefaultHttpMessageConverters does.

https://github.com/spring-projects/spring-framework/blob/5e213b2407bc211aee4bfa02f5e1909128860f2f/spring-web/src/main/java/org/springframework/http/converter/DefaultHttpMessageConverters.java#L146