### PR TITLE
Add MongoDB's configuration properties for consistency

### DIFF
--- a/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoConnectionDetails.java
+++ b/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoConnectionDetails.java
@@ -17,6 +17,9 @@
 package org.springframework.boot.mongodb.autoconfigure;
 
 import com.mongodb.ConnectionString;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
@@ -28,6 +31,7 @@ import org.springframework.boot.ssl.SslBundle;
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Jay Choi
  * @since 4.0.0
  */
 public interface MongoConnectionDetails extends ConnectionDetails {
@@ -43,6 +47,30 @@ public interface MongoConnectionDetails extends ConnectionDetails {
 	 * @return the SSL bundle to use
 	 */
 	default @Nullable SslBundle getSslBundle() {
+		return null;
+	}
+
+	/**
+	 * The {@link ReadConcern} for MongoDB.
+	 * @return the read concern option
+	 */
+	default @Nullable ReadConcern getReadConcern() {
+		return null;
+	}
+
+	/**
+	 * The {@link WriteConcern} for MongoDB.
+	 * @return the write concern options
+	 */
+	default @Nullable WriteConcern getWriteConcern() {
+		return null;
+	}
+
+	/**
+	 * The {@link ReadPreference} for MongoDB.
+	 * @return the read preference options
+	 */
+	default @Nullable ReadPreference getReadPreference() {
 		return null;
 	}
 

--- a/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoProperties.java
+++ b/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoProperties.java
@@ -16,7 +16,9 @@
 
 package org.springframework.boot.mongodb.autoconfigure;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
 import com.mongodb.ConnectionString;
 import org.bson.UuidRepresentation;
@@ -37,6 +39,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Mark Paluch
  * @author Artsiom Yudovin
  * @author Safeer Ansari
+ * @author Jay Choi
  * @since 4.0.0
  */
 @ConfigurationProperties("spring.mongodb")
@@ -104,9 +107,19 @@ public class MongoProperties {
 	 */
 	private @Nullable String replicaSetName;
 
+	/**
+	 * Read concern level for read operations. Supported values are 'local', 'available',
+	 * 'majority', 'linearizable', and 'snapshot'. Overrides the value in 'uri' if set.
+	 */
+	private @Nullable String readConcern;
+
 	private final Representation representation = new Representation();
 
 	private final Ssl ssl = new Ssl();
+
+	private final WriteConcern writeConcern = new WriteConcern();
+
+	private final ReadPreference readPreference = new ReadPreference();
 
 	public void setProtocol(String protocol) {
 		this.protocol = protocol;
@@ -199,12 +212,28 @@ public class MongoProperties {
 		this.additionalHosts = additionalHosts;
 	}
 
+	public @Nullable String getReadConcern() {
+		return this.readConcern;
+	}
+
+	public void setReadConcern(@Nullable String readConcern) {
+		this.readConcern = readConcern;
+	}
+
 	public Representation getRepresentation() {
 		return this.representation;
 	}
 
 	public Ssl getSsl() {
 		return this.ssl;
+	}
+
+	public WriteConcern getWriteConcern() {
+		return this.writeConcern;
+	}
+
+	public ReadPreference getReadPreference() {
+		return this.readPreference;
 	}
 
 	public static class Representation {
@@ -251,6 +280,103 @@ public class MongoProperties {
 
 		public void setBundle(@Nullable String bundle) {
 			this.bundle = bundle;
+		}
+
+	}
+
+	public static class WriteConcern {
+
+		/**
+		 * The w value. Can be 'majority' or a number representing the number of nodes
+		 * that must acknowledge the write. Overrides the write concern in 'uri' if any
+		 * write-concern property is set.
+		 */
+		private @Nullable String w;
+
+		/**
+		 * Whether to block until write operations have been committed to the journal.
+		 * Overrides the write concern in 'uri' if any write-concern property is set.
+		 */
+		private @Nullable Boolean journal;
+
+		/**
+		 * Timeout for secondaries to acknowledge the write before failing. Overrides the
+		 * write concern in 'uri' if any write-concern property is set.
+		 */
+		private @Nullable Duration wTimeout;
+
+		public @Nullable String getW() {
+			return this.w;
+		}
+
+		public void setW(@Nullable String w) {
+			this.w = w;
+		}
+
+		public @Nullable Boolean getJournal() {
+			return this.journal;
+		}
+
+		public void setJournal(@Nullable Boolean journal) {
+			this.journal = journal;
+		}
+
+		public @Nullable Duration getWTimeout() {
+			return this.wTimeout;
+		}
+
+		public void setWTimeout(@Nullable Duration wTimeout) {
+			this.wTimeout = wTimeout;
+		}
+
+	}
+
+	public static class ReadPreference {
+
+		/**
+		 * Read preference mode for read operations. Supported values are 'primary',
+		 * 'primaryPreferred', 'secondary', 'secondaryPreferred', and 'nearest'. Overrides
+		 * the read preference in 'uri' if any read-preference property is set.
+		 */
+		private @Nullable String mode;
+
+		/**
+		 * List of tag sets for read preference. Each entry in the list represents a tag
+		 * set with fallback priority. An empty map represents a wildcard tag set that
+		 * matches any replica set member. Overrides the read preference in 'uri' if any
+		 * read-preference property is set.
+		 */
+		private @Nullable List<Map<String, String>> tags;
+
+		/**
+		 * Maximum staleness duration for read preference. The minimum value is 90
+		 * seconds. Overrides the read preference in 'uri' if any read-preference property
+		 * is set.
+		 */
+		private @Nullable Duration maxStaleness;
+
+		public @Nullable String getMode() {
+			return this.mode;
+		}
+
+		public void setMode(@Nullable String mode) {
+			this.mode = mode;
+		}
+
+		public @Nullable List<Map<String, String>> getTags() {
+			return this.tags;
+		}
+
+		public void setTags(@Nullable List<Map<String, String>> tags) {
+			this.tags = tags;
+		}
+
+		public @Nullable Duration getMaxStaleness() {
+			return this.maxStaleness;
+		}
+
+		public void setMaxStaleness(@Nullable Duration maxStaleness) {
+			this.maxStaleness = maxStaleness;
 		}
 
 	}

--- a/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/StandardMongoClientSettingsBuilderCustomizer.java
+++ b/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/StandardMongoClientSettingsBuilderCustomizer.java
@@ -17,6 +17,9 @@
 package org.springframework.boot.mongodb.autoconfigure;
 
 import com.mongodb.MongoClientSettings;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
 import com.mongodb.connection.SslSettings;
 import org.bson.UuidRepresentation;
 
@@ -31,6 +34,7 @@ import org.springframework.util.Assert;
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Jay Choi
  * @since 4.0.0
  */
 public class StandardMongoClientSettingsBuilderCustomizer implements MongoClientSettingsBuilderCustomizer, Ordered {
@@ -52,6 +56,18 @@ public class StandardMongoClientSettingsBuilderCustomizer implements MongoClient
 		settingsBuilder.uuidRepresentation(this.uuidRepresentation);
 		settingsBuilder.applyConnectionString(this.connectionDetails.getConnectionString());
 		settingsBuilder.applyToSslSettings(this::configureSslIfNeeded);
+		ReadConcern readConcern = this.connectionDetails.getReadConcern();
+		if (readConcern != null) {
+			settingsBuilder.readConcern(readConcern);
+		}
+		WriteConcern writeConcern = this.connectionDetails.getWriteConcern();
+		if (writeConcern != null) {
+			settingsBuilder.writeConcern(writeConcern);
+		}
+		ReadPreference readPreference = this.connectionDetails.getReadPreference();
+		if (readPreference != null) {
+			settingsBuilder.readPreference(readPreference);
+		}
 	}
 
 	private void configureSslIfNeeded(SslSettings.Builder settings) {


### PR DESCRIPTION
## Related Issue

Closes gh-46261

## Summary

This adds configuration properties for MongoDB's read and write consistency settings, enabling declarative configuration of `ReadConcern`, `WriteConcern`, and `ReadPreference` via application properties.

Currently, configuring MongoDB consistency settings requires either:
- Using connection URI query parameters (e.g., `?readPreference=secondaryPreferred`)
- Implementing custom `MongoClientSettingsBuilderCustomizer` in Java

This approach lacks consistency with other properties and increases configuration complexity for operations teams. This enhancement allows configuration like:

```yaml
spring:
  mongodb:
    read-concern: majority
    write-concern:
      w: majority
      journal: true
      w-timeout: 5s
    read-preference:
      mode: secondary
      tags:
        - region: east
          zone: primary
        - datacenter: A
      max-staleness: 90s
```

## Changes

- Added `readConcern` property to `MongoProperties` for read concern level configuration
- Added `WriteConcern` nested class with `w`, `journal`, and `wTimeout` properties
- Added `ReadPreference` nested class with `mode`, `tags`, and `maxStaleness` properties
- Extended `MongoConnectionDetails` interface with `getReadConcern()`, `getWriteConcern()`, and `getReadPreference()` methods
- Implemented conversion logic in `PropertiesMongoConnectionDetails`
- Applied settings in `StandardMongoClientSettingsBuilderCustomizer`
- Added comprehensive unit and integration tests

## Design Decisions

- New properties are applied after `applyConnectionString()`, so individual properties override URI settings.
- The getters in `PropertiesMongoConnectionDetails` that create `ReadConcern`, `WriteConcern`, and `ReadPreference` objects were written with reference to the logic in `ConnectionString` that creates each object.
- Validation throws `InvalidConfigurationPropertyValueException` when `tags` or `max-staleness` is configured without `mode`.
- The `read-preference.tags` property support priority-based fallback using `List<Map<String, String>>` structure.
- The `read-preference.tags` property can accept an empty map as the last fallback, which can be specified using `-` or `- {}` in YAML. This is not supported in `application.properties` due to format limitations.

