### PR TITLE
Configuring Two DataSources How-To code sample is inconsistent

### DIFF
--- a/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteAdditionalDataSourceConfiguration.java
+++ b/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteAdditionalDataSourceConfiguration.java
@@ -38,8 +38,8 @@ public class MyCompleteAdditionalDataSourceConfiguration {
 	@Bean(defaultCandidate = false)
 	@ConfigurationProperties("app.datasource.configuration")
 	public HikariDataSource secondDataSource(
-			@Qualifier("secondDataSourceProperties") DataSourceProperties secondDataSourceProperties) {
-		return secondDataSourceProperties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
+			@Qualifier("second") DataSourceProperties dataSourceProperties) {
+		return dataSourceProperties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
 	}
 
 }

--- a/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteAdditionalDataSourceConfiguration.kt
+++ b/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/dataaccess/configuretwodatasources/MyCompleteAdditionalDataSourceConfiguration.kt
@@ -37,8 +37,8 @@ class MyCompleteAdditionalDataSourceConfiguration {
 	@Qualifier("second")
 	@Bean(defaultCandidate = false)
 	@ConfigurationProperties("app.datasource.configuration")
-	fun secondDataSource(secondDataSourceProperties: DataSourceProperties): HikariDataSource {
-		return secondDataSourceProperties.initializeDataSourceBuilder().type(HikariDataSource::class.java).build()
+	fun secondDataSource(@Qualifier("second") dataSourceProperties: DataSourceProperties): HikariDataSource {
+		return dataSourceProperties.initializeDataSourceBuilder().type(HikariDataSource::class.java).build()
 	}
 
 }

--- a/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/dataaccess/usemultipleentitymanagers/MyAdditionalEntityManagerFactoryConfiguration.kt
+++ b/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/dataaccess/usemultipleentitymanagers/MyAdditionalEntityManagerFactoryConfiguration.kt
@@ -40,7 +40,7 @@ class MyAdditionalEntityManagerFactoryConfiguration {
 
 	@Qualifier("second")
 	@Bean(defaultCandidate = false)
-	fun firstEntityManagerFactory(
+	fun secondEntityManagerFactory(
 		@Qualifier("second") dataSource: DataSource,
 		@Qualifier("second") jpaProperties: JpaProperties
 	): LocalContainerEntityManagerFactoryBean {

--- a/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/dataaccess/usemultipleentitymanagers/OrderConfiguration.kt
+++ b/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/dataaccess/usemultipleentitymanagers/OrderConfiguration.kt
@@ -20,6 +20,6 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
 @Configuration(proxyBeanMethods = false)
-@EnableJpaRepositories(basePackageClasses = [Order::class], entityManagerFactoryRef = "firstEntityManagerFactory")
+@EnableJpaRepositories(basePackageClasses = [Order::class], entityManagerFactoryRef = "entityManagerFactory")
 class OrderConfiguration
 


### PR DESCRIPTION
This PR fixes mismatched bean names in Java and Kotlin example codes.

- Fix Qualifier usage
- Fix incorrect EntityManagerFactory naming