### PR TITLE
Offer a capability to disable structured logging

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/ApplicationProperties.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/ApplicationProperties.java
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  * Spring application properties.
  *
  * @author Moritz Halbritter
+ * @author Vasily Pelikh
  */
 class ApplicationProperties {
 
@@ -105,9 +106,18 @@ class ApplicationProperties {
 		if (this.bannerMode != null) {
 			return this.bannerMode;
 		}
-		String applicationPropertyName = LoggingSystemProperty.CONSOLE_STRUCTURED_FORMAT.getApplicationPropertyName();
-		Assert.state(applicationPropertyName != null, "applicationPropertyName must not be null");
-		boolean structuredLoggingEnabled = environment.containsProperty(applicationPropertyName);
+
+		String disabledPropertyName = LoggingSystemProperty.STRUCTURED_LOGGING_DISABLED.getApplicationPropertyName();
+		Assert.state(disabledPropertyName != null, "disabledPropertyName must not be null");
+		boolean structuredLoggingDisabledProperty = environment.getProperty(disabledPropertyName, Boolean.class,
+				Boolean.FALSE);
+		if (structuredLoggingDisabledProperty) {
+			return Mode.CONSOLE;
+		}
+
+		String formatPropertyName = LoggingSystemProperty.CONSOLE_STRUCTURED_FORMAT.getApplicationPropertyName();
+		Assert.state(formatPropertyName != null, "formatPropertyName must not be null");
+		boolean structuredLoggingEnabled = environment.containsProperty(formatPropertyName);
 		return (structuredLoggingEnabled) ? Mode.OFF : Banner.Mode.CONSOLE;
 	}
 

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperties.java
@@ -135,6 +135,7 @@ public class LoggingSystemProperties {
 		setSystemProperty(LoggingSystemProperty.EXCEPTION_CONVERSION_WORD, resolver);
 		setSystemProperty(LoggingSystemProperty.CONSOLE_PATTERN, resolver);
 		setSystemProperty(LoggingSystemProperty.FILE_PATTERN, resolver);
+		setSystemProperty(LoggingSystemProperty.STRUCTURED_LOGGING_DISABLED, resolver, "false");
 		setSystemProperty(LoggingSystemProperty.CONSOLE_STRUCTURED_FORMAT, resolver);
 		setSystemProperty(LoggingSystemProperty.FILE_STRUCTURED_FORMAT, resolver);
 		setSystemProperty(LoggingSystemProperty.LEVEL_PATTERN, resolver);

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperty.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/LoggingSystemProperty.java
@@ -89,6 +89,12 @@ public enum LoggingSystemProperty {
 	FILE_PATTERN("FILE_LOG_PATTERN", "logging.pattern.file"),
 
 	/**
+	 * Logging system property for explicitly disabling structured logging.
+	 * @since 4.0.3
+	 */
+	STRUCTURED_LOGGING_DISABLED("STRUCTURED_LOGGING_DISABLED", "logging.structured.disable"),
+
+	/**
 	 * Logging system property for the console structured logging format.
 	 * @since 3.4.0
 	 */

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/DefaultLogbackConfiguration.java
@@ -54,6 +54,7 @@ import org.springframework.util.StringUtils;
  * @author Scott Frederick
  * @author Jonatan Ivanov
  * @author Moritz Halbritter
+ * @author Vasily Pelikh
  */
 class DefaultLogbackConfiguration {
 
@@ -115,6 +116,7 @@ class DefaultLogbackConfiguration {
 		putProperty(config, "FILE_LOG_CHARSET", "${FILE_LOG_CHARSET:-" + DEFAULT_CHARSET + "}");
 		putProperty(config, "FILE_LOG_THRESHOLD", "${FILE_LOG_THRESHOLD:-TRACE}");
 		putProperty(config, "FILE_LOG_STRUCTURED_FORMAT", "${FILE_LOG_STRUCTURED_FORMAT:-}");
+		putProperty(config, "STRUCTURED_LOGGING_DISABLED", "${STRUCTURED_LOGGING_DISABLED:-false}");
 		config.logger("org.apache.catalina.startup.DigesterFactory", Level.ERROR);
 		config.logger("org.apache.catalina.util.LifecycleBase", Level.ERROR);
 		config.logger("org.apache.coyote.http11.Http11NioProtocol", Level.WARN);
@@ -170,11 +172,14 @@ class DefaultLogbackConfiguration {
 
 	private Encoder<ILoggingEvent> createEncoder(LogbackConfigurator config, String type) {
 		Charset charset = resolveCharset(config, "${" + type + "_LOG_CHARSET}");
-		String structuredLogFormat = resolve(config, "${" + type + "_LOG_STRUCTURED_FORMAT}");
-		if (StringUtils.hasLength(structuredLogFormat)) {
-			StructuredLogEncoder encoder = createStructuredLogEncoder(structuredLogFormat);
-			encoder.setCharset(charset);
-			return encoder;
+		boolean structuredLogDisabled = resolveBoolean(config, "${STRUCTURED_LOGGING_DISABLED}");
+		if (!structuredLogDisabled) {
+			String structuredLogFormat = resolve(config, "${" + type + "_LOG_STRUCTURED_FORMAT}");
+			if (StringUtils.hasLength(structuredLogFormat)) {
+				StructuredLogEncoder encoder = createStructuredLogEncoder(structuredLogFormat);
+				encoder.setCharset(charset);
+				return encoder;
+			}
 		}
 		PatternLayoutEncoder encoder = new PatternLayoutEncoder();
 		encoder.setCharset(charset);

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/StructuredLogEncoder.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/StructuredLogEncoder.java
@@ -59,6 +59,10 @@ public class StructuredLogEncoder extends EncoderBase<ILoggingEvent> {
 		this.format = format;
 	}
 
+	public @Nullable Charset getCharset() {
+		return this.charset;
+	}
+
 	public void setCharset(@Nullable Charset charset) {
 		this.charset = charset;
 	}

--- a/core/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -235,6 +235,12 @@
       "defaultValue": true
     },
     {
+      "name": "logging.structured.disable",
+      "type": "java.lang.Boolean",
+      "description": "Whether to explicitly disable structured logging.",
+      "defaultValue": false
+    },
+    {
       "name": "logging.structured.ecs.service.environment",
       "type": "java.lang.String",
       "description": "Structured ECS service environment."

--- a/core/spring-boot/src/main/resources/org/springframework/boot/logging/log4j2/log4j2-file.xml
+++ b/core/spring-boot/src/main/resources/org/springframework/boot/logging/log4j2/log4j2-file.xml
@@ -6,10 +6,15 @@
 		<Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ss.SSSXXX</Property>
 		<Property name="CONSOLE_LOG_PATTERN">%clr{%d{${sys:LOG_DATEFORMAT_PATTERN}}}{faint} %clr{${sys:LOG_LEVEL_PATTERN}} %clr{%pid}{magenta} %clr{--- %esb{${sys:APPLICATION_NAME:-}}%esb{${sys:APPLICATION_GROUP:-}}[%15.15t] ${sys:LOG_CORRELATION_PATTERN:-}}{faint}%clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
 		<Property name="FILE_LOG_PATTERN">%d{${sys:LOG_DATEFORMAT_PATTERN}} ${sys:LOG_LEVEL_PATTERN} %pid --- %esb{${sys:APPLICATION_NAME:-}}%esb{${sys:APPLICATION_GROUP:-}}[%t] ${sys:LOG_CORRELATION_PATTERN:-}%-40.40c{1.} : %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
+		<Property name="CONSOLE_LOG_CHARSET">UTF-8</Property>
+		<Property name="FILE_LOG_CHARSET">UTF-8</Property>
 	</Properties>
 	<Appenders>
 		<Console name="Console" target="SYSTEM_OUT" follow="true">
 			<Select>
+				<SystemPropertyArbiter propertyName="STRUCTURED_LOGGING_DISABLED" propertyValue="true">
+					<PatternLayout pattern="${sys:CONSOLE_LOG_PATTERN}" charset="${sys:CONSOLE_LOG_CHARSET}"/>
+				</SystemPropertyArbiter>
 				<SystemPropertyArbiter propertyName="CONSOLE_LOG_STRUCTURED_FORMAT">
 					<StructuredLogLayout format="${sys:CONSOLE_LOG_STRUCTURED_FORMAT}" charset="${sys:CONSOLE_LOG_CHARSET}"/>
 				</SystemPropertyArbiter>
@@ -23,6 +28,9 @@
 		</Console>
 		<RollingFile name="File" fileName="${sys:LOG_FILE}" filePattern="${sys:LOG_PATH}/$${date:yyyy-MM}/app-%d{yyyy-MM-dd-HH}-%i.log.gz">
 			<Select>
+				<SystemPropertyArbiter propertyName="STRUCTURED_LOGGING_DISABLED" propertyValue="true">
+					<PatternLayout pattern="${sys:FILE_LOG_PATTERN}" charset="${sys:FILE_LOG_CHARSET}"/>
+				</SystemPropertyArbiter>
 				<SystemPropertyArbiter propertyName="FILE_LOG_STRUCTURED_FORMAT">
 					<StructuredLogLayout format="${sys:FILE_LOG_STRUCTURED_FORMAT}" charset="${sys:FILE_LOG_CHARSET}"/>
 				</SystemPropertyArbiter>

--- a/core/spring-boot/src/main/resources/org/springframework/boot/logging/log4j2/log4j2.xml
+++ b/core/spring-boot/src/main/resources/org/springframework/boot/logging/log4j2/log4j2.xml
@@ -5,10 +5,14 @@
 		<Property name="LOG_LEVEL_PATTERN">%5p</Property>
 		<Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd'T'HH:mm:ss.SSSXXX</Property>
 		<Property name="CONSOLE_LOG_PATTERN">%clr{%d{${sys:LOG_DATEFORMAT_PATTERN}}}{faint} %clr{${sys:LOG_LEVEL_PATTERN}} %clr{%pid}{magenta} %clr{--- %esb{${sys:APPLICATION_NAME:-}}%esb{${sys:APPLICATION_GROUP:-}}[%15.15t] ${sys:LOG_CORRELATION_PATTERN:-}}{faint}%clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
+		<Property name="CONSOLE_LOG_CHARSET">UTF-8</Property>
 	</Properties>
 	<Appenders>
 		<Console name="Console" target="SYSTEM_OUT" follow="true">
 			<Select>
+				<SystemPropertyArbiter propertyName="STRUCTURED_LOGGING_DISABLED" propertyValue="true">
+					<PatternLayout pattern="${sys:CONSOLE_LOG_PATTERN}" charset="${sys:CONSOLE_LOG_CHARSET}"/>
+				</SystemPropertyArbiter>
 				<SystemPropertyArbiter propertyName="CONSOLE_LOG_STRUCTURED_FORMAT">
 					<StructuredLogLayout format="${sys:CONSOLE_LOG_STRUCTURED_FORMAT}" charset="${sys:CONSOLE_LOG_CHARSET}"/>
 				</SystemPropertyArbiter>

--- a/core/spring-boot/src/test/java/org/springframework/boot/ApplicationPropertiesTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/ApplicationPropertiesTests.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link ApplicationProperties}.
  *
  * @author Moritz Halbritter
+ * @author Vasily Pelikh
  */
 class ApplicationPropertiesTests {
 
@@ -40,11 +41,19 @@ class ApplicationPropertiesTests {
 	}
 
 	@Test
-	void bannerModeShouldBeOffIfStructuredLoggingIsEnabled() {
+	void bannerModeShouldBeOffIfStructuredLoggingConsoleFormatIsSet() {
 		ApplicationProperties properties = new ApplicationProperties();
 		MockEnvironment environment = new MockEnvironment();
 		environment.setProperty("logging.structured.format.console", "ecs");
 		assertThat(properties.getBannerMode(environment)).isEqualTo(Mode.OFF);
+	}
+
+	@Test
+	void bannerModeShouldBeConsoleIfStructuredLoggingIsDisabled() {
+		ApplicationProperties properties = new ApplicationProperties();
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("logging.structured.disable", "true");
+		assertThat(properties.getBannerMode(environment)).isEqualTo(Mode.CONSOLE);
 	}
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/LoggingSystemPropertiesTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/LoggingSystemPropertiesTests.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.spy;
  * @author Eddú Meléndez
  * @author Jonatan Ivanov
  * @author Moritz Halbritter
+ * @author Vasily Pelikh
  */
 class LoggingSystemPropertiesTests {
 
@@ -214,6 +215,22 @@ class LoggingSystemPropertiesTests {
 		new LoggingSystemProperties(new MockEnvironment().withProperty("logging.threshold.file", "false")).apply(null);
 		assertThat(System.getProperty(LoggingSystemProperty.FILE_THRESHOLD.getEnvironmentVariableName()))
 			.isEqualTo("OFF");
+	}
+
+	@Test
+	void shouldSupportEnabledStructuredLogging() {
+		new LoggingSystemProperties(new MockEnvironment().withProperty("logging.structured.disable", "true"))
+			.apply(null);
+		assertThat(System.getProperty(LoggingSystemProperty.STRUCTURED_LOGGING_DISABLED.getEnvironmentVariableName()))
+			.isEqualTo("true");
+	}
+
+	@Test
+	void shouldSupportDisabledStructuredLogging() {
+		new LoggingSystemProperties(new MockEnvironment().withProperty("logging.structured.disable", "false"))
+			.apply(null);
+		assertThat(System.getProperty(LoggingSystemProperty.STRUCTURED_LOGGING_DISABLED.getEnvironmentVariableName()))
+			.isEqualTo("false");
 	}
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/DefaultLogbackConfigurationTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/DefaultLogbackConfigurationTests.java
@@ -18,11 +18,24 @@ package org.springframework.boot.logging.logback;
 
 import java.io.Console;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
 import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.ConsoleAppender;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.logging.LoggingSystemProperty;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.util.StreamUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,12 +47,26 @@ import static org.mockito.Mockito.spy;
  * Tests for {@link DefaultLogbackConfiguration}
  *
  * @author Phillip Webb
+ * @author Vasily Pelikh
  */
 class DefaultLogbackConfigurationTests {
 
-	private final LoggerContext loggerContext = new LoggerContext();
+	private LoggerContext loggerContext;
 
-	private final LogbackConfigurator logbackConfigurator = new LogbackConfigurator(this.loggerContext);
+	private LogbackConfigurator logbackConfigurator;
+
+	@BeforeEach
+	void setup() {
+		MockEnvironment environment = new MockEnvironment();
+		this.loggerContext = new LoggerContext();
+		this.loggerContext.putObject(Environment.class.getName(), environment);
+		this.logbackConfigurator = new LogbackConfigurator(this.loggerContext);
+	}
+
+	@AfterEach
+	void cleanup() {
+		this.loggerContext.removeObject(Environment.class.getName());
+	}
 
 	@Test
 	void defaultLogbackXmlContainsConsoleLogPattern() throws Exception {
@@ -93,6 +120,91 @@ class DefaultLogbackConfigurationTests {
 		assertThat(this.loggerContext.getProperty("FILE_LOG_CHARSET")).isEqualTo(StandardCharsets.UTF_8.name());
 	}
 
+	@Test
+	void whenStructuredLogIsDisabledThenConsoleUsesDefault() {
+		Map<String, String> properties = Map
+			.of(LoggingSystemProperty.STRUCTURED_LOGGING_DISABLED.getEnvironmentVariableName(), "true");
+		withSystemProperties(properties, () -> {
+			new DefaultLogbackConfiguration(null).apply(this.logbackConfigurator);
+			assertThat(consoleAppender()).asInstanceOf(InstanceOfAssertFactories.type(ConsoleAppender.class))
+				.extracting(ConsoleAppender<ILoggingEvent>::getEncoder)
+				.isInstanceOf(PatternLayoutEncoder.class);
+		});
+	}
+
+	@Test
+	void whenStructuredLogIsEnabledAndFormatIsNotSetThenConsoleUsesDefault() {
+		Map<String, String> properties = Map
+			.of(LoggingSystemProperty.STRUCTURED_LOGGING_DISABLED.getEnvironmentVariableName(), "false");
+		withSystemProperties(properties, () -> {
+			new DefaultLogbackConfiguration(null).apply(this.logbackConfigurator);
+			assertThat(consoleAppender()).asInstanceOf(InstanceOfAssertFactories.type(ConsoleAppender.class))
+				.extracting(ConsoleAppender<ILoggingEvent>::getEncoder)
+				.isInstanceOf(PatternLayoutEncoder.class);
+		});
+	}
+
+	@Test
+	void whenStructuredLogIsEnabledAndFormatIsEmptyThenConsoleUsesDefault() {
+		Map<String, String> properties = Map.of(
+				LoggingSystemProperty.STRUCTURED_LOGGING_DISABLED.getEnvironmentVariableName(), "false",
+				LoggingSystemProperty.CONSOLE_STRUCTURED_FORMAT.getEnvironmentVariableName(), "");
+		withSystemProperties(properties, () -> {
+			new DefaultLogbackConfiguration(null).apply(this.logbackConfigurator);
+			assertThat(consoleAppender()).asInstanceOf(InstanceOfAssertFactories.type(ConsoleAppender.class))
+				.extracting(ConsoleAppender<ILoggingEvent>::getEncoder)
+				.isInstanceOf(PatternLayoutEncoder.class);
+		});
+	}
+
+	@Test
+	void whenStructuredLogIsEnabledThenConsoleUsesIt() {
+		Map<String, String> properties = Map.of(
+				LoggingSystemProperty.STRUCTURED_LOGGING_DISABLED.getEnvironmentVariableName(), "false",
+				LoggingSystemProperty.CONSOLE_STRUCTURED_FORMAT.getEnvironmentVariableName(), "ecs");
+		withSystemProperties(properties, () -> {
+			new DefaultLogbackConfiguration(null).apply(this.logbackConfigurator);
+			assertThat(consoleAppender()).asInstanceOf(InstanceOfAssertFactories.type(ConsoleAppender.class))
+				.extracting(ConsoleAppender<ILoggingEvent>::getEncoder)
+				.isInstanceOf(StructuredLogEncoder.class);
+		});
+	}
+
+	@Test
+	void whenStructuredLogIsEnabledAndCharsetIsSetThenConsoleUsesIt() {
+		Map<String, String> properties = Map.of(
+				LoggingSystemProperty.STRUCTURED_LOGGING_DISABLED.getEnvironmentVariableName(), "false",
+				LoggingSystemProperty.CONSOLE_STRUCTURED_FORMAT.getEnvironmentVariableName(), "ecs",
+				LoggingSystemProperty.CONSOLE_CHARSET.getEnvironmentVariableName(), "ISO_8859_1");
+		withSystemProperties(properties, () -> {
+			new DefaultLogbackConfiguration(null).apply(this.logbackConfigurator);
+			assertThat(consoleAppender()).asInstanceOf(InstanceOfAssertFactories.type(ConsoleAppender.class))
+				.extracting(ConsoleAppender<ILoggingEvent>::getEncoder)
+				.asInstanceOf(InstanceOfAssertFactories.type(StructuredLogEncoder.class))
+				.extracting(StructuredLogEncoder::getCharset, InstanceOfAssertFactories.type(Charset.class))
+				.isEqualTo(StandardCharsets.ISO_8859_1);
+		});
+	}
+
+	@Test
+	void whenStructuredLogIsEnabledAndCharsetIsNotSetThenConsoleUsesStructuredLoggingWithDefaultCharset() {
+		Map<String, String> properties = Map.of(
+				LoggingSystemProperty.STRUCTURED_LOGGING_DISABLED.getEnvironmentVariableName(), "false",
+				LoggingSystemProperty.CONSOLE_STRUCTURED_FORMAT.getEnvironmentVariableName(), "ecs");
+		withSystemProperties(properties, () -> {
+			new DefaultLogbackConfiguration(null).apply(this.logbackConfigurator);
+			assertThat(consoleAppender()).asInstanceOf(InstanceOfAssertFactories.type(ConsoleAppender.class))
+				.extracting(ConsoleAppender<ILoggingEvent>::getEncoder)
+				.asInstanceOf(InstanceOfAssertFactories.type(StructuredLogEncoder.class))
+				.extracting(StructuredLogEncoder::getCharset, InstanceOfAssertFactories.type(Charset.class))
+				.isEqualTo(StandardCharsets.UTF_8);
+		});
+	}
+
+	private Appender<ILoggingEvent> consoleAppender() {
+		return this.loggerContext.getLogger("ROOT").getAppender("CONSOLE");
+	}
+
 	private void assertThatDefaultXmlContains(String name, String value) throws Exception {
 		String expected = "<property name=\"%s\" value=\"%s\"/>".formatted(name, value);
 		assertThat(defaultXmlContent()).contains(expected);
@@ -117,6 +229,31 @@ class DefaultLogbackConfigurationTests {
 			}
 		}
 
+	}
+
+	private static void withSystemProperties(Map<String, String> properties, Runnable action) {
+		Map<String, String> previousMap = new HashMap<>(properties.size());
+		properties.forEach((name, newValue) -> {
+			String previousValue = System.getProperty(name);
+			previousMap.put(name, previousValue);
+
+			System.setProperty(name, newValue);
+		});
+
+		try {
+			action.run();
+		}
+		finally {
+			properties.forEach((name, newValue) -> {
+				String previousValue = previousMap.get(name);
+				if (previousValue != null) {
+					System.setProperty(name, previousValue);
+				}
+				else {
+					System.clearProperty(name);
+				}
+			});
+		}
 	}
 
 }

--- a/core/spring-boot/src/test/resources/log4j2-test.xml
+++ b/core/spring-boot/src/test/resources/log4j2-test.xml
@@ -3,10 +3,18 @@
 	<Properties>
 		<Property name="LOG_EXCEPTION_CONVERSION_WORD">%xwEx</Property>
 		<Property name="LOG_LEVEL_PATTERN">%5p</Property>
+		<Property name="CONSOLE_LOG_CHARSET">UTF-8</Property>
 	</Properties>
 	<Appenders>
 		<Console name="STDOUT" target="SYSTEM_OUT" follow="true">
-			<PatternLayout pattern="%clr{%d{yyyy-MM-dd HH:mm:ss.SSS}}{faint} %clr{${LOG_LEVEL_PATTERN}} %clr{${sys:PID}}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}"/>
+			<Select>
+				<SystemPropertyArbiter propertyName="STRUCTURED_LOGGING_ENABLED" propertyValue="true">
+					<StructuredLogLayout format="${sys:CONSOLE_LOG_STRUCTURED_FORMAT}" charset="${sys:CONSOLE_LOG_CHARSET}"/>
+				</SystemPropertyArbiter>
+				<DefaultArbiter>
+					<PatternLayout pattern="%clr{%d{yyyy-MM-dd HH:mm:ss.SSS}}{faint} %clr{${LOG_LEVEL_PATTERN}} %clr{${sys:PID}}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}"/>
+				</DefaultArbiter>
+			</Select>
 		</Console>
 	</Appenders>
 	<Loggers>

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/logging.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/logging.adoc
@@ -373,6 +373,10 @@ The properties that are transferred are described in the following table:
 | `LOG_LEVEL_PATTERN`
 | The format to use when rendering the log level (default `%5p`).
 
+| configprop:logging.structured.disable[]
+| `STRUCTURED_LOGGING_DISABLED`
+| If structured logging should be explicitly disabled (default `false`).
+
 | configprop:logging.structured.format.console[]
 | `CONSOLE_LOG_STRUCTURED_FORMAT`
 | The structured logging format to use for console logging.
@@ -451,6 +455,9 @@ Spring Boot supports structured logging and has support for the following JSON f
 * xref:#features.logging.structured.logstash[Logstash]
 
 To enable structured logging, set the property configprop:logging.structured.format.console[] (for console output) or configprop:logging.structured.format.file[] (for file output) to the id of the format you want to use.
+
+When testing, you most likely want to see the logs in a usual human-readable format.
+In order to explicitly disable structured logging, you can set the configprop:logging.structured.disable[] property to `true`.
 
 If you are using xref:#features.logging.custom-log-configuration[Custom Log Configuration], update your configuration to respect `CONSOLE_LOG_STRUCTURED_FORMAT` and `FILE_LOG_STRUCTURED_FORMAT` system properties.
 Take `CONSOLE_LOG_STRUCTURED_FORMAT` for example:

--- a/smoke-test/spring-boot-smoke-test-structured-logging-log4j2/src/main/resources/application.properties
+++ b/smoke-test/spring-boot-smoke-test-structured-logging-log4j2/src/main/resources/application.properties
@@ -3,5 +3,9 @@ logging.structured.format.console=ecs
 spring.config.activate.on-profile=custom
 logging.structured.format.console=smoketest.structuredlogging.log4j2.CustomStructuredLogFormatter
 #---
+spring.config.activate.on-profile=structured-disabled
+logging.structured.disable=true
+logging.structured.format.console=smoketest.structuredlogging.log4j2.CustomStructuredLogFormatter
+#---
 spring.config.activate.on-profile=on-error
 logging.structured.json.customizer=smoketest.structuredlogging.log4j2.DuplicateJsonMembersCustomizer

--- a/smoke-test/spring-boot-smoke-test-structured-logging-log4j2/src/test/java/smoketest/structuredlogging/log4j2/SampleLog4j2StructuredLoggingApplicationTests.java
+++ b/smoke-test/spring-boot-smoke-test-structured-logging-log4j2/src/test/java/smoketest/structuredlogging/log4j2/SampleLog4j2StructuredLoggingApplicationTests.java
@@ -63,6 +63,14 @@ class SampleLog4j2StructuredLoggingApplicationTests {
 	}
 
 	@Test
+	void structuredDisabled(CapturedOutput output) {
+		SampleLog4j2StructuredLoggingApplication.main(new String[] { "--spring.profiles.active=structured-disabled" });
+		assertThat(output).contains(" :: Spring Boot :: ");
+		assertThat(output).doesNotContain("epoch=")
+			.doesNotContain("msg=\"Starting SampleLog4j2StructuredLoggingApplication");
+	}
+
+	@Test
 	void shouldCaptureCustomizerError(CapturedOutput output) {
 		SampleLog4j2StructuredLoggingApplication.main(new String[] { "--spring.profiles.active=on-error" });
 		assertThat(output).contains("The name 'test' has already been written");

--- a/smoke-test/spring-boot-smoke-test-structured-logging/src/main/resources/application.properties
+++ b/smoke-test/spring-boot-smoke-test-structured-logging/src/main/resources/application.properties
@@ -8,6 +8,10 @@ logging.structured.json.customizer=smoketest.structuredlogging.SampleJsonMembers
 spring.config.activate.on-profile=custom
 logging.structured.format.console=smoketest.structuredlogging.CustomStructuredLogFormatter
 #---
+spring.config.activate.on-profile=structured-disabled
+logging.structured.disable=true
+logging.structured.format.console=smoketest.structuredlogging.CustomStructuredLogFormatter
+#---
 spring.config.activate.on-profile=on-error
 logging.structured.json.customizer=smoketest.structuredlogging.DuplicateJsonMembersCustomizer
 #---

--- a/smoke-test/spring-boot-smoke-test-structured-logging/src/test/java/smoketest/structuredlogging/SampleStructuredLoggingApplicationTests.java
+++ b/smoke-test/spring-boot-smoke-test-structured-logging/src/test/java/smoketest/structuredlogging/SampleStructuredLoggingApplicationTests.java
@@ -67,6 +67,13 @@ class SampleStructuredLoggingApplicationTests {
 	}
 
 	@Test
+	void structuredDisabled(CapturedOutput output) {
+		SampleStructuredLoggingApplication.main(new String[] { "--spring.profiles.active=structured-disabled" });
+		assertThat(output).contains(" :: Spring Boot :: ");
+		assertThat(output).doesNotContain("epoch=").doesNotContain("msg=\"Starting SampleStructuredLoggingApplication");
+	}
+
+	@Test
 	void shouldCaptureCustomizerError(CapturedOutput output) {
 		SampleStructuredLoggingApplication.main(new String[] { "--spring.profiles.active=on-error" });
 		assertThat(output).contains("The name 'test' has already been written");


### PR DESCRIPTION
Add `logging.structured.disable` property to explicitly disable structured logging.

Closes GH-45407