### PR TITLE
Support welcome pages in WebFlux for paths other than / #47384

### DIFF
--- a/module/spring-boot-webflux/src/main/java/org/springframework/boot/webflux/autoconfigure/WelcomePageRouterFunctionFactory.java
+++ b/module/spring-boot-webflux/src/main/java/org/springframework/boot/webflux/autoconfigure/WelcomePageRouterFunctionFactory.java
@@ -81,7 +81,7 @@ final class WelcomePageRouterFunctionFactory {
 	}
 
 	@Nullable RouterFunction<ServerResponse> createRouterFunction() {
-		if (this.welcomePage != null && "/**".equals(this.staticPathPattern)) {
+		if (this.welcomePage != null) {
 			return RouterFunctions.route(GET("/").and(accept(MediaType.TEXT_HTML)),
 					(req) -> ServerResponse.ok().contentType(MediaType.TEXT_HTML).bodyValue(this.welcomePage));
 		}

--- a/module/spring-boot-webflux/src/test/java/org/springframework/boot/webflux/autoconfigure/WelcomePageRouterFunctionFactoryTests.java
+++ b/module/spring-boot-webflux/src/test/java/org/springframework/boot/webflux/autoconfigure/WelcomePageRouterFunctionFactoryTests.java
@@ -167,6 +167,21 @@ class WelcomePageRouterFunctionFactoryTests {
 			.isEqualTo("welcome-page-static");
 	}
 
+	@Test
+	void handlesRequestForStaticPageWithCustomPathPattern() {
+		WelcomePageRouterFunctionFactory factory = factoryWithoutTemplateSupport(this.indexLocations, "/static/**");
+		RouterFunction<ServerResponse> routerFunction = factory.createRouterFunction();
+		assertThat(routerFunction).isNotNull();
+		WebTestClient client = WebTestClient.bindToRouterFunction(routerFunction).build();
+		client.get()
+			.uri("/")
+			.accept(MediaType.TEXT_HTML)
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody(String.class)
+			.isEqualTo("welcome-page-static");
+	}
 	private WebTestClient withStaticIndex() {
 		WelcomePageRouterFunctionFactory factory = factoryWithoutTemplateSupport(this.indexLocations, "/**");
 		RouterFunction<ServerResponse> routerFunction = factory.createRouterFunction();


### PR DESCRIPTION
Fixed WebFlux to support welcome pages with custom static-path-pattern  based on                                                                                                                                     
spring.webflux.static-path-pattern property 

