### PR TITLE
Use Charset instead of String for Mustache template encoding

### DIFF
--- a/module/spring-boot-mustache/src/main/java/org/springframework/boot/mustache/autoconfigure/MustacheProperties.java
+++ b/module/spring-boot-mustache/src/main/java/org/springframework/boot/mustache/autoconfigure/MustacheProperties.java
@@ -124,6 +124,12 @@ public class MustacheProperties {
 		return this.charset;
 	}
 
+	/**
+	 * Get the charset name.
+	 * @return the charset name
+	 * @deprecated since 4.1.0 in favor of {@link #getCharset()}
+	 */
+	@Deprecated(since = "4.1.0")
 	public String getCharsetName() {
 		return this.charset.name();
 	}

--- a/module/spring-boot-mustache/src/main/java/org/springframework/boot/mustache/autoconfigure/MustacheResourceTemplateLoader.java
+++ b/module/spring-boot-mustache/src/main/java/org/springframework/boot/mustache/autoconfigure/MustacheResourceTemplateLoader.java
@@ -62,6 +62,17 @@ public class MustacheResourceTemplateLoader implements TemplateLoader, ResourceL
 	/**
 	 * Set the charset.
 	 * @param charSet the charset
+	 * @deprecated since 4.1.0 in favor of {@link #setCharset(Charset)}
+	 */
+	@Deprecated(since = "4.1.0")
+	public void setCharset(String charSet) {
+		this.charSet = Charset.forName(charSet);
+	}
+
+	/**
+	 * Set the charset.
+	 * @param charSet the charset
+	 * @since 4.1.0
 	 */
 	public void setCharset(Charset charSet) {
 		this.charSet = charSet;


### PR DESCRIPTION
The MustacheResourceTemplateLoader previously defined the template encoding as a String, defaulting to "UTF-8". This change replaces the field with a Charset and initializes it with StandardCharsets.UTF_8.

Using Charset improves type safety and aligns with modern Spring Boot standards, while avoiding implicit charset lookup issues.
