### PR TITLE
Correct the annotation in the Kotlin @ConfigurationPropertiesSource example

### DIFF
--- a/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/appendix/configurationmetadata/annotationprocessor/automaticmetadatageneration/source/Host.kt
+++ b/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/appendix/configurationmetadata/annotationprocessor/automaticmetadatageneration/source/Host.kt
@@ -16,9 +16,9 @@
 
 package org.springframework.boot.docs.appendix.configurationmetadata.annotationprocessor.automaticmetadatageneration.source
 
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.context.properties.ConfigurationPropertiesSource
 
-@ConfigurationPropertiesScan
+@ConfigurationPropertiesSource
 class Host {
 
 	/**


### PR DESCRIPTION
…opertiesSource

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

I found an incorrect annotation in the Kotlin sample code within the documentation describing [`@ConfigurationPropertiesSource`](https://docs.spring.io/spring-boot/4.0-SNAPSHOT/specification/configuration-metadata/annotation-processor.html#appendix.configuration-metadata.annotation-processor.automatic-metadata-generation.source).
Current Kotlin sample code in the doc mistakenly uses `@ConfigurationPropertiesScan`. It should be corrected to use `@ConfigurationPropertiesSource` annotation.

For reference, the equivalent Java code appears to be correct.
https://github.com/spring-projects/spring-boot/blob/e5928f7d5bfc4a15788f119455f893d4b4227d90/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/appendix/configurationmetadata/annotationprocessor/automaticmetadatageneration/source/Host.java#L21
