### PR TITLE
Add ASM to managed dependencies

### DIFF
--- a/platform/spring-boot-dependencies/build.gradle
+++ b/platform/spring-boot-dependencies/build.gradle
@@ -75,6 +75,21 @@ bom {
 			releaseNotes("https://activemq.apache.org/components/artemis/download/release-notes-{version}")
 		}
 	}
+	library("ASM", "9.9") {
+		group("org.ow2.asm") {
+			modules = [
+				"asm",
+				"asm-analysis",
+				"asm-commons",
+				"asm-tree",
+				"asm-util"
+			]
+		}
+		links {
+			site("https://asm.ow2.io")
+			releaseNotes("https://gitlab.ow2.org/asm/asm/-/releases/{version}")
+		}
+	}
 	library("AspectJ", "1.9.25.1") {
 		group("org.aspectj") {
 			modules = [


### PR DESCRIPTION
This commit adds org.ow2.asm as a managed dependency with version 9.9 to resolve the version conflict between spring-boot-starter-jetty (which requires ASM 9.9 via Jetty 12.1.5) and spring-boot-starter-test (which pulls ASM 9.7.1 via json-path -> json-smart -> accessors-smart).

Fixes gh-48942

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
