### PR TITLE
Ensure JsonMapper is autoconfigured when non-JSON ObjectMapper beans …

### DIFF
--- a/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration.java
+++ b/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration.java
@@ -108,10 +108,20 @@ public final class JacksonAutoConfiguration {
 			customizer.customize(builder);
 		}
 	}
+	/**
+	 * Default JSON Mapper autoconfiguration.
+	 *
+	 * Reason for change: Previously, @ConditionalOnMissingBean checked for ObjectMapper.
+	 * If a user-defined CsvMapper (a subclass of ObjectMapper) existed, the default
+	 * JsonMapper would not be created. Changing it to check only for JsonMapper ensures
+	 * that the default JSON functionality is always available.
+	 *
+	 * @Primary ensures that this Bean is preferred when injecting JSON Mappers.
+	 */
 
 	@Bean
 	@Primary
-	@ConditionalOnMissingBean
+	@ConditionalOnMissingBean(JsonMapper.class)
 	JsonMapper jacksonJsonMapper(JsonMapper.Builder builder) {
 		return builder.build();
 	}

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfigurationTests.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfigurationTests.java
@@ -26,6 +26,8 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import tools.jackson.databind.json.JsonMapper;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -1155,5 +1157,34 @@ class JacksonAutoConfigurationTests {
 		}
 
 	}
+
+	@Test
+	void jsonMapperIsCreatedEvenWhenAnObjectMapperSubclassIsDefined() {
+		// Simulate a user-defined ObjectMapper subclass.
+		// This represents cases such as CsvMapper, XmlMapper, etc.
+		this.contextRunner.withUserConfiguration(CustomObjectMapperSubclassConfiguration.class)
+				.run((context) -> {
+					// The presence of an ObjectMapper subclass should not prevent
+					// the default JsonMapper from being autoconfigured.
+					assertThat(context).hasSingleBean(JsonMapper.class);
+
+					// The user-defined ObjectMapper subclass should still be present.
+					assertThat(context).hasSingleBean(ObjectMapper.class);
+				});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomObjectMapperSubclassConfiguration {
+
+		@Bean
+		ObjectMapper customObjectMapper() {
+			// Use an anonymous subclass to avoid introducing additional
+			// Jackson dataformat dependencies into the test.
+			return new ObjectMapper() {
+			};
+		}
+
+	}
+
 
 }


### PR DESCRIPTION
Fixes an issue where the presence of a non-JSON `ObjectMapper` (such as `CsvMapper`)
prevents the auto-configuration of the default `JsonMapper`.

Previously, any `ObjectMapper` bean caused `JsonMapper` auto-configuration to back off,
which could lead to unexpected JSON serialization failures in web applications.

This change ensures that `JsonMapper` is still auto-configured when non-JSON
`ObjectMapper` beans are present.

A test has been added to verify the correct behavior.
