### PR TITLE
Fix links matcher for root base path

### DIFF
--- a/module/spring-boot-security/src/main/java/org/springframework/boot/security/autoconfigure/actuate/web/reactive/EndpointRequest.java
+++ b/module/spring-boot-security/src/main/java/org/springframework/boot/security/autoconfigure/actuate/web/reactive/EndpointRequest.java
@@ -334,7 +334,7 @@ public final class EndpointRequest {
 			streamPaths(this.includes, endpoints).forEach(paths::add);
 			streamPaths(this.excludes, endpoints).forEach(paths::remove);
 			List<ServerWebExchangeMatcher> delegateMatchers = getDelegateMatchers(paths, this.httpMethod);
-			if (this.includeLinks && StringUtils.hasText(endpoints.getBasePath())) {
+			if (this.includeLinks) {
 				delegateMatchers.add(new LinksServerWebExchangeMatcher());
 			}
 			if (delegateMatchers.isEmpty()) {
@@ -370,12 +370,13 @@ public final class EndpointRequest {
 
 		@Override
 		protected ServerWebExchangeMatcher createDelegate(WebEndpointProperties properties) {
-			if (StringUtils.hasText(properties.getBasePath())) {
-				return new OrServerWebExchangeMatcher(
-						new PathPatternParserServerWebExchangeMatcher(properties.getBasePath()),
-						new PathPatternParserServerWebExchangeMatcher(properties.getBasePath() + "/"));
+			String basePath = properties.getBasePath();
+			String linksBasePath = (StringUtils.hasText(basePath)) ? basePath : "/";
+			if ("/".equals(linksBasePath)) {
+				return new PathPatternParserServerWebExchangeMatcher(linksBasePath);
 			}
-			return EMPTY_MATCHER;
+			return new OrServerWebExchangeMatcher(new PathPatternParserServerWebExchangeMatcher(linksBasePath),
+					new PathPatternParserServerWebExchangeMatcher(linksBasePath + "/"));
 		}
 
 		@Override

--- a/module/spring-boot-security/src/main/java/org/springframework/boot/security/autoconfigure/actuate/web/servlet/EndpointRequest.java
+++ b/module/spring-boot-security/src/main/java/org/springframework/boot/security/autoconfigure/actuate/web/servlet/EndpointRequest.java
@@ -226,8 +226,11 @@ public final class EndpointRequest {
 		protected List<RequestMatcher> getLinksMatchers(RequestMatcherFactory requestMatcherFactory,
 				RequestMatcherProvider matcherProvider, String basePath) {
 			List<RequestMatcher> linksMatchers = new ArrayList<>();
-			linksMatchers.add(requestMatcherFactory.antPath(matcherProvider, null, basePath));
-			linksMatchers.add(requestMatcherFactory.antPath(matcherProvider, null, basePath, "/"));
+			String linksBasePath = (StringUtils.hasText(basePath)) ? basePath : "/";
+			linksMatchers.add(requestMatcherFactory.antPath(matcherProvider, null, linksBasePath));
+			if (!"/".equals(linksBasePath)) {
+				linksMatchers.add(requestMatcherFactory.antPath(matcherProvider, null, linksBasePath, "/"));
+			}
 			return linksMatchers;
 		}
 
@@ -341,7 +344,7 @@ public final class EndpointRequest {
 			List<RequestMatcher> delegateMatchers = getDelegateMatchers(requestMatcherFactory, matcherProvider, paths,
 					this.httpMethod);
 			String basePath = endpoints.getBasePath();
-			if (this.includeLinks && StringUtils.hasText(basePath)) {
+			if (this.includeLinks) {
 				delegateMatchers.addAll(getLinksMatchers(requestMatcherFactory, matcherProvider, basePath));
 			}
 			if (delegateMatchers.isEmpty()) {
@@ -376,11 +379,8 @@ public final class EndpointRequest {
 				RequestMatcherFactory requestMatcherFactory) {
 			WebEndpointProperties properties = context.getBean(WebEndpointProperties.class);
 			String basePath = properties.getBasePath();
-			if (StringUtils.hasText(basePath)) {
-				return new OrRequestMatcher(
-						getLinksMatchers(requestMatcherFactory, getRequestMatcherProvider(context), basePath));
-			}
-			return EMPTY_MATCHER;
+			RequestMatcherProvider matcherProvider = getRequestMatcherProvider(context);
+			return new OrRequestMatcher(getLinksMatchers(requestMatcherFactory, matcherProvider, basePath));
 		}
 
 		@Override

--- a/module/spring-boot-security/src/test/java/org/springframework/boot/security/autoconfigure/actuate/web/reactive/EndpointRequestTests.java
+++ b/module/spring-boot-security/src/test/java/org/springframework/boot/security/autoconfigure/actuate/web/reactive/EndpointRequestTests.java
@@ -85,10 +85,10 @@ class EndpointRequestTests {
 	}
 
 	@Test
-	void toAnyEndpointWhenBasePathIsEmptyShouldNotMatchLinks() {
+	void toAnyEndpointWhenBasePathIsEmptyShouldMatchLinks() {
 		ServerWebExchangeMatcher matcher = EndpointRequest.toAnyEndpoint();
 		RequestMatcherAssert assertMatcher = assertMatcher(matcher, "");
-		assertMatcher.doesNotMatch("/");
+		assertMatcher.matches("/");
 		assertMatcher.matches("/foo");
 		assertMatcher.matches("/bar");
 	}
@@ -137,12 +137,12 @@ class EndpointRequestTests {
 	}
 
 	@Test
-	void toLinksWhenBasePathEmptyShouldNotMatch() {
+	void toLinksWhenBasePathEmptyShouldMatch() {
 		ServerWebExchangeMatcher matcher = EndpointRequest.toLinks();
 		RequestMatcherAssert assertMatcher = assertMatcher(matcher, "");
 		assertMatcher.doesNotMatch("/actuator/foo");
 		assertMatcher.doesNotMatch("/actuator/bar");
-		assertMatcher.doesNotMatch("/");
+		assertMatcher.matches("/");
 	}
 
 	@Test
@@ -258,11 +258,11 @@ class EndpointRequestTests {
 	}
 
 	@Test
-	void toAnyEndpointWhenEndpointPathMappedToRootIsExcludedShouldNotMatchRoot() {
+	void toAnyEndpointWhenEndpointPathMappedToRootIsExcludedShouldStillMatchLinks() {
 		ServerWebExchangeMatcher matcher = EndpointRequest.toAnyEndpoint().excluding("root");
 		RequestMatcherAssert assertMatcher = assertMatcher(matcher, new PathMappedEndpoints("/", () -> List
 			.of(mockEndpoint(EndpointId.of("root"), "/"), mockEndpoint(EndpointId.of("alpha"), "alpha"))));
-		assertMatcher.doesNotMatch("/");
+		assertMatcher.matches("/");
 		assertMatcher.matches("/alpha");
 		assertMatcher.matches("/alpha/sub");
 	}

--- a/module/spring-boot-security/src/test/java/org/springframework/boot/security/autoconfigure/actuate/web/servlet/EndpointRequestTests.java
+++ b/module/spring-boot-security/src/test/java/org/springframework/boot/security/autoconfigure/actuate/web/servlet/EndpointRequestTests.java
@@ -84,10 +84,10 @@ class EndpointRequestTests {
 	}
 
 	@Test
-	void toAnyEndpointWhenBasePathIsEmptyShouldNotMatchLinks() {
+	void toAnyEndpointWhenBasePathIsEmptyShouldMatchLinks() {
 		RequestMatcher matcher = EndpointRequest.toAnyEndpoint();
 		RequestMatcherAssert assertMatcher = assertMatcher(matcher, "");
-		assertMatcher.doesNotMatch("/");
+		assertMatcher.matches("/");
 		assertMatcher.matches("/foo");
 		assertMatcher.matches("/bar");
 	}
@@ -143,12 +143,12 @@ class EndpointRequestTests {
 	}
 
 	@Test
-	void toLinksWhenBasePathEmptyShouldNotMatch() {
+	void toLinksWhenBasePathEmptyShouldMatch() {
 		RequestMatcher matcher = EndpointRequest.toLinks();
 		RequestMatcherAssert assertMatcher = assertMatcher(matcher, "");
 		assertMatcher.doesNotMatch("/actuator/foo");
 		assertMatcher.doesNotMatch("/actuator/bar");
-		assertMatcher.doesNotMatch("/");
+		assertMatcher.matches("/");
 	}
 
 	@Test
@@ -262,11 +262,11 @@ class EndpointRequestTests {
 	}
 
 	@Test
-	void toAnyEndpointWhenEndpointPathMappedToRootIsExcludedShouldNotMatchRoot() {
+	void toAnyEndpointWhenEndpointPathMappedToRootIsExcludedShouldStillMatchLinks() {
 		EndpointRequestMatcher matcher = EndpointRequest.toAnyEndpoint().excluding("root");
 		RequestMatcherAssert assertMatcher = assertMatcher(matcher, new PathMappedEndpoints("", () -> List
 			.of(mockEndpoint(EndpointId.of("root"), "/"), mockEndpoint(EndpointId.of("alpha"), "alpha"))));
-		assertMatcher.doesNotMatch("/");
+		assertMatcher.matches("/");
 		assertMatcher.matches("/alpha");
 		assertMatcher.matches("/alpha/sub");
 	}


### PR DESCRIPTION
Issue link:
- https://github.com/spring-projects/spring-boot/issues/34834

Summary:
- Ensure EndpointRequest link matchers include root when the web base path is configured as '/'.
- Update servlet and reactive matcher tests for the root base path behavior.

Motivation:
- `management.endpoints.web.base-path=/` is cleaned to an empty base path, which currently makes `EndpointRequest.toLinks()` return `EMPTY_MATCHER` and skip links at the management root.

Validation:
- `JAVA_HOME=$(scoop prefix temurin22-jdk) .\\gradlew :module:spring-boot-security:test --tests "org.springframework.boot.security.autoconfigure.actuate.web.servlet.EndpointRequestTests" --tests "org.springframework.boot.security.autoconfigure.actuate.web.reactive.EndpointRequestTests" --no-daemon` (fails: NullAway error at `core/spring-boot-autoconfigure/.../OnBeanCondition.java:578`)
