### PR TITLE
Adjust getOrder method to return a higher precedence

### DIFF
--- a/module/spring-boot-restclient/src/main/java/org/springframework/boot/restclient/autoconfigure/service/PropertiesRestClientHttpServiceGroupConfigurer.java
+++ b/module/spring-boot-restclient/src/main/java/org/springframework/boot/restclient/autoconfigure/service/PropertiesRestClientHttpServiceGroupConfigurer.java
@@ -64,10 +64,13 @@ class PropertiesRestClientHttpServiceGroupConfigurer implements RestClientHttpSe
 			.getIfAvailable(() -> ClientHttpRequestFactoryBuilder.detect(classLoader));
 	}
 
-	@Override
-	public int getOrder() {
-		return Ordered.HIGHEST_PRECEDENCE;
-	}
+	@@
+     @Override
+     public int getOrder() {
+-        return Ordered.HIGHEST_PRECEDENCE;
++        return Ordered.HIGHEST_PRECEDENCE + 10;
+     }
+
 
 	@Override
 	public void configureGroups(Groups<RestClient.Builder> groups) {


### PR DESCRIPTION
Adjust ordering of PropertiesRestClientHttpServiceGroupConfigurer

Previously, PropertiesRestClientHttpServiceGroupConfigurer returned Ordered.HIGHEST_PRECEDENCE, preventing any user-defined RestClientHttpServiceGroupConfigurer from being ordered ahead of it.

This caused issues for applications wanting to supply an initial RestClient.Builder instance (supported recently in Spring Framework), since the properties configurer would always force early default builder initialization.

This commit increases the order to (Ordered.HIGHEST_PRECEDENCE + 10), keeping property-based configuration at very high precedence while allowing custom configurers to deliberately override it when required.

Closes gh-48296

<!-- Standard Spring Boot contribution notes remain unchanged -->
Summary

PropertiesRestClientHttpServiceGroupConfigurer was using
Ordered.HIGHEST_PRECEDENCE (effectively Integer.MIN_VALUE).
This prevented any user-defined RestClientHttpServiceGroupConfigurer
from running ahead of the properties configurer.

This became problematic after Spring Framework added support for supplying an initial RestClient.Builder.
Since the properties configurer always executed first, it forced early default builder creation — blocking applications from providing their own base builder.

What this PR changes

The ordering of the configurer has been updated from:

return Ordered.HIGHEST_PRECEDENCE;


to:

return Ordered.HIGHEST_PRECEDENCE + 10;