### PR TITLE
Fix unit test failure in PaketoBuilderTests.plainWarApp() caused by container permission issue

### DIFF
--- a/system-test/spring-boot-image-system-tests/src/systemTest/java/org/springframework/boot/image/paketo/PaketoBuilderTests.java
+++ b/system-test/spring-boot-image-system-tests/src/systemTest/java/org/springframework/boot/image/paketo/PaketoBuilderTests.java
@@ -270,6 +270,7 @@ class PaketoBuilderTests {
 		assertThat(result.getOutput()).contains("Running creator");
 		try (GenericContainer<?> container = new GenericContainer<>(imageName)) {
 			container.withExposedPorts(8080);
+			container.withCreateContainerCmdModifier(cmd -> cmd.withUser("root"));
 			container.waitingFor(Wait.forHttp("/test")).start();
 			ContainerConfig config = container.getContainerInfo().getConfig();
 			ImageAssertions.assertThat(config).buildMetadata((metadata) -> {


### PR DESCRIPTION
I found that the unit test always fails at [PaketoBuilderTests.plainWarApp()](https://github.com/spring-projects/spring-boot/blob/00bd0efc56700942803158ce5e33041808c5e747/system-test/spring-boot-image-system-tests/src/systemTest/java/org/springframework/boot/image/paketo/PaketoBuilderTests.java#L263).

After investigation, I discovered that the failure is caused by insufficient permissions of the container’s default user. The default user in the container is:

`uid=1002(cnb) gid=1000(ubuntu) groups=1000(ubuntu)`

However, the startup script

`/layers/paketo-buildpacks_apache-tomcat/tomcat/bin/catalina.sh`

has permissions set to `-rwxr-x--- 1 1001 1001`.

In fact, there is no user or group with ID `1001` inside the container. This might be a bug in `paketobuildpacks/apache-tomcat`. I changed the default running user of the container to root, and that solved the problem.

I know using root is not a good practice, but since this is just a simple test, there not be any security or permission issues. What are your thoughts? Do you have any recommended approaches?