### PR TITLE
Remove JUnit 4 references from test slice annotations javadoc

### DIFF
--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonTest.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonTest.java
@@ -56,9 +56,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * {@link JacksonTester}, {@link JsonbTester} and {@link GsonTester} fields. More
  * fine-grained control can be provided through the
  * {@link AutoConfigureJsonTesters @AutoConfigureJsonTesters} annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Phillip Webb
  * @author Artsiom Yudovin

--- a/module/spring-boot-data-cassandra-test/src/main/java/org/springframework/boot/data/cassandra/test/autoconfigure/DataCassandraTest.java
+++ b/module/spring-boot-data-cassandra-test/src/main/java/org/springframework/boot/data/cassandra/test/autoconfigure/DataCassandraTest.java
@@ -42,9 +42,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Using this annotation only enables auto-configuration that is relevant to Data Casandra
  * tests. Similarly, component scanning is limited to Cassandra repositories and entities
  * ({@code @Table}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Artsiom Yudovin
  * @author Stephane Nicoll

--- a/module/spring-boot-data-couchbase-test/src/main/java/org/springframework/boot/data/couchbase/test/autoconfigure/DataCouchbaseTest.java
+++ b/module/spring-boot-data-couchbase-test/src/main/java/org/springframework/boot/data/couchbase/test/autoconfigure/DataCouchbaseTest.java
@@ -42,9 +42,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Using this annotation only enables auto-configuration that is relevant to Data
  * Couchbase tests. Similarly, component scanning is limited to Couchbase repositories and
  * entities ({@code @Document}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Eddú Meléndez
  * @since 4.0.0

--- a/module/spring-boot-data-elasticsearch-test/src/main/java/org/springframework/boot/data/elasticsearch/test/autoconfigure/DataElasticsearchTest.java
+++ b/module/spring-boot-data-elasticsearch-test/src/main/java/org/springframework/boot/data/elasticsearch/test/autoconfigure/DataElasticsearchTest.java
@@ -42,9 +42,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Using this annotation only enables auto-configuration that is relevant to Data
  * Elasticsearch tests. Similarly, component scanning is limited to Elasticsearch
  * repositories and entities ({@code @Document}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Eddú Meléndez
  * @since 4.0.0

--- a/module/spring-boot-data-jdbc-test/src/main/java/org/springframework/boot/data/jdbc/test/autoconfigure/DataJdbcTest.java
+++ b/module/spring-boot-data-jdbc-test/src/main/java/org/springframework/boot/data/jdbc/test/autoconfigure/DataJdbcTest.java
@@ -56,9 +56,6 @@ import org.springframework.transaction.annotation.Transactional;
  * database, you should consider {@link SpringBootTest @SpringBootTest} combined with
  * {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase} rather than this
  * annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Andy Wilkinson
  * @since 4.0.0

--- a/module/spring-boot-data-jpa-test/src/main/java/org/springframework/boot/data/jpa/test/autoconfigure/DataJpaTest.java
+++ b/module/spring-boot-data-jpa-test/src/main/java/org/springframework/boot/data/jpa/test/autoconfigure/DataJpaTest.java
@@ -63,9 +63,6 @@ import org.springframework.transaction.annotation.Transactional;
  * database, you should consider {@link SpringBootTest @SpringBootTest} combined with
  * {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase} rather than this
  * annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Phillip Webb
  * @author Artsiom Yudovin

--- a/module/spring-boot-data-ldap-test/src/main/java/org/springframework/boot/data/ldap/test/autoconfigure/DataLdapTest.java
+++ b/module/spring-boot-data-ldap-test/src/main/java/org/springframework/boot/data/ldap/test/autoconfigure/DataLdapTest.java
@@ -45,9 +45,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * <p>
  * By default, tests annotated with {@code @DataLdapTest} will use an embedded in-memory
  * LDAP process (if available).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Eddú Meléndez
  * @author Artsiom Yudovin

--- a/module/spring-boot-data-mongodb-test/src/main/java/org/springframework/boot/data/mongodb/test/autoconfigure/DataMongoTest.java
+++ b/module/spring-boot-data-mongodb-test/src/main/java/org/springframework/boot/data/mongodb/test/autoconfigure/DataMongoTest.java
@@ -42,9 +42,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Using this annotation only enables auto-configuration that is relevant to Data Mongo
  * tests. Similarly, component scanning is limited to Mongo repositories and entities
  * ({@code @Document}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Michael Simons
  * @author Stephane Nicoll

--- a/module/spring-boot-data-neo4j-test/src/main/java/org/springframework/boot/data/neo4j/test/autoconfigure/DataNeo4jTest.java
+++ b/module/spring-boot-data-neo4j-test/src/main/java/org/springframework/boot/data/neo4j/test/autoconfigure/DataNeo4jTest.java
@@ -48,9 +48,6 @@ import org.springframework.transaction.annotation.Transactional;
  * usual test-related semantics (i.e. rollback by default). This feature is not supported
  * with reactive access so this should be disabled by annotating the test class with
  * {@code @Transactional(propagation = Propagation.NOT_SUPPORTED)}.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Eddú Meléndez
  * @author Stephane Nicoll

--- a/module/spring-boot-data-r2dbc-test/src/main/java/org/springframework/boot/data/r2dbc/test/autoconfigure/DataR2dbcTest.java
+++ b/module/spring-boot-data-r2dbc-test/src/main/java/org/springframework/boot/data/r2dbc/test/autoconfigure/DataR2dbcTest.java
@@ -42,9 +42,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Using this annotation only enables auto-configuration that is relevant to Data R2DBC
  * tests. Similarly, component scanning is limited to R2DBC repositories and entities
  * ({@code @Table}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Mark Paluch
  * @author Stephane Nicoll

--- a/module/spring-boot-data-redis-test/src/main/java/org/springframework/boot/data/redis/test/autoconfigure/DataRedisTest.java
+++ b/module/spring-boot-data-redis-test/src/main/java/org/springframework/boot/data/redis/test/autoconfigure/DataRedisTest.java
@@ -42,9 +42,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Using this annotation only enables auto-configuration that is relevant to Data Redis
  * tests. Similarly, component scanning is limited to Redis repositories and entities
  * ({@code @RedisHash}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Jayaram Pradhan
  * @author Artsiom Yudovin

--- a/module/spring-boot-jdbc-test/src/main/java/org/springframework/boot/jdbc/test/autoconfigure/JdbcTest.java
+++ b/module/spring-boot-jdbc-test/src/main/java/org/springframework/boot/jdbc/test/autoconfigure/JdbcTest.java
@@ -54,9 +54,6 @@ import org.springframework.transaction.annotation.Transactional;
  * database, you should consider {@link SpringBootTest @SpringBootTest} combined with
  * {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase} rather than this
  * annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Stephane Nicoll
  * @author Artsiom Yudovin

--- a/module/spring-boot-jooq-test/src/main/java/org/springframework/boot/jooq/test/autoconfigure/JooqTest.java
+++ b/module/spring-boot-jooq-test/src/main/java/org/springframework/boot/jooq/test/autoconfigure/JooqTest.java
@@ -48,9 +48,6 @@ import org.springframework.transaction.annotation.Transactional;
  * want to replace any explicit or usually auto-configured DataSource by an embedded
  * in-memory database, the {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase}
  * annotation can be used to override these settings.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Michael Simons
  * @author Stephane Nicoll

--- a/module/spring-boot-restclient-test/src/main/java/org/springframework/boot/restclient/test/autoconfigure/RestClientTest.java
+++ b/module/spring-boot-restclient-test/src/main/java/org/springframework/boot/restclient/test/autoconfigure/RestClientTest.java
@@ -59,9 +59,6 @@ import org.springframework.web.client.RestClient.Builder;
  * {@link MockRestServiceServer}. For more fine-grained control the
  * {@link AutoConfigureMockRestServiceServer @AutoConfigureMockRestServiceServer}
  * annotation can be used.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Stephane Nicoll
  * @author Phillip Webb

--- a/module/spring-boot-webclient-test/src/main/java/org/springframework/boot/webclient/test/autoconfigure/WebClientTest.java
+++ b/module/spring-boot-webclient-test/src/main/java/org/springframework/boot/webclient/test/autoconfigure/WebClientTest.java
@@ -50,9 +50,6 @@ import org.springframework.web.client.RestClient.Builder;
  * <ul>
  * <li>{@code JacksonModule}, if Jackson is available</li>
  * </ul>
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Andy Wilkinson
  * @since 4.0.0

--- a/module/spring-boot-webflux-test/src/main/java/org/springframework/boot/webflux/test/autoconfigure/WebFluxTest.java
+++ b/module/spring-boot-webflux-test/src/main/java/org/springframework/boot/webflux/test/autoconfigure/WebFluxTest.java
@@ -78,9 +78,6 @@ import org.springframework.test.web.reactive.server.WebTestClient;
  * you should consider {@link SpringBootTest @SpringBootTest} combined with
  * {@link AutoConfigureWebTestClient @AutoConfigureWebTestClient} rather than this
  * annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Stephane Nicoll
  * @author Artsiom Yudovin

--- a/module/spring-boot-webmvc-test/src/main/java/org/springframework/boot/webmvc/test/autoconfigure/WebMvcTest.java
+++ b/module/spring-boot-webmvc-test/src/main/java/org/springframework/boot/webmvc/test/autoconfigure/WebMvcTest.java
@@ -84,9 +84,6 @@ import org.springframework.test.web.servlet.MockMvc;
  * If you are looking to load your full application configuration and use MockMVC, you
  * should consider {@link SpringBootTest @SpringBootTest} combined with
  * {@link AutoConfigureMockMvc @AutoConfigureMockMvc} rather than this annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Phillip Webb
  * @author Artsiom Yudovin

--- a/module/spring-boot-webservices-test/src/main/java/org/springframework/boot/webservices/test/autoconfigure/client/WebServiceClientTest.java
+++ b/module/spring-boot-webservices-test/src/main/java/org/springframework/boot/webservices/test/autoconfigure/client/WebServiceClientTest.java
@@ -47,9 +47,6 @@ import org.springframework.ws.test.client.MockWebServiceServer;
  * If you are testing a bean that doesn't use {@link WebServiceTemplateBuilder} but
  * instead injects a {@link WebServiceTemplate} directly, you can add
  * {@code @AutoConfigureWebServiceClient(registerWebServiceTemplate=true)}.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Dmytro Nosan
  * @since 2.3.0


### PR DESCRIPTION
Closes #47228

## Summary

This PR removes outdated JUnit 4 usage instructions from javadoc comments in all test slice annotations.

## Changes

Removed the following paragraph from 18 test annotation classes:
```
When using JUnit 4, this annotation should be used in combination with
@RunWith(SpringRunner.class).
```

These annotations now only work with JUnit 5 (Jupiter) via `@ExtendWith(SpringExtension.class)`, making the JUnit 4 instructions obsolete and potentially confusing for users.

## Affected Annotations

- `@DataCassandraTest`
- `@DataCouchbaseTest`
- `@DataElasticsearchTest`
- `@DataJdbcTest`
- `@DataJpaTest`
- `@DataLdapTest`
- `@DataMongoTest`
- `@DataNeo4jTest`
- `@DataR2dbcTest`
- `@DataRedisTest`
- `@JdbcTest`
- `@JooqTest`
- `@JsonTest`
- `@RestClientTest`
- `@WebClientTest`
- `@WebFluxTest`
- `@WebMvcTest`
- `@WebServiceClientTest`