### PR TITLE
Deprecate Derby support

### DIFF
--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/DatabaseDriver.java
@@ -44,7 +44,9 @@ public enum DatabaseDriver {
 
 	/**
 	 * Apache Derby.
+	 * @deprecated Derby is retired, use HSQLDB or H2
 	 */
+	@Deprecated(forRemoval = true, since = "4.1")
 	DERBY("Apache Derby", "org.apache.derby.jdbc.EmbeddedDriver", "org.apache.derby.jdbc.EmbeddedXADataSource",
 			"SELECT 1 FROM SYSIBM.SYSDUMMY1"),
 

--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnection.java
@@ -57,7 +57,9 @@ public enum EmbeddedDatabaseConnection {
 
 	/**
 	 * Derby Database Connection.
+	 * @deprecated Derby is retired, use HSQLDB or H2
 	 */
+	@Deprecated(forRemoval = true, since = "4.1")
 	DERBY("jdbc:derby:memory:%s;create=true"),
 
 	/**
@@ -83,6 +85,7 @@ public enum EmbeddedDatabaseConnection {
 	 * Returns the driver class name.
 	 * @return the driver class name
 	 */
+	@SuppressWarnings("removal")
 	public @Nullable String getDriverClassName() {
 		// See https://github.com/spring-projects/spring-boot/issues/32865
 		return switch (this) {
@@ -97,6 +100,7 @@ public enum EmbeddedDatabaseConnection {
 	 * Returns the {@link EmbeddedDatabaseType} for the connection.
 	 * @return the database type
 	 */
+	@SuppressWarnings("removal")
 	public @Nullable EmbeddedDatabaseType getType() {
 		// See https://github.com/spring-projects/spring-boot/issues/32865
 		return switch (this) {
@@ -117,6 +121,7 @@ public enum EmbeddedDatabaseConnection {
 		return (this.url != null) ? String.format(this.url, databaseName) : null;
 	}
 
+	@SuppressWarnings("removal")
 	boolean isEmbeddedUrl(String url) {
 		// See https://github.com/spring-projects/spring-boot/issues/32865
 		return switch (this) {
@@ -151,6 +156,7 @@ public enum EmbeddedDatabaseConnection {
 		return (url == null || connection.isEmbeddedUrl(url));
 	}
 
+	@SuppressWarnings("removal")
 	private static EmbeddedDatabaseConnection getEmbeddedDatabaseConnection(String driverClass) {
 		return Stream.of(H2, HSQLDB, DERBY)
 			.filter((connection) -> connection.isDriverCompatible(driverClass))

--- a/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/DatabaseDriverTests.java
+++ b/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/DatabaseDriverTests.java
@@ -61,6 +61,7 @@ class DatabaseDriverTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void databaseProductNameLookups() {
 		assertThat(DatabaseDriver.fromProductName("newone")).isEqualTo(DatabaseDriver.UNKNOWN);
 		assertThat(DatabaseDriver.fromProductName("Apache Derby")).isEqualTo(DatabaseDriver.DERBY);
@@ -88,6 +89,7 @@ class DatabaseDriverTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void databaseJdbcUrlLookups() {
 		assertThat(DatabaseDriver.fromJdbcUrl("jdbc:newone://localhost")).isEqualTo(DatabaseDriver.UNKNOWN);
 		assertThat(DatabaseDriver.fromJdbcUrl("jdbc:derby:sample")).isEqualTo(DatabaseDriver.DERBY);

--- a/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnectionTests.java
+++ b/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/EmbeddedDatabaseConnectionTests.java
@@ -51,6 +51,7 @@ class EmbeddedDatabaseConnectionTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void derbyCustomDatabaseName() {
 		assertThat(EmbeddedDatabaseConnection.DERBY.getUrl("myderbydb"))
 			.isEqualTo("jdbc:derby:memory:myderbydb;create=true");
@@ -80,6 +81,7 @@ class EmbeddedDatabaseConnectionTests {
 		assertThat(EmbeddedDatabaseConnection.isEmbedded(driverClassName, url)).isEqualTo(embedded);
 	}
 
+	@SuppressWarnings("removal")
 	static Object[] embeddedDriverAndUrlParameters() {
 		return new Object[] {
 				new Object[] { EmbeddedDatabaseConnection.H2.getDriverClassName(), "jdbc:h2:~/test", false },


### PR DESCRIPTION
Deprecate Derby support since Apache Derby is retired.

Closes gh-48567

I did no log any warnings when Derby support is used. I'm not aware of such a thing being done anywhere today, let me know if I should add it.

I marked only main code for removal, no tests. I had to add `@SuppressWarnings` to main and test code using deprecated Derby code for the build to work.

I believe this should go to the 4.1 changelog. I did find a changelog checked in. Are these manually maintained?