### PR TITLE
Validate publish registry URL against image name

### DIFF
--- a/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildImageMojo.java
+++ b/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildImageMojo.java
@@ -259,6 +259,7 @@ public abstract class BuildImageMojo extends AbstractPackagerMojo {
 		try {
 			BuildRequest request = getBuildRequest(libraries);
 			Docker docker = (this.docker != null) ? this.docker : new Docker();
+			docker.validatePublishRegistry(request.getName(), request.isPublish());
 			BuilderDockerConfiguration dockerConfiguration = docker.asDockerConfiguration(getLog(),
 					request.isPublish());
 			Builder builder = new Builder(new MojoBuildLog(this::getLog), dockerConfiguration);


### PR DESCRIPTION
Issue: https://github.com/spring-projects/spring-boot/issues/29281

Summary:
- Validate that docker.publishRegistry.url matches the image registry when publishing.
- Fail early with a clear configuration error in both Gradle and Maven plugins.
- Add unit tests covering matching and mismatching registry URLs.

Motivation:
- Avoid confusing pushes to docker.io when imageName omits the registry host by making mismatches explicit.

Validation:
- ./gradlew :build-plugin:spring-boot-gradle-plugin:test --tests "org.springframework.boot.gradle.tasks.bundling.BootBuildImageTests" :build-plugin:spring-boot-maven-plugin:test --tests "org.springframework.boot.maven.DockerTests" --no-daemon (JDK 22, Scoop temurin22-jdk)