### PR TITLE
Add UseStaticImport

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -69,6 +69,16 @@ runs:
         COMMERCIAL_REPO_USERNAME: ${{ inputs.commercial-repository-username }}
         COMMERCIAL_SNAPSHOT_REPO_URL: ${{ inputs.commercial-snapshot-repository-url }}
       run: ./gradlew build
+    - name: Sanity Check
+      id: sanity
+      if: ${{ inputs.publish == 'false' }}
+      shell: bash
+      env:
+        COMMERCIAL_RELEASE_REPO_URL: ${{ inputs.commercial-release-repository-url }}
+        COMMERCIAL_REPO_PASSWORD: ${{ inputs.commercial-repository-password }}
+        COMMERCIAL_REPO_USERNAME: ${{ inputs.commercial-repository-username }}
+        COMMERCIAL_SNAPSHOT_REPO_URL: ${{ inputs.commercial-snapshot-repository-url }}
+      run: ./gradlew rewriteDryRun -Dorg.gradle.jvmargs=-Xmx12G
     - name: Publish
       id: publish
       if: ${{ inputs.publish == 'true' }}

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Build
         id: build
         uses: ./.github/actions/build
+      - name: Sanity
+        id: sanity
+        uses: ./.github/actions/build
       - name: Print JVM Thread Dumps When Cancelled
         if: cancelled()
         uses: ./.github/actions/print-jvm-thread-dumps

--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoProperties.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoProperties.java
@@ -37,6 +37,8 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.jspecify.annotations.Nullable;
 
+import static java.util.Collections.emptySet;
+
 /**
  * The properties that are written into the {@code build-info.properties} file.
  *
@@ -148,7 +150,7 @@ public abstract class BuildInfoProperties implements Serializable {
 	}
 
 	private <T> @Nullable T getIfNotExcluded(Property<T> property, String name, Supplier<@Nullable T> defaultValue) {
-		if (this.excludes.getOrElse(Collections.emptySet()).contains(name)) {
+		if (this.excludes.getOrElse(emptySet()).contains(name)) {
 			return null;
 		}
 		if (property.isPresent()) {
@@ -172,7 +174,7 @@ public abstract class BuildInfoProperties implements Serializable {
 
 	private Map<String, Object> applyExclusions(Map<String, Object> input) {
 		Map<String, Object> output = new HashMap<>();
-		Set<String> exclusions = this.excludes.getOrElse(Collections.emptySet());
+		Set<String> exclusions = this.excludes.getOrElse(emptySet());
 		input.forEach((key, value) -> {
 			boolean isExcluded = exclusions.contains(key);
 			if (!isExcluded) {

--- a/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ArtifactsLibrariesTests.java
+++ b/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ArtifactsLibrariesTests.java
@@ -41,6 +41,7 @@ import org.springframework.boot.loader.tools.LibraryCallback;
 import org.springframework.boot.loader.tools.LibraryCoordinates;
 import org.springframework.boot.loader.tools.LibraryScope;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.BDDMockito.given;
@@ -200,7 +201,7 @@ class ArtifactsLibrariesTests {
 		MavenProject mavenProject = mock(MavenProject.class);
 		given(mavenProject.getArtifact()).willReturn(artifact);
 		this.artifacts = Collections.singleton(artifact);
-		new ArtifactsLibraries(this.artifacts, Collections.emptySet(), Collections.singleton(mavenProject), null,
+		new ArtifactsLibraries(this.artifacts, emptySet(), Collections.singleton(mavenProject), null,
 				mock(Log.class))
 			.doWithLibraries((library) -> assertThat(library.isIncluded()).isFalse());
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@
 
 plugins {
 	id "base"
+	id "org.openrewrite.rewrite" version "7.23.0" apply false
 }
 
 description = "Spring Boot Build"
@@ -46,3 +47,5 @@ subprojects {
 		resolutionStrategy.cacheChangingModulesFor 0, "minutes"
 	}
 }
+
+apply from: rootProject.file("gradle/plugins/config/sanity.gradle")

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/FilePermissionsTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/FilePermissionsTests.java
@@ -23,7 +23,6 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.util.Collections;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -32,6 +31,7 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -86,7 +86,7 @@ class FilePermissionsTests {
 
 	@Test
 	void posixPermissionsToUmaskWithEmptyPermissions() {
-		Set<PosixFilePermission> permissions = Collections.emptySet();
+		Set<PosixFilePermission> permissions = emptySet();
 		assertThat(FilePermissions.posixPermissionsToUmask(permissions)).isZero();
 	}
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/fieldvalues/javac/VariableTree.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/fieldvalues/javac/VariableTree.java
@@ -16,10 +16,11 @@
 
 package org.springframework.boot.configurationprocessor.fieldvalues.javac;
 
-import java.util.Collections;
 import java.util.Set;
 
 import javax.lang.model.element.Modifier;
+
+import static java.util.Collections.emptySet;
 
 /**
  * Reflection based access to {@code com.sun.source.tree.VariableTree}.
@@ -49,7 +50,7 @@ class VariableTree extends ReflectionWrapper {
 	Set<Modifier> getModifierFlags() throws Exception {
 		Object modifiers = findMethod("getModifiers").invoke(getInstance());
 		if (modifiers == null) {
-			return Collections.emptySet();
+			return emptySet();
 		}
 		return (Set<Modifier>) findMethod(findClass("com.sun.source.tree.ModifiersTree"), "getFlags").invoke(modifiers);
 	}

--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelector.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationImportSelector.java
@@ -61,6 +61,8 @@ import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
+import static java.util.Collections.emptySet;
+
 /**
  * {@link DeferredImportSelector} to handle {@link EnableAutoConfiguration
  * auto-configuration}. This class can also be subclassed if a custom variant of
@@ -546,7 +548,7 @@ public class AutoConfigurationImportSelector implements DeferredImportSelector, 
 
 		private AutoConfigurationEntry() {
 			this.configurations = Collections.emptyList();
-			this.exclusions = Collections.emptySet();
+			this.exclusions = emptySet();
 		}
 
 		/**

--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationSorter.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationSorter.java
@@ -37,6 +37,8 @@ import org.springframework.core.type.classreading.MetadataReader;
 import org.springframework.core.type.classreading.MetadataReaderFactory;
 import org.springframework.util.Assert;
 
+import static java.util.Collections.emptySet;
+
 /**
  * Sort {@link EnableAutoConfiguration auto-configuration} classes into priority order by
  * reading {@link AutoConfigureOrder @AutoConfigureOrder},
@@ -226,7 +228,7 @@ class AutoConfigurationSorter {
 
 		private Set<String> getSet(String metadataKey) {
 			Assert.state(this.autoConfigurationMetadata != null, "'autoConfigurationMetadata' must not be null");
-			return this.autoConfigurationMetadata.getSet(this.className, metadataKey, Collections.emptySet());
+			return this.autoConfigurationMetadata.getSet(this.className, metadataKey, emptySet());
 		}
 
 		private Set<String> applyReplacements(Set<String> values) {
@@ -265,7 +267,7 @@ class AutoConfigurationSorter {
 			Map<String, @Nullable Object> attributes = getAnnotationMetadata()
 				.getAnnotationAttributes(annotation.getName(), true);
 			if (attributes == null) {
-				return Collections.emptySet();
+				return emptySet();
 			}
 			Set<String> result = new LinkedHashSet<>();
 			String[] value = (String[]) attributes.get("value");

--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnBeanCondition.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnBeanCondition.java
@@ -72,6 +72,8 @@ import org.springframework.util.ObjectUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
+import static java.util.Collections.emptySet;
+
 /**
  * {@link Condition} that checks for the presence or absence of specific beans.
  *
@@ -315,7 +317,7 @@ class OnBeanCondition extends FilteringSpringBootCondition implements Configurat
 				.keySet();
 			result = addAll(result, ignoredNames);
 		}
-		return (result != null) ? result : Collections.emptySet();
+		return (result != null) ? result : emptySet();
 	}
 
 	private Map<String, @Nullable BeanDefinition> getBeanDefinitionsForType(ListableBeanFactory beanFactory,
@@ -607,7 +609,7 @@ class OnBeanCondition extends FilteringSpringBootCondition implements Configurat
 		private Set<String> extract(@Nullable MultiValueMap<String, @Nullable Object> attributes,
 				String... attributeNames) {
 			if (CollectionUtils.isEmpty(attributes)) {
-				return Collections.emptySet();
+				return emptySet();
 			}
 			Set<String> result = new LinkedHashSet<>();
 			for (String attributeName : attributeNames) {
@@ -621,7 +623,7 @@ class OnBeanCondition extends FilteringSpringBootCondition implements Configurat
 					}
 				}
 			}
-			return result.isEmpty() ? Collections.emptySet() : result;
+			return result.isEmpty() ? emptySet() : result;
 		}
 
 		private void merge(Set<String> result, String... additional) {

--- a/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionEvaluationReportAutoConfigurationImportListenerTests.java
+++ b/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionEvaluationReportAutoConfigurationImportListenerTests.java
@@ -30,6 +30,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurationImportEvent;
 import org.springframework.boot.autoconfigure.AutoConfigurationImportListener;
 import org.springframework.core.io.support.SpringFactoriesLoader;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -61,7 +62,7 @@ class ConditionEvaluationReportAutoConfigurationImportListenerTests {
 	@Test
 	void onAutoConfigurationImportEventShouldRecordCandidates() {
 		List<String> candidateConfigurations = Collections.singletonList("Test");
-		Set<String> exclusions = Collections.emptySet();
+		Set<String> exclusions = emptySet();
 		AutoConfigurationImportEvent event = new AutoConfigurationImportEvent(this, candidateConfigurations,
 				exclusions);
 		this.listener.onAutoConfigurationImportEvent(event);
@@ -83,7 +84,7 @@ class ConditionEvaluationReportAutoConfigurationImportListenerTests {
 	@Test
 	void onAutoConfigurationImportEventShouldApplyExclusionsGlobally() {
 		AutoConfigurationImportEvent event = new AutoConfigurationImportEvent(this, Arrays.asList("First", "Second"),
-				Collections.emptySet());
+				emptySet());
 		this.listener.onAutoConfigurationImportEvent(event);
 		AutoConfigurationImportEvent anotherEvent = new AutoConfigurationImportEvent(this, Collections.emptyList(),
 				Collections.singleton("First"));
@@ -99,7 +100,7 @@ class ConditionEvaluationReportAutoConfigurationImportListenerTests {
 				Collections.singleton("First"));
 		this.listener.onAutoConfigurationImportEvent(excludeEvent);
 		AutoConfigurationImportEvent event = new AutoConfigurationImportEvent(this, Arrays.asList("First", "Second"),
-				Collections.emptySet());
+				emptySet());
 		this.listener.onAutoConfigurationImportEvent(event);
 		ConditionEvaluationReport report = ConditionEvaluationReport.get(this.beanFactory);
 		assertThat(report.getUnconditionalClasses()).containsExactly("Second");

--- a/core/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/core/DockerCliIntegrationTests.java
+++ b/core/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/core/DockerCliIntegrationTests.java
@@ -45,6 +45,7 @@ import org.springframework.boot.testsupport.process.DisabledIfProcessUnavailable
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.util.FileCopyUtils;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -74,7 +75,7 @@ class DockerCliIntegrationTests {
 		File composeFile = createComposeFile("redis-compose.yaml");
 		String projectName = UUID.randomUUID().toString();
 		DockerCli cli = new DockerCli(null, new DockerComposeOptions(DockerComposeFile.of(composeFile),
-				Collections.emptySet(), List.of("--project-name=" + projectName)));
+				emptySet(), List.of("--project-name=" + projectName)));
 		try {
 			// Verify that no services are running (this is a fresh compose project)
 			List<DockerCliComposePsResponse> ps = cli.run(new ComposePs());

--- a/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DockerCli.java
+++ b/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DockerCli.java
@@ -35,6 +35,8 @@ import org.springframework.boot.logging.LogLevel;
 import org.springframework.core.log.LogMessage;
 import org.springframework.util.CollectionUtils;
 
+import static java.util.Collections.emptySet;
+
 /**
  * Wrapper around {@code docker} and {@code docker-compose} command line tools.
  *
@@ -212,7 +214,7 @@ class DockerCli {
 		DockerComposeOptions(@Nullable DockerComposeFile composeFile, @Nullable Set<String> activeProfiles,
 				@Nullable List<String> arguments) {
 			this.composeFile = composeFile;
-			this.activeProfiles = (activeProfiles != null) ? activeProfiles : Collections.emptySet();
+			this.activeProfiles = (activeProfiles != null) ? activeProfiles : emptySet();
 			this.arguments = (arguments != null) ? arguments : Collections.emptyList();
 		}
 

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/filter/annotation/StandardAnnotationCustomizableTypeExcludeFilter.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/filter/annotation/StandardAnnotationCustomizableTypeExcludeFilter.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.test.context.filter.annotation;
 
 import java.lang.annotation.Annotation;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -28,6 +27,8 @@ import org.springframework.core.annotation.MergedAnnotation;
 import org.springframework.core.annotation.MergedAnnotations;
 import org.springframework.core.annotation.MergedAnnotations.SearchStrategy;
 import org.springframework.util.Assert;
+
+import static java.util.Collections.emptySet;
 
 /**
  * {@link AnnotationCustomizableTypeExcludeFilter} that can be used to any test annotation
@@ -87,12 +88,12 @@ public abstract class StandardAnnotationCustomizableTypeExcludeFilter<A extends 
 	}
 
 	protected Set<Class<?>> getKnownIncludes() {
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@Override
 	protected Set<Class<?>> getComponentIncludes() {
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/core/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/SslBundleSource.java
+++ b/core/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/SslBundleSource.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.testcontainers.service.connection;
 
 import java.lang.annotation.Annotation;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -36,6 +35,8 @@ import org.springframework.core.annotation.MergedAnnotation;
 import org.springframework.core.annotation.MergedAnnotations;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+
+import static java.util.Collections.emptySet;
 
 /**
  * {@link SslBundle} source created from annotations. Used as a cache key and as a
@@ -141,7 +142,7 @@ record SslBundleSource(@Nullable Ssl ssl, @Nullable PemKeyStore pemKeyStore, @Nu
 	private static <A extends Annotation> @Nullable A getAnnotation(@Nullable ListableBeanFactory beanFactory,
 			@Nullable String beanName, @Nullable MergedAnnotations annotations, Class<A> annotationType) {
 		Set<A> found = (beanFactory != null && beanName != null)
-				? beanFactory.findAllAnnotationsOnBean(beanName, annotationType, false) : Collections.emptySet();
+				? beanFactory.findAllAnnotationsOnBean(beanName, annotationType, false) : emptySet();
 		if (annotations != null) {
 			found = new LinkedHashSet<>(found);
 			annotations.stream(annotationType).map(MergedAnnotation::synthesize).forEach(found::add);

--- a/core/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -108,6 +108,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.util.function.ThrowingConsumer;
 import org.springframework.util.function.ThrowingSupplier;
 
+import static java.util.Collections.emptySet;
+
 /**
  * Class that can be used to bootstrap and launch a Spring application from a Java main
  * method. By default class will perform the following steps to bootstrap your
@@ -234,7 +236,7 @@ public class SpringApplication {
 
 	private final List<BootstrapRegistryInitializer> bootstrapRegistryInitializers;
 
-	private Set<String> additionalProfiles = Collections.emptySet();
+	private Set<String> additionalProfiles = emptySet();
 
 	private boolean isCustomEnvironment;
 
@@ -1431,7 +1433,7 @@ public class SpringApplication {
 	 */
 	public static SpringApplication.Augmented from(ThrowingConsumer<String[]> main) {
 		Assert.notNull(main, "'main' must not be null");
-		return new Augmented(main, Collections.emptySet(), Collections.emptySet());
+		return new Augmented(main, emptySet(), emptySet());
 	}
 
 	/**

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigData.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigData.java
@@ -31,6 +31,8 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertySource;
 import org.springframework.util.Assert;
 
+import static java.util.Collections.emptySet;
+
 /**
  * Configuration data that has been loaded from a {@link ConfigDataResource} and may
  * ultimately contribute {@link PropertySource property sources} to Spring's
@@ -51,7 +53,7 @@ public final class ConfigData {
 	/**
 	 * A {@link ConfigData} instance that contains no data.
 	 */
