### PR TITLE
Dependency management for Kafka should not manage Scala 2.12 libraries

### DIFF
--- a/platform/spring-boot-dependencies/build.gradle
+++ b/platform/spring-boot-dependencies/build.gradle
@@ -1189,14 +1189,9 @@ bom {
 				"kafka-storage",
 				"kafka-storage-api",
 				"kafka-streams",
-				"kafka-streams-scala_2.12",
 				"kafka-streams-scala_2.13",
 				"kafka-streams-test-utils",
 				"kafka-tools",
-				"kafka_2.12",
-				"kafka_2.12" {
-					classifier = "test"
-				},
 				"kafka_2.13",
 				"kafka_2.13" {
 					classifier = "test"


### PR DESCRIPTION
Fixes #47990
