### PR TITLE
Format startup duration in human-readable units.

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/ApplicationProperties.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/ApplicationProperties.java
@@ -69,6 +69,11 @@ class ApplicationProperties {
 	private boolean logStartupInfo = true;
 
 	/**
+	 * Format used to display application startup time in logs.
+	 */
+	private StartupTimeFormat logStartupTimeFormat = StartupTimeFormat.DEFAULT;
+
+	/**
 	 * Whether the application should have a shutdown hook registered.
 	 */
 	private boolean registerShutdownHook = true;
@@ -137,6 +142,14 @@ class ApplicationProperties {
 
 	void setLogStartupInfo(boolean logStartupInfo) {
 		this.logStartupInfo = logStartupInfo;
+	}
+
+	StartupTimeFormat getLogStartupTimeFormat() {
+		return this.logStartupTimeFormat;
+	}
+
+	void setLogStartupTimeFormat(StartupTimeFormat logStartupTimeFormat) {
+		this.logStartupTimeFormat = logStartupTimeFormat;
 	}
 
 	boolean isRegisterShutdownHook() {

--- a/core/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -322,7 +322,8 @@ public class SpringApplication {
 			afterRefresh(context, applicationArguments);
 			Duration timeTakenToStarted = startup.started();
 			if (this.properties.isLogStartupInfo()) {
-				new StartupInfoLogger(this.mainApplicationClass, environment).logStarted(getApplicationLog(), startup);
+				new StartupInfoLogger(this.mainApplicationClass, environment, this.properties.getLogStartupTimeFormat())
+					.logStarted(getApplicationLog(), startup);
 			}
 			listeners.started(context, timeTakenToStarted);
 			callRunners(context, applicationArguments);

--- a/core/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/StartupInfoLogger.java
@@ -44,9 +44,16 @@ class StartupInfoLogger {
 
 	private final Environment environment;
 
+	private final StartupTimeFormat startupTimeFormat;
+
 	StartupInfoLogger(@Nullable Class<?> sourceClass, Environment environment) {
+		this(sourceClass, environment, StartupTimeFormat.DEFAULT);
+	}
+
+	StartupInfoLogger(@Nullable Class<?> sourceClass, Environment environment, StartupTimeFormat startupTimeFormat) {
 		this.sourceClass = sourceClass;
 		this.environment = environment;
+		this.startupTimeFormat = startupTimeFormat;
 	}
 
 	void logStarting(Log applicationLog) {
@@ -87,14 +94,16 @@ class StartupInfoLogger {
 		message.append(startup.action());
 		appendApplicationName(message);
 		message.append(" in ");
-		message.append(startup.timeTakenToStarted().toMillis() / 1000.0);
-		message.append(" seconds");
+		message.append(formatDuration(startup.timeTakenToStarted().toMillis()));
 		Long uptimeMs = startup.processUptime();
 		if (uptimeMs != null) {
-			double uptime = uptimeMs / 1000.0;
-			message.append(" (process running for ").append(uptime).append(")");
+			message.append(" (process running for ").append(formatDuration(uptimeMs)).append(")");
 		}
 		return message;
+	}
+
+	private String formatDuration(long millis) {
+		return this.startupTimeFormat.format(millis);
 	}
 
 	private void appendAotMode(StringBuilder message) {

--- a/core/spring-boot/src/main/java/org/springframework/boot/StartupTimeFormat.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/StartupTimeFormat.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot;
+
+import java.time.Duration;
+
+/**
+ * Format styles for displaying application startup time in logs.
+ *
+ * @author Huang Xiao
+ * @since 3.5.0
+ */
+public enum StartupTimeFormat {
+
+	/**
+	 * Default format displays time in seconds with millisecond precision (e.g., "3.456
+	 * seconds"). This maintains backward compatibility with existing log parsing tools.
+	 */
+	DEFAULT {
+
+		@Override
+		public String format(long millis) {
+			return String.format("%.3f seconds", millis / 1000.0);
+		}
+
+	},
+
+	/**
+	 * Human format displays time in a more intuitive way using appropriate units (e.g.,
+	 * "1 minute 30 seconds" or "1 hour 15 minutes"). Times under 60 seconds still use the
+	 * default format for consistency.
+	 */
+	HUMAN {
+
+		@Override
+		public String format(long millis) {
+			Duration duration = Duration.ofMillis(millis);
+			long seconds = duration.getSeconds();
+			if (seconds < 60) {
+				return String.format("%.3f seconds", millis / 1000.0);
+			}
+			long hours = duration.toHours();
+			int minutes = duration.toMinutesPart();
+			int secs = duration.toSecondsPart();
+			if (hours > 0) {
+				return String.format("%d hour%s %d minute%s", hours, (hours != 1) ? "s" : "", minutes,
+						(minutes != 1) ? "s" : "");
+			}
+			return String.format("%d minute%s %d second%s", minutes, (minutes != 1) ? "s" : "", secs,
+					(secs != 1) ? "s" : "");
+		}
+
+	};
+
+	/**
+	 * Format the given duration in milliseconds according to this format style.
+	 * @param millis the duration in milliseconds
+	 * @return the formatted string
+	 */
+	public abstract String format(long millis);
+
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
Currently, the startup time of Spring Boot applications is displayed in seconds, but this is not human-friendly for applications with exceptionally long startup times.

<img width="1029" height="649" alt="image" src="https://github.com/user-attachments/assets/32f41c23-64d1-4dae-9b40-6b413403e5be" />


Times under 60 seconds continue to use decimal seconds (e.g., "3.456 seconds"), while longer durations are displayed in minutes and seconds (e.g., "1 minute 30 seconds") or hours and minutes (e.g., "1 hour 15 minutes"). This makes startup logs more accessible for applications with longer initialization times.
