### PR TITLE
Fix typo in REST client documentation

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/io/rest-client.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/io/rest-client.adoc
@@ -228,7 +228,7 @@ In order of preference, the following clients are supported:
 . JDK client (`java.net.http.HttpClient`)
 . Simple JDK client (`java.net.HttpURLConnection`)
 
-If multiple clients are available on the classpath, and global configuration is not provided, the most preferred client will be used.
+If multiple clients are available on the classpath, and no global configuration is provided, the most preferred client will be used.
 
 
 


### PR DESCRIPTION
Fixes a grammatical error in the REST client documentation where "not global configuration is provided" should read "global configuration is not provided".

