### PR TITLE
Document Cloud Foundry support dependency requirement

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/cloud-foundry.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/cloud-foundry.adoc
@@ -4,6 +4,8 @@
 Spring Boot's actuator module includes additional support that is activated when you deploy to a compatible Cloud Foundry instance.
 The `/cloudfoundryapplication` path provides an alternative secured route to all javadoc:org.springframework.boot.actuate.endpoint.annotation.Endpoint[format=annotation] beans.
 
+To enable this support, add the `spring-boot-starter-cloudfoundry` starter or the `spring-boot-cloudfoundry` module to your application.
+
 The extended support lets Cloud Foundry management UIs (such as the web application that you can use to view deployed applications) be augmented with Spring Boot actuator information.
 For example, an application status page can include full health information instead of the typical "`running`" or "`stopped`" status.
 


### PR DESCRIPTION
Issue link:
- https://github.com/spring-projects/spring-boot/issues/48675

Summary:
- Mention required Cloud Foundry starter/module on the Cloud Foundry Support page.

Motivation:
- Clarify the dependency needed to activate Cloud Foundry actuator support.

Validation:
- `JAVA_HOME=$(scoop prefix temurin22-jdk) .\\gradlew :documentation:spring-boot-docs:build --no-daemon` (fails: NullAway error at `core/spring-boot-autoconfigure/.../OnBeanCondition.java:578` and javadoc `--no-fonts` invalid)
