### PR TITLE
Remove unnecessary @ConfigurationPropertiesSource

### DIFF
--- a/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/autoconfigure/ApiversionProperties.java
+++ b/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/autoconfigure/ApiversionProperties.java
@@ -18,7 +18,6 @@ package org.springframework.boot.http.client.autoconfigure;
 
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.boot.context.properties.ConfigurationPropertiesSource;
 import org.springframework.boot.context.properties.bind.Name;
 
 /**
@@ -27,7 +26,6 @@ import org.springframework.boot.context.properties.bind.Name;
  * @author Phillip Webb
  * @since 4.0.0
  */
-@ConfigurationPropertiesSource
 public class ApiversionProperties {
 
 	/**
@@ -53,7 +51,6 @@ public class ApiversionProperties {
 		return this.insert;
 	}
 
-	@ConfigurationPropertiesSource
 	public static class Insert {
 
 		/**

--- a/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/autoconfigure/HttpClientProperties.java
+++ b/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/autoconfigure/HttpClientProperties.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.boot.context.properties.ConfigurationPropertiesSource;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
@@ -34,7 +33,6 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  * @author Phillip Webb
  * @since 4.0.0
  */
-@ConfigurationPropertiesSource
 public class HttpClientProperties extends HttpClientSettingsProperties {
 
 	/**

--- a/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/autoconfigure/HttpClientSettingsProperties.java
+++ b/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/autoconfigure/HttpClientSettingsProperties.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.boot.context.properties.ConfigurationPropertiesSource;
 import org.springframework.boot.http.client.HttpClientSettings;
 import org.springframework.boot.http.client.HttpRedirects;
 
@@ -31,7 +30,6 @@ import org.springframework.boot.http.client.HttpRedirects;
  * @since 4.0.0
  * @see HttpClientSettings
  */
-@ConfigurationPropertiesSource
 public abstract class HttpClientSettingsProperties {
 
 	/**
@@ -85,7 +83,6 @@ public abstract class HttpClientSettingsProperties {
 	/**
 	 * SSL configuration.
 	 */
-	@ConfigurationPropertiesSource
 	public static class Ssl {
 
 		/**

--- a/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/export/properties/PushRegistryProperties.java
+++ b/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/export/properties/PushRegistryProperties.java
@@ -18,8 +18,6 @@ package org.springframework.boot.micrometer.metrics.autoconfigure.export.propert
 
 import java.time.Duration;
 
-import org.springframework.boot.context.properties.ConfigurationPropertiesSource;
-
 /**
  * Base class for properties that configure a metrics registry that pushes aggregated
  * metrics on a regular interval.
@@ -29,7 +27,6 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesSource
  * @author Stephane Nicoll
  * @since 4.0.0
  */
-@ConfigurationPropertiesSource
 public abstract class PushRegistryProperties {
 
 	/**

--- a/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/Compression.java
+++ b/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/Compression.java
@@ -18,7 +18,6 @@ package org.springframework.boot.web.server;
 
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.boot.context.properties.ConfigurationPropertiesSource;
 import org.springframework.util.unit.DataSize;
 
 /**
@@ -29,7 +28,6 @@ import org.springframework.util.unit.DataSize;
  * @author Stephane Nicoll
  * @since 2.0.0
  */
-@ConfigurationPropertiesSource
 public class Compression {
 
 	/**

--- a/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/Cookie.java
+++ b/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/Cookie.java
@@ -21,7 +21,6 @@ import java.time.temporal.ChronoUnit;
 
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.boot.context.properties.ConfigurationPropertiesSource;
 import org.springframework.boot.convert.DurationUnit;
 
 /**
@@ -33,7 +32,6 @@ import org.springframework.boot.convert.DurationUnit;
  * @author Weix Sun
  * @since 2.6.0
  */
-@ConfigurationPropertiesSource
 public class Cookie {
 
 	/**

--- a/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/Http2.java
+++ b/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/Http2.java
@@ -16,15 +16,12 @@
 
 package org.springframework.boot.web.server;
 
-import org.springframework.boot.context.properties.ConfigurationPropertiesSource;
-
 /**
  * Simple server-independent abstraction for HTTP/2 configuration.
  *
  * @author Brian Clozel
  * @since 2.0.0
  */
-@ConfigurationPropertiesSource
 public class Http2 {
 
 	/**

--- a/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/servlet/Jsp.java
+++ b/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/servlet/Jsp.java
@@ -19,8 +19,6 @@ package org.springframework.boot.web.server.servlet;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.springframework.boot.context.properties.ConfigurationPropertiesSource;
-
 /**
  * Configuration for the server's JSP servlet.
  *
@@ -28,7 +26,6 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesSource
  * @author Stephane Nicoll
  * @since 4.0.0
  */
-@ConfigurationPropertiesSource
 public class Jsp {
 
 	/**

--- a/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/servlet/Session.java
+++ b/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/servlet/Session.java
@@ -23,7 +23,6 @@ import java.util.Set;
 
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.boot.context.properties.ConfigurationPropertiesSource;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.boot.convert.DurationUnit;
 import org.springframework.boot.web.server.Cookie;
@@ -34,7 +33,6 @@ import org.springframework.boot.web.server.Cookie;
  * @author Andy Wilkinson
  * @since 4.0.0
  */
-@ConfigurationPropertiesSource
 public class Session {
 
 	/**


### PR DESCRIPTION
The Javadoc said:
>> this annotation is only required for types located in a different module than the `@ConfigurationProperties` class that references them.