### PR TITLE
Add `Java8toJava11` #48692

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -69,6 +69,16 @@ runs:
         COMMERCIAL_REPO_USERNAME: ${{ inputs.commercial-repository-username }}
         COMMERCIAL_SNAPSHOT_REPO_URL: ${{ inputs.commercial-snapshot-repository-url }}
       run: ./gradlew build
+    - name: Sanity Check
+      id: sanity
+      if: ${{ inputs.publish == 'false' }}
+      shell: bash
+      env:
+        COMMERCIAL_RELEASE_REPO_URL: ${{ inputs.commercial-release-repository-url }}
+        COMMERCIAL_REPO_PASSWORD: ${{ inputs.commercial-repository-password }}
+        COMMERCIAL_REPO_USERNAME: ${{ inputs.commercial-repository-username }}
+        COMMERCIAL_SNAPSHOT_REPO_URL: ${{ inputs.commercial-snapshot-repository-url }}
+      run: ./gradlew rewriteDryRun -Dorg.gradle.jvmargs=-Xmx12G
     - name: Publish
       id: publish
       if: ${{ inputs.publish == 'true' }}

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Build
         id: build
         uses: ./.github/actions/build
+      - name: Sanity
+        id: sanity
+        uses: ./.github/actions/build
       - name: Print JVM Thread Dumps When Cancelled
         if: cancelled()
         uses: ./.github/actions/print-jvm-thread-dumps

