### PR TITLE
Simplify Property handling using map().getOrNull()

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootArchiveSupport.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootArchiveSupport.java
@@ -147,7 +147,7 @@ class BootArchiveSupport {
 	}
 
 	private @Nullable Integer asUnixNumeric(Property<ConfigurableFilePermissions> permissions) {
-		return permissions.isPresent() ? permissions.get().toUnixNumeric() : null;
+		return permissions.map(ConfigurableFilePermissions::toUnixNumeric).getOrNull();
 	}
 
 	private @Nullable Integer getDirMode(CopySpec copySpec) {


### PR DESCRIPTION
This change improves the readability and idiomatic use of Gradle's
`Property<T>` API by replacing an explicit `isPresent()` check with
`map(...).getOrNull()`.

The new version is functionally equivalent but more concise and aligns
with recommended usage patterns in Gradle property handling. Using
`map().getOrNull()` also avoids potential null-check boilerplate and
reflects the intended design of Gradle's Property API.

No behavioral changes.

Signed-off-by: djlee <ddongjunn@gmail.com>