### PR TITLE
Redis health check reports an error when redis_version is missing from the INFO response

### DIFF
--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/health/DataRedisHealth.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/health/DataRedisHealth.java
@@ -33,9 +33,7 @@ final class DataRedisHealth {
 	}
 
 	static Health.Builder up(Health.Builder builder, Properties info) {
-		info.forEach((key, value) -> {
-			builder.withDetail(String.valueOf(key), value);
-		});
+		builder.withDetail("version", info.getProperty("redis_version", "unknown"));
 		return builder.up();
 	}
 

--- a/module/spring-boot-data-redis/src/test/java/org/springframework/boot/data/redis/health/DataRedisReactiveHealthIndicatorTests.java
+++ b/module/spring-boot-data-redis/src/test/java/org/springframework/boot/data/redis/health/DataRedisReactiveHealthIndicatorTests.java
@@ -69,6 +69,23 @@ class DataRedisReactiveHealthIndicatorTests {
 	}
 
 	@Test
+	void redisIsUpWithMissingVersion() {
+		Properties info = new Properties();
+		ReactiveRedisConnection redisConnection = mock(ReactiveRedisConnection.class);
+		given(redisConnection.closeLater()).willReturn(Mono.empty());
+		ReactiveServerCommands commands = mock(ReactiveServerCommands.class);
+		given(commands.info("server")).willReturn(Mono.just(info));
+		DataRedisReactiveHealthIndicator healthIndicator = createHealthIndicator(redisConnection, commands);
+		Mono<Health> health = healthIndicator.health();
+		StepVerifier.create(health).consumeNextWith((h) -> {
+			assertThat(h.getStatus()).isEqualTo(Status.UP);
+			assertThat(h.getDetails()).containsOnlyKeys("version");
+			assertThat(h.getDetails()).containsEntry("version", "unknown");
+		}).expectComplete().verify(Duration.ofSeconds(30));
+		then(redisConnection).should().closeLater();
+	}
+
+	@Test
 	void healthWhenClusterStateIsAbsentShouldBeUp() {
 		ReactiveRedisConnectionFactory redisConnectionFactory = createClusterConnectionFactory(null);
 		DataRedisReactiveHealthIndicator healthIndicator = new DataRedisReactiveHealthIndicator(redisConnectionFactory);

--- a/module/spring-boot-data-redis/src/test/java/org/springframework/boot/data/redis/health/RedisHealthIndicatorTests.java
+++ b/module/spring-boot-data-redis/src/test/java/org/springframework/boot/data/redis/health/RedisHealthIndicatorTests.java
@@ -63,6 +63,19 @@ class RedisHealthIndicatorTests {
 	}
 
 	@Test
+	void redisIsUpWithMissingVersion() {
+		Properties info = new Properties();
+		RedisConnection redisConnection = mock(RedisConnection.class);
+		RedisServerCommands serverCommands = mock(RedisServerCommands.class);
+		given(redisConnection.serverCommands()).willReturn(serverCommands);
+		given(serverCommands.info()).willReturn(info);
+		DataRedisHealthIndicator healthIndicator = createHealthIndicator(redisConnection);
+		Health health = healthIndicator.health();
+		assertThat(health.getStatus()).isEqualTo(Status.UP);
+		assertThat(health.getDetails()).containsEntry("version", "unknown");
+	}
+
+	@Test
 	void redisIsDown() {
 		RedisConnection redisConnection = mock(RedisConnection.class);
 		RedisServerCommands serverCommands = mock(RedisServerCommands.class);


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Currently, the health check details displayed for Redis are as follows:

<img width="621" height="199" alt="image" src="https://github.com/user-attachments/assets/e2fe6475-68b2-43ba-9022-9a8a532e1a22" />

But, the health check will report an error when different Redis distributions return different information.

<img width="796" height="846" alt="image" src="https://github.com/user-attachments/assets/724f17b1-65b2-4bb4-a73d-93c49df835ff" />

<img width="853" height="240" alt="image" src="https://github.com/user-attachments/assets/ce157391-09ae-4142-bdd1-b04cc5ad32b5" />

<img width="978" height="757" alt="image" src="https://github.com/user-attachments/assets/4a2a8b2e-4d7b-4edc-8966-c3d4588c5a2f" />

<img width="766" height="399" alt="image" src="https://github.com/user-attachments/assets/1fc1f1f9-4026-4f0d-8b76-fe8b0ff1a80c" />

---

To avoid this issue, when enabling "always" or "when_authorized" it's preferable to display all details rather than just the version number:
```properties
management.endpoint.health.show-details=always | when_authorized
```

> This issue might also exist in older versions and may require a backport. 
> Similarly, other component distributions may also have similar issues.



