### PR TITLE
Auto-configuration exclusions are checked using a different class loader to the one that loads auto-configuration classes

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelector.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelector.java
@@ -205,8 +205,9 @@ public class AutoConfigurationImportSelector implements DeferredImportSelector, 
 
 	private void checkExcludedClasses(List<String> configurations, Set<String> exclusions) {
 		List<String> invalidExcludes = new ArrayList<>(exclusions.size());
+		ClassLoader classLoader = (this.beanClassLoader != null) ? this.beanClassLoader : getClass().getClassLoader();
 		for (String exclusion : exclusions) {
-			if (ClassUtils.isPresent(exclusion, getClass().getClassLoader()) && !configurations.contains(exclusion)) {
+			if (ClassUtils.isPresent(exclusion, classLoader) && !configurations.contains(exclusion)) {
 				invalidExcludes.add(exclusion);
 			}
 		}


### PR DESCRIPTION
When validating exclusions, prefer the selector's beanClassLoader for ClassUtils.isPresent checks and fall back to the selector class loader if the beanClassLoader is not set. This makes presence checks consistent with the classloader context used for loading auto-configuration candidates.
