### PR TITLE
Fix incorrect null check using .equals(null)

### DIFF
--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/diagnostics/analyzer/NoSuchBeanDefinitionFailureAnalyzer.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/diagnostics/analyzer/NoSuchBeanDefinitionFailureAnalyzer.java
@@ -141,7 +141,7 @@ class NoSuchBeanDefinitionFailureAnalyzer extends AbstractInjectionFailureAnalyz
 		String[] beanNames = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(this.beanFactory, type);
 		return Arrays.stream(beanNames)
 			.map((beanName) -> new UserConfigurationResult(getFactoryMethodMetadata(beanName),
-					this.beanFactory.getBean(beanName).equals(null)))
+					this.beanFactory.getBean(beanName) == null))
 			.toList();
 	}
 


### PR DESCRIPTION
Fix incorrect null check: `.equals(null)` should be `== null`