### PR TITLE
Fix method naming to follow Java camelCase conventions

### DIFF
--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/transport/LocalHttpClientTransport.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/transport/LocalHttpClientTransport.java
@@ -89,11 +89,11 @@ final class LocalHttpClientTransport extends HttpClientTransport {
 		private static final Lookup<@Nullable TlsSocketStrategy> NO_TLS_SOCKET = (name) -> null;
 
 		LocalConnectionManager(ResolvedDockerHost dockerHost) {
-			super(createhttpClientConnectionOperator(dockerHost), null);
+			super(createHttpClientConnectionOperator(dockerHost), null);
 			setConnectionConfig(CONNECTION_CONFIG);
 		}
 
-		private static DefaultHttpClientConnectionOperator createhttpClientConnectionOperator(
+		private static DefaultHttpClientConnectionOperator createHttpClientConnectionOperator(
 				ResolvedDockerHost dockerHost) {
 			LocalDetachedSocketFactory detachedSocketFactory = new LocalDetachedSocketFactory(dockerHost);
 			LocalDnsResolver dnsResolver = new LocalDnsResolver();


### PR DESCRIPTION
This PR fixes a method naming issue in `LocalHttpClientTransport` where the method name `createhttpClientConnectionOperator` does not follow standard Java camelCase naming conventions.

## Changes

Renamed `createhttpClientConnectionOperator` to `createHttpClientConnectionOperator` to ensure proper capitalization of the "Http" portion of the method name, following Java naming conventions where each word in a compound name should start with an uppercase letter.

## Why This Matters

Consistent naming conventions improve code readability and maintainability. The original method name `createhttpClientConnectionOperator` incorrectly uses lowercase "http" instead of "Http", which deviates from the standard Java camelCase convention used throughout the Spring Boot codebase.