### PR TITLE
Implement tests for HttpClientSettingsPropertyMapper

### DIFF
--- a/module/spring-boot-http-client/src/test/java/org/springframework/boot/http/client/autoconfigure/HttpClientSettingsPropertyMapperTests.java
+++ b/module/spring-boot-http-client/src/test/java/org/springframework/boot/http/client/autoconfigure/HttpClientSettingsPropertyMapperTests.java
@@ -16,19 +16,123 @@
 
 package org.springframework.boot.http.client.autoconfigure;
 
-import org.junit.jupiter.api.Disabled;
+import java.time.Duration;
+
 import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.http.client.HttpClientSettings;
+import org.springframework.boot.http.client.HttpRedirects;
+import org.springframework.boot.ssl.SslBundle;
+import org.springframework.boot.ssl.SslBundles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link HttpClientSettingsPropertyMapper}.
  *
  * @author Phillip Webb
  */
-@Disabled("TODO")
 class HttpClientSettingsPropertyMapperTests {
 
 	@Test
-	void mapMapsProperties() {
+	void mapWhenPropertiesIsNullReturnsBaseSettings() {
+		HttpClientSettings baseSettings = HttpClientSettings.defaults()
+			.withConnectTimeout(Duration.ofSeconds(10));
+		HttpClientSettingsPropertyMapper mapper = new HttpClientSettingsPropertyMapper(null, baseSettings);
+		HttpClientSettings result = mapper.map(null);
+		assertThat(result).isEqualTo(baseSettings);
+	}
+
+	@Test
+	void mapWhenPropertiesIsNullAndBaseSettingsIsNullReturnsDefaults() {
+		HttpClientSettingsPropertyMapper mapper = new HttpClientSettingsPropertyMapper(null, null);
+		HttpClientSettings result = mapper.map(null);
+		assertThat(result).isEqualTo(HttpClientSettings.defaults());
+	}
+
+	@Test
+	void mapMapsRedirects() {
+		HttpClientSettingsPropertyMapper mapper = new HttpClientSettingsPropertyMapper(null, null);
+		TestHttpClientSettingsProperties properties = new TestHttpClientSettingsProperties();
+		properties.setRedirects(HttpRedirects.DONT_FOLLOW);
+		HttpClientSettings result = mapper.map(properties);
+		assertThat(result.redirects()).isEqualTo(HttpRedirects.DONT_FOLLOW);
+	}
+
+	@Test
+	void mapMapsConnectTimeout() {
+		HttpClientSettingsPropertyMapper mapper = new HttpClientSettingsPropertyMapper(null, null);
+		TestHttpClientSettingsProperties properties = new TestHttpClientSettingsProperties();
+		properties.setConnectTimeout(Duration.ofSeconds(5));
+		HttpClientSettings result = mapper.map(properties);
+		assertThat(result.connectTimeout()).isEqualTo(Duration.ofSeconds(5));
+	}
+
+	@Test
+	void mapMapsReadTimeout() {
+		HttpClientSettingsPropertyMapper mapper = new HttpClientSettingsPropertyMapper(null, null);
+		TestHttpClientSettingsProperties properties = new TestHttpClientSettingsProperties();
+		properties.setReadTimeout(Duration.ofSeconds(30));
+		HttpClientSettings result = mapper.map(properties);
+		assertThat(result.readTimeout()).isEqualTo(Duration.ofSeconds(30));
+	}
+
+	@Test
+	void mapMapsSslBundle() {
+		SslBundle sslBundle = mock(SslBundle.class);
+		SslBundles sslBundles = mock(SslBundles.class);
+		given(sslBundles.getBundle("test-bundle")).willReturn(sslBundle);
+		HttpClientSettingsPropertyMapper mapper = new HttpClientSettingsPropertyMapper(sslBundles, null);
+		TestHttpClientSettingsProperties properties = new TestHttpClientSettingsProperties();
+		properties.getSsl().setBundle("test-bundle");
+		HttpClientSettings result = mapper.map(properties);
+		assertThat(result.sslBundle()).isSameAs(sslBundle);
+	}
+
+	@Test
+	void mapMapsAllProperties() {
+		SslBundle sslBundle = mock(SslBundle.class);
+		SslBundles sslBundles = mock(SslBundles.class);
+		given(sslBundles.getBundle("my-bundle")).willReturn(sslBundle);
+		HttpClientSettingsPropertyMapper mapper = new HttpClientSettingsPropertyMapper(sslBundles, null);
+		TestHttpClientSettingsProperties properties = new TestHttpClientSettingsProperties();
+		properties.setRedirects(HttpRedirects.FOLLOW);
+		properties.setConnectTimeout(Duration.ofSeconds(10));
+		properties.setReadTimeout(Duration.ofSeconds(20));
+		properties.getSsl().setBundle("my-bundle");
+		HttpClientSettings result = mapper.map(properties);
+		assertThat(result.redirects()).isEqualTo(HttpRedirects.FOLLOW);
+		assertThat(result.connectTimeout()).isEqualTo(Duration.ofSeconds(10));
+		assertThat(result.readTimeout()).isEqualTo(Duration.ofSeconds(20));
+		assertThat(result.sslBundle()).isSameAs(sslBundle);
+	}
+
+	@Test
+	void mapUsesBaseSettingsForMissingProperties() {
+		HttpClientSettings baseSettings = new HttpClientSettings(HttpRedirects.FOLLOW_WHEN_POSSIBLE,
+				Duration.ofSeconds(15), Duration.ofSeconds(25), null);
+		HttpClientSettingsPropertyMapper mapper = new HttpClientSettingsPropertyMapper(null, baseSettings);
+		TestHttpClientSettingsProperties properties = new TestHttpClientSettingsProperties();
+		properties.setConnectTimeout(Duration.ofSeconds(5));
+		HttpClientSettings result = mapper.map(properties);
+		assertThat(result.redirects()).isEqualTo(HttpRedirects.FOLLOW_WHEN_POSSIBLE);
+		assertThat(result.connectTimeout()).isEqualTo(Duration.ofSeconds(5));
+		assertThat(result.readTimeout()).isEqualTo(Duration.ofSeconds(25));
+	}
+
+	@Test
+	void mapWhenSslBundleRequestedButSslBundlesIsNullThrowsException() {
+		HttpClientSettingsPropertyMapper mapper = new HttpClientSettingsPropertyMapper(null, null);
+		TestHttpClientSettingsProperties properties = new TestHttpClientSettingsProperties();
+		properties.getSsl().setBundle("test-bundle");
+		assertThatIllegalStateException().isThrownBy(() -> mapper.map(properties))
+			.withMessage("No 'sslBundles' available");
+	}
+
+	static class TestHttpClientSettingsProperties extends HttpClientSettingsProperties {
 
 	}
 


### PR DESCRIPTION
Add comprehensive tests for the HttpClientSettingsPropertyMapper class that was previously disabled with a TODO comment. The tests cover:
- Mapping with null properties
- Mapping individual properties (redirects, connectTimeout, readTimeout, SSL bundle)
- Mapping all properties together
- Using base settings for missing properties
- Error handling when SSL bundles are unavailable
