### PR TITLE
Fix WebSecurityCustomizer beans are excluded by WebMvcTest.

### DIFF
--- a/module/spring-boot-webmvc-test/src/main/java/org/springframework/boot/webmvc/test/autoconfigure/WebMvcTest.java
+++ b/module/spring-boot-webmvc-test/src/main/java/org/springframework/boot/webmvc/test/autoconfigure/WebMvcTest.java
@@ -69,6 +69,7 @@ import org.springframework.test.web.servlet.MockMvc;
  * <li>{@code WebMvcConfigurer}</li>
  * <li>{@code WebMvcRegistrations}</li>
  * <li>{@code WebSecurityConfigurer}</li>
+ * <li>{@code WebSecurityCustomizer}</li>
  * </ul>
  * <p>
  * By default, tests annotated with {@code @WebMvcTest} will also auto-configure Spring

--- a/module/spring-boot-webmvc-test/src/main/java/org/springframework/boot/webmvc/test/autoconfigure/WebMvcTypeExcludeFilter.java
+++ b/module/spring-boot-webmvc-test/src/main/java/org/springframework/boot/webmvc/test/autoconfigure/WebMvcTypeExcludeFilter.java
@@ -44,6 +44,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * @author Phillip Webb
  * @author Madhura Bhave
  * @author Yanming Zhou
+ * @author Luman Suen
  */
 class WebMvcTypeExcludeFilter extends StandardAnnotationCustomizableTypeExcludeFilter<WebMvcTest> {
 
@@ -52,7 +53,9 @@ class WebMvcTypeExcludeFilter extends StandardAnnotationCustomizableTypeExcludeF
 	private static final String[] OPTIONAL_INCLUDES = { "tools.jackson.databind.JacksonModule",
 			"org.springframework.boot.jackson.JacksonComponent",
 			"org.springframework.security.config.annotation.web.WebSecurityConfigurer",
-			"org.springframework.security.web.SecurityFilterChain", "org.thymeleaf.dialect.IDialect",
+			"org.springframework.security.web.SecurityFilterChain",
+			"org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer",
+			"org.thymeleaf.dialect.IDialect",
 			"com.fasterxml.jackson.databind.Module", "org.springframework.boot.jackson2.JsonComponent" };
 
 	private static final Set<Class<?>> KNOWN_INCLUDES;


### PR DESCRIPTION
See gh-47255

Added `org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer` as an optional include to enable the loading of the following configurations.
```java
@Configuration
public class WebSecurityCustomizersConfiguration implements WebSecurityCustomizer {
    public void customize(WebSecurity web){
        web.ignoring().requestMatchers("/favicon.ico");
    }
}
```

However, please note that loading of `@Bean` definitions is still not supported.
```java
@Configuration
public class WebSecurityCustomizersConfiguration implements WebSecurityCustomizer {
   @Bean
    public WebSecurityCustomizer faviconSecurityCustomizer() {
        return (web) -> web.ignoring().requestMatchers("/favicon.ico");
    }
}

```

Because `@Configuration` classes are not loaded by `@WebMvcTest`, I also can’t directly add `Configuration.class` to the `includes`, as that would make the change too extensive.

Therefore, I added `org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer` in the same way as `org.springframework.security.web.SecurityFilterChain`.