### PR TITLE
Fix a typo in ContextPairs.flat()

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/ContextPairs.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/ContextPairs.java
@@ -52,12 +52,12 @@ public class ContextPairs {
 	/**
 	 * Add pairs using flat naming.
 	 * @param <T> the item type
-	 * @param delimeter the delimiter used if there is a prefix
+	 * @param delimiter the delimiter used if there is a prefix
 	 * @param pairs callback to add all the pairs
 	 * @return a {@link BiConsumer} for use with the {@link JsonWriter}
 	 */
-	public <T> BiConsumer<T, BiConsumer<String, Object>> flat(String delimeter, Consumer<Pairs<T>> pairs) {
-		return flat(joinWith(delimeter), pairs);
+	public <T> BiConsumer<T, BiConsumer<String, Object>> flat(String delimiter, Consumer<Pairs<T>> pairs) {
+		return flat(joinWith(delimiter), pairs);
 	}
 
 	/**

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/structured/ContextPairsTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/structured/ContextPairsTests.java
@@ -58,7 +58,7 @@ class ContextPairsTests {
 	}
 
 	@Test
-	void flatWhenPrefixEndingWithDelimeterAppliesPrefix() {
+	void flatWhenPrefixEndingWithDelimiterAppliesPrefix() {
 		ContextPairs contextPairs = new ContextPairs(true, "the_");
 		Map<String, String> map = Map.of("spring", "boot");
 		Map<String, Object> actual = apply(contextPairs.flat("_", (pairs) -> pairs.addMapEntries((item) -> map)));
@@ -66,7 +66,7 @@ class ContextPairsTests {
 	}
 
 	@Test
-	void flatWhenPrefixAndNameStartingWithDelimeterAppliesPrefix() {
+	void flatWhenPrefixAndNameStartingWithDelimiterAppliesPrefix() {
 		ContextPairs contextPairs = new ContextPairs(true, "the");
 		Map<String, String> map = Map.of("_spring", "boot");
 		Map<String, Object> actual = apply(contextPairs.flat("_", (pairs) -> pairs.addMapEntries((item) -> map)));


### PR DESCRIPTION
Changed 'delimeter' to 'delimiter' in the method parameter name and its usage.