### PR TITLE
Support configuring bootBuildImage's environment through the command line

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/dockerTest/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageIntegrationTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/dockerTest/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageIntegrationTests.java
@@ -470,6 +470,20 @@ class BootBuildImageIntegrationTests {
 	}
 
 	@TestTemplate
+	void buildsImageWithMultipleCommandLineEnvironments() throws IOException {
+		writeMainClass();
+		writeLongNameResource();
+		BuildResult result = this.gradleBuild.build("bootBuildImage", "--environment", "BP_LIVE_RELOAD_ENABLED=true",
+				"--environment", "MY_CUSTOM_VAR=hello_world");
+		BuildTask task = result.task(":bootBuildImage");
+		assertThat(task).isNotNull();
+		assertThat(task.getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+		assertThat(result.getOutput()).contains("BP_LIVE_RELOAD_ENABLED=true");
+		assertThat(result.getOutput()).contains("MY_CUSTOM_VAR=hello_world");
+		removeImages(this.gradleBuild.getProjectDir().getName());
+	}
+
+	@TestTemplate
 	@EnabledOnOs(value = { OS.LINUX, OS.MAC }, architectures = "amd64",
 			disabledReason = "The expected failure condition will not fail on ARM architectures")
 	void failsWhenBuildingOnLinuxAmdWithImagePlatformLinuxArm() throws IOException {

--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImage.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImage.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.RegularFileProperty;
@@ -30,6 +31,7 @@ import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
@@ -159,6 +161,20 @@ public abstract class BootBuildImage extends DefaultTask {
 	 */
 	@Input
 	public abstract MapProperty<String, String> getEnvironment();
+
+	/**
+	 * Returns environment variables contributed from the command line. Each entry must be
+	 * in the form NAME=VALUE.
+	 * @return the environment variables from the command line
+	 */
+	@Internal
+	public abstract ListProperty<String> getEnvironmentFromCommandLine();
+
+	@Option(option = "environment",
+			description = "Environment variable to set for the build (NAME=VALUE). Can be specified multiple times.")
+	public void environment(List<String> environment) {
+		getEnvironmentFromCommandLine().addAll(environment);
+	}
 
 	/**
 	 * Returns whether caches should be cleaned before packaging.
@@ -413,8 +429,8 @@ public abstract class BootBuildImage extends DefaultTask {
 	}
 
 	private BuildRequest customizeEnvironment(BuildRequest request) {
-		Map<String, String> environment = getEnvironment().getOrNull();
-		if (!CollectionUtils.isEmpty(environment)) {
+		Map<String, String> environment = getEffectiveEnvironment();
+		if (!environment.isEmpty()) {
 			request = request.withEnv(environment);
 		}
 		return request;
@@ -500,6 +516,33 @@ public abstract class BootBuildImage extends DefaultTask {
 			}
 		}
 		return request;
+	}
+
+	private Map<String, String> getEffectiveEnvironment() {
+		Map<String, String> environment = new java.util.LinkedHashMap<>();
+		Map<String, String> configured = getEnvironment().getOrNull();
+		if (!CollectionUtils.isEmpty(configured)) {
+			environment.putAll(configured);
+		}
+		List<String> fromCli = getEnvironmentFromCommandLine().getOrNull();
+		if (!CollectionUtils.isEmpty(fromCli)) {
+			for (String entry : fromCli) {
+				Map.Entry<String, String> parsed = parseEnvironmentEntry(entry);
+				environment.put(parsed.getKey(), parsed.getValue());
+			}
+		}
+		return environment;
+	}
+
+	private Map.Entry<String, String> parseEnvironmentEntry(String entry) {
+		int index = entry.indexOf('=');
+		if (index <= 0) {
+			throw new GradleException(
+					"Invalid value for option '--environment'. Expected 'NAME=VALUE' but got '" + entry + "'.");
+		}
+		String name = entry.substring(0, index);
+		String value = entry.substring(index + 1);
+		return Map.entry(name, value);
 	}
 
 }


### PR DESCRIPTION
This PR is intentionally opened as a draft to gather feedback on the overall approach.

## Related Issue

Closes #45306

## Goal

Add support for passing Buildpacks environment variables to the bootBuildImage task via CLI options.

This is particularly useful for CI pipelines and automated local workflows (e.g., Kubernetes, Skaffold, or Tilt), where modifying build.gradle or pom.xml to set dynamic values is often undesirable.

## Background

In BootBuildImage, the environment configuration is currently defined as a MapProperty<String, String>:

```java
@Input
public abstract MapProperty<String, String> getEnvironment();
```

However, Gradle’s "Option" annotation does not support Map types, making it impossible to directly expose this property as a CLI option.

As discussed in #45306, this PR explores an alternative approach where CLI-provided values are collected separately as a list and then mapped into the existing environment property.

## Approach

1. Introduce a CLI-only input:
Use an "Internal" ListProperty<String> to capture the raw options provided by the user.

2. Validation & Parsing:
The input strings are parsed into key-value pairs at execution time.

 - Strictly enforces the KEY=VALUE format.

 - If the format is invalid (e.g., missing the = separator), the task fails immediately with a GradleException to provide clear feedback to the user.

 - Example error: "Invalid value for option '--environment'. Expected 'NAME=VALUE' but got '...'."

3. Merge:
The parsed values are merged into the existing environment (MapProperty), allowing CLI options to complement or override build script configurations.

### CLI Usage
```bash
./gradlew bootBuildImage \
  --environment BP_LIVE_RELOAD_ENABLED=true \
  --environment BPL_JAVA_NMT_ENABLED=false
```
- The --environment option is repeatable
- Each entry must be provided in KEY=VALUE format