### PR TITLE
  Fix multiple HTTP message converters of the same type being lost

### DIFF
--- a/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/DefaultClientHttpMessageConvertersCustomizer.java
+++ b/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/DefaultClientHttpMessageConvertersCustomizer.java
@@ -17,6 +17,9 @@
 package org.springframework.boot.http.converter.autoconfigure;
 
 import java.util.Collection;
+import java.util.EnumSet;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 
 import org.jspecify.annotations.Nullable;
 
@@ -47,24 +50,32 @@ class DefaultClientHttpMessageConvertersCustomizer implements ClientHttpMessageC
 		}
 		else {
 			builder.registerDefaults();
-			this.converters.forEach((converter) -> {
-				if (converter instanceof StringHttpMessageConverter) {
-					builder.withStringConverter(converter);
-				}
-				else if (converter instanceof KotlinSerializationJsonHttpMessageConverter) {
-					builder.withKotlinSerializationJsonConverter(converter);
-				}
-				else if (supportsMediaType(converter, MediaType.APPLICATION_JSON)) {
-					builder.withJsonConverter(converter);
-				}
-				else if (supportsMediaType(converter, MediaType.APPLICATION_XML)) {
-					builder.withXmlConverter(converter);
+			EnumSet<ConverterType> registered = EnumSet.noneOf(ConverterType.class);
+			for (HttpMessageConverter<?> converter : this.converters) {
+				ConverterType type = findConverterType(converter);
+				if (type != null) {
+					if (!registered.contains(type)) {
+						type.registerWith(builder, converter);
+						registered.add(type);
+					}
+					else {
+						builder.addCustomConverter(converter);
+					}
 				}
 				else {
 					builder.addCustomConverter(converter);
 				}
-			});
+			}
 		}
+	}
+
+	private static @Nullable ConverterType findConverterType(HttpMessageConverter<?> converter) {
+		for (ConverterType type : ConverterType.values()) {
+			if (type.matches(converter)) {
+				return type;
+			}
+		}
+		return null;
 	}
 
 	private static boolean supportsMediaType(HttpMessageConverter<?> converter, MediaType mediaType) {
@@ -74,6 +85,38 @@ class DefaultClientHttpMessageConvertersCustomizer implements ClientHttpMessageC
 			}
 		}
 		return false;
+	}
+
+	private enum ConverterType {
+
+		STRING(StringHttpMessageConverter.class::isInstance, ClientBuilder::withStringConverter),
+
+		KOTLIN_SERIALIZATION_JSON(KotlinSerializationJsonHttpMessageConverter.class::isInstance,
+				ClientBuilder::withKotlinSerializationJsonConverter),
+
+		JSON(converter -> supportsMediaType(converter, MediaType.APPLICATION_JSON),
+				ClientBuilder::withJsonConverter),
+
+		XML(converter -> supportsMediaType(converter, MediaType.APPLICATION_XML), ClientBuilder::withXmlConverter);
+
+		private final Predicate<HttpMessageConverter<?>> matcher;
+
+		private final BiConsumer<ClientBuilder, HttpMessageConverter<?>> registrar;
+
+		ConverterType(Predicate<HttpMessageConverter<?>> matcher,
+				BiConsumer<ClientBuilder, HttpMessageConverter<?>> registrar) {
+			this.matcher = matcher;
+			this.registrar = registrar;
+		}
+
+		boolean matches(HttpMessageConverter<?> converter) {
+			return this.matcher.test(converter);
+		}
+
+		void registerWith(ClientBuilder builder, HttpMessageConverter<?> converter) {
+			this.registrar.accept(builder, converter);
+		}
+
 	}
 
 }

