### PR TITLE
Use static imports for Assertions.assertThat() consistently

### DIFF
--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/json/JsonContentAssert.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/json/JsonContentAssert.java
@@ -30,7 +30,6 @@ import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.Assert;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import org.assertj.core.api.MapAssert;
 import org.jspecify.annotations.Nullable;
@@ -44,6 +43,8 @@ import org.springframework.lang.CheckReturnValue;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.util.function.ThrowingFunction;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * AssertJ {@link Assert} for {@link JsonContent}.
@@ -920,7 +921,7 @@ public class JsonContentAssert extends AbstractAssert<JsonContentAssert, CharSeq
 	 */
 	@CheckReturnValue
 	public AbstractObjectAssert<?, Object> extractingJsonPathValue(CharSequence expression, Object... args) {
-		return Assertions.assertThat(new JsonPathValue(expression, args).getValue(false));
+		return assertThat(new JsonPathValue(expression, args).getValue(false));
 	}
 
 	/**
@@ -934,7 +935,7 @@ public class JsonContentAssert extends AbstractAssert<JsonContentAssert, CharSeq
 	@CheckReturnValue
 	public AbstractCharSequenceAssert<?, String> extractingJsonPathStringValue(CharSequence expression,
 			Object... args) {
-		return Assertions.assertThat(extractingJsonPathValue(expression, args, String.class, "a string"));
+		return assertThat(extractingJsonPathValue(expression, args, String.class, "a string"));
 	}
 
 	/**
@@ -947,7 +948,7 @@ public class JsonContentAssert extends AbstractAssert<JsonContentAssert, CharSeq
 	 */
 	@CheckReturnValue
 	public AbstractObjectAssert<?, Number> extractingJsonPathNumberValue(CharSequence expression, Object... args) {
-		return Assertions.assertThat(extractingJsonPathValue(expression, args, Number.class, "a number"));
+		return assertThat(extractingJsonPathValue(expression, args, Number.class, "a number"));
 	}
 
 	/**
@@ -960,7 +961,7 @@ public class JsonContentAssert extends AbstractAssert<JsonContentAssert, CharSeq
 	 */
 	@CheckReturnValue
 	public AbstractBooleanAssert<?> extractingJsonPathBooleanValue(CharSequence expression, Object... args) {
-		return Assertions.assertThat(extractingJsonPathValue(expression, args, Boolean.class, "a boolean"));
+		return assertThat(extractingJsonPathValue(expression, args, Boolean.class, "a boolean"));
 	}
 
 	/**
@@ -975,7 +976,7 @@ public class JsonContentAssert extends AbstractAssert<JsonContentAssert, CharSeq
 	@SuppressWarnings("unchecked")
 	@CheckReturnValue
 	public <E> ListAssert<E> extractingJsonPathArrayValue(CharSequence expression, Object... args) {
-		return Assertions.assertThat(extractingJsonPathValue(expression, args, List.class, "an array"));
+		return assertThat(extractingJsonPathValue(expression, args, List.class, "an array"));
 	}
 
 	/**
@@ -991,7 +992,7 @@ public class JsonContentAssert extends AbstractAssert<JsonContentAssert, CharSeq
 	@SuppressWarnings("unchecked")
 	@CheckReturnValue
 	public <K, V> MapAssert<K, V> extractingJsonPathMapValue(CharSequence expression, Object... args) {
-		return Assertions.assertThat(extractingJsonPathValue(expression, args, Map.class, "a map"));
+		return assertThat(extractingJsonPathValue(expression, args, Map.class, "a map"));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/module/spring-boot-jetty/src/test/java/org/springframework/boot/jetty/autoconfigure/metrics/JettyMetricsAutoConfigurationTests.java
+++ b/module/spring-boot-jetty/src/test/java/org/springframework/boot/jetty/autoconfigure/metrics/JettyMetricsAutoConfigurationTests.java
@@ -19,7 +19,6 @@ package org.springframework.boot.jetty.autoconfigure.metrics;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.SpringApplication;
@@ -63,7 +62,7 @@ class JettyMetricsAutoConfigurationTests {
 				context.publishEvent(createApplicationStartedEvent(context.getSourceApplicationContext()));
 				assertThat(context).hasSingleBean(JettyServerThreadPoolMetricsBinder.class);
 				SimpleMeterRegistry registry = context.getBean(SimpleMeterRegistry.class);
-				Assertions.assertThat(registry.find("jetty.threads.config.min").meter()).isNotNull();
+				assertThat(registry.find("jetty.threads.config.min").meter()).isNotNull();
 			});
 	}
 
@@ -76,7 +75,7 @@ class JettyMetricsAutoConfigurationTests {
 			.run((context) -> {
 				context.publishEvent(createApplicationStartedEvent(context.getSourceApplicationContext()));
 				SimpleMeterRegistry registry = context.getBean(SimpleMeterRegistry.class);
-				Assertions.assertThat(registry.find("jetty.threads.config.min").meter()).isNotNull();
+				assertThat(registry.find("jetty.threads.config.min").meter()).isNotNull();
 			});
 	}
 
@@ -98,7 +97,7 @@ class JettyMetricsAutoConfigurationTests {
 				context.publishEvent(createApplicationStartedEvent(context.getSourceApplicationContext()));
 				assertThat(context).hasSingleBean(JettyConnectionMetricsBinder.class);
 				SimpleMeterRegistry registry = context.getBean(SimpleMeterRegistry.class);
-				Assertions.assertThat(registry.find("jetty.connections.messages.in").meter()).isNotNull();
+				assertThat(registry.find("jetty.connections.messages.in").meter()).isNotNull();
 			});
 	}
 
@@ -111,7 +110,7 @@ class JettyMetricsAutoConfigurationTests {
 			.run((context) -> {
 				context.publishEvent(createApplicationStartedEvent(context.getSourceApplicationContext()));
 				SimpleMeterRegistry registry = context.getBean(SimpleMeterRegistry.class);
-				Assertions.assertThat(registry.find("jetty.connections.messages.in").meter()).isNotNull();
+				assertThat(registry.find("jetty.connections.messages.in").meter()).isNotNull();
 			});
 	}
 
@@ -127,11 +126,9 @@ class JettyMetricsAutoConfigurationTests {
 				assertThat(context).hasSingleBean(JettyConnectionMetricsBinder.class)
 					.hasBean("customJettyConnectionMetricsBinder");
 				SimpleMeterRegistry registry = context.getBean(SimpleMeterRegistry.class);
-				Assertions
-					.assertThat(registry.find("jetty.connections.messages.in")
-						.tag("custom-tag-name", "custom-tag-value")
-						.meter())
-					.isNotNull();
+				assertThat(registry.find("jetty.connections.messages.in")
+					.tag("custom-tag-name", "custom-tag-value")
+					.meter()).isNotNull();
 			});
 	}
 
@@ -148,7 +145,7 @@ class JettyMetricsAutoConfigurationTests {
 				context.publishEvent(createApplicationStartedEvent(context.getSourceApplicationContext()));
 				assertThat(context).hasSingleBean(JettySslHandshakeMetricsBinder.class);
 				SimpleMeterRegistry registry = context.getBean(SimpleMeterRegistry.class);
-				Assertions.assertThat(registry.find("jetty.ssl.handshakes").meter()).isNotNull();
+				assertThat(registry.find("jetty.ssl.handshakes").meter()).isNotNull();
 			});
 	}
 
@@ -164,7 +161,7 @@ class JettyMetricsAutoConfigurationTests {
 			.run((context) -> {
 				context.publishEvent(createApplicationStartedEvent(context.getSourceApplicationContext()));
 				SimpleMeterRegistry registry = context.getBean(SimpleMeterRegistry.class);
-				Assertions.assertThat(registry.find("jetty.ssl.handshakes").meter()).isNotNull();
+				assertThat(registry.find("jetty.ssl.handshakes").meter()).isNotNull();
 			});
 	}
 
@@ -183,9 +180,7 @@ class JettyMetricsAutoConfigurationTests {
 				assertThat(context).hasSingleBean(JettySslHandshakeMetricsBinder.class)
 					.hasBean("customJettySslHandshakeMetricsBinder");
 				SimpleMeterRegistry registry = context.getBean(SimpleMeterRegistry.class);
-				Assertions
-					.assertThat(
-							registry.find("jetty.ssl.handshakes").tag("custom-tag-name", "custom-tag-value").meter())
+				assertThat(registry.find("jetty.ssl.handshakes").tag("custom-tag-name", "custom-tag-value").meter())
 					.isNotNull();
 			});
 

--- a/module/spring-boot-micrometer-tracing-opentelemetry/src/test/java/org/springframework/boot/micrometer/tracing/opentelemetry/autoconfigure/OpenTelemetryEventPublishingContextWrapperBeansTestExecutionListenerIntegrationTests.java
+++ b/module/spring-boot-micrometer-tracing-opentelemetry/src/test/java/org/springframework/boot/micrometer/tracing/opentelemetry/autoconfigure/OpenTelemetryEventPublishingContextWrapperBeansTestExecutionListenerIntegrationTests.java
@@ -21,12 +21,13 @@ import java.util.List;
 import java.util.function.Function;
 
 import io.opentelemetry.context.ContextStorage;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.boot.micrometer.tracing.opentelemetry.autoconfigure.OpenTelemetryEventPublisherBeansApplicationListener.Wrapper.Storage;
 import org.springframework.boot.testsupport.classpath.ForkedClassPath;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration tests for {@link OpenTelemetryEventPublisherBeansTestExecutionListener}.
@@ -45,7 +46,7 @@ class OpenTelemetryEventPublishingContextWrapperBeansTestExecutionListenerIntegr
 		Method getWrappersMethod = wrappersClass.getDeclaredMethod("getWrappers");
 		getWrappersMethod.setAccessible(true);
 		List<Function> wrappers = (List<Function>) getWrappersMethod.invoke(null);
-		Assertions.assertThat(wrappers).anyMatch((function) -> function.apply(this.parent) instanceof Storage);
+		assertThat(wrappers).anyMatch((function) -> function.apply(this.parent) instanceof Storage);
 	}
 
 }

--- a/module/spring-boot-micrometer-tracing-opentelemetry/src/test/java/org/springframework/boot/micrometer/tracing/opentelemetry/autoconfigure/otlp/OtlpTracingAutoConfigurationIntegrationTests.java
+++ b/module/spring-boot-micrometer-tracing-opentelemetry/src/test/java/org/springframework/boot/micrometer/tracing/opentelemetry/autoconfigure/otlp/OtlpTracingAutoConfigurationIntegrationTests.java
@@ -32,7 +32,6 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import okio.Buffer;
 import okio.GzipSource;
-import org.assertj.core.api.Assertions;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.io.Content;
@@ -99,13 +98,13 @@ class OtlpTracingAutoConfigurationIntegrationTests {
 				assertThat(context.getBean(OtlpHttpSpanExporter.class).flush())
 					.isSameAs(CompletableResultCode.ofSuccess());
 				RecordedRequest request = this.mockWebServer.takeRequest(10, TimeUnit.SECONDS);
-				Assertions.assertThat(request).isNotNull();
-				Assertions.assertThat(request.getRequestLine()).contains("/v1/traces");
-				Assertions.assertThat(request.getHeader("Content-Type")).isEqualTo("application/x-protobuf");
-				Assertions.assertThat(request.getHeader("custom")).isEqualTo("42");
-				Assertions.assertThat(request.getBodySize()).isPositive();
+				assertThat(request).isNotNull();
+				assertThat(request.getRequestLine()).contains("/v1/traces");
+				assertThat(request.getHeader("Content-Type")).isEqualTo("application/x-protobuf");
+				assertThat(request.getHeader("custom")).isEqualTo("42");
+				assertThat(request.getBodySize()).isPositive();
 				try (Buffer body = request.getBody()) {
-					Assertions.assertThat(body.readString(StandardCharsets.UTF_8)).contains("org.springframework.boot");
+					assertThat(body.readString(StandardCharsets.UTF_8)).contains("org.springframework.boot");
 				}
 			});
 	}
@@ -123,15 +122,14 @@ class OtlpTracingAutoConfigurationIntegrationTests {
 				assertThat(context.getBean(OtlpHttpSpanExporter.class).flush())
 					.isSameAs(CompletableResultCode.ofSuccess());
 				RecordedRequest request = this.mockWebServer.takeRequest(10, TimeUnit.SECONDS);
-				Assertions.assertThat(request).isNotNull();
-				Assertions.assertThat(request.getRequestLine()).contains("/test");
-				Assertions.assertThat(request.getHeader("Content-Type")).isEqualTo("application/x-protobuf");
-				Assertions.assertThat(request.getHeader("Content-Encoding")).isEqualTo("gzip");
-				Assertions.assertThat(request.getBodySize()).isPositive();
+				assertThat(request).isNotNull();
+				assertThat(request.getRequestLine()).contains("/test");
+				assertThat(request.getHeader("Content-Type")).isEqualTo("application/x-protobuf");
+				assertThat(request.getHeader("Content-Encoding")).isEqualTo("gzip");
+				assertThat(request.getBodySize()).isPositive();
 				try (Buffer uncompressed = new Buffer(); Buffer body = request.getBody()) {
 					uncompressed.writeAll(new GzipSource(body));
-					Assertions.assertThat(uncompressed.readString(StandardCharsets.UTF_8))
-						.contains("org.springframework.boot");
+					assertThat(uncompressed.readString(StandardCharsets.UTF_8)).contains("org.springframework.boot");
 				}
 			});
 	}
@@ -150,8 +148,8 @@ class OtlpTracingAutoConfigurationIntegrationTests {
 					.isSameAs(CompletableResultCode.ofSuccess());
 				RecordedGrpcRequest request = this.mockGrpcServer.takeRequest(10, TimeUnit.SECONDS);
 				assertThat(request).isNotNull();
-				Assertions.assertThat(request.headers().get("Content-Type")).isEqualTo("application/grpc");
-				Assertions.assertThat(request.headers().get("custom")).isEqualTo("42");
+				assertThat(request.headers().get("Content-Type")).isEqualTo("application/grpc");
+				assertThat(request.headers().get("custom")).isEqualTo("42");
 				assertThat(request.bodyAsString()).contains("org.springframework.boot");
 			});
 	}

--- a/module/spring-boot-mustache/src/test/java/org/springframework/boot/mustache/autoconfigure/MustacheAutoConfigurationServletIntegrationTests.java
+++ b/module/spring-boot-mustache/src/test/java/org/springframework/boot/mustache/autoconfigure/MustacheAutoConfigurationServletIntegrationTests.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -75,7 +74,7 @@ class MustacheAutoConfigurationServletIntegrationTests {
 		Template tmpl = Mustache.compiler().compile(source);
 		Map<String, String> context = new HashMap<>();
 		context.put("arg", "world");
-		Assertions.assertThat(tmpl.execute(context)).isEqualTo("Hello world!");
+		assertThat(tmpl.execute(context)).isEqualTo("Hello world!");
 	}
 
 	@Test

--- a/module/spring-boot-mustache/src/test/java/org/springframework/boot/mustache/autoconfigure/MustacheAutoConfigurationTests.java
+++ b/module/spring-boot-mustache/src/test/java/org/springframework/boot/mustache/autoconfigure/MustacheAutoConfigurationTests.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.function.Supplier;
 
 import com.samskivert.mustache.Mustache;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -62,7 +61,7 @@ class MustacheAutoConfigurationTests {
 				assertThat(context).hasSingleBean(Mustache.Compiler.class);
 				assertThat(context).hasSingleBean(MustacheResourceTemplateLoader.class);
 				assertThat(context).hasSingleBean(MustacheViewResolver.class);
-				Assertions.assertThat(context.getBean(Mustache.Compiler.class).standardsMode).isTrue();
+				assertThat(context.getBean(Mustache.Compiler.class).standardsMode).isTrue();
 			});
 	}
 
@@ -86,7 +85,7 @@ class MustacheAutoConfigurationTests {
 				assertThat(context).doesNotHaveBean(MustacheViewResolver.class);
 				assertThat(context)
 					.hasSingleBean(org.springframework.boot.mustache.reactive.view.MustacheViewResolver.class);
-				Assertions.assertThat(context.getBean(Mustache.Compiler.class).standardsMode).isTrue();
+				assertThat(context.getBean(Mustache.Compiler.class).standardsMode).isTrue();
 			});
 	}
 
@@ -117,7 +116,7 @@ class MustacheAutoConfigurationTests {
 			assertThat(viewResolver).extracting("prefix").isEqualTo("classpath:/templates/");
 			assertThat(viewResolver).extracting("requestContextAttribute").isNull();
 			assertThat(viewResolver).extracting("suffix").isEqualTo(".mustache");
-			Assertions.assertThat(viewResolver.getSupportedMediaTypes())
+			assertThat(viewResolver.getSupportedMediaTypes())
 				.containsExactly(MediaType.parseMediaType("text/html;charset=UTF-8"));
 		});
 	}

--- a/module/spring-boot-mustache/src/test/java/org/springframework/boot/mustache/reactive/view/MustacheViewTests.java
+++ b/module/spring-boot-mustache/src/test/java/org/springframework/boot/mustache/reactive/view/MustacheViewTests.java
@@ -21,7 +21,6 @@ import java.time.Duration;
 import java.util.Collections;
 
 import com.samskivert.mustache.Mustache;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
@@ -30,6 +29,8 @@ import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.http.MediaType;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link MustacheView}.
@@ -52,7 +53,7 @@ class MustacheViewTests {
 		view.render(Collections.singletonMap("World", "Spring"), MediaType.TEXT_HTML, exchange)
 			.block(Duration.ofSeconds(30));
 		StepVerifier.create(exchange.getResponse().getBodyAsString())
-			.assertNext((body) -> Assertions.assertThat(body).isEqualToIgnoringWhitespace("Hello Spring"))
+			.assertNext((body) -> assertThat(body).isEqualToIgnoringWhitespace("Hello Spring"))
 			.expectComplete()
 			.verify(Duration.ofSeconds(30));
 	}

--- a/module/spring-boot-mustache/src/test/java/org/springframework/boot/mustache/servlet/view/MustacheViewResolverTests.java
+++ b/module/spring-boot-mustache/src/test/java/org/springframework/boot/mustache/servlet/view/MustacheViewResolverTests.java
@@ -18,7 +18,6 @@ package org.springframework.boot.mustache.servlet.view;
 
 import java.util.Locale;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -66,7 +65,7 @@ class MustacheViewResolverTests {
 		this.resolver.setContentType("application/octet-stream");
 		View view = this.resolver.resolveViewName("template", Locale.ROOT);
 		assertThat(view).isNotNull();
-		Assertions.assertThat(view.getContentType()).isEqualTo("application/octet-stream");
+		assertThat(view.getContentType()).isEqualTo("application/octet-stream");
 
 	}
 

--- a/module/spring-boot-thymeleaf/src/test/java/org/springframework/boot/thymeleaf/autoconfigure/ThymeleafReactiveAutoConfigurationTests.java
+++ b/module/spring-boot-thymeleaf/src/test/java/org/springframework/boot/thymeleaf/autoconfigure/ThymeleafReactiveAutoConfigurationTests.java
@@ -25,7 +25,6 @@ import java.util.Locale;
 
 import nz.net.ultraq.thymeleaf.layoutdialect.LayoutDialect;
 import nz.net.ultraq.thymeleaf.layoutdialect.decorators.strategies.GroupingStrategy;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -90,27 +89,26 @@ class ThymeleafReactiveAutoConfigurationTests {
 			assertThat(resolver).isInstanceOf(SpringResourceTemplateResolver.class);
 			assertThat(((SpringResourceTemplateResolver) resolver).getCharacterEncoding()).isEqualTo("UTF-16");
 			ThymeleafReactiveViewResolver views = context.getBean(ThymeleafReactiveViewResolver.class);
-			Assertions.assertThat(views.getDefaultCharset().name()).isEqualTo("UTF-16");
+			assertThat(views.getDefaultCharset().name()).isEqualTo("UTF-16");
 		});
 	}
 
 	@Test
 	void defaultMediaTypes() {
-		this.contextRunner.run((context) -> Assertions
-			.assertThat(context.getBean(ThymeleafReactiveViewResolver.class).getSupportedMediaTypes())
-			.containsExactly(MediaType.TEXT_HTML, MediaType.APPLICATION_XHTML_XML, MediaType.APPLICATION_XML,
-					MediaType.TEXT_XML, MediaType.APPLICATION_RSS_XML, MediaType.APPLICATION_ATOM_XML,
-					new MediaType("application", "javascript"), new MediaType("application", "ecmascript"),
-					new MediaType("text", "javascript"), new MediaType("text", "ecmascript"),
-					MediaType.APPLICATION_JSON, new MediaType("text", "css"), MediaType.TEXT_PLAIN,
-					MediaType.TEXT_EVENT_STREAM));
+		this.contextRunner
+			.run((context) -> assertThat(context.getBean(ThymeleafReactiveViewResolver.class).getSupportedMediaTypes())
+				.containsExactly(MediaType.TEXT_HTML, MediaType.APPLICATION_XHTML_XML, MediaType.APPLICATION_XML,
+						MediaType.TEXT_XML, MediaType.APPLICATION_RSS_XML, MediaType.APPLICATION_ATOM_XML,
+						new MediaType("application", "javascript"), new MediaType("application", "ecmascript"),
+						new MediaType("text", "javascript"), new MediaType("text", "ecmascript"),
+						MediaType.APPLICATION_JSON, new MediaType("text", "css"), MediaType.TEXT_PLAIN,
+						MediaType.TEXT_EVENT_STREAM));
 	}
 
 	@Test
 	void overrideMediaTypes() {
 		this.contextRunner.withPropertyValues("spring.thymeleaf.reactive.media-types:text/html,text/plain")
-			.run((context) -> Assertions
-				.assertThat(context.getBean(ThymeleafReactiveViewResolver.class).getSupportedMediaTypes())
+			.run((context) -> assertThat(context.getBean(ThymeleafReactiveViewResolver.class).getSupportedMediaTypes())
 				.containsExactly(MediaType.TEXT_HTML, MediaType.TEXT_PLAIN));
 	}
 

--- a/module/spring-boot-thymeleaf/src/test/java/org/springframework/boot/thymeleaf/autoconfigure/ThymeleafServletAutoConfigurationTests.java
+++ b/module/spring-boot-thymeleaf/src/test/java/org/springframework/boot/thymeleaf/autoconfigure/ThymeleafServletAutoConfigurationTests.java
@@ -28,7 +28,6 @@ import jakarta.servlet.DispatcherType;
 import jakarta.servlet.ServletContext;
 import nz.net.ultraq.thymeleaf.layoutdialect.LayoutDialect;
 import nz.net.ultraq.thymeleaf.layoutdialect.decorators.strategies.GroupingStrategy;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -358,7 +357,7 @@ class ThymeleafServletAutoConfigurationTests {
 	@Test
 	void cachingCanBeDisabled() {
 		this.contextRunner.withPropertyValues("spring.thymeleaf.cache:false").run((context) -> {
-			Assertions.assertThat(context.getBean(ThymeleafViewResolver.class).isCache()).isFalse();
+			assertThat(context.getBean(ThymeleafViewResolver.class).isCache()).isFalse();
 			SpringResourceTemplateResolver templateResolver = context.getBean(SpringResourceTemplateResolver.class);
 			assertThat(templateResolver.isCacheable()).isFalse();
 		});

--- a/system-test/spring-boot-image-system-tests/src/systemTest/java/org/springframework/boot/image/assertions/ImageAssert.java
+++ b/system-test/spring-boot-image-system-tests/src/systemTest/java/org/springframework/boot/image/assertions/ImageAssert.java
@@ -27,7 +27,6 @@ import java.util.function.Consumer;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 
 import org.springframework.boot.buildpack.platform.docker.DockerApi;
@@ -36,6 +35,8 @@ import org.springframework.boot.buildpack.platform.docker.type.Layer;
 import org.springframework.boot.test.json.JsonContentAssert;
 import org.springframework.lang.CheckReturnValue;
 import org.springframework.util.StreamUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * AssertJ {@link org.assertj.core.api.Assert} for Docker image contents.
@@ -94,7 +95,7 @@ public class ImageAssert extends AbstractAssert<ImageAssert, ImageReference> {
 			catch (IOException ex) {
 				failWithMessage("IOException while reading image layer archive: '%s'", ex.getMessage());
 			}
-			return Assertions.assertThat(entryNames);
+			return assertThat(entryNames);
 		}
 
 		public void jsonEntry(String name, Consumer<JsonContentAssert> assertConsumer) {


### PR DESCRIPTION
This PR changes to use static imports for `Assertions.assertThat()` consistently where possible.