### PR TITLE
Remove unnecessary casts

### DIFF
--- a/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/properties/AnnotationsPropertySource.java
+++ b/spring-boot-project/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/properties/AnnotationsPropertySource.java
@@ -138,7 +138,7 @@ public class AnnotationsPropertySource extends EnumerablePropertySource<Class<?>
 		}
 		else if (value instanceof MergedAnnotation<?> annotation) {
 			for (Method attribute : annotation.getType().getDeclaredMethods()) {
-				collectProperties(name, defaultSkip, (MergedAnnotation<?>) value, attribute, properties);
+				collectProperties(name, defaultSkip, annotation, attribute, properties);
 			}
 		}
 		else {

--- a/spring-boot-project/spring-boot-tools/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/CommandRunner.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/CommandRunner.java
@@ -242,7 +242,7 @@ public class CommandRunner implements Iterable<Command> {
 		if (ex instanceof CommandException commandException) {
 			options = commandException.getOptions();
 			if (options.contains(CommandException.Option.RETHROW)) {
-				throw (CommandException) ex;
+				throw commandException;
 			}
 		}
 		boolean couldNotShowMessage = false;


### PR DESCRIPTION
Replace explicit casts with pattern variables introduced in Java 16 to improve readability and remove redundancy.

This commit updates the following classes:
- CommandRunner
- AnnotationsPropertySource

This is a refactoring only and does not change existing behaviour.

