### PR TITLE
Fix typo in PortInUseException Javadoc

### DIFF
--- a/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/PortInUseException.java
+++ b/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/PortInUseException.java
@@ -65,7 +65,7 @@ public class PortInUseException extends WebServerException {
 	 * Throw a {@link PortInUseException} if the given exception was caused by a "port in
 	 * use" {@link BindException}.
 	 * @param ex the source exception
-	 * @param port a suppler used to provide the port
+	 * @param port a supplier used to provide the port
 	 * @since 2.2.7
 	 */
 	public static void throwIfPortBindingException(Exception ex, IntSupplier port) {


### PR DESCRIPTION
 Fix a typo in the Javadoc for `PortInUseException.throwIfPortBindingException()`.

  Changed "a suppler" to "a supplier" in the @param port documentation.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
