### PR TITLE
Add spring.data.rest.return-body-on-delete configuration property

### DIFF
--- a/module/spring-boot-data-rest/src/main/java/org/springframework/boot/data/rest/autoconfigure/DataRestProperties.java
+++ b/module/spring-boot-data-rest/src/main/java/org/springframework/boot/data/rest/autoconfigure/DataRestProperties.java
@@ -86,6 +86,11 @@ public class DataRestProperties {
 	private @Nullable Boolean returnBodyOnUpdate;
 
 	/**
+	 * Whether to return a response body after deleting an entity.
+	 */
+	private @Nullable Boolean returnBodyOnDelete;
+
+	/**
 	 * Whether to enable enum value translation through the Spring Data REST default
 	 * resource bundle.
 	 */
@@ -171,6 +176,14 @@ public class DataRestProperties {
 		this.returnBodyOnUpdate = returnBodyOnUpdate;
 	}
 
+	public @Nullable Boolean getReturnBodyOnDelete() {
+		return this.returnBodyOnDelete;
+	}
+
+	public void setReturnBodyOnDelete(@Nullable Boolean returnBodyOnDelete) {
+		this.returnBodyOnDelete = returnBodyOnDelete;
+	}
+
 	public @Nullable Boolean getEnableEnumTranslation() {
 		return this.enableEnumTranslation;
 	}
@@ -191,6 +204,7 @@ public class DataRestProperties {
 		map.from(this::getDefaultMediaType).to(rest::setDefaultMediaType);
 		map.from(this::getReturnBodyOnCreate).to(rest::setReturnBodyOnCreate);
 		map.from(this::getReturnBodyOnUpdate).to(rest::setReturnBodyOnUpdate);
+		map.from(this::getReturnBodyOnDelete).to(rest::setReturnBodyOnDelete);
 		map.from(this::getEnableEnumTranslation).to(rest::setEnableEnumTranslation);
 	}
 

--- a/module/spring-boot-data-rest/src/test/java/org/springframework/boot/data/rest/autoconfigure/DataRestAutoConfigurationTests.java
+++ b/module/spring-boot-data-rest/src/test/java/org/springframework/boot/data/rest/autoconfigure/DataRestAutoConfigurationTests.java
@@ -91,7 +91,7 @@ class DataRestAutoConfigurationTests {
 				"spring.data.rest.sort-param-name:_sort", "spring.data.rest.detection-strategy=visibility",
 				"spring.data.rest.default-media-type:application/my-json",
 				"spring.data.rest.return-body-on-create:false", "spring.data.rest.return-body-on-update:false",
-				"spring.data.rest.enable-enum-translation:true");
+				"spring.data.rest.return-body-on-delete:false", "spring.data.rest.enable-enum-translation:true");
 		assertThat(getContext().getBean(RepositoryRestMvcConfiguration.class)).isNotNull();
 		RepositoryRestConfiguration bean = getContext().getBean(RepositoryRestConfiguration.class);
 		assertThat(bean.getDefaultPageSize()).isEqualTo(42);
@@ -108,6 +108,7 @@ class DataRestAutoConfigurationTests {
 	private void assertReturnBody(RepositoryRestConfiguration bean) {
 		assertThat(bean.returnBodyOnCreate(null)).isFalse();
 		assertThat(bean.returnBodyOnUpdate(null)).isFalse();
+		assertThat(bean.returnBodyOnDelete(null)).isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
  This enhancement adds the `spring.data.rest.return-body-on-delete` property
  to configure whether Spring Data REST returns a response body after DELETE
  operations.

  ### Problem

  The existing `DataRestProperties` class supports `returnBodyOnCreate` and
  `returnBodyOnUpdate` but lacks the corresponding `returnBodyOnDelete` property,
  even though `RepositoryRestConfiguration.setReturnBodyOnDelete()` has been
  available since Spring Data REST 4.1.

  ### Solution

  - Add `returnBodyOnDelete` property with getter/setter
  - Map the property to `RepositoryRestConfiguration.setReturnBodyOnDelete()`
    in the `applyTo()` method
  - Add test coverage in `DataRestAutoConfigurationTests`

  ### Usage

  ```properties
  spring.data.rest.return-body-on-delete=false

  This completes the symmetric CRUD response body configuration, giving users
  full control over response body behavior for all mutation operations.