### PR TITLE
spring-boot-starter-elasticsearch should depend on elasticsearch-java

### DIFF
--- a/starter/spring-boot-starter-elasticsearch/build.gradle
+++ b/starter/spring-boot-starter-elasticsearch/build.gradle
@@ -24,4 +24,8 @@ dependencies {
 	api(project(":starter:spring-boot-starter"))
 
 	api(project(":module:spring-boot-elasticsearch"))
+
+	api("co.elastic.clients:elasticsearch-java") {
+		exclude group: "commons-logging", module: "commons-logging"
+	}
 }


### PR DESCRIPTION
When I did #47945 I was not aware that there was a new spring-boot-starter-elasticsearch in Spring Boot 4. @anbusampath brought this to my attention with https://github.com/spring-projects/spring-boot/pull/47945#issuecomment-3535086169. 

I'll leave this up to the Spring Boot team to decide whether the starter should be more opinionated and bring in the High Level elasticsearch-java client. In my opinion I believe that spring-boot-elasticsearch should stay as it is, i.e. only bring in the minimal dependencies, the elasticsearch-rest5-client. However, the starter can be a bit more opinionated and bring in more.

