### PR TITLE
Correct docs to use new location for error handling configuration properties

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/web/servlet.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/web/servlet.adoc
@@ -342,7 +342,7 @@ By default, Spring Boot provides an `/error` mapping that handles all errors in 
 For machine clients, it produces a JSON response with details of the error, the HTTP status, and the exception message.
 For browser clients, there is a "`whitelabel`" error view that renders the same data in HTML format (to customize it, add a javadoc:org.springframework.web.servlet.View[] that resolves to `error`).
 
-There are a number of `server.error` properties that can be set if you want to customize the default error handling behavior.
+There are a number of `spring.web.error` properties that can be set if you want to customize the default error handling behavior.
 See the xref:appendix:application-properties/index.adoc#appendix.application-properties.server[Server Properties] section of the Appendix.
 
 To replace the default behavior completely, you can implement javadoc:org.springframework.boot.webmvc.error.ErrorController[] and register a bean definition of that type or add a bean of type javadoc:org.springframework.boot.webmvc.error.ErrorAttributes[] to use the existing mechanism but replace the contents.


### PR DESCRIPTION
server.error -> **spring.web**.error

#48201 moved server.error properties to spring.web.error
