### PR TITLE
Documentation has an outdated reference to the Jackson Kotlin Module

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/kotlin.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/kotlin.adoc
@@ -24,7 +24,6 @@ Since https://discuss.kotlinlang.org/t/classes-final-by-default/166[Kotlin class
 
 https://github.com/FasterXML/jackson-module-kotlin[Jackson's Kotlin module] is required for serializing / deserializing JSON data in Kotlin.
 It is automatically registered when found on the classpath.
-A warning message is logged if Jackson and Kotlin are present but the Jackson Kotlin module is not.
 
 TIP: These dependencies and plugins are provided by default if one bootstraps a Kotlin project on https://start.spring.io/#!language=kotlin[start.spring.io].
 


### PR DESCRIPTION
In the [Kotlin Support reference](https://docs.spring.io/spring-boot/reference/features/kotlin.html#features.kotlin.requirements) it is stated that:

> [Jackson’s Kotlin module](https://github.com/FasterXML/jackson-module-kotlin) is required for serializing / deserializing JSON data in Kotlin. It is automatically registered when found on the classpath. **A warning message is logged if Jackson and Kotlin are present but the Jackson Kotlin module is not.**


However this warning message was removed in https://github.com/spring-projects/spring-framework/commit/6251222a23415d8b8788e79b9c208d3208988685

This PR removes this outdated statement from the documentation.