### PR TITLE
Fix #48811: avoid JSON preempting resource responses

### DIFF
--- a/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/DefaultClientHttpMessageConvertersCustomizer.java
+++ b/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/DefaultClientHttpMessageConvertersCustomizer.java
@@ -20,12 +20,25 @@ import java.util.Collection;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverters.ClientBuilder;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.GsonHttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.http.converter.json.JsonbHttpMessageConverter;
 import org.springframework.http.converter.json.KotlinSerializationJsonHttpMessageConverter;
+import org.springframework.http.converter.xml.JacksonXmlHttpMessageConverter;
+import org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter;
 
 @SuppressWarnings("deprecation")
 class DefaultClientHttpMessageConvertersCustomizer implements ClientHttpMessageConvertersCustomizer {
+
+	private static final String JACKSON2_JSON_CONVERTER =
+			"org.springframework.http.converter.json.MappingJackson2HttpMessageConverter";
+
+	private static final String JACKSON2_XML_CONVERTER =
+			"org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter";
 
 	private final @Nullable HttpMessageConverters legacyConverters;
 
@@ -46,14 +59,45 @@ class DefaultClientHttpMessageConvertersCustomizer implements ClientHttpMessageC
 		else {
 			builder.registerDefaults();
 			this.converters.forEach((converter) -> {
-				if (converter instanceof KotlinSerializationJsonHttpMessageConverter) {
+				if (converter instanceof StringHttpMessageConverter) {
+					builder.withStringConverter(converter);
+				}
+				else if (converter instanceof KotlinSerializationJsonHttpMessageConverter) {
 					builder.withKotlinSerializationJsonConverter(converter);
+				}
+				else if (isJsonConverter(converter) && supportsMediaType(converter, MediaType.APPLICATION_JSON)) {
+					builder.withJsonConverter(converter);
+				}
+				else if (isXmlConverter(converter) && supportsMediaType(converter, MediaType.APPLICATION_XML)) {
+					builder.withXmlConverter(converter);
 				}
 				else {
 					builder.addCustomConverter(converter);
 				}
 			});
 		}
+	}
+
+	private static boolean supportsMediaType(HttpMessageConverter<?> converter, MediaType mediaType) {
+		for (MediaType supportedMediaType : converter.getSupportedMediaTypes()) {
+			if (supportedMediaType.equalsTypeAndSubtype(mediaType)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean isJsonConverter(HttpMessageConverter<?> converter) {
+		return converter.getClass().equals(JacksonJsonHttpMessageConverter.class)
+				|| converter.getClass().getName().equals(JACKSON2_JSON_CONVERTER)
+				|| converter.getClass().equals(GsonHttpMessageConverter.class)
+				|| converter.getClass().equals(JsonbHttpMessageConverter.class);
+	}
+
+	private static boolean isXmlConverter(HttpMessageConverter<?> converter) {
+		return converter.getClass().equals(JacksonXmlHttpMessageConverter.class)
+				|| converter.getClass().getName().equals(JACKSON2_XML_CONVERTER)
+				|| converter.getClass().equals(Jaxb2RootElementHttpMessageConverter.class);
 	}
 
 }

--- a/module/spring-boot-webmvc/src/test/java/org/springframework/boot/webmvc/autoconfigure/ResourceHttpMessageConverterIntegrationTests.java
+++ b/module/spring-boot-webmvc/src/test/java/org/springframework/boot/webmvc/autoconfigure/ResourceHttpMessageConverterIntegrationTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.webmvc.autoconfigure;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.http.converter.autoconfigure.HttpMessageConvertersAutoConfiguration;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResourceHttpMessageConverterIntegrationTests {
+
+	private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(WebMvcAutoConfiguration.class, DispatcherServletAutoConfiguration.class,
+				HttpMessageConvertersAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class))
+		.withUserConfiguration(ResourceControllerConfiguration.class);
+
+	@Test
+	void responseEntityResourceUsesResourceHttpMessageConverter() throws IOException {
+		Path file = Files.createTempFile("spring-boot", ".bin");
+		try {
+			byte[] content = "test-content".getBytes(StandardCharsets.UTF_8);
+			Files.write(file, content);
+			this.contextRunner.withPropertyValues("test.file=" + file.toAbsolutePath()).run((context) -> {
+				MockMvcTester mvc = MockMvcTester.from(context);
+				MvcTestResult result = mvc.get().uri("/file").exchange();
+				assertThat(result.getResponse().getContentType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM_VALUE);
+				assertThat(result.getResponse().getContentAsByteArray()).isEqualTo(content);
+				assertThat(Files.readAllBytes(file)).isEqualTo(content);
+			});
+		}
+		finally {
+			Files.deleteIfExists(file);
+		}
+	}
+
+	@Test
+	void responseEntityResourcePrefersResourceConverterOverCustomJsonConverter() throws IOException {
+		Path file = Files.createTempFile("spring-boot", ".bin");
+		try {
+			byte[] content = "custom-json-content".getBytes(StandardCharsets.UTF_8);
+			Files.write(file, content);
+			this.contextRunner.withUserConfiguration(CustomJsonConverterConfiguration.class)
+				.withPropertyValues("test.file=" + file.toAbsolutePath())
+				.run((context) -> {
+					MockMvcTester mvc = MockMvcTester.from(context);
+					MvcTestResult result = mvc.get().uri("/file").exchange();
+					assertThat(result.getResponse().getContentType())
+						.isEqualTo(MediaType.APPLICATION_OCTET_STREAM_VALUE);
+					assertThat(result.getResponse().getContentAsByteArray()).isEqualTo(content);
+				});
+		}
+		finally {
+			Files.deleteIfExists(file);
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ResourceControllerConfiguration {
+
+		@Bean
+		Resource fileResource(@Value("${test.file}") String file) {
+			return new FileSystemResource(file);
+		}
+
+		@RestController
+		static class FileController {
+
+			private final Resource resource;
+
+			FileController(Resource resource) {
+				this.resource = resource;
+			}
+
+			@GetMapping(value = "/file", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+			ResponseEntity<Resource> file() {
+				return ResponseEntity.ok()
+					.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE)
+					.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"test.bin\"")
+					.body(this.resource);
+			}
+
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomJsonConverterConfiguration {
+
+		@Bean
+		JsonMapper jsonMapper() {
+			return new JsonMapper();
+		}
+
+		@Bean
+		JacksonJsonHttpMessageConverter customJsonHttpMessageConverter(JsonMapper jsonMapper) {
+			JacksonJsonHttpMessageConverter converter = new JacksonJsonHttpMessageConverter(jsonMapper);
+			converter.setSupportedMediaTypes(
+					List.of(MediaType.APPLICATION_JSON, MediaType.APPLICATION_OCTET_STREAM));
+			return converter;
+		}
+
+	}
+
+}


### PR DESCRIPTION
Issue: https://github.com/spring-projects/spring-boot/issues/48811

## Summary
- register standard JSON/XML/String converters via the builder so resource responses are not preempted by custom JSON converters
- add an integration test that covers a Resource response when a JSON converter also supports `application/octet-stream`

## Motivation
Custom JSON converter beans that advertise `application/octet-stream` are currently added ahead of the `ResourceHttpMessageConverter`, which can cause resource responses to be serialized as JSON after 4.0.1. Registering the standard converter types via the builder keeps resource handling ahead while leaving type-constrained converters in the custom list.

## Validation
- ./gradlew :module:spring-boot-webmvc:test --tests "org.springframework.boot.webmvc.autoconfigure.ResourceHttpMessageConverterIntegrationTests" --no-daemon -I <init-script>