### PR TITLE
Provide configuration properties for Jackson read and write features that are common to multiple formats

### DIFF
--- a/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration.java
+++ b/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration.java
@@ -158,10 +158,10 @@ public final class JacksonAutoConfiguration {
 			@Override
 			public void customize(JsonMapper.Builder builder) {
 				super.customize(builder);
+				configureFeatures(builder, properties().getRead(), builder::configure);
+				configureFeatures(builder, properties().getWrite(), builder::configure);
 				configureFeatures(builder, properties().getJson().getRead(), builder::configure);
 				configureFeatures(builder, properties().getJson().getWrite(), builder::configure);
-				configureFeatures(builder, properties().getStream().getRead(), builder::configure);
-				configureFeatures(builder, properties().getStream().getWrite(), builder::configure);
 			}
 
 		}

--- a/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonProperties.java
+++ b/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonProperties.java
@@ -125,9 +125,17 @@ public class JacksonProperties {
 
 	private final Datatype datatype = new Datatype();
 
-	private final Json json = new Json();
+	/**
+	 * Jackson on/off token reader features common to multiple formats.
+	 */
+	private final Map<StreamReadFeature, Boolean> read = new EnumMap<>(StreamReadFeature.class);
 
-	private final Stream stream = new Stream();
+	/**
+	 * Jackson on/off token writer features common to multiple formats.
+	 */
+	private final Map<StreamWriteFeature, Boolean> write = new EnumMap<>(StreamWriteFeature.class);
+
+	private final Json json = new Json();
 
 	public @Nullable String getDateFormat() {
 		return this.dateFormat;
@@ -221,12 +229,16 @@ public class JacksonProperties {
 		return this.datatype;
 	}
 
-	public Json getJson() {
-		return this.json;
+	public Map<StreamReadFeature, Boolean> getRead() {
+		return this.read;
 	}
 
-	public Stream getStream() {
-		return this.stream;
+	public Map<StreamWriteFeature, Boolean> getWrite() {
+		return this.write;
+	}
+
+	public Json getJson() {
+		return this.json;
 	}
 
 	public enum ConstructorDetectorStrategy {
@@ -302,28 +314,6 @@ public class JacksonProperties {
 		}
 
 		public Map<JsonWriteFeature, Boolean> getWrite() {
-			return this.write;
-		}
-
-	}
-
-	public static class Stream {
-
-		/**
-		 * Jackson on/off token reader features that are not specific to JSON.
-		 */
-		private final Map<StreamReadFeature, Boolean> read = new EnumMap<>(StreamReadFeature.class);
-
-		/**
-		 * Jackson on/off token writer features that are not specific to JSON.
-		 */
-		private final Map<StreamWriteFeature, Boolean> write = new EnumMap<>(StreamWriteFeature.class);
-
-		public Map<StreamReadFeature, Boolean> getRead() {
-			return this.read;
-		}
-
-		public Map<StreamWriteFeature, Boolean> getWrite() {
 			return this.write;
 		}
 

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfigurationTests.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfigurationTests.java
@@ -349,12 +349,20 @@ class JacksonAutoConfigurationTests {
 
 	@Test
 	void enableWriteBigDecimalAsPlain() {
-		this.contextRunner.withPropertyValues("spring.jackson.stream.write.write-bigdecimal-as-plain:true")
-			.run((context) -> {
-				JsonMapper mapper = context.getBean(JsonMapper.class);
-				assertThat(StreamWriteFeature.WRITE_BIGDECIMAL_AS_PLAIN.enabledByDefault()).isFalse();
-				assertThat(mapper.isEnabled(StreamWriteFeature.WRITE_BIGDECIMAL_AS_PLAIN)).isTrue();
-			});
+		this.contextRunner.withPropertyValues("spring.jackson.write.write-bigdecimal-as-plain:true").run((context) -> {
+			JsonMapper mapper = context.getBean(JsonMapper.class);
+			assertThat(StreamWriteFeature.WRITE_BIGDECIMAL_AS_PLAIN.enabledByDefault()).isFalse();
+			assertThat(mapper.isEnabled(StreamWriteFeature.WRITE_BIGDECIMAL_AS_PLAIN)).isTrue();
+		});
+	}
+
+	@Test
+	void enableStringDuplicateDetection() {
+		this.contextRunner.withPropertyValues("spring.jackson.read.strict-duplicate-detection:true").run((context) -> {
+			JsonMapper mapper = context.getBean(JsonMapper.class);
+			assertThat(StreamReadFeature.STRICT_DUPLICATE_DETECTION.enabledByDefault()).isFalse();
+			assertThat(mapper.isEnabled(StreamReadFeature.STRICT_DUPLICATE_DETECTION)).isTrue();
+		});
 	}
 
 	@EnumSource


### PR DESCRIPTION
In Spring Boot 3 write-bigdecimal-as-plain was managed by application property.

It does not work in Spring Boot 4 that way and requires custom Java `@Configuration`.

Configuration via application property is automatically catch by WebMvcTest. It gives a high level of trust, because vanilla WebMvcTest may verify that plain BigDecimal works.

With custom Java `@Configuration`, the configuration must be added to WebMvcTest. It introduces doubt it really works in production, because test looks rigged to produce the desired result.

Anyway, when working with BigDecimal it's typical IMHO to prefer plain, and it would be nice to configure it as easy as in Spring Boot 3

Goal is
```
spring:
  jackson:
    stream:
      write:
        write-bigdecimal-as-plain: true
```

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
