### PR TITLE
Upgrade to Commons Lang3 3.19.0

### DIFF
--- a/spring-boot-project/spring-boot-dependencies/build.gradle
+++ b/spring-boot-project/spring-boot-dependencies/build.gradle
@@ -242,7 +242,7 @@ bom {
 			releaseNotes("https://commons.apache.org/proper/commons-dbcp/changes-report.html#a{version}")
 		}
 	}
-	library("Commons Lang3", "3.17.0") {
+	library("Commons Lang3", "3.19.0") {
 		group("org.apache.commons") {
 			modules = [
 				"commons-lang3"


### PR DESCRIPTION
This PR upgrades commons-lang3 to 3.19.0 to apply security patches that address a recently disclosed CVE affecting earlier versions of Commons Lang.
Upgrading ensures the project no longer depends on a vulnerable release and stays aligned with the latest stable version that includes security and performance improvements.