### PR TITLE
Optimize StringBuilder initialization in CorrelationIdFormatter

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/CorrelationIdFormatter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/CorrelationIdFormatter.java
@@ -87,7 +87,7 @@ public final class CorrelationIdFormatter {
 	 * @return a formatted correlation id
 	 */
 	public String format(UnaryOperator<@Nullable String> resolver) {
-		StringBuilder result = new StringBuilder();
+		StringBuilder result = new StringBuilder(this.blank.length());
 		formatTo(resolver, result);
 		return result.toString();
 	}


### PR DESCRIPTION
Initialize StringBuilder with the expected capacity (this.blank.length()) to avoid unnecessary resizing and array copying during string construction.

The blank field already contains the exact length needed for the formatted output, making it an ideal initial capacity. This improves performance for correlation ID formatting, which is frequently called during logging operations.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
