### PR TITLE
Auto-configure meter conventions for JVM and system metrics

### DIFF
--- a/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/jvm/JvmMetricsAutoConfiguration.java
+++ b/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/jvm/JvmMetricsAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.micrometer.metrics.autoconfigure.jvm;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmCompilationMetrics;
@@ -25,12 +26,16 @@ import io.micrometer.core.instrument.binder.jvm.JvmHeapPressureMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmInfoMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmClassLoadingMeterConventions;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmMemoryMeterConventions;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmThreadMeterConventions;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -71,20 +76,23 @@ public final class JvmMetricsAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	JvmMemoryMetrics jvmMemoryMetrics() {
-		return new JvmMemoryMetrics();
+	JvmMemoryMetrics jvmMemoryMetrics(ObjectProvider<JvmMemoryMeterConventions> jvmMemoryMeterConventions) {
+		JvmMemoryMeterConventions conventions = jvmMemoryMeterConventions.getIfAvailable();
+		return (conventions != null) ? new JvmMemoryMetrics(Tags.empty(), conventions) : new JvmMemoryMetrics();
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
-	JvmThreadMetrics jvmThreadMetrics() {
-		return new JvmThreadMetrics();
+	JvmThreadMetrics jvmThreadMetrics(ObjectProvider<JvmThreadMeterConventions> jvmThreadMeterConventions) {
+		JvmThreadMeterConventions conventions = jvmThreadMeterConventions.getIfAvailable();
+		return (conventions != null) ? new JvmThreadMetrics(Tags.empty(), conventions) : new JvmThreadMetrics();
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
-	ClassLoaderMetrics classLoaderMetrics() {
-		return new ClassLoaderMetrics();
+	ClassLoaderMetrics classLoaderMetrics(ObjectProvider<JvmClassLoadingMeterConventions> jvmClassLoadingMeterConventions) {
+		JvmClassLoadingMeterConventions conventions = jvmClassLoadingMeterConventions.getIfAvailable();
+		return (conventions != null) ? new ClassLoaderMetrics(conventions) : new ClassLoaderMetrics();
 	}
 
 	@Bean

--- a/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/system/SystemMetricsAutoConfiguration.java
+++ b/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/system/SystemMetricsAutoConfiguration.java
@@ -21,10 +21,12 @@ import java.util.List;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuMeterConventions;
 import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -58,8 +60,9 @@ public final class SystemMetricsAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	ProcessorMetrics processorMetrics() {
-		return new ProcessorMetrics();
+	ProcessorMetrics processorMetrics(ObjectProvider<JvmCpuMeterConventions> jvmCpuMeterConventions) {
+		JvmCpuMeterConventions conventions = jvmCpuMeterConventions.getIfAvailable();
+		return (conventions != null) ? new ProcessorMetrics(Tags.empty(), conventions) : new ProcessorMetrics();
 	}
 
 	@Bean

--- a/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/autoconfigure/system/SystemMetricsAutoConfigurationTests.java
+++ b/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/autoconfigure/system/SystemMetricsAutoConfigurationTests.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuMeterConventions;
 import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
@@ -34,6 +35,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link SystemMetricsAutoConfiguration}.
@@ -62,6 +64,16 @@ class SystemMetricsAutoConfigurationTests {
 	@Test
 	void autoConfiguresProcessorMetrics() {
 		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(ProcessorMetrics.class));
+	}
+
+	@Test
+	void autoConfiguresProcessorMetricsWithCustomJvmCpuMeterConventions() {
+		this.contextRunner.withUserConfiguration(JvmCpuMeterConventionsConfiguration.class).run((context) -> {
+			assertThat(context).hasSingleBean(ProcessorMetrics.class);
+			ProcessorMetrics processorMetrics = context.getBean(ProcessorMetrics.class);
+			assertThat(processorMetrics).extracting("conventions")
+					.isSameAs(context.getBean(JvmCpuMeterConventions.class));
+		});
 	}
 
 	@Test
@@ -134,6 +146,16 @@ class SystemMetricsAutoConfigurationTests {
 		@Bean
 		ProcessorMetrics customProcessorMetrics() {
 			return new ProcessorMetrics();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class JvmCpuMeterConventionsConfiguration {
+
+		@Bean
+		JvmCpuMeterConventions customJvmCpuMeterConventions() {
+			return mock(JvmCpuMeterConventions.class);
 		}
 
 	}


### PR DESCRIPTION
Enhance metrics auto-configuration to support custom meter conventions
by auto-wiring them when available:

- ProcessorMetrics now accepts JvmCpuMeterConventions
- JvmMemoryMetrics now accepts JvmMemoryMeterConventions  
- JvmThreadMetrics now accepts JvmThreadMeterConventions
- ClassLoaderMetrics now accepts JvmClassLoadingMeterConventions

Metrics beans gracefully fall back to default behavior when no custom conventions are provided, maintaining backward compatibility.

Closes gh-47908