### PR TITLE
ProblemDetail is rendered to XML incorrectly

### DIFF
--- a/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration.java
+++ b/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration.java
@@ -66,6 +66,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.core.Ordered;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.converter.json.ProblemDetailJacksonMixin;
+import org.springframework.http.converter.json.ProblemDetailJacksonXmlMixin;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
@@ -282,7 +283,7 @@ public final class JacksonAutoConfiguration {
 
 				@Override
 				public void customize(XmlMapper.Builder builder) {
-					builder.addMixIn(ProblemDetail.class, ProblemDetailJacksonMixin.class);
+					builder.addMixIn(ProblemDetail.class, ProblemDetailJacksonXmlMixin.class);
 				}
 
 			}

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfigurationTests.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfigurationTests.java
@@ -691,7 +691,7 @@ class JacksonAutoConfigurationTests {
 			problemDetail.setProperty("spring", "boot");
 			String xml = mapper.writeValueAsString(problemDetail);
 			assertThat(xml).isEqualTo(
-					"<ProblemDetail><status>404</status><title>Not Found</title><spring>boot</spring></ProblemDetail>");
+					"<problem xmlns=\"urn:ietf:rfc:7807\"><status>404</status><title>Not Found</title><spring>boot</spring></problem>");
 		});
 	}
 


### PR DESCRIPTION

This PR fixes an issue where the `ProblemDetailXmlMapperBuilderCustomizer` incorrectly applies the `ProblemDetailJacksonMixin` (intended for JSON) to the Jackson `XmlMapper.Builder`. It now correctly applies the `ProblemDetailJacksonXmlMixin` for proper XML serialization.

Previously, with the wrong mixin, Jackson produced XML like this:

```<ProblemDetail><status>404</status><title>Not Found</title><spring>boot</spring></ProblemDetail>```

After applying the correct mixin, the output matches the expected format as defined in [RFC 7807, Appendix A](https://www.rfc-editor.org/rfc/rfc7807#appendix-A):

```<problem xmlns=\"urn:ietf:rfc:7807\"><status>404</status><title>Not Found</title><spring>boot</spring></problem>```

This format includes the correct root element (`problem`) and namespace declaration, consistent with Spring Boot 3.x output.

The related test has been updated accordingly to verify the correct XML output.