--- a/build-plugin/spring-boot-gradle-plugin/src/dockerTest/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageIntegrationTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/dockerTest/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageIntegrationTests.java
@@ -354,8 +354,8 @@ class BootBuildImageIntegrationTests {
 		assertThat(result.getOutput()).contains("---> Test Info buildpack done");
 		removeImages(projectName);
 		String tempDir = System.getProperty("java.io.tmpdir");
-		Path buildCachePath = Paths.get(tempDir, "junit-image-cache-" + projectName + "-build");
-		Path launchCachePath = Paths.get(tempDir, "junit-image-cache-" + projectName + "-launch");
+		Path buildCachePath = Path.of(tempDir, "junit-image-cache-" + projectName + "-build");
+		Path launchCachePath = Path.of(tempDir, "junit-image-cache-" + projectName + "-launch");
 		assertThat(buildCachePath).exists().isDirectory();
 		assertThat(launchCachePath).exists().isDirectory();
 		cleanupCache(buildCachePath);
@@ -595,7 +595,7 @@ class BootBuildImageIntegrationTests {
 		new Random().ints('a', 'z' + 1).limit(128).forEach((i) -> name.append((char) i));
 		Path path = this.gradleBuild.getProjectDir()
 			.toPath()
-			.resolve(Paths.get("src", "main", "resources", name.toString()));
+			.resolve(Path.of("src", "main", "resources", name.toString()));
 		Files.createDirectories(path.getParent());
 		Files.createFile(path);
 	}
@@ -620,13 +620,13 @@ class BootBuildImageIntegrationTests {
 			writer.println("[[stacks]]\n");
 			writer.println("id = \"*\"");
 		}
-		File detect = Files.createFile(Paths.get(binDir.getAbsolutePath(), "detect"), execFileAttribute).toFile();
+		File detect = Files.createFile(Path.of(binDir.getAbsolutePath(), "detect"), execFileAttribute).toFile();
 		try (PrintWriter writer = new PrintWriter(new FileWriter(detect))) {
 			writer.println("#!/usr/bin/env bash");
 			writer.println("set -eo pipefail");
 			writer.println("exit 0");
 		}
-		File build = Files.createFile(Paths.get(binDir.getAbsolutePath(), "build"), execFileAttribute).toFile();
+		File build = Files.createFile(Path.of(binDir.getAbsolutePath(), "build"), execFileAttribute).toFile();
 		try (PrintWriter writer = new PrintWriter(new FileWriter(build))) {
 			writer.println("#!/usr/bin/env bash");
 			writer.println("set -eo pipefail");

--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/AbstractBootArchiveIntegrationTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/AbstractBootArchiveIntegrationTests.java
@@ -26,7 +26,6 @@ import java.io.PrintWriter;
 import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -725,7 +724,7 @@ abstract class AbstractBootArchiveIntegrationTests {
 		try {
 			Path path = this.gradleBuild.getProjectDir()
 				.toPath()
-				.resolve(Paths.get("src", "main", "resources", "static", "file.txt"));
+				.resolve(Path.of("src", "main", "resources", "static", "file.txt"));
 			Files.createDirectories(path.getParent());
 			Files.createFile(path);
 		}

--- a/build-plugin/spring-boot-maven-plugin/src/dockerTest/java/org/springframework/boot/maven/BuildImageTests.java
+++ b/build-plugin/spring-boot-maven-plugin/src/dockerTest/java/org/springframework/boot/maven/BuildImageTests.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.OffsetDateTime;
 import java.util.Random;
 import java.util.stream.IntStream;
@@ -455,8 +454,8 @@ class BuildImageTests extends AbstractArchiveIntegrationTests {
 					.contains("Successfully built image");
 				removeImage("build-image-bind-caches", "0.0.1.BUILD-SNAPSHOT");
 				String tempDir = System.getProperty("java.io.tmpdir");
-				Path buildCachePath = Paths.get(tempDir, "junit-image-cache-" + testBuildId + "-build");
-				Path launchCachePath = Paths.get(tempDir, "junit-image-cache-" + testBuildId + "-launch");
+				Path buildCachePath = Path.of(tempDir, "junit-image-cache-" + testBuildId + "-build");
+				Path launchCachePath = Path.of(tempDir, "junit-image-cache-" + testBuildId + "-launch");
 				assertThat(buildCachePath).exists().isDirectory();
 				assertThat(launchCachePath).exists().isDirectory();
 				cleanupCache(buildCachePath);
@@ -627,7 +626,7 @@ class BuildImageTests extends AbstractArchiveIntegrationTests {
 		StringBuilder name = new StringBuilder();
 		new Random().ints('a', 'z' + 1).limit(128).forEach((i) -> name.append((char) i));
 		try {
-			Path path = project.toPath().resolve(Paths.get("src", "main", "resources", name.toString()));
+			Path path = project.toPath().resolve(Path.of("src", "main", "resources", name.toString()));
 			Files.createDirectories(path.getParent());
 			Files.createFile(path);
 		}

--- a/build-plugin/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/MavenBuild.java
+++ b/build-plugin/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/MavenBuild.java
@@ -23,7 +23,6 @@ import java.io.PrintWriter;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
@@ -163,7 +162,7 @@ class MavenBuild {
 				}
 
 			});
-			String settingsXml = Files.readString(Paths.get("build", "generated-resources", "settings", "settings.xml"))
+			String settingsXml = Files.readString(Path.of("build", "generated-resources", "settings", "settings.xml"))
 				.replace("@localCentralUrl@", new File("build/test-maven-repository").toURI().toURL().toString())
 				.replace("@localRepositoryPath@", new File("build/local-maven-repository").getAbsolutePath());
 			Files.writeString(destination.resolve("settings.xml"), settingsXml, StandardOpenOption.CREATE_NEW);

--- a/build-plugin/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/MavenBuildExtension.java
+++ b/build-plugin/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/MavenBuildExtension.java
@@ -19,7 +19,6 @@ package org.springframework.boot.maven;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
@@ -49,7 +48,7 @@ class MavenBuildExtension implements TestTemplateInvocationContextProvider {
 		try {
 			// Returning a stream which must be closed here is fine, as JUnit will take
 			// care of closing it
-			return Files.list(Paths.get("build/maven-binaries")).map(MavenVersionTestTemplateInvocationContext::new);
+			return Files.list(Path.of("build/maven-binaries")).map(MavenVersionTestTemplateInvocationContext::new);
 		}
 		catch (IOException ex) {
 			throw new RuntimeException(ex);

--- a/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/ClassPath.java
+++ b/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/ClassPath.java
@@ -24,7 +24,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -139,7 +138,7 @@ final class ClassPath {
 
 	private static String toPathString(URL url) {
 		try {
-			return Paths.get(url.toURI()).toString();
+			return Path.of(url.toURI()).toString();
 		}
 		catch (URISyntaxException ex) {
 			throw new IllegalArgumentException(ex);

--- a/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ClassPathTests.java
+++ b/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ClassPathTests.java
@@ -18,7 +18,6 @@ package org.springframework.boot.maven;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +65,7 @@ class ClassPathTests {
 		List<String> args = classPath.args(true);
 		assertThat(args.get(0)).isEqualTo("-cp");
 		assertThat(args.get(1)).startsWith("@");
-		assertThat(Paths.get(args.get(1).substring(1)))
+		assertThat(Path.of(args.get(1).substring(1)))
 			.hasContent("\"" + (path1 + File.pathSeparator + path2).replace("\\", "\\\\") + "\"");
 	}
 

--- a/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/CommandLineBuilderTests.java
+++ b/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/CommandLineBuilderTests.java
@@ -23,7 +23,6 @@ import java.lang.management.ManagementFactory;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -115,7 +114,7 @@ class CommandLineBuilderTests {
 		assertThat(args.get(0)).isEqualTo("-cp");
 		assertThat(args.get(1)).startsWith("@");
 		assertThat(args.get(2)).isEqualTo(CLASS_NAME);
-		assertThat(Paths.get(args.get(1).substring(1)))
+		assertThat(Path.of(args.get(1).substring(1)))
 			.hasContent("\"" + (file + File.pathSeparator + file1).replace("\\", "\\\\") + "\"");
 	}
 
@@ -140,7 +139,7 @@ class CommandLineBuilderTests {
 
 	private URL toURL(String path) {
 		try {
-			return Paths.get(path).toUri().toURL();
+			return Path.of(path).toUri().toURL();
 		}
 		catch (MalformedURLException ex) {
 			throw new RuntimeException(ex);

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@
 
 plugins {
 	id "base"
+	id "org.openrewrite.rewrite" version "7.23.0" apply false
 }
 
 description = "Spring Boot Build"
@@ -46,3 +47,5 @@ subprojects {
 		resolutionStrategy.cacheChangingModulesFor 0, "minutes"
 	}
 }
+
+apply from: rootProject.file("gradle/plugins/config/sanity.gradle")

--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildpackReference.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildpackReference.java
@@ -20,7 +20,6 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.jspecify.annotations.Nullable;
 
@@ -54,7 +53,7 @@ public final class BuildpackReference {
 		try {
 			URL url = new URL(this.value);
 			if (url.getProtocol().equals("file")) {
-				return Paths.get(url.toURI());
+				return Path.of(url.toURI());
 			}
 			return null;
 		}
@@ -62,7 +61,7 @@ public final class BuildpackReference {
 			// not a URL, fall through to attempting to find a plain file path
 		}
 		try {
-			return Paths.get(this.value);
+			return Path.of(this.value);
 		}
 		catch (Exception ex) {
 			return null;

--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/DirectoryBuildpack.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/DirectoryBuildpack.java
@@ -21,7 +21,6 @@ import java.io.InputStream;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
@@ -82,7 +81,7 @@ final class DirectoryBuildpack implements Buildpack {
 
 	private void addLayerContent(Layout layout) throws IOException {
 		String id = this.coordinates.getSanitizedId();
-		Path cnbPath = Paths.get("/cnb/buildpacks/", id, this.coordinates.getVersion());
+		Path cnbPath = Path.of("/cnb/buildpacks/", id, this.coordinates.getVersion());
 		writeBasePathEntries(layout, cnbPath);
 		Files.walkFileTree(this.path, new LayoutFileVisitor(this.path, cnbPath, layout));
 	}
@@ -152,7 +151,7 @@ final class DirectoryBuildpack implements Buildpack {
 
 		private String relocate(Path path) {
 			Path node = path.subpath(this.basePath.getNameCount(), path.getNameCount());
-			return Paths.get(this.layerPath.toString(), node.toString()).toString();
+			return Path.of(this.layerPath.toString(), node.toString()).toString();
 		}
 
 	}

--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/TarGzipBuildpack.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/TarGzipBuildpack.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -86,7 +85,7 @@ final class TarGzipBuildpack implements Buildpack {
 
 	private void copyAndRebaseEntries(OutputStream outputStream) throws IOException {
 		String id = this.coordinates.getSanitizedId();
-		Path basePath = Paths.get("/cnb/buildpacks/", id, this.coordinates.getVersion());
+		Path basePath = Path.of("/cnb/buildpacks/", id, this.coordinates.getVersion());
 		try (TarArchiveInputStream tar = new TarArchiveInputStream(
 				new GzipCompressorInputStream(Files.newInputStream(this.path)));
 				TarArchiveOutputStream output = new TarArchiveOutputStream(outputStream)) {

--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/ResolvedDockerHost.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/ResolvedDockerHost.java
@@ -17,7 +17,7 @@
 package org.springframework.boot.buildpack.platform.docker.configuration;
 
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import com.sun.jna.Platform;
 import org.jspecify.annotations.Nullable;
@@ -70,7 +70,7 @@ public class ResolvedDockerHost extends DockerHost {
 
 	public boolean isLocalFileReference() {
 		try {
-			return Files.exists(Paths.get(getAddress()));
+			return Files.exists(Path.of(getAddress()));
 		}
 		catch (Exception ex) {
 			return false;

--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/ssl/SslContextFactory.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/ssl/SslContextFactory.java
@@ -18,7 +18,6 @@ package org.springframework.boot.buildpack.platform.docker.ssl;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -53,10 +52,10 @@ public class SslContextFactory {
 	 */
 	public SSLContext forDirectory(String directory) {
 		try {
-			Path keyPath = Paths.get(directory, "key.pem");
-			Path certPath = Paths.get(directory, "cert.pem");
-			Path caPath = Paths.get(directory, "ca.pem");
-			Path caKeyPath = Paths.get(directory, "ca-key.pem");
+			Path keyPath = Path.of(directory, "key.pem");
+			Path certPath = Path.of(directory, "cert.pem");
+			Path caPath = Path.of(directory, "ca.pem");
+			Path caKeyPath = Path.of(directory, "ca-key.pem");
 			verifyCertificateFiles(keyPath, certPath, caPath);
 			KeyManagerFactory keyManagerFactory = getKeyManagerFactory(keyPath, certPath);
 			TrustManagerFactory trustManagerFactory = getTrustManagerFactory(caPath, caKeyPath);

--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/socket/NamedPipeSocket.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/socket/NamedPipeSocket.java
@@ -28,7 +28,7 @@ import java.nio.channels.AsynchronousFileChannel;
 import java.nio.channels.Channels;
 import java.nio.channels.CompletionHandler;
 import java.nio.file.FileSystemException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -62,7 +62,7 @@ public class NamedPipeSocket extends Socket {
 		long startTime = System.nanoTime();
 		while (true) {
 			try {
-				return new AsynchronousFileByteChannel(AsynchronousFileChannel.open(Paths.get(path),
+				return new AsynchronousFileByteChannel(AsynchronousFileChannel.open(Path.of(path),
 						StandardOpenOption.READ, StandardOpenOption.WRITE));
 			}
 			catch (FileSystemException ex) {

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildpackCoordinatesTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildpackCoordinatesTests.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -39,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  */
 class BuildpackCoordinatesTests extends AbstractJsonTests {
 
-	private final Path archive = Paths.get("/buildpack/path");
+	private final Path archive = Path.of("/buildpack/path");
 
 	@Test
 	void fromToml() throws IOException {

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildpackReferenceTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildpackReferenceTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.buildpack.platform.build;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 
@@ -84,13 +84,13 @@ class BuildpackReferenceTests {
 	@Test
 	void asPathWhenFileUrlReturnsPath() {
 		BuildpackReference reference = BuildpackReference.of("file:///test.dat");
-		assertThat(reference.asPath()).isEqualTo(Paths.get("/test.dat"));
+		assertThat(reference.asPath()).isEqualTo(Path.of("/test.dat"));
 	}
 
 	@Test
 	void asPathWhenPathReturnsPath() {
 		BuildpackReference reference = BuildpackReference.of("/test.dat");
-		assertThat(reference.asPath()).isEqualTo(Paths.get("/test.dat"));
+		assertThat(reference.asPath()).isEqualTo(Path.of("/test.dat"));
 	}
 
 }

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/DirectoryBuildpackTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/DirectoryBuildpackTests.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.List;
@@ -97,7 +96,7 @@ class DirectoryBuildpackTests {
 
 	@Test
 	void resolveWhenFileReturnsNull() throws Exception {
-		Path file = Files.createFile(Paths.get(this.buildpackDir.toString(), "test"));
+		Path file = Files.createFile(Path.of(this.buildpackDir.toString(), "test"));
 		BuildpackReference reference = BuildpackReference.of(file.toString());
 		Buildpack buildpack = DirectoryBuildpack.resolve(this.resolverContext, reference);
 		assertThat(buildpack).isNull();
@@ -145,7 +144,7 @@ class DirectoryBuildpackTests {
 	}
 
 	private void writeBuildpackDescriptor() throws IOException {
-		Path descriptor = Files.createFile(Paths.get(this.buildpackDir.getAbsolutePath(), "buildpack.toml"),
+		Path descriptor = Files.createFile(Path.of(this.buildpackDir.getAbsolutePath(), "buildpack.toml"),
 				PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--")));
 		try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(descriptor))) {
 			writer.println("[buildpack]");
@@ -159,16 +158,16 @@ class DirectoryBuildpackTests {
 	}
 
 	private void writeScripts() throws IOException {
-		Path binDirectory = Files.createDirectory(Paths.get(this.buildpackDir.getAbsolutePath(), "bin"),
+		Path binDirectory = Files.createDirectory(Path.of(this.buildpackDir.getAbsolutePath(), "bin"),
 				PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxr-xr-x")));
 		binDirectory.toFile().mkdirs();
-		Path detect = Files.createFile(Paths.get(binDirectory.toString(), "detect"),
+		Path detect = Files.createFile(Path.of(binDirectory.toString(), "detect"),
 				PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxr--r--")));
 		try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(detect))) {
 			writer.println("#!/usr/bin/env bash");
 			writer.println("echo \"---> detect\"");
 		}
-		Path build = Files.createFile(Paths.get(binDirectory.toString(), "build"),
+		Path build = Files.createFile(Path.of(binDirectory.toString(), "build"),
 				PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxr--r--")));
 		try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(build))) {
 			writer.println("#!/usr/bin/env bash");

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/TestTarGzip.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/TestTarGzip.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -59,7 +58,7 @@ class TestTarGzip {
 	}
 
 	private Path createArchive(boolean addContent) throws Exception {
-		Path path = Paths.get(this.buildpackDir.getAbsolutePath(), "buildpack.tar");
+		Path path = Path.of(this.buildpackDir.getAbsolutePath(), "buildpack.tar");
 		Path archive = Files.createFile(path);
 		if (addContent) {
 			writeBuildpackContentToArchive(archive);
@@ -68,7 +67,7 @@ class TestTarGzip {
 	}
 
 	private Path compressBuildpackArchive(Path archive) throws Exception {
-		Path tgzPath = Paths.get(this.buildpackDir.getAbsolutePath(), "buildpack.tgz");
+		Path tgzPath = Path.of(this.buildpackDir.getAbsolutePath(), "buildpack.tgz");
 		FileCopyUtils.copy(Files.newInputStream(archive),
 				new GzipCompressorOutputStream(Files.newOutputStream(tgzPath)));
 		return tgzPath;

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/configuration/DockerConfigurationMetadataTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/configuration/DockerConfigurationMetadataTests.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -141,7 +140,7 @@ class DockerConfigurationMetadataTests extends AbstractJsonTests {
 
 	private String pathToResource(String resource) throws URISyntaxException {
 		URL url = getClass().getResource(resource);
-		Path parent = Paths.get(url.toURI()).getParent();
+		Path parent = Path.of(url.toURI()).getParent();
 		assertThat(parent).isNotNull();
 		return parent.toAbsolutePath().toString();
 	}

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/configuration/ResolvedDockerHostTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/configuration/ResolvedDockerHostTests.java
@@ -21,7 +21,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -212,7 +211,7 @@ class ResolvedDockerHostTests {
 
 	private String pathToResource(String resource) throws URISyntaxException {
 		URL url = getClass().getResource(resource);
-		Path parent = Paths.get(url.toURI()).getParent();
+		Path parent = Path.of(url.toURI()).getParent();
 		assertThat(parent).isNotNull();
 		return parent.toAbsolutePath().toString();
 	}

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ssl/PemFileWriter.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ssl/PemFileWriter.java
@@ -19,7 +19,6 @@ package org.springframework.boot.buildpack.platform.docker.ssl;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 
 import org.springframework.util.FileSystemUtils;
@@ -179,7 +178,7 @@ public class PemFileWriter {
 	}
 
 	Path writeFile(String name, String... contents) throws IOException {
-		Path path = Paths.get(this.tempDir.toString(), name);
+		Path path = Path.of(this.tempDir.toString(), name);
 		for (String content : contents) {
 			Files.write(path, content.replaceAll(EXAMPLE_SECRET_QUALIFIER, "").getBytes(), StandardOpenOption.CREATE,
 					StandardOpenOption.APPEND);

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/LocalHttpClientTransportTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/LocalHttpClientTransportTests.java
@@ -19,7 +19,6 @@ package org.springframework.boot.buildpack.platform.docker.transport;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -47,7 +46,7 @@ class LocalHttpClientTransportTests {
 
 	@Test
 	void createWhenDockerHostIsFileThatDoesNotExistReturnsTransport(@TempDir Path tempDir) {
-		String socketFilePath = Paths.get(tempDir.toString(), "dummy").toAbsolutePath().toString();
+		String socketFilePath = Path.of(tempDir.toString(), "dummy").toAbsolutePath().toString();
 		ResolvedDockerHost dockerHost = ResolvedDockerHost.from(new DockerConnectionConfiguration.Host(socketFilePath));
 		LocalHttpClientTransport transport = LocalHttpClientTransport.create(dockerHost);
 		assertThat(transport).isNotNull();

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/FilePermissionsTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/FilePermissionsTests.java
@@ -19,7 +19,6 @@ package org.springframework.boot.buildpack.platform.io;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
@@ -61,7 +60,7 @@ class FilePermissionsTests {
 	@DisabledOnOs(OS.WINDOWS)
 	void umaskForPathWithNonExistentFile() {
 		assertThatIOException()
-			.isThrownBy(() -> FilePermissions.umaskForPath(Paths.get(this.tempDir.toString(), "does-not-exist")));
+			.isThrownBy(() -> FilePermissions.umaskForPath(Path.of(this.tempDir.toString(), "does-not-exist")));
 	}
 
 	@Test

--- a/cli/spring-boot-cli/src/intTest/java/org/springframework/boot/cli/infrastructure/CommandLineInvoker.java
+++ b/cli/spring-boot-cli/src/intTest/java/org/springframework/boot/cli/infrastructure/CommandLineInvoker.java
@@ -27,7 +27,6 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -68,7 +67,7 @@ public final class CommandLineInvoker {
 	private Process runCliProcess(String... args) throws IOException {
 		Path m2 = this.temp.toPath().resolve(".m2");
 		Files.createDirectories(m2);
-		Files.copy(Paths.get("src", "intTest", "resources", "settings.xml"), m2.resolve("settings.xml"),
+		Files.copy(Path.of("src", "intTest", "resources", "settings.xml"), m2.resolve("settings.xml"),
 				StandardCopyOption.REPLACE_EXISTING);
 		List<String> command = new ArrayList<>();
 		command.add(findLaunchScript().getAbsolutePath());

--- a/configuration-metadata/spring-boot-configuration-processor/build.gradle
+++ b/configuration-metadata/spring-boot-configuration-processor/build.gradle
@@ -37,6 +37,8 @@ architectureCheck {
 }
 
 dependencies {
+    compileOnly "jakarta.annotation:jakarta.annotation-api:1.3.5"
+
 	testCompileOnly("com.google.code.findbugs:jsr305:3.0.2")
 	testCompileOnly("org.jspecify:jspecify")
 

--- a/core/spring-boot-autoconfigure-processor/build.gradle
+++ b/core/spring-boot-autoconfigure-processor/build.gradle
@@ -23,6 +23,8 @@ plugins {
 description = "Spring Boot AutoConfigure Annotation Processor"
 
 dependencies {
+    compileOnly "jakarta.annotation:jakarta.annotation-api:1.3.5"
+
 	testImplementation(enforcedPlatform(project(":platform:spring-boot-dependencies")))
 	testImplementation(project(":test-support:spring-boot-test-support"))
 }

--- a/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/lifecycle/DockerComposeLifecycleManagerTests.java
+++ b/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/lifecycle/DockerComposeLifecycleManagerTests.java
@@ -18,7 +18,7 @@ package org.springframework.boot.docker.compose.lifecycle;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -157,7 +157,7 @@ class DockerComposeLifecycleManagerTests {
 				this.applicationContext, this.shutdownHandlers, this.properties, this.eventListeners, this.skipCheck,
 				this.serviceReadinessChecks);
 		assertThatIllegalStateException().isThrownBy(manager::start)
-			.withMessageContaining(Paths.get(".").toAbsolutePath().toString());
+			.withMessageContaining(Path.of(".").toAbsolutePath().toString());
 	}
 
 	@Test
@@ -166,7 +166,7 @@ class DockerComposeLifecycleManagerTests {
 				this.shutdownHandlers, this.properties, this.eventListeners, this.skipCheck,
 				this.serviceReadinessChecks);
 		assertThatIllegalStateException().isThrownBy(manager::start)
-			.withMessageContaining(Paths.get(".").toAbsolutePath().toString());
+			.withMessageContaining(Path.of(".").toAbsolutePath().toString());
 	}
 
 	@Test

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestAotProcessor.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestAotProcessor.java
@@ -54,9 +54,9 @@ public class SpringBootTestAotProcessor extends TestAotProcessor {
 			.map(Paths::get)
 			.collect(Collectors.toSet());
 		Settings settings = Settings.builder()
-			.sourceOutput(Paths.get(args[1]))
-			.resourceOutput(Paths.get(args[2]))
-			.classOutput(Paths.get(args[3]))
+			.sourceOutput(Path.of(args[1]))
+			.resourceOutput(Path.of(args[2]))
+			.classOutput(Path.of(args[3]))
 			.groupId(args[4])
 			.artifactId(args[5])
 			.build();

--- a/core/spring-boot/src/main/java/org/springframework/boot/SpringApplicationAotProcessor.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/SpringApplicationAotProcessor.java
@@ -17,7 +17,7 @@
 package org.springframework.boot;
 
 import java.lang.reflect.Method;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 import org.springframework.boot.SpringApplication.AbandonedRunException;
@@ -85,9 +85,9 @@ public class SpringApplicationAotProcessor extends ContextAotProcessor {
 				+ " <applicationMainClass> <sourceOutput> <resourceOutput> <classOutput> <groupId> <artifactId> <originalArgs...>");
 		Class<?> application = Class.forName(args[0]);
 		Settings settings = Settings.builder()
-			.sourceOutput(Paths.get(args[1]))
-			.resourceOutput(Paths.get(args[2]))
-			.classOutput(Paths.get(args[3]))
+			.sourceOutput(Path.of(args[1]))
+			.resourceOutput(Path.of(args[2]))
+			.classOutput(Path.of(args[3]))
 			.groupId((StringUtils.hasText(args[4])) ? args[4] : "unspecified")
 			.artifactId(args[5])
 			.build();

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigTreeConfigDataResource.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigTreeConfigDataResource.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.context.config;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Objects;
 
 import org.springframework.boot.env.ConfigTreePropertySource;
@@ -37,7 +36,7 @@ public class ConfigTreeConfigDataResource extends ConfigDataResource {
 
 	ConfigTreeConfigDataResource(String path) {
 		Assert.notNull(path, "'path' must not be null");
-		this.path = Paths.get(path).toAbsolutePath();
+		this.path = Path.of(path).toAbsolutePath();
 	}
 
 	ConfigTreeConfigDataResource(Path path) {

--- a/core/spring-boot/src/main/java/org/springframework/boot/system/ApplicationTemp.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/system/ApplicationTemp.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
@@ -135,7 +134,7 @@ public class ApplicationTemp {
 	private Path getTempDirectory() {
 		String property = System.getProperty("java.io.tmpdir");
 		Assert.state(StringUtils.hasLength(property), "No 'java.io.tmpdir' property set");
-		Path tempDirectory = Paths.get(property);
+		Path tempDirectory = Path.of(property);
 		Assert.state(Files.exists(tempDirectory), () -> "Temp directory '" + tempDirectory + "' does not exist");
 		Assert.state(Files.isDirectory(tempDirectory),
 				() -> "Temp location '" + tempDirectory + "' is not a directory");

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/ValueObjectBinderTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/ValueObjectBinderTests.java
@@ -18,7 +18,6 @@ package org.springframework.boot.context.properties.bind;
 
 import java.lang.reflect.Constructor;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -352,7 +351,7 @@ class ValueObjectBinderTests {
 		Bindable<PathBean> target = Bindable.of(PathBean.class);
 		PathBean bound = this.binder.bind("test", target).get();
 		assertThat(bound.getName()).isEqualTo("test");
-		assertThat(bound.getPath()).isEqualTo(Paths.get("specific_value"));
+		assertThat(bound.getPath()).isEqualTo(Path.of("specific_value"));
 	}
 
 	@Test
@@ -363,7 +362,7 @@ class ValueObjectBinderTests {
 		Bindable<PathBean> target = Bindable.of(PathBean.class);
 		PathBean bound = this.binder.bindOrCreate("test", target);
 		assertThat(bound.getName()).isEqualTo("test");
-		assertThat(bound.getPath()).isEqualTo(Paths.get("default_value"));
+		assertThat(bound.getPath()).isEqualTo(Path.of("default_value"));
 	}
 
 	@Test

--- a/gradle/plugins/config/sanity.gradle
+++ b/gradle/plugins/config/sanity.gradle
@@ -1,0 +1,14 @@
+project.apply(plugin: "org.openrewrite.rewrite")
+dependencies {
+	rewrite("org.openrewrite.recipe:rewrite-testing-frameworks:3.24.0")
+	rewrite("org.openrewrite.recipe:rewrite-migrate-java:3.24.0")
+}
+repositories {
+	mavenCentral()
+}
+rewrite {
+	activeRecipe("org.springframework.boot.openrewrite.SanityCheck")
+	configFile = project.getRootProject().file("${rootDir}/gradle/plugins/config/sanity.yml")
+	setExportDatatables(true)
+	setFailOnDryRunResults(true)
+}

--- a/gradle/plugins/config/sanity.yml
+++ b/gradle/plugins/config/sanity.yml
@@ -1,0 +1,26 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.springframework.boot.openrewrite.SanityCheck
+displayName: Apply all common best practices
+description: Comprehensive code quality recipe combining modernization, security, and best practices.
+recipeList:
+  - org.openrewrite.java.migrate.Java8toJava11
+# - org.openrewrite.java.migrate.UpgradeToJava17
+# - org.openrewrite.java.migrate.UpgradeToJava21 300 changes
+  - org.openrewrite.java.testing.assertj.StaticImports # https://github.com/spring-projects/spring-boot/pull/48630 https://github.com/openrewrite/rewrite-testing-frameworks/issues/885
+  - org.openrewrite.java.testing.junit5.StaticImports
+  - org.springframework.boot.openrewrite.UseStaticImport
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.springframework.boot.openrewrite.UseStaticImport
+displayName: Use static import
+recipeList:
+  - org.openrewrite.java.UseStaticImport:
+      methodPattern: org.assertj.core.api.Assertions *(..)
+# - org.openrewrite.java.UseStaticImport:
+#     methodPattern: java.util.Collections emptyList()
+# - org.openrewrite.java.UseStaticImport:
+#     methodPattern: java.util.Collections emptyMap()
+# - org.openrewrite.java.UseStaticImport:
+#     methodPattern: java.util.Collections emptySet()
+---

--- a/loader/spring-boot-jarmode-tools/src/main/java/org/springframework/boot/jarmode/tools/Context.java
+++ b/loader/spring-boot-jarmode-tools/src/main/java/org/springframework/boot/jarmode/tools/Context.java
@@ -22,7 +22,7 @@ import java.net.JarURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.Locale;
@@ -49,7 +49,7 @@ class Context {
 	 * Create a new {@link Context} instance.
 	 */
 	Context() {
-		this(getSourceArchiveFile(), Paths.get(".").toAbsolutePath().normalize().toFile());
+		this(getSourceArchiveFile(), Path.of(".").toAbsolutePath().normalize().toFile());
 	}
 
 	/**

--- a/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/launch/JarFileArchive.java
+++ b/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/launch/JarFileArchive.java
@@ -24,7 +24,6 @@ import java.net.URL;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
@@ -58,7 +57,7 @@ class JarFileArchive implements Archive {
 	private static final FileAttribute<?>[] FILE_PERMISSION_ATTRIBUTES = asFileAttributes(
 			PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE);
 
-	private static final Path TEMP = Paths.get(System.getProperty("java.io.tmpdir"));
+	private static final Path TEMP = Path.of(System.getProperty("java.io.tmpdir"));
 
 	private final File file;
 
@@ -133,7 +132,7 @@ class JarFileArchive implements Archive {
 
 	private Path createUnpackDirectory(Path parent) {
 		int attempts = 0;
-		String fileName = Paths.get(this.jarFile.getName()).getFileName().toString();
+		String fileName = Path.of(this.jarFile.getName()).getFileName().toString();
 		while (attempts++ < 100) {
 			Path unpackDirectory = parent.resolve(fileName + "-spring-boot-libs-" + UUID.randomUUID());
 			try {

--- a/test-support/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/classpath/resources/Resources.java
+++ b/test-support/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/classpath/resources/Resources.java
@@ -26,7 +26,6 @@ import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -83,11 +82,11 @@ class Resources {
 			for (URL source : sources) {
 				URI sourceUri = source.toURI();
 				try {
-					consumer.accept(Paths.get(sourceUri));
+					consumer.accept(Path.of(sourceUri));
 				}
 				catch (FileSystemNotFoundException ex) {
 					try (FileSystem fileSystem = FileSystems.newFileSystem(sourceUri, Collections.emptyMap())) {
-						consumer.accept(Paths.get(sourceUri));
+						consumer.accept(Path.of(sourceUri));
 					}
 				}
 			}


### PR DESCRIPTION
### Add `Java8toJava11` #48692

```
Changes have been made to build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/AbstractBootArchiveIntegrationTests.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to build-plugin/spring-boot-gradle-plugin/src/dockerTest/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageIntegrationTests.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/ClassPath.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ClassPathTests.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/CommandLineBuilderTests.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to build-plugin/spring-boot-maven-plugin/src/dockerTest/java/org/springframework/boot/maven/BuildImageTests.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to build-plugin/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/MavenBuild.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to build-plugin/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/MavenBuildExtension.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/ResolvedDockerHost.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/ssl/SslContextFactory.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/TarGzipBuildpack.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/DirectoryBuildpack.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildpackReference.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/socket/NamedPipeSocket.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/configuration/DockerConfigurationMetadataTests.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/configuration/ResolvedDockerHostTests.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ssl/PemFileWriter.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/LocalHttpClientTransportTests.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/FilePermissionsTests.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildpackCoordinatesTests.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildpackReferenceTests.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/TestTarGzip.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/DirectoryBuildpackTests.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to cli/spring-boot-cli/src/intTest/java/org/springframework/boot/cli/infrastructure/CommandLineInvoker.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to configuration-metadata/spring-boot-configuration-processor/build.gradle by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.javax.AddCommonAnnotationsDependencies
            org.openrewrite.java.dependencies.AddDependency: {groupId=jakarta.annotation, artifactId=jakarta.annotation-api, version=1.3.x, onlyIfUsing=javax.annotation..*, scope=provided, acceptTransitive=true}
Changes have been made to core/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigTreeConfigDataResource.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to core/spring-boot/src/main/java/org/springframework/boot/system/ApplicationTemp.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to core/spring-boot/src/main/java/org/springframework/boot/SpringApplicationAotProcessor.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/ValueObjectBinderTests.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to core/spring-boot-autoconfigure-processor/build.gradle by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.javax.AddCommonAnnotationsDependencies
            org.openrewrite.java.dependencies.AddDependency: {groupId=jakarta.annotation, artifactId=jakarta.annotation-api, version=1.3.x, onlyIfUsing=javax.annotation..*, scope=provided, acceptTransitive=true}
Changes have been made to core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/lifecycle/DockerComposeLifecycleManagerTests.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to core/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestAotProcessor.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to loader/spring-boot-jarmode-tools/src/main/java/org/springframework/boot/jarmode/tools/Context.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/launch/JarFileArchive.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Changes have been made to smoke-test/spring-boot-smoke-test-webservices/build.gradle by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.javax.AddJaxwsDependencies
            org.openrewrite.java.migrate.javax.AddJaxwsRuntime
                org.openrewrite.java.migrate.javax.AddJaxwsRuntime$AddJaxwsRuntimeGradle
Changes have been made to starter/spring-boot-starter-web-services/build.gradle by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.javax.AddJaxwsDependencies
            org.openrewrite.java.migrate.javax.AddJaxwsRuntime
                org.openrewrite.java.migrate.javax.AddJaxwsRuntime$AddJaxwsRuntimeGradle
Changes have been made to starter/spring-boot-starter-webservices/build.gradle by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.javax.AddJaxwsDependencies
            org.openrewrite.java.migrate.javax.AddJaxwsRuntime
                org.openrewrite.java.migrate.javax.AddJaxwsRuntime$AddJaxwsRuntimeGradle
Changes have been made to test-support/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/classpath/resources/Resources.java by:
    org.openrewrite.java.migrate.Java8toJava11
        org.openrewrite.java.migrate.nio.file.PathsGetToPathOf
            org.openrewrite.java.ChangeMethodTargetToStatic: {methodPattern=java.nio.file.Paths get(..), fullyQualifiedTargetTypeName=java.nio.file.Path}
            org.openrewrite.java.ChangeMethodName: {methodPattern=java.nio.file.Path get(..), newMethodName=of}
Please review and commit the results.
Estimate time saved: 3h 10m

BUILD SUCCESSFUL in 8m 35s
842 actionable tasks: 3 executed, 5 from cache, 834 up-to-date
➜  spring-boot git:(fix-EqualityRulesRecipes-pr) ✗
```

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