-	public static final ConfigData EMPTY = new ConfigData(Collections.emptySet());
+	public static final ConfigData EMPTY = new ConfigData(emptySet());
 
 	/**
 	 * Create a new {@link ConfigData} instance with the same options applied to each
@@ -177,7 +179,7 @@ public final class ConfigData {
 		/**
 		 * No options.
 		 */
-		public static final Options NONE = new Options(Collections.emptySet());
+		public static final Options NONE = new Options(emptySet());
 
 		private final Set<Option> options;
 

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/config/Profiles.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/config/Profiles.java
@@ -43,6 +43,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 
+import static java.util.Collections.emptySet;
+
 /**
  * Provides access to environment profiles that have either been set directly on the
  * {@link Environment} or will be set based on configuration data property values.
@@ -103,7 +105,7 @@ public class Profiles implements Iterable<String> {
 			Type type) {
 		String environmentPropertyValue = environment.getProperty(type.getName());
 		Set<String> environmentPropertyProfiles = (!StringUtils.hasLength(environmentPropertyValue))
-				? Collections.emptySet()
+				? emptySet()
 				: StringUtils.commaDelimitedListToSet(StringUtils.trimAllWhitespace(environmentPropertyValue));
 		validator.validate(environmentPropertyProfiles,
 				() -> "Invalid profile property value found in Environment under '%s'".formatted(type.getName()));
@@ -227,7 +229,7 @@ public class Profiles implements Iterable<String> {
 	private enum Type {
 
 		ACTIVE(AbstractEnvironment.ACTIVE_PROFILES_PROPERTY_NAME, Environment::getActiveProfiles, true,
-				Collections.emptySet()),
+				emptySet()),
 
 		DEFAULT(AbstractEnvironment.DEFAULT_PROFILES_PROPERTY_NAME, Environment::getDefaultProfiles, false,
 				Collections.singleton("default"));

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/config/StandardConfigDataLocationResolver.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/config/StandardConfigDataLocationResolver.java
@@ -48,6 +48,8 @@ import org.springframework.util.ObjectUtils;
 import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
 
+import static java.util.Collections.emptySet;
+
 /**
  * {@link ConfigDataLocationResolver} for standard locations.
  *
@@ -228,7 +230,7 @@ public class StandardConfigDataLocationResolver
 			}
 		}
 		if (configDataLocation.isOptional()) {
-			return Collections.emptySet();
+			return emptySet();
 		}
 		if (configDataLocation.hasPrefix(PREFIX) || configDataLocation.hasPrefix(ResourceUtils.FILE_URL_PREFIX)
 				|| configDataLocation.hasPrefix(ResourceUtils.CLASSPATH_URL_PREFIX)
@@ -289,7 +291,7 @@ public class StandardConfigDataLocationResolver
 		String directory = reference.getDirectory();
 		Assert.state(directory != null, "'directory' must not be null");
 		Resource resource = this.resourceLoader.getResource(directory);
-		return (resource instanceof ClassPathResource || !resource.exists()) ? Collections.emptySet()
+		return (resource instanceof ClassPathResource || !resource.exists()) ? emptySet()
 				: Collections.singleton(new StandardConfigDataResource(reference, resource, true));
 	}
 

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySource.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySource.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.context.properties.source;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,6 +41,8 @@ import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.env.SystemEnvironmentPropertySource;
 import org.springframework.util.Assert;
 import org.springframework.util.ConcurrentReferenceHashMap;
+
+import static java.util.Collections.emptySet;
 
 /**
  * {@link ConfigurationPropertySource} backed by an {@link EnumerablePropertySource}.
@@ -321,7 +322,7 @@ class SpringIterableConfigurationPropertySource extends SpringConfigurationPrope
 		Set<String> getMapped(ConfigurationPropertyName configurationPropertyName) {
 			Data data = this.data;
 			Assert.state(data != null, "'data' must not be null");
-			return data.mappings().getOrDefault(configurationPropertyName, Collections.emptySet());
+			return data.mappings().getOrDefault(configurationPropertyName, emptySet());
 		}
 
 		@Nullable ConfigurationPropertyName[] getConfigurationPropertyNames(String[] propertyNames) {

--- a/core/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/BindFailureAnalyzer.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/diagnostics/analyzer/BindFailureAnalyzer.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.diagnostics.analyzer;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -32,6 +31,8 @@ import org.springframework.boot.diagnostics.AbstractFailureAnalyzer;
 import org.springframework.boot.diagnostics.FailureAnalysis;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.util.StringUtils;
+
+import static java.util.Collections.emptySet;
 
 /**
  * An {@link AbstractFailureAnalyzer} that performs analysis of failures caused by a
@@ -127,7 +128,7 @@ class BindFailureAnalyzer extends AbstractFailureAnalyzer<BindException> {
 				return Stream.of(enumConstants).map(Object::toString).collect(Collectors.toCollection(TreeSet::new));
 			}
 		}
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 }

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/StructuredLoggingJsonProperties.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/StructuredLoggingJsonProperties.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.logging.structured;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -40,6 +39,8 @@ import org.springframework.boot.logging.StandardStackTracePrinter;
 import org.springframework.boot.util.Instantiator;
 import org.springframework.core.env.Environment;
 import org.springframework.util.Assert;
+
+import static java.util.Collections.emptySet;
 
 /**
  * Properties that can be used to customize structured logging JSON.
@@ -68,7 +69,7 @@ record StructuredLoggingJsonProperties(Set<String> include, Set<String> exclude,
 		this.add = add;
 		this.stackTrace = stackTrace;
 		this.context = context;
-		this.customizer = (customizer != null) ? customizer : Collections.emptySet();
+		this.customizer = (customizer != null) ? customizer : emptySet();
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })

--- a/core/spring-boot/src/main/java/org/springframework/boot/task/SimpleAsyncTaskExecutorBuilder.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/task/SimpleAsyncTaskExecutorBuilder.java
@@ -31,6 +31,8 @@ import org.springframework.core.task.TaskDecorator;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 
+import static java.util.Collections.emptySet;
+
 /**
  * Builder that can be used to configure and create a {@link SimpleAsyncTaskExecutor}.
  * Provides convenience methods to set common {@link SimpleAsyncTaskExecutor} settings and
@@ -279,7 +281,7 @@ public class SimpleAsyncTaskExecutorBuilder {
 	}
 
 	private <T> Set<T> append(@Nullable Set<T> set, Iterable<? extends T> additions) {
-		Set<T> result = new LinkedHashSet<>((set != null) ? set : Collections.emptySet());
+		Set<T> result = new LinkedHashSet<>((set != null) ? set : emptySet());
 		additions.forEach(result::add);
 		return Collections.unmodifiableSet(result);
 	}

--- a/core/spring-boot/src/main/java/org/springframework/boot/task/SimpleAsyncTaskSchedulerBuilder.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/task/SimpleAsyncTaskSchedulerBuilder.java
@@ -30,6 +30,8 @@ import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 
+import static java.util.Collections.emptySet;
+
 /**
  * Builder that can be used to configure and create a {@link SimpleAsyncTaskScheduler}.
  * Provides convenience methods to set common {@link SimpleAsyncTaskScheduler} settings.
@@ -214,7 +216,7 @@ public class SimpleAsyncTaskSchedulerBuilder {
 	}
 
 	private <T> Set<T> append(@Nullable Set<T> set, Iterable<? extends T> additions) {
-		Set<T> result = new LinkedHashSet<>((set != null) ? set : Collections.emptySet());
+		Set<T> result = new LinkedHashSet<>((set != null) ? set : emptySet());
 		additions.forEach(result::add);
 		return Collections.unmodifiableSet(result);
 	}

--- a/core/spring-boot/src/main/java/org/springframework/boot/task/ThreadPoolTaskExecutorBuilder.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/task/ThreadPoolTaskExecutorBuilder.java
@@ -31,6 +31,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 
+import static java.util.Collections.emptySet;
+
 /**
  * Builder that can be used to configure and create a {@link ThreadPoolTaskExecutor}.
  * Provides convenience methods to set common {@link ThreadPoolTaskExecutor} settings and
@@ -342,7 +344,7 @@ public class ThreadPoolTaskExecutorBuilder {
 	}
 
 	private <T> Set<T> append(@Nullable Set<T> set, Iterable<? extends T> additions) {
-		Set<T> result = new LinkedHashSet<>((set != null) ? set : Collections.emptySet());
+		Set<T> result = new LinkedHashSet<>((set != null) ? set : emptySet());
 		additions.forEach(result::add);
 		return Collections.unmodifiableSet(result);
 	}

--- a/core/spring-boot/src/main/java/org/springframework/boot/task/ThreadPoolTaskSchedulerBuilder.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/task/ThreadPoolTaskSchedulerBuilder.java
@@ -30,6 +30,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 
+import static java.util.Collections.emptySet;
+
 /**
  * Builder that can be used to configure and create a {@link ThreadPoolTaskScheduler}.
  * Provides convenience methods to set common {@link ThreadPoolTaskScheduler} settings.
@@ -222,7 +224,7 @@ public class ThreadPoolTaskSchedulerBuilder {
 	}
 
 	private <T> Set<T> append(@Nullable Set<T> set, Iterable<? extends T> additions) {
-		Set<T> result = new LinkedHashSet<>((set != null) ? set : Collections.emptySet());
+		Set<T> result = new LinkedHashSet<>((set != null) ? set : emptySet());
 		additions.forEach(result::add);
 		return Collections.unmodifiableSet(result);
 	}

--- a/core/spring-boot/src/main/java/org/springframework/boot/web/error/ErrorAttributeOptions.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/web/error/ErrorAttributeOptions.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import org.jspecify.annotations.Nullable;
 
+import static java.util.Collections.emptySet;
+
 /**
  * Options controlling the contents of {@code ErrorAttributes}.
  *
@@ -125,7 +127,7 @@ public final class ErrorAttributeOptions {
 	 */
 	public static ErrorAttributeOptions of(Collection<Include> includes) {
 		return new ErrorAttributeOptions(
-				(includes.isEmpty()) ? Collections.emptySet() : Collections.unmodifiableSet(EnumSet.copyOf(includes)));
+				(includes.isEmpty()) ? emptySet() : Collections.unmodifiableSet(EnumSet.copyOf(includes)));
 	}
 
 	/**

--- a/core/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletContextInitializerBeans.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/web/servlet/ServletContextInitializerBeans.java
@@ -51,6 +51,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 
+import static java.util.Collections.emptySet;
+
 /**
  * A collection {@link ServletContextInitializer}s obtained from a
  * {@link ListableBeanFactory}. Includes all {@link ServletContextInitializer} beans and
@@ -426,10 +428,10 @@ public class ServletContextInitializerBeans extends AbstractCollection<ServletCo
 			// If it has been directly seen, or the implemented ServletContextInitializer
 			// has been seen already
 			if (type != ServletContextInitializer.class
-					&& this.seen.getOrDefault(type, Collections.emptySet()).contains(object)) {
+					&& this.seen.getOrDefault(type, emptySet()).contains(object)) {
 				return true;
 			}
-			return this.seen.getOrDefault(ServletContextInitializer.class, Collections.emptySet()).contains(object);
+			return this.seen.getOrDefault(ServletContextInitializer.class, emptySet()).contains(object);
 		}
 
 		static Seen empty() {

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/CollectionBinderTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/CollectionBinderTests.java
@@ -39,6 +39,7 @@ import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.env.SystemEnvironmentPropertySource;
 import org.springframework.test.context.support.TestPropertySourceUtils;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -332,7 +333,7 @@ class CollectionBinderTests {
 		MockConfigurationPropertySource source = new MockConfigurationPropertySource();
 		source.put("foo.values", "a,b,c");
 		this.sources.add(source);
-		Set<String> result = this.binder.bind("foo.values", STRING_SET.withExistingValue(Collections.emptySet())).get();
+		Set<String> result = this.binder.bind("foo.values", STRING_SET.withExistingValue(emptySet())).get();
 		assertThat(result).hasSize(3);
 	}
 

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/MapBinderTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/MapBinderTests.java
@@ -49,6 +49,7 @@ import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.context.support.TestPropertySourceUtils;
 import org.springframework.util.StringUtils;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.entry;
@@ -824,7 +825,7 @@ class MapBinderTests {
 
 			@Override
 			public Set<Entry<String, Object>> entrySet() {
-				return Collections.emptySet();
+				return emptySet();
 			}
 
 			String getSource() {

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/validation/ValidationErrorsTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/validation/ValidationErrorsTests.java
@@ -31,6 +31,7 @@ import org.springframework.boot.origin.Origin;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
@@ -48,7 +49,7 @@ class ValidationErrorsTests {
 	@SuppressWarnings("NullAway") // Test null check
 	void createWhenNameIsNullShouldThrowException() {
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> new ValidationErrors(null, Collections.emptySet(), Collections.emptyList()))
+			.isThrownBy(() -> new ValidationErrors(null, emptySet(), Collections.emptyList()))
 			.withMessageContaining("'name' must not be null");
 	}
 
@@ -62,14 +63,14 @@ class ValidationErrorsTests {
 	@Test
 	@SuppressWarnings("NullAway") // Test null check
 	void createWhenErrorsIsNullShouldThrowException() {
-		assertThatIllegalArgumentException().isThrownBy(() -> new ValidationErrors(NAME, Collections.emptySet(), null))
+		assertThatIllegalArgumentException().isThrownBy(() -> new ValidationErrors(NAME, emptySet(), null))
 			.withMessageContaining("'errors' must not be null");
 	}
 
 	@Test
 	void getNameShouldReturnName() {
 		ConfigurationPropertyName name = NAME;
-		ValidationErrors errors = new ValidationErrors(name, Collections.emptySet(), Collections.emptyList());
+		ValidationErrors errors = new ValidationErrors(name, emptySet(), Collections.emptyList());
 		assertThat((Object) errors.getName()).isEqualTo(name);
 	}
 
@@ -85,7 +86,7 @@ class ValidationErrorsTests {
 	void getErrorsShouldReturnErrors() {
 		List<ObjectError> allErrors = new ArrayList<>();
 		allErrors.add(new ObjectError("foo", "bar"));
-		ValidationErrors errors = new ValidationErrors(NAME, Collections.emptySet(), allErrors);
+		ValidationErrors errors = new ValidationErrors(NAME, emptySet(), allErrors);
 		assertThat(errors.getAllErrors()).isEqualTo(allErrors);
 	}
 
@@ -93,7 +94,7 @@ class ValidationErrorsTests {
 	void iteratorShouldIterateErrors() {
 		List<ObjectError> allErrors = new ArrayList<>();
 		allErrors.add(new ObjectError("foo", "bar"));
-		ValidationErrors errors = new ValidationErrors(NAME, Collections.emptySet(), allErrors);
+		ValidationErrors errors = new ValidationErrors(NAME, emptySet(), allErrors);
 		assertThat(errors.iterator()).toIterable().containsExactlyElementsOf(allErrors);
 	}
 

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/structured/StructuredLoggingJsonPropertiesJsonMembersCustomizerTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/structured/StructuredLoggingJsonPropertiesJsonMembersCustomizerTests.java
@@ -30,6 +30,7 @@ import org.springframework.boot.json.JsonWriter.Members;
 import org.springframework.boot.json.JsonWriter.NameProcessor;
 import org.springframework.boot.util.Instantiator;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
@@ -48,7 +49,7 @@ class StructuredLoggingJsonPropertiesJsonMembersCustomizerTests {
 
 	@Test
 	void customizeWhenHasExcludeFiltersMember() {
-		StructuredLoggingJsonProperties properties = new StructuredLoggingJsonProperties(Collections.emptySet(),
+		StructuredLoggingJsonProperties properties = new StructuredLoggingJsonProperties(emptySet(),
 				Set.of("a"), Collections.emptyMap(), Collections.emptyMap(), null, null, null);
 		StructuredLoggingJsonPropertiesJsonMembersCustomizer customizer = new StructuredLoggingJsonPropertiesJsonMembersCustomizer(
 				this.instantiator, properties, false);
@@ -58,7 +59,7 @@ class StructuredLoggingJsonPropertiesJsonMembersCustomizerTests {
 	@Test
 	void customizeWhenHasIncludeFiltersOtherMembers() {
 		StructuredLoggingJsonProperties properties = new StructuredLoggingJsonProperties(Set.of("a"),
-				Collections.emptySet(), Collections.emptyMap(), Collections.emptyMap(), null, null, null);
+				emptySet(), Collections.emptyMap(), Collections.emptyMap(), null, null, null);
 		StructuredLoggingJsonPropertiesJsonMembersCustomizer customizer = new StructuredLoggingJsonPropertiesJsonMembersCustomizer(
 				this.instantiator, properties, false);
 		assertThat(writeSampleJson(customizer)).contains("a")
@@ -81,8 +82,8 @@ class StructuredLoggingJsonPropertiesJsonMembersCustomizerTests {
 
 	@Test
 	void customizeWhenHasRenameRenamesMember() {
-		StructuredLoggingJsonProperties properties = new StructuredLoggingJsonProperties(Collections.emptySet(),
-				Collections.emptySet(), Map.of("a", "z"), Collections.emptyMap(), null, null, null);
+		StructuredLoggingJsonProperties properties = new StructuredLoggingJsonProperties(emptySet(),
+				emptySet(), Map.of("a", "z"), Collections.emptyMap(), null, null, null);
 		StructuredLoggingJsonPropertiesJsonMembersCustomizer customizer = new StructuredLoggingJsonPropertiesJsonMembersCustomizer(
 				this.instantiator, properties, false);
 		assertThat(writeSampleJson(customizer)).contains("\"z\":\"a\"");
@@ -90,8 +91,8 @@ class StructuredLoggingJsonPropertiesJsonMembersCustomizerTests {
 
 	@Test
 	void customizeWhenHasAddAddsMember() {
-		StructuredLoggingJsonProperties properties = new StructuredLoggingJsonProperties(Collections.emptySet(),
-				Collections.emptySet(), Collections.emptyMap(), Map.of("z", "z"), null, null, null);
+		StructuredLoggingJsonProperties properties = new StructuredLoggingJsonProperties(emptySet(),
+				emptySet(), Collections.emptyMap(), Map.of("z", "z"), null, null, null);
 		StructuredLoggingJsonPropertiesJsonMembersCustomizer customizer = new StructuredLoggingJsonPropertiesJsonMembersCustomizer(
 				this.instantiator, properties, false);
 		assertThat(writeSampleJson(customizer)).contains("\"z\":\"z\"");
@@ -99,8 +100,8 @@ class StructuredLoggingJsonPropertiesJsonMembersCustomizerTests {
 
 	@Test
 	void customizeWhenHasNestedAddAddsMember() {
-		StructuredLoggingJsonProperties properties = new StructuredLoggingJsonProperties(Collections.emptySet(),
-				Collections.emptySet(), Collections.emptyMap(), Map.of("y.z", "yz"), null, null, null);
+		StructuredLoggingJsonProperties properties = new StructuredLoggingJsonProperties(emptySet(),
+				emptySet(), Collections.emptyMap(), Map.of("y.z", "yz"), null, null, null);
 		StructuredLoggingJsonPropertiesJsonMembersCustomizer customizer = new StructuredLoggingJsonPropertiesJsonMembersCustomizer(
 				this.instantiator, properties, true);
 		assertThat(writeSampleJson(customizer)).contains("\"y\":{\"z\":\"yz\"}");
@@ -112,8 +113,8 @@ class StructuredLoggingJsonPropertiesJsonMembersCustomizerTests {
 		StructuredLoggingJsonMembersCustomizer<?> uppercaseCustomizer = (members) -> members
 			.applyingNameProcessor(NameProcessor.of(String::toUpperCase));
 		given(this.instantiator.instantiateType(TestCustomizer.class)).willReturn(uppercaseCustomizer);
-		StructuredLoggingJsonProperties properties = new StructuredLoggingJsonProperties(Collections.emptySet(),
-				Collections.emptySet(), Collections.emptyMap(), Collections.emptyMap(), null, null,
+		StructuredLoggingJsonProperties properties = new StructuredLoggingJsonProperties(emptySet(),
+				emptySet(), Collections.emptyMap(), Collections.emptyMap(), null, null,
 				Set.of(TestCustomizer.class));
 		StructuredLoggingJsonPropertiesJsonMembersCustomizer customizer = new StructuredLoggingJsonPropertiesJsonMembersCustomizer(
 				this.instantiator, properties, false);
@@ -125,8 +126,8 @@ class StructuredLoggingJsonPropertiesJsonMembersCustomizerTests {
 	void customizeWhenHasCustomizersCustomizesMember() {
 		given(this.instantiator.instantiateType(FooCustomizer.class)).willReturn(new FooCustomizer());
 		given(this.instantiator.instantiateType(BarCustomizer.class)).willReturn(new BarCustomizer());
-		StructuredLoggingJsonProperties properties = new StructuredLoggingJsonProperties(Collections.emptySet(),
-				Collections.emptySet(), Collections.emptyMap(), Collections.emptyMap(), null, null,
+		StructuredLoggingJsonProperties properties = new StructuredLoggingJsonProperties(emptySet(),
+				emptySet(), Collections.emptyMap(), Collections.emptyMap(), null, null,
 				Set.of(FooCustomizer.class, BarCustomizer.class));
 		StructuredLoggingJsonPropertiesJsonMembersCustomizer customizer = new StructuredLoggingJsonPropertiesJsonMembersCustomizer(
 				this.instantiator, properties, false);

--- a/documentation/spring-boot-actuator-docs/src/test/java/org/springframework/boot/actuate/docs/quartz/QuartzEndpointDocumentationTests.java
+++ b/documentation/spring-boot-actuator-docs/src/test/java/org/springframework/boot/actuate/docs/quartz/QuartzEndpointDocumentationTests.java
@@ -67,6 +67,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -515,7 +516,7 @@ class QuartzEndpointDocumentationTests extends MockMvcEndpointDocumentationTests
 
 		@Bean
 		QuartzEndpointWebExtension endpointWebExtension(QuartzEndpoint endpoint) {
-			return new QuartzEndpointWebExtension(endpoint, Show.ALWAYS, Collections.emptySet());
+			return new QuartzEndpointWebExtension(endpoint, Show.ALWAYS, emptySet());
 		}
 
 	}

--- a/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/actuator/cloudfoundry/customcontextpath/MyCloudFoundryConfiguration.java
+++ b/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/actuator/cloudfoundry/customcontextpath/MyCloudFoundryConfiguration.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.docs.actuator.cloudfoundry.customcontextpath;
 
 import java.io.IOException;
-import java.util.Collections;
 
 import jakarta.servlet.GenericServlet;
 import jakarta.servlet.Servlet;
@@ -35,6 +34,8 @@ import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static java.util.Collections.emptySet;
+
 @Configuration(proxyBeanMethods = false)
 public class MyCloudFoundryConfiguration {
 
@@ -49,7 +50,7 @@ public class MyCloudFoundryConfiguration {
 				child.addLifecycleListener(new Tomcat.FixContextListener());
 				child.setPath("/cloudfoundryapplication");
 				ServletContainerInitializer initializer = getServletContextInitializer(getContextPath());
-				child.addServletContainerInitializer(initializer, Collections.emptySet());
+				child.addServletContainerInitializer(initializer, emptySet());
 				child.setCrossContext(true);
 				host.addChild(child);
 			}

--- a/gradle/plugins/config/sanity.gradle
+++ b/gradle/plugins/config/sanity.gradle
@@ -1,0 +1,13 @@
+project.apply(plugin: "org.openrewrite.rewrite")
+dependencies {
+	rewrite("org.openrewrite.recipe:rewrite-testing-frameworks:3.24.0")
+}
+repositories {
+	mavenCentral()
+}
+rewrite {
+	activeRecipe("org.springframework.boot.openrewrite.SanityCheck")
+	configFile = project.getRootProject().file("${rootDir}/gradle/plugins/config/sanity.yml")
+	setExportDatatables(true)
+	setFailOnDryRunResults(true)
+}

--- a/gradle/plugins/config/sanity.yml
+++ b/gradle/plugins/config/sanity.yml
@@ -1,0 +1,19 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.springframework.boot.openrewrite.SanityCheck
+displayName: Apply all common best practices
+description: Comprehensive code quality recipe combining modernization, security, and best practices.
+recipeList:
+  - org.openrewrite.java.testing.assertj.StaticImports # https://github.com/spring-projects/spring-boot/pull/48630 https://github.com/openrewrite/rewrite-testing-frameworks/issues/885
+  - org.openrewrite.java.testing.junit5.StaticImports
+  - org.springframework.boot.openrewrite.UseStaticImport
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.springframework.boot.openrewrite.UseStaticImport
+displayName: Use static import
+recipeList:
+  - org.openrewrite.java.UseStaticImport:
+      methodPattern: org.assertj.core.api.Assertions *(..)
+  - org.openrewrite.java.UseStaticImport:
+      methodPattern: java.util.Collections emptySet()
+---

--- a/integration-test/spring-boot-actuator-integration-tests/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointWebIntegrationTests.java
+++ b/integration-test/spring-boot-actuator-integration-tests/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointWebIntegrationTests.java
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -115,7 +116,7 @@ class ConfigurationPropertiesReportEndpointWebIntegrationTests {
 		@Bean
 		ConfigurationPropertiesReportEndpointWebExtension endpointWebExtension(
 				ConfigurationPropertiesReportEndpoint endpoint) {
-			return new ConfigurationPropertiesReportEndpointWebExtension(endpoint, Show.ALWAYS, Collections.emptySet());
+			return new ConfigurationPropertiesReportEndpointWebExtension(endpoint, Show.ALWAYS, emptySet());
 		}
 
 		@Bean

--- a/integration-test/spring-boot-actuator-integration-tests/src/test/java/org/springframework/boot/actuate/env/EnvironmentEndpointWebIntegrationTests.java
+++ b/integration-test/spring-boot-actuator-integration-tests/src/test/java/org/springframework/boot/actuate/env/EnvironmentEndpointWebIntegrationTests.java
@@ -32,6 +32,8 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
+import static java.util.Collections.emptySet;
+
 class EnvironmentEndpointWebIntegrationTests {
 
 	private ConfigurableApplicationContext context;
@@ -147,7 +149,7 @@ class EnvironmentEndpointWebIntegrationTests {
 
 		@Bean
 		EnvironmentEndpointWebExtension environmentEndpointWebExtension(EnvironmentEndpoint endpoint) {
-			return new EnvironmentEndpointWebExtension(endpoint, Show.ALWAYS, Collections.emptySet());
+			return new EnvironmentEndpointWebExtension(endpoint, Show.ALWAYS, emptySet());
 		}
 
 	}

--- a/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/MetaInfVersionsInfo.java
+++ b/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/MetaInfVersionsInfo.java
@@ -16,12 +16,13 @@
 
 package org.springframework.boot.loader.jar;
 
-import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.IntFunction;
 
 import org.springframework.boot.loader.zip.ZipContent;
+
+import static java.util.Collections.emptySet;
 
 /**
  * Info obtained from a {@link ZipContent} instance relating to the directories listed
@@ -31,7 +32,7 @@ import org.springframework.boot.loader.zip.ZipContent;
  */
 final class MetaInfVersionsInfo {
 
-	static final MetaInfVersionsInfo NONE = new MetaInfVersionsInfo(Collections.emptySet());
+	static final MetaInfVersionsInfo NONE = new MetaInfVersionsInfo(emptySet());
 
 	private static final String META_INF_VERSIONS = NestedJarFile.META_INF_VERSIONS;
 

--- a/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/launch/PropertiesLauncher.java
+++ b/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/launch/PropertiesLauncher.java
@@ -43,6 +43,8 @@ import org.springframework.boot.loader.launch.Archive.Entry;
 import org.springframework.boot.loader.log.DebugLogger;
 import org.springframework.boot.loader.net.protocol.jar.JarUrl;
 
+import static java.util.Collections.emptySet;
+
 /**
  * {@link Launcher} for archives with user-configured classpath and main class through a
  * properties file.
@@ -507,7 +509,7 @@ public class PropertiesLauncher extends Launcher {
 		boolean isJustArchive = isArchive(path);
 		if (!path.equals("/") && path.startsWith("/")
 				|| (this.archive.isExploded() && this.archive.getRootDirectory().equals(this.homeDirectory))) {
-			return Collections.emptySet();
+			return emptySet();
 		}
 		File file = null;
 		if (isJustArchive) {

--- a/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/nio/file/NestedFileSystem.java
+++ b/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/nio/file/NestedFileSystem.java
@@ -35,6 +35,8 @@ import java.util.Set;
 
 import org.springframework.boot.loader.net.protocol.nested.NestedLocation;
 
+import static java.util.Collections.emptySet;
+
 /**
  * {@link FileSystem} implementation for {@link NestedLocation nested} jar files.
  *
@@ -158,13 +160,13 @@ class NestedFileSystem extends FileSystem {
 	@Override
 	public Iterable<Path> getRootDirectories() {
 		assertNotClosed();
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@Override
 	public Iterable<FileStore> getFileStores() {
 		assertNotClosed();
-		return Collections.emptySet();
+		return emptySet();
 	}
 
 	@Override

--- a/loader/spring-boot-loader/src/test/java/org/springframework/boot/loader/launch/LauncherTests.java
+++ b/loader/spring-boot-loader/src/test/java/org/springframework/boot/loader/launch/LauncherTests.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.loader.launch;
 
 import java.net.URL;
-import java.util.Collections;
 import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
@@ -30,6 +29,7 @@ import org.springframework.boot.loader.zip.AssertFileChannelDataBlocksClosed;
 import org.springframework.boot.testsupport.system.CapturedOutput;
 import org.springframework.boot.testsupport.system.OutputCaptureExtension;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -99,7 +99,7 @@ class LauncherTests {
 
 			@Override
 			protected Set<URL> getClassPathUrls() throws Exception {
-				return Collections.emptySet();
+				return emptySet();
 			}
 
 		}
@@ -215,7 +215,7 @@ class LauncherTests {
 
 			@Override
 			protected Set<URL> getClassPathUrls() throws Exception {
-				return Collections.emptySet();
+				return emptySet();
 			}
 
 			@Override

--- a/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/expose/IncludeExcludeEndpointFilter.java
+++ b/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/expose/IncludeExcludeEndpointFilter.java
@@ -19,7 +19,6 @@ package org.springframework.boot.actuate.autoconfigure.endpoint.expose;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -33,6 +32,8 @@ import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.core.env.Environment;
 import org.springframework.util.Assert;
+
+import static java.util.Collections.emptySet;
 
 /**
  * {@link EndpointFilter} that will filter endpoints based on {@code include} and
@@ -156,7 +157,7 @@ public class IncludeExcludeEndpointFilter<E extends ExposableEndpoint<?>> implem
 		}
 
 		EndpointPatterns(@Nullable Collection<String> patterns) {
-			patterns = (patterns != null) ? patterns : Collections.emptySet();
+			patterns = (patterns != null) ? patterns : emptySet();
 			boolean matchesAll = false;
 			Set<EndpointId> endpointIds = new LinkedHashSet<>();
 			for (String pattern : patterns) {

--- a/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementWebServerFactoryCustomizer.java
+++ b/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ManagementWebServerFactoryCustomizer.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.actuate.autoconfigure.web.server;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.jspecify.annotations.Nullable;
@@ -33,6 +32,8 @@ import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.boot.web.server.autoconfigure.ServerProperties;
 import org.springframework.core.Ordered;
 import org.springframework.util.Assert;
+
+import static java.util.Collections.emptySet;
 
 /**
  * {@link WebServerFactoryCustomizer} that customizes the {@link WebServerFactory} used to
@@ -75,7 +76,7 @@ public class ManagementWebServerFactoryCustomizer<T extends ConfigurableWebServe
 			customizeSameAsParentContext(factory);
 		}
 		// Then reset the error pages
-		factory.setErrorPages(Collections.emptySet());
+		factory.setErrorPages(emptySet());
 		// and add the management-specific bits
 		ServerProperties serverProperties = BeanFactoryUtils.beanOfTypeIncludingAncestors(this.beanFactory,
 				ServerProperties.class);

--- a/module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/EndpointDiscoverer.java
+++ b/module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/EndpointDiscoverer.java
@@ -59,6 +59,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 
+import static java.util.Collections.emptySet;
+
 /**
  * A Base for {@link EndpointsSupplier} implementations that discover
  * {@link Endpoint @Endpoint} beans and {@link EndpointExtension @EndpointExtension} beans
@@ -376,7 +378,7 @@ public abstract class EndpointDiscoverer<E extends ExposableEndpoint<O>, O exten
 
 	private E getFilterEndpoint(EndpointBean endpointBean) {
 		return this.filterEndpoints.computeIfAbsent(endpointBean, (key) -> createEndpoint(endpointBean.getBean(),
-				endpointBean.getId(), endpointBean.getDefaultAccess(), Collections.emptySet()));
+				endpointBean.getId(), endpointBean.getDefaultAccess(), emptySet()));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointWebExtensionTests.java
+++ b/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointWebExtensionTests.java
@@ -27,6 +27,7 @@ import org.springframework.boot.actuate.context.properties.ConfigurationProperti
 import org.springframework.boot.actuate.endpoint.SecurityContext;
 import org.springframework.boot.actuate.endpoint.Show;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -51,7 +52,7 @@ class ConfigurationPropertiesReportEndpointWebExtensionTests {
 	@Test
 	void whenShowValuesIsNever() {
 		this.webExtension = new ConfigurationPropertiesReportEndpointWebExtension(this.delegate, Show.NEVER,
-				Collections.emptySet());
+				emptySet());
 		this.webExtension.configurationProperties(SecurityContext.NONE);
 		then(this.delegate).should().getConfigurationProperties(false);
 		verifyPrefixed(SecurityContext.NONE, false);
@@ -60,7 +61,7 @@ class ConfigurationPropertiesReportEndpointWebExtensionTests {
 	@Test
 	void whenShowValuesIsAlways() {
 		this.webExtension = new ConfigurationPropertiesReportEndpointWebExtension(this.delegate, Show.ALWAYS,
-				Collections.emptySet());
+				emptySet());
 		this.webExtension.configurationProperties(SecurityContext.NONE);
 		then(this.delegate).should().getConfigurationProperties(true);
 		verifyPrefixed(SecurityContext.NONE, true);
@@ -71,7 +72,7 @@ class ConfigurationPropertiesReportEndpointWebExtensionTests {
 		SecurityContext securityContext = mock(SecurityContext.class);
 		given(securityContext.getPrincipal()).willReturn(mock(Principal.class));
 		this.webExtension = new ConfigurationPropertiesReportEndpointWebExtension(this.delegate, Show.WHEN_AUTHORIZED,
-				Collections.emptySet());
+				emptySet());
 		this.webExtension.configurationProperties(securityContext);
 		then(this.delegate).should().getConfigurationProperties(true);
 		verifyPrefixed(securityContext, true);
@@ -82,7 +83,7 @@ class ConfigurationPropertiesReportEndpointWebExtensionTests {
 	void whenShowValuesIsWhenAuthorizedAndSecurityContextIsNotAuthorized() {
 		SecurityContext securityContext = mock(SecurityContext.class);
 		this.webExtension = new ConfigurationPropertiesReportEndpointWebExtension(this.delegate, Show.WHEN_AUTHORIZED,
-				Collections.emptySet());
+				emptySet());
 		this.webExtension.configurationProperties(securityContext);
 		then(this.delegate).should().getConfigurationProperties(false);
 		verifyPrefixed(securityContext, false);

--- a/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/ShowTests.java
+++ b/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/ShowTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -37,14 +38,14 @@ class ShowTests {
 
 	@Test
 	void isShownWhenNever() {
-		assertThat(Show.NEVER.isShown(SecurityContext.NONE, Collections.emptySet())).isFalse();
+		assertThat(Show.NEVER.isShown(SecurityContext.NONE, emptySet())).isFalse();
 		assertThat(Show.NEVER.isShown(true)).isFalse();
 		assertThat(Show.NEVER.isShown(false)).isFalse();
 	}
 
 	@Test
 	void isShownWhenAlways() {
-		assertThat(Show.ALWAYS.isShown(SecurityContext.NONE, Collections.emptySet())).isTrue();
+		assertThat(Show.ALWAYS.isShown(SecurityContext.NONE, emptySet())).isTrue();
 		assertThat(Show.ALWAYS.isShown(true)).isTrue();
 		assertThat(Show.ALWAYS.isShown(true)).isTrue();
 	}
@@ -82,7 +83,7 @@ class ShowTests {
 	void isShownWhenRolesEmpty() {
 		SecurityContext securityContext = mock(SecurityContext.class);
 		given(securityContext.getPrincipal()).willReturn(mock(Principal.class));
-		assertThat(Show.WHEN_AUTHORIZED.isShown(securityContext, Collections.emptySet())).isTrue();
+		assertThat(Show.WHEN_AUTHORIZED.isShown(securityContext, emptySet())).isTrue();
 	}
 
 	@Test

--- a/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/env/EnvironmentEndpointWebExtensionTests.java
+++ b/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/env/EnvironmentEndpointWebExtensionTests.java
@@ -27,6 +27,7 @@ import org.springframework.boot.actuate.endpoint.SecurityContext;
 import org.springframework.boot.actuate.endpoint.Show;
 import org.springframework.boot.actuate.env.EnvironmentEndpoint.EnvironmentEntryDescriptor;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -50,7 +51,7 @@ class EnvironmentEndpointWebExtensionTests {
 
 	@Test
 	void whenShowValuesIsNever() {
-		this.webExtension = new EnvironmentEndpointWebExtension(this.delegate, Show.NEVER, Collections.emptySet());
+		this.webExtension = new EnvironmentEndpointWebExtension(this.delegate, Show.NEVER, emptySet());
 		this.webExtension.environment(SecurityContext.NONE, null);
 		then(this.delegate).should().getEnvironmentDescriptor(null, false);
 		verifyPrefixed(SecurityContext.NONE, false);
@@ -58,7 +59,7 @@ class EnvironmentEndpointWebExtensionTests {
 
 	@Test
 	void whenShowValuesIsAlways() {
-		this.webExtension = new EnvironmentEndpointWebExtension(this.delegate, Show.ALWAYS, Collections.emptySet());
+		this.webExtension = new EnvironmentEndpointWebExtension(this.delegate, Show.ALWAYS, emptySet());
 		this.webExtension.environment(SecurityContext.NONE, null);
 		then(this.delegate).should().getEnvironmentDescriptor(null, true);
 		verifyPrefixed(SecurityContext.NONE, true);
@@ -69,7 +70,7 @@ class EnvironmentEndpointWebExtensionTests {
 		SecurityContext securityContext = mock(SecurityContext.class);
 		given(securityContext.getPrincipal()).willReturn(mock(Principal.class));
 		this.webExtension = new EnvironmentEndpointWebExtension(this.delegate, Show.WHEN_AUTHORIZED,
-				Collections.emptySet());
+				emptySet());
 		this.webExtension.environment(securityContext, null);
 		then(this.delegate).should().getEnvironmentDescriptor(null, true);
 		verifyPrefixed(securityContext, true);
@@ -80,7 +81,7 @@ class EnvironmentEndpointWebExtensionTests {
 	void whenShowValuesIsWhenAuthorizedAndSecurityContextIsNotAuthorized() {
 		SecurityContext securityContext = mock(SecurityContext.class);
 		this.webExtension = new EnvironmentEndpointWebExtension(this.delegate, Show.WHEN_AUTHORIZED,
-				Collections.emptySet());
+				emptySet());
 		this.webExtension.environment(securityContext, null);
 		then(this.delegate).should().getEnvironmentDescriptor(null, false);
 		verifyPrefixed(securityContext, false);

--- a/module/spring-boot-batch-jdbc/src/test/java/org/springframework/boot/batch/jdbc/autoconfigure/BatchJdbcAutoConfigurationTests.java
+++ b/module/spring-boot-batch-jdbc/src/test/java/org/springframework/boot/batch/jdbc/autoconfigure/BatchJdbcAutoConfigurationTests.java
@@ -92,6 +92,7 @@ import org.springframework.test.util.AopTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Isolation;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
@@ -641,7 +642,7 @@ class BatchJdbcAutoConfigurationTests {
 
 				@Override
 				public Collection<String> getStepNames() {
-					return Collections.emptySet();
+					return emptySet();
 				}
 
 				@Override
@@ -678,7 +679,7 @@ class BatchJdbcAutoConfigurationTests {
 
 				@Override
 				public Collection<String> getStepNames() {
-					return Collections.emptySet();
+					return emptySet();
 				}
 
 				@Override
@@ -709,7 +710,7 @@ class BatchJdbcAutoConfigurationTests {
 
 				@Override
 				public Collection<String> getStepNames() {
-					return Collections.emptySet();
+					return emptySet();
 				}
 
 				@Override
@@ -755,7 +756,7 @@ class BatchJdbcAutoConfigurationTests {
 
 				@Override
 				public Collection<String> getStepNames() {
-					return Collections.emptySet();
+					return emptySet();
 				}
 
 				@Override

--- a/module/spring-boot-batch/src/test/java/org/springframework/boot/batch/autoconfigure/BatchJobLauncherAutoConfigurationTests.java
+++ b/module/spring-boot-batch/src/test/java/org/springframework/boot/batch/autoconfigure/BatchJobLauncherAutoConfigurationTests.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.batch.autoconfigure;
 
 import java.util.Collection;
-import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +37,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -146,7 +146,7 @@ class BatchJobLauncherAutoConfigurationTests {
 
 				@Override
 				public Collection<String> getStepNames() {
-					return Collections.emptySet();
+					return emptySet();
 				}
 
 				@Override
@@ -183,7 +183,7 @@ class BatchJobLauncherAutoConfigurationTests {
 
 				@Override
 				public Collection<String> getStepNames() {
-					return Collections.emptySet();
+					return emptySet();
 				}
 
 				@Override
@@ -214,7 +214,7 @@ class BatchJobLauncherAutoConfigurationTests {
 
 				@Override
 				public Collection<String> getStepNames() {
-					return Collections.emptySet();
+					return emptySet();
 				}
 
 				@Override
@@ -260,7 +260,7 @@ class BatchJobLauncherAutoConfigurationTests {
 
 				@Override
 				public Collection<String> getStepNames() {
-					return Collections.emptySet();
+					return emptySet();
 				}
 
 				@Override

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/LocalDevToolsAutoConfigurationTests.java
@@ -57,6 +57,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.view.AbstractTemplateViewResolver;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
@@ -130,7 +131,7 @@ class LocalDevToolsAutoConfigurationTests {
 		this.context = getContext(() -> initializeAndRun(ConfigWithMockLiveReload.class, properties));
 		LiveReloadServer server = this.context.getBean(LiveReloadServer.class);
 		reset(server);
-		ClassPathChangedEvent event = new ClassPathChangedEvent(this.context, Collections.emptySet(), false);
+		ClassPathChangedEvent event = new ClassPathChangedEvent(this.context, emptySet(), false);
 		this.context.publishEvent(event);
 		then(server).should().triggerReload();
 	}
@@ -142,7 +143,7 @@ class LocalDevToolsAutoConfigurationTests {
 		this.context = getContext(() -> initializeAndRun(ConfigWithMockLiveReload.class, properties));
 		LiveReloadServer server = this.context.getBean(LiveReloadServer.class);
 		reset(server);
-		ClassPathChangedEvent event = new ClassPathChangedEvent(this.context, Collections.emptySet(), true);
+		ClassPathChangedEvent event = new ClassPathChangedEvent(this.context, emptySet(), true);
 		this.context.publishEvent(event);
 		then(server).should(never()).triggerReload();
 	}
@@ -159,7 +160,7 @@ class LocalDevToolsAutoConfigurationTests {
 	@Test
 	void restartTriggeredOnClassPathChangeWithRestart(Restarter restarter) throws Exception {
 		this.context = getContext(() -> initializeAndRun(Config.class));
-		ClassPathChangedEvent event = new ClassPathChangedEvent(this.context, Collections.emptySet(), true);
+		ClassPathChangedEvent event = new ClassPathChangedEvent(this.context, emptySet(), true);
 		this.context.publishEvent(event);
 		then(restarter).should().restart(any(FailureHandler.class));
 	}
@@ -167,7 +168,7 @@ class LocalDevToolsAutoConfigurationTests {
 	@Test
 	void restartNotTriggeredOnClassPathChangeWithRestart(Restarter restarter) throws Exception {
 		this.context = getContext(() -> initializeAndRun(Config.class));
-		ClassPathChangedEvent event = new ClassPathChangedEvent(this.context, Collections.emptySet(), false);
+		ClassPathChangedEvent event = new ClassPathChangedEvent(this.context, emptySet(), false);
 		this.context.publishEvent(event);
 		then(restarter).should(never()).restart();
 	}

--- a/module/spring-boot-health/src/main/java/org/springframework/boot/health/autoconfigure/actuate/endpoint/GroupsHealthContributorNameValidator.java
+++ b/module/spring-boot-health/src/main/java/org/springframework/boot/health/autoconfigure/actuate/endpoint/GroupsHealthContributorNameValidator.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.health.autoconfigure.actuate.endpoint;
 
-import java.util.Collections;
 import java.util.Set;
 
 import org.jspecify.annotations.Nullable;
@@ -24,6 +23,8 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.boot.health.actuate.endpoint.HealthEndpointGroups;
 import org.springframework.boot.health.registry.HealthContributorNameValidator;
 import org.springframework.util.Assert;
+
+import static java.util.Collections.emptySet;
 
 /**
  * {@link HealthContributorNameValidator} to ensure names don't clash with groups.
@@ -35,7 +36,7 @@ class GroupsHealthContributorNameValidator implements HealthContributorNameValid
 	private final Set<String> groupNames;
 
 	GroupsHealthContributorNameValidator(@Nullable HealthEndpointGroups groups) {
-		this.groupNames = (groups != null) ? groups.getNames() : Collections.emptySet();
+		this.groupNames = (groups != null) ? groups.getNames() : emptySet();
 	}
 
 	@Override

--- a/module/spring-boot-health/src/main/java/org/springframework/boot/health/autoconfigure/actuate/endpoint/IncludeExcludeGroupMemberPredicate.java
+++ b/module/spring-boot-health/src/main/java/org/springframework/boot/health/autoconfigure/actuate/endpoint/IncludeExcludeGroupMemberPredicate.java
@@ -26,6 +26,8 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.lang.Contract;
 
+import static java.util.Collections.emptySet;
+
 /**
  * Member predicate that matches based on {@code include} and {@code exclude} sets.
  *
@@ -81,7 +83,7 @@ class IncludeExcludeGroupMemberPredicate implements Predicate<String> {
 
 	private Set<String> clean(@Nullable Set<String> names) {
 		if (names == null) {
-			return Collections.emptySet();
+			return emptySet();
 		}
 		Set<String> cleaned = names.stream().map(this::clean).collect(Collectors.toCollection(LinkedHashSet::new));
 		return Collections.unmodifiableSet(cleaned);

--- a/module/spring-boot-health/src/test/java/org/springframework/boot/health/autoconfigure/actuate/endpoint/AutoConfiguredHealthEndpointGroupTests.java
+++ b/module/spring-boot-health/src/test/java/org/springframework/boot/health/autoconfigure/actuate/endpoint/AutoConfiguredHealthEndpointGroupTests.java
@@ -32,6 +32,7 @@ import org.springframework.boot.health.actuate.endpoint.StatusAggregator;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -63,7 +64,7 @@ class AutoConfiguredHealthEndpointGroupTests {
 	@Test
 	void isMemberWhenMemberPredicateMatchesAcceptsTrue() {
 		AutoConfiguredHealthEndpointGroup group = new AutoConfiguredHealthEndpointGroup((name) -> name.startsWith("a"),
-				this.statusAggregator, this.httpCodeStatusMapper, null, Show.ALWAYS, Collections.emptySet(), null);
+				this.statusAggregator, this.httpCodeStatusMapper, null, Show.ALWAYS, emptySet(), null);
 		assertThat(group.isMember("albert")).isTrue();
 		assertThat(group.isMember("arnold")).isTrue();
 	}
@@ -71,7 +72,7 @@ class AutoConfiguredHealthEndpointGroupTests {
 	@Test
 	void isMemberWhenMemberPredicateRejectsReturnsTrue() {
 		AutoConfiguredHealthEndpointGroup group = new AutoConfiguredHealthEndpointGroup((name) -> name.startsWith("a"),
-				this.statusAggregator, this.httpCodeStatusMapper, null, Show.ALWAYS, Collections.emptySet(), null);
+				this.statusAggregator, this.httpCodeStatusMapper, null, Show.ALWAYS, emptySet(), null);
 		assertThat(group.isMember("bert")).isFalse();
 		assertThat(group.isMember("ernie")).isFalse();
 	}
@@ -79,21 +80,21 @@ class AutoConfiguredHealthEndpointGroupTests {
 	@Test
 	void showDetailsWhenShowDetailsIsNeverReturnsFalse() {
 		AutoConfiguredHealthEndpointGroup group = new AutoConfiguredHealthEndpointGroup((name) -> true,
-				this.statusAggregator, this.httpCodeStatusMapper, null, Show.NEVER, Collections.emptySet(), null);
+				this.statusAggregator, this.httpCodeStatusMapper, null, Show.NEVER, emptySet(), null);
 		assertThat(group.showDetails(SecurityContext.NONE)).isFalse();
 	}
 
 	@Test
 	void showDetailsWhenShowDetailsIsAlwaysReturnsTrue() {
 		AutoConfiguredHealthEndpointGroup group = new AutoConfiguredHealthEndpointGroup((name) -> true,
-				this.statusAggregator, this.httpCodeStatusMapper, null, Show.ALWAYS, Collections.emptySet(), null);
+				this.statusAggregator, this.httpCodeStatusMapper, null, Show.ALWAYS, emptySet(), null);
 		assertThat(group.showDetails(SecurityContext.NONE)).isTrue();
 	}
 
 	@Test
 	void showDetailsWhenShowDetailsIsWhenAuthorizedAndPrincipalIsNullReturnsFalse() {
 		AutoConfiguredHealthEndpointGroup group = new AutoConfiguredHealthEndpointGroup((name) -> true,
-				this.statusAggregator, this.httpCodeStatusMapper, null, Show.WHEN_AUTHORIZED, Collections.emptySet(),
+				this.statusAggregator, this.httpCodeStatusMapper, null, Show.WHEN_AUTHORIZED, emptySet(),
 				null);
 		given(this.securityContext.getPrincipal()).willReturn(null);
 		assertThat(group.showDetails(this.securityContext)).isFalse();
@@ -102,7 +103,7 @@ class AutoConfiguredHealthEndpointGroupTests {
 	@Test
 	void showDetailsWhenShowDetailsIsWhenAuthorizedAndRolesAreEmptyReturnsTrue() {
 		AutoConfiguredHealthEndpointGroup group = new AutoConfiguredHealthEndpointGroup((name) -> true,
-				this.statusAggregator, this.httpCodeStatusMapper, null, Show.WHEN_AUTHORIZED, Collections.emptySet(),
+				this.statusAggregator, this.httpCodeStatusMapper, null, Show.WHEN_AUTHORIZED, emptySet(),
 				null);
 		given(this.securityContext.getPrincipal()).willReturn(this.principal);
 		assertThat(group.showDetails(this.securityContext)).isTrue();
@@ -155,17 +156,17 @@ class AutoConfiguredHealthEndpointGroupTests {
 	@Test
 	void showComponentsWhenShowComponentsIsNullDelegatesToShowDetails() {
 		AutoConfiguredHealthEndpointGroup alwaysGroup = new AutoConfiguredHealthEndpointGroup((name) -> true,
-				this.statusAggregator, this.httpCodeStatusMapper, null, Show.ALWAYS, Collections.emptySet(), null);
+				this.statusAggregator, this.httpCodeStatusMapper, null, Show.ALWAYS, emptySet(), null);
 		assertThat(alwaysGroup.showComponents(SecurityContext.NONE)).isTrue();
 		AutoConfiguredHealthEndpointGroup neverGroup = new AutoConfiguredHealthEndpointGroup((name) -> true,
-				this.statusAggregator, this.httpCodeStatusMapper, null, Show.NEVER, Collections.emptySet(), null);
+				this.statusAggregator, this.httpCodeStatusMapper, null, Show.NEVER, emptySet(), null);
 		assertThat(neverGroup.showComponents(SecurityContext.NONE)).isFalse();
 	}
 
 	@Test
 	void showComponentsWhenShowComponentsIsNeverReturnsFalse() {
 		AutoConfiguredHealthEndpointGroup group = new AutoConfiguredHealthEndpointGroup((name) -> true,
-				this.statusAggregator, this.httpCodeStatusMapper, Show.NEVER, Show.ALWAYS, Collections.emptySet(),
+				this.statusAggregator, this.httpCodeStatusMapper, Show.NEVER, Show.ALWAYS, emptySet(),
 				null);
 		assertThat(group.showComponents(SecurityContext.NONE)).isFalse();
 	}
@@ -173,7 +174,7 @@ class AutoConfiguredHealthEndpointGroupTests {
 	@Test
 	void showComponentsWhenShowComponentsIsAlwaysReturnsTrue() {
 		AutoConfiguredHealthEndpointGroup group = new AutoConfiguredHealthEndpointGroup((name) -> true,
-				this.statusAggregator, this.httpCodeStatusMapper, Show.ALWAYS, Show.NEVER, Collections.emptySet(),
+				this.statusAggregator, this.httpCodeStatusMapper, Show.ALWAYS, Show.NEVER, emptySet(),
 				null);
 		assertThat(group.showComponents(SecurityContext.NONE)).isTrue();
 	}
@@ -182,7 +183,7 @@ class AutoConfiguredHealthEndpointGroupTests {
 	void showComponentsWhenShowComponentsIsWhenAuthorizedAndPrincipalIsNullReturnsFalse() {
 		AutoConfiguredHealthEndpointGroup group = new AutoConfiguredHealthEndpointGroup((name) -> true,
 				this.statusAggregator, this.httpCodeStatusMapper, Show.WHEN_AUTHORIZED, Show.NEVER,
-				Collections.emptySet(), null);
+				emptySet(), null);
 		given(this.securityContext.getPrincipal()).willReturn(null);
 		assertThat(group.showComponents(this.securityContext)).isFalse();
 	}
@@ -191,7 +192,7 @@ class AutoConfiguredHealthEndpointGroupTests {
 	void showComponentsWhenShowComponentsIsWhenAuthorizedAndRolesAreEmptyReturnsTrue() {
 		AutoConfiguredHealthEndpointGroup group = new AutoConfiguredHealthEndpointGroup((name) -> true,
 				this.statusAggregator, this.httpCodeStatusMapper, Show.WHEN_AUTHORIZED, Show.NEVER,
-				Collections.emptySet(), null);
+				emptySet(), null);
 		given(this.securityContext.getPrincipal()).willReturn(this.principal);
 		assertThat(group.showComponents(this.securityContext)).isTrue();
 	}
@@ -243,14 +244,14 @@ class AutoConfiguredHealthEndpointGroupTests {
 	@Test
 	void getStatusAggregatorReturnsStatusAggregator() {
 		AutoConfiguredHealthEndpointGroup group = new AutoConfiguredHealthEndpointGroup((name) -> true,
-				this.statusAggregator, this.httpCodeStatusMapper, null, Show.ALWAYS, Collections.emptySet(), null);
+				this.statusAggregator, this.httpCodeStatusMapper, null, Show.ALWAYS, emptySet(), null);
 		assertThat(group.getStatusAggregator()).isSameAs(this.statusAggregator);
 	}
 
 	@Test
 	void getHttpCodeStatusMapperReturnsHttpCodeStatusMapper() {
 		AutoConfiguredHealthEndpointGroup group = new AutoConfiguredHealthEndpointGroup((name) -> true,
-				this.statusAggregator, this.httpCodeStatusMapper, null, Show.ALWAYS, Collections.emptySet(), null);
+				this.statusAggregator, this.httpCodeStatusMapper, null, Show.ALWAYS, emptySet(), null);
 		assertThat(group.getHttpCodeStatusMapper()).isSameAs(this.httpCodeStatusMapper);
 	}
 

--- a/module/spring-boot-jpa/src/main/java/org/springframework/boot/jpa/JpaDatabaseInitializerDetector.java
+++ b/module/spring-boot-jpa/src/main/java/org/springframework/boot/jpa/JpaDatabaseInitializerDetector.java
@@ -30,6 +30,8 @@ import org.springframework.boot.sql.init.dependency.DatabaseInitializerDetector;
 import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
 
+import static java.util.Collections.emptySet;
+
 /**
  * A {@link DatabaseInitializerDetector} for JPA.
  *
@@ -47,7 +49,7 @@ class JpaDatabaseInitializerDetector extends AbstractBeansOfTypeDatabaseInitiali
 	protected Set<Class<?>> getDatabaseInitializerBeanTypes() {
 		boolean deferred = this.environment.getProperty("spring.jpa.defer-datasource-initialization", boolean.class,
 				false);
-		return deferred ? Collections.singleton(EntityManagerFactory.class) : Collections.emptySet();
+		return deferred ? Collections.singleton(EntityManagerFactory.class) : emptySet();
 	}
 
 	@Override

--- a/module/spring-boot-jpa/src/main/java/org/springframework/boot/jpa/JpaDependsOnDatabaseInitializationDetector.java
+++ b/module/spring-boot-jpa/src/main/java/org/springframework/boot/jpa/JpaDependsOnDatabaseInitializationDetector.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.jpa;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -27,6 +26,8 @@ import org.springframework.boot.sql.init.dependency.AbstractBeansOfTypeDependsOn
 import org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitializationDetector;
 import org.springframework.core.env.Environment;
 import org.springframework.orm.jpa.AbstractEntityManagerFactoryBean;
+
+import static java.util.Collections.emptySet;
 
 /**
  * {@link DependsOnDatabaseInitializationDetector} for JPA.
@@ -45,7 +46,7 @@ class JpaDependsOnDatabaseInitializationDetector extends AbstractBeansOfTypeDepe
 	protected Set<Class<?>> getDependsOnDatabaseInitializationBeanTypes() {
 		boolean postpone = this.environment.getProperty("spring.jpa.defer-datasource-initialization", boolean.class,
 				false);
-		return postpone ? Collections.emptySet()
+		return postpone ? emptySet()
 				: new HashSet<>(Arrays.asList(EntityManagerFactory.class, AbstractEntityManagerFactoryBean.class));
 	}
 

--- a/module/spring-boot-persistence/src/main/java/org/springframework/boot/persistence/autoconfigure/EntityScanner.java
+++ b/module/spring-boot-persistence/src/main/java/org/springframework/boot/persistence/autoconfigure/EntityScanner.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.persistence.autoconfigure;
 
 import java.lang.annotation.Annotation;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -30,6 +29,8 @@ import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
+
+import static java.util.Collections.emptySet;
 
 /**
  * An entity scanner that searches the classpath from an {@link EntityScan @EntityScan}
@@ -61,7 +62,7 @@ public class EntityScanner {
 	public final Set<Class<?>> scan(Class<? extends Annotation>... annotationTypes) throws ClassNotFoundException {
 		List<String> packages = getPackages();
 		if (packages.isEmpty()) {
-			return Collections.emptySet();
+			return emptySet();
 		}
 		ClassPathScanningCandidateComponentProvider scanner = createClassPathScanningCandidateComponentProvider(
 				this.context);

--- a/module/spring-boot-persistence/src/test/java/org/springframework/boot/persistence/autoconfigure/EntityScannerTests.java
+++ b/module/spring-boot-persistence/src/test/java/org/springframework/boot/persistence/autoconfigure/EntityScannerTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.persistence.autoconfigure;
 
-import java.util.Collections;
 import java.util.Set;
 
 import jakarta.persistence.Embeddable;
@@ -36,6 +35,7 @@ import org.springframework.context.annotation.ClassPathScanningCandidateComponen
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.assertArg;
@@ -107,7 +107,7 @@ class EntityScannerTests {
 				ClassPathScanningCandidateComponentProvider.class);
 		given(candidateComponentProvider
 			.findCandidateComponents("org.springframework.boot.persistence.autoconfigure.scan"))
-			.willReturn(Collections.emptySet());
+			.willReturn(emptySet());
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ScanConfig.class);
 		TestEntityScanner scanner = new TestEntityScanner(context, candidateComponentProvider);
 		scanner.scan(Entity.class);

--- a/module/spring-boot-quartz/src/test/java/org/springframework/boot/quartz/actuate/endpoint/QuartzEndpointTests.java
+++ b/module/spring-boot-quartz/src/test/java/org/springframework/boot/quartz/actuate/endpoint/QuartzEndpointTests.java
@@ -72,6 +72,7 @@ import org.springframework.scheduling.quartz.DelegatingJob;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.within;
@@ -196,7 +197,7 @@ class QuartzEndpointTests {
 	@Test
 	void quartzJobGroupSummaryWithEmptyGroup() throws SchedulerException {
 		given(this.scheduler.getJobGroupNames()).willReturn(Collections.singletonList("samples"));
-		given(this.scheduler.getJobKeys(GroupMatcher.jobGroupEquals("samples"))).willReturn(Collections.emptySet());
+		given(this.scheduler.getJobKeys(GroupMatcher.jobGroupEquals("samples"))).willReturn(emptySet());
 		QuartzJobGroupSummaryDescriptor summary = this.endpoint.quartzJobGroupSummary("samples");
 		assertThat(summary).isNotNull();
 		assertThat(summary.getGroup()).isEqualTo("samples");
@@ -230,7 +231,7 @@ class QuartzEndpointTests {
 	void quartzTriggerGroupSummaryWithEmptyGroup() throws SchedulerException {
 		given(this.scheduler.getTriggerGroupNames()).willReturn(Collections.singletonList("samples"));
 		given(this.scheduler.getTriggerKeys(GroupMatcher.triggerGroupEquals("samples")))
-			.willReturn(Collections.emptySet());
+			.willReturn(emptySet());
 		QuartzTriggerGroupSummaryDescriptor summary = this.endpoint.quartzTriggerGroupSummary("samples");
 		assertThat(summary).isNotNull();
 		assertThat(summary.getGroup()).isEqualTo("samples");

--- a/module/spring-boot-quartz/src/test/java/org/springframework/boot/quartz/actuate/endpoint/QuartzEndpointWebExtensionTests.java
+++ b/module/spring-boot-quartz/src/test/java/org/springframework/boot/quartz/actuate/endpoint/QuartzEndpointWebExtensionTests.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.quartz.actuate.endpoint;
 
 import java.security.Principal;
-import java.util.Collections;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +33,7 @@ import org.springframework.boot.quartz.actuate.endpoint.QuartzEndpoint.QuartzJob
 import org.springframework.boot.quartz.actuate.endpoint.QuartzEndpoint.QuartzTriggerGroupSummaryDescriptor;
 import org.springframework.boot.quartz.actuate.endpoint.QuartzEndpointWebExtension.QuartzEndpointWebExtensionRuntimeHints;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -57,7 +57,7 @@ class QuartzEndpointWebExtensionTests {
 	@Test
 	void whenShowValuesIsNever() throws Exception {
 		QuartzEndpointWebExtension webExtension = new QuartzEndpointWebExtension(this.delegate, Show.NEVER,
-				Collections.emptySet());
+				emptySet());
 		webExtension.quartzJobOrTrigger(SecurityContext.NONE, "jobs", "a", "b");
 		webExtension.quartzJobOrTrigger(SecurityContext.NONE, "triggers", "a", "b");
 		then(this.delegate).should().quartzJob("a", "b", false);
@@ -67,7 +67,7 @@ class QuartzEndpointWebExtensionTests {
 	@Test
 	void whenShowValuesIsAlways() throws Exception {
 		QuartzEndpointWebExtension webExtension = new QuartzEndpointWebExtension(this.delegate, Show.ALWAYS,
-				Collections.emptySet());
+				emptySet());
 		webExtension.quartzJobOrTrigger(SecurityContext.NONE, "a", "b", "c");
 		webExtension.quartzJobOrTrigger(SecurityContext.NONE, "jobs", "a", "b");
 		webExtension.quartzJobOrTrigger(SecurityContext.NONE, "triggers", "a", "b");
@@ -80,7 +80,7 @@ class QuartzEndpointWebExtensionTests {
 		SecurityContext securityContext = mock(SecurityContext.class);
 		given(securityContext.getPrincipal()).willReturn(mock(Principal.class));
 		QuartzEndpointWebExtension webExtension = new QuartzEndpointWebExtension(this.delegate, Show.WHEN_AUTHORIZED,
-				Collections.emptySet());
+				emptySet());
 		webExtension.quartzJobOrTrigger(securityContext, "jobs", "a", "b");
 		webExtension.quartzJobOrTrigger(securityContext, "triggers", "a", "b");
 		then(this.delegate).should().quartzJob("a", "b", true);
@@ -91,7 +91,7 @@ class QuartzEndpointWebExtensionTests {
 	void whenShowValuesIsWhenAuthorizedAndSecurityContextIsNotAuthorized() throws Exception {
 		SecurityContext securityContext = mock(SecurityContext.class);
 		QuartzEndpointWebExtension webExtension = new QuartzEndpointWebExtension(this.delegate, Show.WHEN_AUTHORIZED,
-				Collections.emptySet());
+				emptySet());
 		webExtension.quartzJobOrTrigger(securityContext, "jobs", "a", "b");
 		webExtension.quartzJobOrTrigger(securityContext, "triggers", "a", "b");
 		then(this.delegate).should().quartzJob("a", "b", false);

--- a/module/spring-boot-quartz/src/test/java/org/springframework/boot/quartz/actuate/endpoint/QuartzEndpointWebIntegrationTests.java
+++ b/module/spring-boot-quartz/src/test/java/org/springframework/boot/quartz/actuate/endpoint/QuartzEndpointWebIntegrationTests.java
@@ -53,6 +53,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import static java.util.Collections.emptySet;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -311,7 +312,7 @@ class QuartzEndpointWebIntegrationTests {
 
 		@Bean
 		QuartzEndpointWebExtension quartzEndpointWebExtension(QuartzEndpoint endpoint) {
-			return new QuartzEndpointWebExtension(endpoint, Show.ALWAYS, Collections.emptySet());
+			return new QuartzEndpointWebExtension(endpoint, Show.ALWAYS, emptySet());
 		}
 
 		private void mockJobs(Scheduler scheduler, JobDetail... jobs) throws SchedulerException {

--- a/module/spring-boot-restclient/src/main/java/org/springframework/boot/restclient/RestTemplateBuilder.java
+++ b/module/spring-boot-restclient/src/main/java/org/springframework/boot/restclient/RestTemplateBuilder.java
@@ -47,6 +47,8 @@ import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriTemplateHandler;
 
+import static java.util.Collections.emptySet;
+
 /**
  * Builder that can be used to configure and create a {@link RestTemplate}. Provides
  * convenience methods to register {@link #messageConverters(HttpMessageConverter...)
@@ -114,7 +116,7 @@ public class RestTemplateBuilder {
 		this.basicAuthentication = null;
 		this.defaultHeaders = Collections.emptyMap();
 		this.customizers = copiedSetOf(customizers);
-		this.requestCustomizers = Collections.emptySet();
+		this.requestCustomizers = emptySet();
 	}
 
 	private RestTemplateBuilder(HttpClientSettings clientSettings, boolean detectRequestFactory,
@@ -713,7 +715,7 @@ public class RestTemplateBuilder {
 
 	private static <T> Set<T> append(@Nullable Collection<? extends T> collection,
 			@Nullable Collection<? extends T> additions) {
-		Set<T> result = new LinkedHashSet<>((collection != null) ? collection : Collections.emptySet());
+		Set<T> result = new LinkedHashSet<>((collection != null) ? collection : emptySet());
 		if (additions != null) {
 			result.addAll(additions);
 		}

--- a/module/spring-boot-restclient/src/test/java/org/springframework/boot/restclient/RestTemplateBuilderClientHttpRequestInitializerTests.java
+++ b/module/spring-boot-restclient/src/test/java/org/springframework/boot/restclient/RestTemplateBuilderClientHttpRequestInitializerTests.java
@@ -31,6 +31,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.mock.http.client.MockClientHttpRequest;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -49,7 +50,7 @@ class RestTemplateBuilderClientHttpRequestInitializerTests {
 	@Test
 	void createRequestWhenHasBasicAuthAndNoAuthHeaderAddsHeader() {
 		new RestTemplateBuilderClientHttpRequestInitializer(new BasicAuthentication("spring", "boot", null),
-				Collections.emptyMap(), Collections.emptySet())
+				Collections.emptyMap(), emptySet())
 			.initialize(this.request);
 		assertThat(this.request.getHeaders().get(HttpHeaders.AUTHORIZATION)).containsExactly("Basic c3ByaW5nOmJvb3Q=");
 	}
@@ -58,7 +59,7 @@ class RestTemplateBuilderClientHttpRequestInitializerTests {
 	void createRequestWhenHasBasicAuthAndExistingAuthHeaderDoesNotAddHeader() {
 		this.request.getHeaders().setBasicAuth("boot", "spring");
 		new RestTemplateBuilderClientHttpRequestInitializer(new BasicAuthentication("spring", "boot", null),
-				Collections.emptyMap(), Collections.emptySet())
+				Collections.emptyMap(), emptySet())
 			.initialize(this.request);
 		assertThat(this.request.getHeaders().get(HttpHeaders.AUTHORIZATION)).doesNotContain("Basic c3ByaW5nOmJvb3Q=");
 	}
@@ -70,7 +71,7 @@ class RestTemplateBuilderClientHttpRequestInitializerTests {
 		defaultHeaders.put("one", Collections.singletonList("1"));
 		defaultHeaders.put("two", Arrays.asList("2", "3"));
 		defaultHeaders.put("three", Collections.singletonList("4"));
-		new RestTemplateBuilderClientHttpRequestInitializer(null, defaultHeaders, Collections.emptySet())
+		new RestTemplateBuilderClientHttpRequestInitializer(null, defaultHeaders, emptySet())
 			.initialize(this.request);
 		assertThat(this.request.getHeaders().get("one")).containsExactly("existing");
 		assertThat(this.request.getHeaders().get("two")).containsExactly("2", "3");

--- a/module/spring-boot-sql/src/main/java/org/springframework/boot/sql/init/dependency/AbstractBeansOfTypeDatabaseInitializerDetector.java
+++ b/module/spring-boot-sql/src/main/java/org/springframework/boot/sql/init/dependency/AbstractBeansOfTypeDatabaseInitializerDetector.java
@@ -16,10 +16,11 @@
 
 package org.springframework.boot.sql.init.dependency;
 
-import java.util.Collections;
 import java.util.Set;
 
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+
+import static java.util.Collections.emptySet;
 
 /**
  * Base class for {@link DatabaseInitializerDetector DatabaseInitializerDetectors} that
@@ -37,7 +38,7 @@ public abstract class AbstractBeansOfTypeDatabaseInitializerDetector implements 
 			return new BeansOfTypeDetector(types).detect(beanFactory);
 		}
 		catch (Throwable ex) {
-			return Collections.emptySet();
+			return emptySet();
 		}
 	}
 

--- a/module/spring-boot-sql/src/main/java/org/springframework/boot/sql/init/dependency/AbstractBeansOfTypeDependsOnDatabaseInitializationDetector.java
+++ b/module/spring-boot-sql/src/main/java/org/springframework/boot/sql/init/dependency/AbstractBeansOfTypeDependsOnDatabaseInitializationDetector.java
@@ -16,10 +16,11 @@
 
 package org.springframework.boot.sql.init.dependency;
 
-import java.util.Collections;
 import java.util.Set;
 
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+
+import static java.util.Collections.emptySet;
 
 /**
  * Base class for {@link DependsOnDatabaseInitializationDetector
@@ -39,7 +40,7 @@ public abstract class AbstractBeansOfTypeDependsOnDatabaseInitializationDetector
 			return new BeansOfTypeDetector(types).detect(beanFactory);
 		}
 		catch (Throwable ex) {
-			return Collections.emptySet();
+			return emptySet();
 		}
 	}
 

--- a/module/spring-boot-sql/src/main/java/org/springframework/boot/sql/init/dependency/DatabaseInitializationDependencyConfigurer.java
+++ b/module/spring-boot-sql/src/main/java/org/springframework/boot/sql/init/dependency/DatabaseInitializationDependencyConfigurer.java
@@ -47,6 +47,8 @@ import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
+import static java.util.Collections.emptySet;
+
 /**
  * Configures beans that depend upon SQL database initialization with
  * {@link BeanDefinition#getDependsOn() dependencies} upon beans that perform database
@@ -125,7 +127,7 @@ public class DatabaseInitializationDependencyConfigurer implements ImportBeanDef
 			if (CollectionUtils.isEmpty(additional)) {
 				return source;
 			}
-			Set<String> result = new LinkedHashSet<>((source != null) ? Arrays.asList(source) : Collections.emptySet());
+			Set<String> result = new LinkedHashSet<>((source != null) ? Arrays.asList(source) : emptySet());
 			result.addAll(additional);
 			return StringUtils.toStringArray(result);
 		}

--- a/module/spring-boot-sql/src/test/java/org/springframework/boot/sql/init/dependency/DatabaseInitializationDependencyConfigurerTests.java
+++ b/module/spring-boot-sql/src/test/java/org/springframework/boot/sql/init/dependency/DatabaseInitializationDependencyConfigurerTests.java
@@ -51,6 +51,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.mock.env.MockEnvironment;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -243,7 +244,7 @@ class DatabaseInitializationDependencyConfigurerTests {
 
 		@Override
 		public Set<String> detect(ConfigurableListableBeanFactory beanFactory) {
-			return Collections.emptySet();
+			return emptySet();
 		}
 
 	}

--- a/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/servlet/TomcatServletWebServerFactory.java
+++ b/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/servlet/TomcatServletWebServerFactory.java
@@ -27,7 +27,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -92,6 +91,8 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
+import static java.util.Collections.emptySet;
+
 /**
  * {@link ConfigurableServletWebServerFactory} that can be used to create
  * {@link TomcatWebServer}s. Can be initialized using Spring's
@@ -122,7 +123,7 @@ public class TomcatServletWebServerFactory extends TomcatWebServerFactory
 
 	private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
-	private static final Set<Class<?>> NO_CLASSES = Collections.emptySet();
+	private static final Set<Class<?>> NO_CLASSES = emptySet();
 
 	private final ServletWebServerSettings settings = new ServletWebServerSettings();
 

--- a/module/spring-boot-webservices/src/main/java/org/springframework/boot/webservices/client/WebServiceTemplateBuilder.java
+++ b/module/spring-boot-webservices/src/main/java/org/springframework/boot/webservices/client/WebServiceTemplateBuilder.java
@@ -40,6 +40,8 @@ import org.springframework.ws.client.support.destination.DestinationProvider;
 import org.springframework.ws.client.support.interceptor.ClientInterceptor;
 import org.springframework.ws.transport.WebServiceMessageSender;
 
+import static java.util.Collections.emptySet;
+
 /**
  * Builder that can be used to configure and create a {@link WebServiceTemplate}. Provides
  * convenience methods to register {@link #messageSenders(WebServiceMessageSender...)
@@ -530,7 +532,7 @@ public class WebServiceTemplateBuilder {
 	}
 
 	private static <T> Set<T> append(@Nullable Set<T> set, @Nullable Collection<? extends T> additions) {
-		Set<T> result = new LinkedHashSet<>((set != null) ? set : Collections.emptySet());
+		Set<T> result = new LinkedHashSet<>((set != null) ? set : emptySet());
 		result.addAll((additions != null) ? additions : Collections.emptyList());
 		return Collections.unmodifiableSet(result);
 	}


### PR DESCRIPTION
Inspired by the change initiated in #48630, this appears to be the matching counterpart to the [`StaticImports`](https://docs.openrewrite.org/recipes/java/testing/assertj/staticimports) rule.

Although the rule is active and covered by tests (the `emptyList` example works as expected), it is currently not functioning as intended. This should therefore be filed as a simple bug report in the Rewrite repository and fixed afterward.

- https://github.com/openrewrite/rewrite-testing-frameworks/issues/885

Despite this, we could also apply the same changes and alignments here, similar to what was done in the framework.

As in the framework, this change involves the same file- and time-based updates and could be aligned accordingly:

- https://github.com/spring-projects/spring-framework/pull/35861

Referes to:
- https://github.com/spring-projects/spring-boot/issues/46749
- https://github.com/spring-projects/spring-boot/issues/48530


Changes:

```
Changes have been made to build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/ClassPath.java by:
    tech.picnic.errorprone.refasterrules.FileRulesRecipes
        tech.picnic.errorprone.refasterrules.FileRulesRecipes$PathOfUriRecipe
Changes have been made to buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/io/InspectedContent.java by:
    tech.picnic.errorprone.refasterrules.FileRulesRecipes
        tech.picnic.errorprone.refasterrules.FileRulesRecipes$FilesCreateTempFileToFileRecipe
Changes have been made to buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/Cache.java by:
    tech.picnic.errorprone.refasterrules.EqualityRulesRecipes
        tech.picnic.errorprone.refasterrules.EqualityRulesRecipes$EnumReferenceEqualityRecipe
Changes have been made to buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildpackReference.java by:
    tech.picnic.errorprone.refasterrules.FileRulesRecipes
        tech.picnic.errorprone.refasterrules.FileRulesRecipes$PathOfUriRecipe
Changes have been made to buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/configuration/DockerConfigurationMetadataTests.java by:
    tech.picnic.errorprone.refasterrules.FileRulesRecipes
        tech.picnic.errorprone.refasterrules.FileRulesRecipes$PathOfUriRecipe
Changes have been made to buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/configuration/ResolvedDockerHostTests.java by:
    tech.picnic.errorprone.refasterrules.FileRulesRecipes
        tech.picnic.errorprone.refasterrules.FileRulesRecipes$PathOfUriRecipe
Changes have been made to buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/EphemeralBuilderTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcConstantRecipe
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$InstantAtOffsetRecipe
Changes have been made to buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildRequestTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcConstantRecipe
Changes have been made to buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/ImageBuildpackTests.java by:
    tech.picnic.errorprone.refasterrules.FileRulesRecipes
        tech.picnic.errorprone.refasterrules.FileRulesRecipes$FilesCreateTempFileToFileRecipe
Changes have been made to cli/spring-boot-cli/src/test/resources/commands/command.groovy by:
    org.openrewrite.java.format.RemoveTrailingWhitespace
Changes have been made to cli/spring-boot-cli/src/test/resources/dir-sample/code/app.groovy by:
    org.openrewrite.java.format.RemoveTrailingWhitespace
Changes have been made to cli/spring-boot-cli/src/test/resources/scripts/closure.groovy by:
    org.openrewrite.java.format.RemoveTrailingWhitespace
Changes have been made to cli/spring-boot-cli/src/test/resources/scripts/command.groovy by:
    org.openrewrite.java.format.RemoveTrailingWhitespace
Changes have been made to core/spring-boot/src/test/java/org/springframework/boot/info/SslInfoTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcConstantRecipe
Changes have been made to core/spring-boot/src/test/java/org/springframework/boot/logging/AbstractLoggingSystemTests.java by:
    tech.picnic.errorprone.refasterrules.FileRulesRecipes
        tech.picnic.errorprone.refasterrules.FileRulesRecipes$FilesCreateTempFileToFileRecipe
Changes have been made to core/spring-boot/src/test/java/org/springframework/boot/convert/PeriodToStringConverterTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$ZeroPeriodRecipe
Changes have been made to core/spring-boot/src/test/java/org/springframework/boot/convert/PeriodStyleTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$ZeroPeriodRecipe
Changes have been made to core/spring-boot-test/src/main/java/org/springframework/boot/test/util/TestPropertyValues.java by:
    tech.picnic.errorprone.refasterrules.EqualityRulesRecipes
        tech.picnic.errorprone.refasterrules.EqualityRulesRecipes$EnumReferenceEqualityRecipe
Changes have been made to core/spring-boot-test/src/main/java/org/springframework/boot/test/system/OutputCapture.java by:
    tech.picnic.errorprone.refasterrules.EqualityRulesRecipes
        tech.picnic.errorprone.refasterrules.EqualityRulesRecipes$EnumReferenceEqualityLambdaRecipe
Changes have been made to loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/nested/NestedUrlConnection.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcConstantRecipe
Changes have been made to loader/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/SizeCalculatingEntryWriter.java by:
    tech.picnic.errorprone.refasterrules.FileRulesRecipes
        tech.picnic.errorprone.refasterrules.FileRulesRecipes$FilesCreateTempFileToFileRecipe
Changes have been made to module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/exchanges/HttpExchange.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$ClockInstantRecipe
Changes have been made to module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/management/HeapDumpWebEndpoint.java by:
    tech.picnic.errorprone.refasterrules.FileRulesRecipes
        tech.picnic.errorprone.refasterrules.FileRulesRecipes$FilesCreateTempFileToFileRecipe
Changes have been made to module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/InfoPropertiesInfoContributor.java by:
    tech.picnic.errorprone.refasterrules.EqualityRulesRecipes
        tech.picnic.errorprone.refasterrules.EqualityRulesRecipes$EnumReferenceEqualityRecipe
Changes have been made to module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/invoker/cache/CachingOperationInvoker.java by:
    tech.picnic.errorprone.refasterrules.EqualityRulesRecipes
        tech.picnic.errorprone.refasterrules.EqualityRulesRecipes$EnumReferenceEqualityRecipe
Changes have been made to module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/filewatch/ChangedFile.java by:
    tech.picnic.errorprone.refasterrules.EqualityRulesRecipes
        tech.picnic.errorprone.refasterrules.EqualityRulesRecipes$EnumReferenceEqualityRecipe
Changes have been made to module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/MainMethodTests.java by:
    org.openrewrite.staticanalysis.ReplaceLambdaWithMethodReference
Changes have been made to module/spring-boot-jetty/src/main/java/org/springframework/boot/jetty/autoconfigure/JettyWebServerFactoryCustomizer.java by:
    tech.picnic.errorprone.refasterrules.EqualityRulesRecipes
        tech.picnic.errorprone.refasterrules.EqualityRulesRecipes$EnumReferenceEqualityRecipe
Changes have been made to module/spring-boot-jetty/src/test/java/org/springframework/boot/jetty/autoconfigure/JettyWebServerFactoryCustomizerTests.java by:
    tech.picnic.errorprone.refasterrules.FileRulesRecipes
        tech.picnic.errorprone.refasterrules.FileRulesRecipes$FilesCreateTempFileToFileRecipe
Changes have been made to module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/ConcurrentKafkaListenerContainerFactoryConfigurer.java by:
    tech.picnic.errorprone.refasterrules.EqualityRulesRecipes
        tech.picnic.errorprone.refasterrules.EqualityRulesRecipes$EnumReferenceEqualityRecipe
Changes have been made to module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/ssl/SslMeterBinder.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$ClockInstantRecipe
Changes have been made to module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/autoconfigure/ssl/SslMeterBinderTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcConstantRecipe
Changes have been made to module/spring-boot-security/src/test/java/org/springframework/boot/security/autoconfigure/UserDetailsServiceAutoConfigurationTests.java by:
    tech.picnic.errorprone.refasterrules.EqualityRulesRecipes
        tech.picnic.errorprone.refasterrules.EqualityRulesRecipes$EnumReferenceEqualityLambdaRecipe
Changes have been made to module/spring-boot-sql/src/main/java/org/springframework/boot/sql/autoconfigure/init/OnDatabaseInitializationCondition.java by:
    tech.picnic.errorprone.refasterrules.EqualityRulesRecipes
        tech.picnic.errorprone.refasterrules.EqualityRulesRecipes$EnumReferenceEqualityRecipe
        tech.picnic.errorprone.refasterrules.EqualityRulesRecipes$NegationRecipe
Changes have been made to module/spring-boot-tomcat/src/test/java/org/springframework/boot/tomcat/servlet/TomcatServletWebServerFactoryTests.java by:
    org.openrewrite.staticanalysis.ReplaceLambdaWithMethodReference
Changes have been made to module/spring-boot-webflux/src/test/java/org/springframework/boot/webflux/observation/autoconfigure/WebFluxObservationAutoConfigurationTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$DurationOfSecondsRecipe
Changes have been made to module/spring-boot-zipkin/src/main/java/org/springframework/boot/zipkin/autoconfigure/ZipkinHttpClientSender.java by:
    org.openrewrite.staticanalysis.ReplaceLambdaWithMethodReference
Changes have been made to test-support/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/classpath/resources/Resources.java by:
    tech.picnic.errorprone.refasterrules.FileRulesRecipes
        tech.picnic.errorprone.refasterrules.FileRulesRecipes$PathOfUriRecipe
Changes have been made to test-support/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/system/OutputCapture.java by:
    tech.picnic.errorprone.refasterrules.EqualityRulesRecipes
        tech.picnic.errorprone.refasterrules.EqualityRulesRecipes$EnumReferenceEqualityLambdaRecipe
Please review and commit the results.
Estimate time saved: 3h 6m

BUILD SUCCESSFUL in 18m 9s
```





<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
