### PR TITLE
Actuator Info class has inconsistent nullability annotations and cannot be built with null value

### DIFF
--- a/module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/Info.java
+++ b/module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/Info.java
@@ -93,7 +93,7 @@ public final class Info {
 	 */
 	public static class Builder {
 
-		private final Map<String, Object> content;
+		private final Map<String, @Nullable Object> content;
 
 		public Builder() {
 			this.content = new LinkedHashMap<>();
@@ -116,7 +116,7 @@ public final class Info {
 		 * @return this {@link Builder} instance
 		 * @see #withDetail(String, Object)
 		 */
-		public Builder withDetails(Map<String, @Nullable ? extends Object> details) {
+		public Builder withDetails(Map<String, @Nullable Object> details) {
 			this.content.putAll(details);
 			return this;
 		}

--- a/module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/MapInfoContributor.java
+++ b/module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/MapInfoContributor.java
@@ -19,6 +19,8 @@ package org.springframework.boot.actuate.info;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A simple {@link InfoContributor} that exposes a map.
  *
@@ -27,7 +29,7 @@ import java.util.Map;
  */
 public class MapInfoContributor implements InfoContributor {
 
-	private final Map<String, Object> info;
+	private final Map<String, @Nullable Object> info;
 
 	public MapInfoContributor(Map<String, Object> info) {
 		this.info = new LinkedHashMap<>(info);


### PR DESCRIPTION
From gh-48401, I wrote a test

```kotlin
    @Test
    fun contextLoads() {
        val map = mutableMapOf<String, Any?>("info" to null)
        assertDoesNotThrow { Info.Builder().withDetails(map).build() }
    }
```

 and it failed

```
> Task :compileTestKotlin FAILED
Argument type mismatch: actual type is 'HashMap<String, Any?>', but '(Mutable)Map<String, out Any>' was expected.
Java type mismatch: expected '(Mutable)Map<String, out Any>' but found 'HashMap<String, Any?>'. Use explicit cast.
```

This PR fixes the above issue.
