### PR TITLE
RabbitHealthIndicator reports an error when version is missing from the connection's server properties

### DIFF
--- a/module/spring-boot-amqp/src/main/java/org/springframework/boot/amqp/health/RabbitHealthIndicator.java
+++ b/module/spring-boot-amqp/src/main/java/org/springframework/boot/amqp/health/RabbitHealthIndicator.java
@@ -52,8 +52,7 @@ public class RabbitHealthIndicator extends AbstractHealthIndicator {
 
 	private @Nullable String getVersion() {
 		return this.rabbitTemplate.execute((channel) -> {
-			Object version = channel.getConnection().getServerProperties().get("version");
-			Assert.state(version != null, "'version' must not be null");
+			Object version = channel.getConnection().getServerProperties().getOrDefault("version", "unknown");
 			return version.toString();
 		});
 	}

--- a/module/spring-boot-amqp/src/test/java/org/springframework/boot/amqp/health/RabbitHealthIndicatorTests.java
+++ b/module/spring-boot-amqp/src/test/java/org/springframework/boot/amqp/health/RabbitHealthIndicatorTests.java
@@ -78,6 +78,17 @@ class RabbitHealthIndicatorTests {
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
 	}
 
+	@Test
+	void healthWhenVersionIsMissingShouldReturnUpWithUnknownVersion() {
+		givenTemplateExecutionWillInvokeCallback();
+		Connection connection = mock(Connection.class);
+		given(this.channel.getConnection()).willReturn(connection);
+		given(connection.getServerProperties()).willReturn(Collections.emptyMap());
+		Health health = new RabbitHealthIndicator(this.rabbitTemplate).health();
+		assertThat(health.getStatus()).isEqualTo(Status.UP);
+		assertThat(health.getDetails()).containsEntry("version", "unknown");
+	}
+
 	private void givenTemplateExecutionWillInvokeCallback() {
 		given(this.rabbitTemplate.execute(any())).willAnswer((invocation) -> {
 			ChannelCallback<?> callback = invocation.getArgument(0);


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->


This problem is similar to "#48320", so I also want it to return "unknown" when "version" cannot be found.

Normally, RabbitMQ will return the following information:
<img width="1400" height="635" alt="image" src="https://github.com/user-attachments/assets/4ffadd56-7ea1-431a-8cf8-8820fd2c2ce4" />
<img width="1400" height="856" alt="image" src="https://github.com/user-attachments/assets/475b8f7d-0e01-462f-adda-15d03fb0a05f" />


Similarly, different distributions may only return the following information:
<img width="1400" height="1345" alt="image" src="https://github.com/user-attachments/assets/e799686a-5296-42f2-b17d-f89f53192687" />

Then the health check will return an exception:
<img width="884" height="690" alt="image" src="https://github.com/user-attachments/assets/e9c85b04-e869-4b89-ab1e-b4deb32c2be8" />

To avoid such errors, return "unknown" when "version" cannot be found.
