### PR TITLE
Fix #48576: Clarify tracing dependency requirements

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/tracing.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/tracing.adoc
@@ -3,6 +3,8 @@
 
 Spring Boot Actuator provides dependency management and auto-configuration for {url-micrometer-tracing-docs}[Micrometer Tracing], a facade for popular tracer libraries.
 
+NOTE: Spring Boot provides modular tracing support. Having `spring-boot-starter-actuator` on the classpath enables tracing infrastructure, but tracing auto-configuration is only activated when a supported tracing bridge and tracer implementation are also present.
+
 TIP: To learn more about Micrometer Tracing capabilities, see its {url-micrometer-tracing-docs}[reference documentation].
 
 
@@ -29,6 +31,9 @@ To recap, our main application code looks like this:
 include-code::MyApplication[]
 
 NOTE: There's an added logger statement in the `home()` method, which will be important later.
+
+NOTE: Tracing is not enabled by adding `spring-boot-starter-actuator` alone. The following dependencies provide the tracing bridge and tracer implementation required for tracing auto-configuration.
+
 
 Now we have to add the following dependencies:
 
@@ -112,7 +117,7 @@ WARNING: If you create the javadoc:org.springframework.web.client.RestTemplate[]
 
 As Micrometer Tracer supports multiple tracer implementations, there are multiple dependency combinations possible with Spring Boot.
 
-All tracer implementations need the `org.springframework.boot:spring-boot-starter-actuator` dependency.
+All tracer implementations need the `org.springframework.boot:spring-boot-starter-actuator` dependency. In addition, a tracing bridge and tracer implementation must be present on the classpath for tracing auto-configuration to be activated.
 
 
 


### PR DESCRIPTION
Fixes #48576

This pull request updates the Spring Boot documentation for Micrometer Tracing to clarify the modular tracing support introduced in Spring Boot 4.

Changes include:

Emphasizing that having spring-boot-starter-actuator on the classpath alone does not enable tracing.

Explaining that tracing is fully auto-configured only when a supported tracing bridge and tracer implementation (e.g., OpenTelemetry bridge + Zipkin) are present.

Updating the "Getting Started" and "Tracer Implementations" sections to reflect this requirement, so developers understand which dependencies are needed to enable tracing.

This ensures that users following the documentation will correctly configure tracing without confusion.