### PR TITLE
Fix SSL metrics for dynamically registered bundles

### DIFF
--- a/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/ssl/SslMeterBinder.java
+++ b/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/ssl/SslMeterBinder.java
@@ -67,7 +67,10 @@ class SslMeterBinder implements MeterBinder {
 	SslMeterBinder(SslInfo sslInfo, SslBundles sslBundles, Clock clock) {
 		this.clock = clock;
 		this.sslInfo = sslInfo;
-		sslBundles.addBundleRegisterHandler((bundleName, ignored) -> onBundleChange(bundleName));
+		sslBundles.addBundleRegisterHandler((bundleName, ignored) -> {
+			onBundleChange(bundleName);
+			sslBundles.addBundleUpdateHandler(bundleName, (ignoredBundle) -> onBundleChange(bundleName));
+		});
 		for (String bundleName : sslBundles.getBundleNames()) {
 			sslBundles.addBundleUpdateHandler(bundleName, (ignored) -> onBundleChange(bundleName));
 		}


### PR DESCRIPTION
When `SslMeterBinder` is constructed, it only registers update handlers for the bundles
returned by `sslBundles.getBundleNames()` at that time. Bundles that are registered later
only trigger the register handler once and never get an update handler, so subsequent
`SslBundleRegistry.updateBundle(...)` calls do not refresh the `ssl.chain.expiry` gauges.

This change updates the register handler to also register an update handler for the
newly registered bundle and adds a regression test:

* `SslMeterBinderTests.shouldWatchUpdatesForBundlesRegisteredAfterConstruction`

The test fails with the original implementation and passes with this change.

Fixes #48144 (gh-48144)