### PR TITLE
Allow beans created in MockRestServiceServerAutoConfiguration to be replaced by user-provided alternatives

### DIFF
--- a/module/spring-boot-restclient-test/src/main/java/org/springframework/boot/restclient/test/autoconfigure/MockRestServiceServerAutoConfiguration.java
+++ b/module/spring-boot-restclient-test/src/main/java/org/springframework/boot/restclient/test/autoconfigure/MockRestServiceServerAutoConfiguration.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.restclient.test.MockServerRestClientCustomizer;
 import org.springframework.boot.restclient.test.MockServerRestTemplateCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -53,16 +54,19 @@ import org.springframework.web.client.RestTemplate;
 public final class MockRestServiceServerAutoConfiguration {
 
 	@Bean
+	@ConditionalOnMissingBean
 	MockServerRestTemplateCustomizer mockServerRestTemplateCustomizer() {
 		return new MockServerRestTemplateCustomizer();
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
 	MockServerRestClientCustomizer mockServerRestClientCustomizer() {
 		return new MockServerRestClientCustomizer();
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
 	MockRestServiceServer mockRestServiceServer(MockServerRestTemplateCustomizer restTemplateCustomizer,
 			MockServerRestClientCustomizer restClientCustomizer) {
 		try {

--- a/module/spring-boot-restclient-test/src/test/java/org/springframework/boot/restclient/test/autoconfigure/MockRestServiceServerAutoConfigurationTests.java
+++ b/module/spring-boot-restclient-test/src/test/java/org/springframework/boot/restclient/test/autoconfigure/MockRestServiceServerAutoConfigurationTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.restclient.test.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.restclient.test.MockServerRestClientCustomizer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MockRestServiceServerAutoConfiguration}.
+ *
+ * @author HuitaePark
+ */
+class MockRestServiceServerAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(MockRestServiceServerAutoConfiguration.class));
+
+	@Test
+	void registersRestClientCustomizerWhenMissing() {
+		this.contextRunner.withPropertyValues("spring.test.restclient.mockrestserviceserver.enabled=true")
+			.run((context) -> assertThat(context).hasSingleBean(MockServerRestClientCustomizer.class));
+	}
+
+	@Test
+	void backsOffWhenUserProvidesRestClientCustomizer() {
+		MockServerRestClientCustomizer customCustomizer = new MockServerRestClientCustomizer();
+
+		this.contextRunner.withPropertyValues("spring.test.restclient.mockrestserviceserver.enabled=true")
+			.withBean("userMockServerRestClientCustomizer", MockServerRestClientCustomizer.class,
+					() -> customCustomizer)
+			.run((context) -> {
+				assertThat(context).hasSingleBean(MockServerRestClientCustomizer.class);
+				assertThat(context.getBean(MockServerRestClientCustomizer.class))
+					.isSameAs(context.getBean("userMockServerRestClientCustomizer"));
+			});
+	}
+
+}


### PR DESCRIPTION
## Related Issue

Closes gh-46853

## Goal

Allow overriding the MockServerRestClientCustomizer bean created by MockRestServiceServerAutoConfiguration.

This is particularly useful for scenarios in 'RestClientTest' where customization of the mock server behavior is required, such as enabling content buffering via setBufferContent(true), which was previously overridden by the default auto-configuration.

## Background

Currently, MockRestServiceServerAutoConfiguration unconditionally defines a MockServerRestClientCustomizer bean:

```java
@Bean
MockServerRestClientCustomizer mockServerRestClientCustomizer() {
    return new MockServerRestClientCustomizer();
}
```

Because of this unconditional registration, if a user attempts to provide their own MockServerRestClientCustomizer bean to customize the MockRestServiceServer, the auto-configured bean may take precedence or cause conflicts. This prevents users from applying necessary configurations like enabling the buffering of response bodies.

## Approach

Apply conditional registration:

Added @ConditionalOnMissingBean to the mockServerRestClientCustomizer bean definition in MockRestServiceServerAutoConfiguration.

This ensures that the auto-configuration backs off if a user has already defined a MockServerRestClientCustomizer bean in the application context.

## Verification

I introduced a new test class MockRestServiceServerAutoConfigurationTests using ApplicationContextRunner to verify the fix.

The tests cover two scenarios:

1. Default Behavior: Verifies that MockServerRestClientCustomizer is registered by the auto-configuration when no user bean is present.

2. Override Behavior: Verifies that the auto-configuration backs off when a user-provided MockServerRestClientCustomizer is present, ensuring the user's bean is used.