--- a/module/spring-boot-http-converter/src/test/java/org/springframework/boot/http/converter/autoconfigure/DefaultServerHttpMessageConvertersCustomizerTests.java
+++ b/module/spring-boot-http-converter/src/test/java/org/springframework/boot/http/converter/autoconfigure/DefaultServerHttpMessageConvertersCustomizerTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.http.converter.autoconfigure;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.HttpMessageConverters.ServerBuilder;
+import org.springframework.http.converter.json.GsonHttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+/**
+ * Tests for {@link DefaultServerHttpMessageConvertersCustomizer}.
+ *
+ * @author Tommy Karlsson
+ */
+@SuppressWarnings("deprecation")
+class DefaultServerHttpMessageConvertersCustomizerTests {
+
+	@Test
+	void customizeWithTwoJsonConvertersConfiguresFirstAsJsonConverterAndSecondAsCustomConverter() {
+		// Create two JSON converters
+		JacksonJsonHttpMessageConverter jsonConverter1 = new JacksonJsonHttpMessageConverter();
+		GsonHttpMessageConverter jsonConverter2 = new GsonHttpMessageConverter();
+
+		// Create the customizer with both converters
+		List<HttpMessageConverter<?>> converters = List.of(jsonConverter1, jsonConverter2);
+		DefaultServerHttpMessageConvertersCustomizer customizer = new DefaultServerHttpMessageConvertersCustomizer(null,
+				converters);
+
+		// Mock the ServerBuilder
+		ServerBuilder builder = mock(ServerBuilder.class);
+
+		// Execute the customize method
+		customizer.customize(builder);
+
+		// Verify that registerDefaults was called
+		then(builder).should().registerDefaults();
+
+		// Verify that the first JSON converter is configured as the JSON converter
+		then(builder).should(times(1)).withJsonConverter(jsonConverter1);
+
+		// Verify that the second JSON converter is configured as a custom converter
+		// (since there should only be one JSON converter registered via withJsonConverter)
+		then(builder).should(times(1)).addCustomConverter(jsonConverter2);
+
+		// Verify that withJsonConverter was only called once (for the first converter)
+		then(builder).should(times(1)).withJsonConverter(any());
+	}
+
+	@Test
+	void customizeWithJsonConverterVerifiesJsonConverterConfiguration() {
+		// Create a single JSON converter
+		JacksonJsonHttpMessageConverter jsonConverter = new JacksonJsonHttpMessageConverter();
+
+		// Verify it supports JSON
+		boolean supportsJson = jsonConverter.getSupportedMediaTypes()
+			.stream()
+			.anyMatch(mediaType -> mediaType.equalsTypeAndSubtype(MediaType.APPLICATION_JSON));
+		assert supportsJson : "Converter should support APPLICATION_JSON";
+
+		// Create the customizer
+		List<HttpMessageConverter<?>> converters = List.of(jsonConverter);
+		DefaultServerHttpMessageConvertersCustomizer customizer = new DefaultServerHttpMessageConvertersCustomizer(null,
+				converters);
+
+		// Mock the ServerBuilder
+		ServerBuilder builder = mock(ServerBuilder.class);
+
+		// Execute the customize method
+		customizer.customize(builder);
+
+		// Verify that registerDefaults was called
+		then(builder).should().registerDefaults();
+
+		// Verify that withJsonConverter was called with the JSON converter
+		then(builder).should().withJsonConverter(jsonConverter);
+
+		// Verify that addCustomConverter was not called for the JSON converter
+		then(builder).should(times(0)).addCustomConverter(any());
+	}
+
+	@Test
+	void customizeWithNonJsonConverterConfiguresAsCustomConverter() {
+		// Create a custom converter that doesn't support JSON
+		HttpMessageConverter<?> customConverter = mock(HttpMessageConverter.class);
+
+		// Create the customizer
+		List<HttpMessageConverter<?>> converters = List.of(customConverter);
+		DefaultServerHttpMessageConvertersCustomizer customizer = new DefaultServerHttpMessageConvertersCustomizer(null,
+				converters);
+
+		// Mock the ServerBuilder
+		ServerBuilder builder = mock(ServerBuilder.class);
+
+		// Execute the customize method
+		customizer.customize(builder);
+
+		// Verify that registerDefaults was called
+		then(builder).should().registerDefaults();
+
+		// Verify that addCustomConverter was called with the custom converter
+		then(builder).should().addCustomConverter(customConverter);
+
+		// Verify that withJsonConverter was not called
+		then(builder).should(times(0)).withJsonConverter(any());
+	}
+
+}


### PR DESCRIPTION
  When multiple HttpMessageConverters of the same specialized type
  (e.g., two JSON converters) were configured, only the last one was
  registered correctly. The first converter would be discarded because
  the specialized registration method was called for all converters
  of the same type, causing each to overwrite the previous one.

  This fix ensures that only the first converter of each specialized
  type (String, Kotlin Serialization JSON, JSON, XML) is registered
  using the specialized method (e.g., withJsonConverter()). Subsequent
  converters of the same type are registered as custom converters via
  addCustomConverter().

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
