### PR TITLE
Remove JUnit 4 references from javadoc and documentation

### DIFF
--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonTest.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonTest.java
@@ -56,9 +56,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * {@link JacksonTester}, {@link JsonbTester} and {@link GsonTester} fields. More
  * fine-grained control can be provided through the
  * {@link AutoConfigureJsonTesters @AutoConfigureJsonTesters} annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Phillip Webb
  * @author Artsiom Yudovin

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/kotlin.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/kotlin.adoc
@@ -136,7 +136,7 @@ Note that some features (such as detecting the default value or deprecated items
 [[features.kotlin.testing]]
 == Testing
 
-While it is possible to use JUnit 4 to test Kotlin code, JUnit 6 is provided by default and is recommended.
+JUnit 6 is provided by default and is recommended for testing Kotlin code.
 JUnit 6 enables a test class to be instantiated once and reused for all of the class's tests.
 This makes it possible to use javadoc:org.junit.jupiter.api.BeforeAll[format=annotation] and javadoc:org.junit.jupiter.api.AfterAll[format=annotation] annotations on non-static methods, which is a good fit for Kotlin.
 

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/index.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/index.adoc
@@ -7,25 +7,5 @@ Test support is provided by two general-purpose modules – `spring-boot-test` c
 
 Most developers use the `spring-boot-starter-test` starter, which imports both general-purpose Spring Boot test modules as well as JUnit Jupiter, AssertJ, Hamcrest, and a number of other useful libraries, and the focused `-test` modules that are applicable to their particular application.
 
-[TIP]
-====
-If you have tests that use JUnit 4, JUnit 6's vintage engine can be used to run them.
-To use the vintage engine, add a dependency on `junit-vintage-engine`, as shown in the following example:
-
-[source,xml]
-----
-<dependency>
-	<groupId>org.junit.vintage</groupId>
-	<artifactId>junit-vintage-engine</artifactId>
-	<scope>test</scope>
-	<exclusions>
-		<exclusion>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
-		</exclusion>
-	</exclusions>
-</dependency>
-----
-====
 
 `hamcrest-core` is excluded in favor of `org.hamcrest:hamcrest` that is part of `spring-boot-starter-test`.

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/spring-boot-applications.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/spring-boot-applications.adoc
@@ -9,8 +9,7 @@ Spring Boot provides a javadoc:org.springframework.boot.test.context.SpringBootT
 The annotation works by xref:testing/spring-boot-applications.adoc#testing.spring-boot-applications.detecting-configuration[creating the javadoc:org.springframework.context.ApplicationContext[] used in your tests through javadoc:org.springframework.boot.SpringApplication[]].
 In addition to javadoc:org.springframework.boot.test.context.SpringBootTest[format=annotation] a number of other annotations are also provided for xref:testing/spring-boot-applications.adoc#testing.spring-boot-applications.autoconfigured-tests[testing more specific slices] of an application.
 
-TIP: If you are using JUnit 4, do not forget to also add `@RunWith(SpringRunner.class)` to your test, otherwise the annotations will be ignored.
-If you are using JUnit 6, there is no need to add the equivalent `@ExtendWith(SpringExtension.class)` as javadoc:org.springframework.boot.test.context.SpringBootTest[format=annotation] and the other `@...Test` annotations are already annotated with it.
+TIP: There is no need to add `@ExtendWith(SpringExtension.class)` as javadoc:org.springframework.boot.test.context.SpringBootTest[format=annotation] and the other `@...Test` annotations are already annotated with it.
 
 By default, javadoc:org.springframework.boot.test.context.SpringBootTest[format=annotation] will not start a server.
 You can use the `webEnvironment` attribute of javadoc:org.springframework.boot.test.context.SpringBootTest[format=annotation] to further refine how your tests run:

--- a/module/spring-boot-data-cassandra-test/src/main/java/org/springframework/boot/data/cassandra/test/autoconfigure/DataCassandraTest.java
+++ b/module/spring-boot-data-cassandra-test/src/main/java/org/springframework/boot/data/cassandra/test/autoconfigure/DataCassandraTest.java
@@ -42,9 +42,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Using this annotation only enables auto-configuration that is relevant to Data Casandra
  * tests. Similarly, component scanning is limited to Cassandra repositories and entities
  * ({@code @Table}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Artsiom Yudovin
  * @author Stephane Nicoll

--- a/module/spring-boot-data-couchbase-test/src/main/java/org/springframework/boot/data/couchbase/test/autoconfigure/DataCouchbaseTest.java
+++ b/module/spring-boot-data-couchbase-test/src/main/java/org/springframework/boot/data/couchbase/test/autoconfigure/DataCouchbaseTest.java
@@ -42,9 +42,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Using this annotation only enables auto-configuration that is relevant to Data
  * Couchbase tests. Similarly, component scanning is limited to Couchbase repositories and
  * entities ({@code @Document}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Eddú Meléndez
  * @since 4.0.0

--- a/module/spring-boot-data-elasticsearch-test/src/main/java/org/springframework/boot/data/elasticsearch/test/autoconfigure/DataElasticsearchTest.java
+++ b/module/spring-boot-data-elasticsearch-test/src/main/java/org/springframework/boot/data/elasticsearch/test/autoconfigure/DataElasticsearchTest.java
@@ -42,9 +42,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Using this annotation only enables auto-configuration that is relevant to Data
  * Elasticsearch tests. Similarly, component scanning is limited to Elasticsearch
  * repositories and entities ({@code @Document}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Eddú Meléndez
  * @since 4.0.0

--- a/module/spring-boot-data-jdbc-test/src/main/java/org/springframework/boot/data/jdbc/test/autoconfigure/DataJdbcTest.java
+++ b/module/spring-boot-data-jdbc-test/src/main/java/org/springframework/boot/data/jdbc/test/autoconfigure/DataJdbcTest.java
@@ -56,9 +56,6 @@ import org.springframework.transaction.annotation.Transactional;
  * database, you should consider {@link SpringBootTest @SpringBootTest} combined with
  * {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase} rather than this
  * annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Andy Wilkinson
  * @since 4.0.0

--- a/module/spring-boot-data-jpa-test/src/main/java/org/springframework/boot/data/jpa/test/autoconfigure/DataJpaTest.java
+++ b/module/spring-boot-data-jpa-test/src/main/java/org/springframework/boot/data/jpa/test/autoconfigure/DataJpaTest.java
@@ -63,9 +63,6 @@ import org.springframework.transaction.annotation.Transactional;
  * database, you should consider {@link SpringBootTest @SpringBootTest} combined with
  * {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase} rather than this
  * annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Phillip Webb
  * @author Artsiom Yudovin

--- a/module/spring-boot-data-ldap-test/src/main/java/org/springframework/boot/data/ldap/test/autoconfigure/DataLdapTest.java
+++ b/module/spring-boot-data-ldap-test/src/main/java/org/springframework/boot/data/ldap/test/autoconfigure/DataLdapTest.java
@@ -45,9 +45,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * <p>
  * By default, tests annotated with {@code @DataLdapTest} will use an embedded in-memory
  * LDAP process (if available).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Eddú Meléndez
  * @author Artsiom Yudovin

--- a/module/spring-boot-data-mongodb-test/src/main/java/org/springframework/boot/data/mongodb/test/autoconfigure/DataMongoTest.java
+++ b/module/spring-boot-data-mongodb-test/src/main/java/org/springframework/boot/data/mongodb/test/autoconfigure/DataMongoTest.java
@@ -42,9 +42,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Using this annotation only enables auto-configuration that is relevant to Data Mongo
  * tests. Similarly, component scanning is limited to Mongo repositories and entities
  * ({@code @Document}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Michael Simons
  * @author Stephane Nicoll

--- a/module/spring-boot-data-neo4j-test/src/main/java/org/springframework/boot/data/neo4j/test/autoconfigure/DataNeo4jTest.java
+++ b/module/spring-boot-data-neo4j-test/src/main/java/org/springframework/boot/data/neo4j/test/autoconfigure/DataNeo4jTest.java
@@ -48,9 +48,6 @@ import org.springframework.transaction.annotation.Transactional;
  * usual test-related semantics (i.e. rollback by default). This feature is not supported
  * with reactive access so this should be disabled by annotating the test class with
  * {@code @Transactional(propagation = Propagation.NOT_SUPPORTED)}.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Eddú Meléndez
  * @author Stephane Nicoll

--- a/module/spring-boot-data-r2dbc-test/src/main/java/org/springframework/boot/data/r2dbc/test/autoconfigure/DataR2dbcTest.java
+++ b/module/spring-boot-data-r2dbc-test/src/main/java/org/springframework/boot/data/r2dbc/test/autoconfigure/DataR2dbcTest.java
@@ -42,9 +42,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Using this annotation only enables auto-configuration that is relevant to Data R2DBC
  * tests. Similarly, component scanning is limited to R2DBC repositories and entities
  * ({@code @Table}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Mark Paluch
  * @author Stephane Nicoll

--- a/module/spring-boot-data-redis-test/src/main/java/org/springframework/boot/data/redis/test/autoconfigure/DataRedisTest.java
+++ b/module/spring-boot-data-redis-test/src/main/java/org/springframework/boot/data/redis/test/autoconfigure/DataRedisTest.java
@@ -42,9 +42,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Using this annotation only enables auto-configuration that is relevant to Data Redis
  * tests. Similarly, component scanning is limited to Redis repositories and entities
  * ({@code @RedisHash}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Jayaram Pradhan
  * @author Artsiom Yudovin

--- a/module/spring-boot-jdbc-test/src/main/java/org/springframework/boot/jdbc/test/autoconfigure/JdbcTest.java
+++ b/module/spring-boot-jdbc-test/src/main/java/org/springframework/boot/jdbc/test/autoconfigure/JdbcTest.java
@@ -54,9 +54,6 @@ import org.springframework.transaction.annotation.Transactional;
  * database, you should consider {@link SpringBootTest @SpringBootTest} combined with
  * {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase} rather than this
  * annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Stephane Nicoll
  * @author Artsiom Yudovin

--- a/module/spring-boot-jooq-test/src/main/java/org/springframework/boot/jooq/test/autoconfigure/JooqTest.java
+++ b/module/spring-boot-jooq-test/src/main/java/org/springframework/boot/jooq/test/autoconfigure/JooqTest.java
@@ -48,9 +48,6 @@ import org.springframework.transaction.annotation.Transactional;
  * want to replace any explicit or usually auto-configured DataSource by an embedded
  * in-memory database, the {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase}
  * annotation can be used to override these settings.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Michael Simons
  * @author Stephane Nicoll

--- a/module/spring-boot-restclient-test/src/main/java/org/springframework/boot/restclient/test/autoconfigure/RestClientTest.java
+++ b/module/spring-boot-restclient-test/src/main/java/org/springframework/boot/restclient/test/autoconfigure/RestClientTest.java
@@ -59,9 +59,6 @@ import org.springframework.web.client.RestClient.Builder;
  * {@link MockRestServiceServer}. For more fine-grained control the
  * {@link AutoConfigureMockRestServiceServer @AutoConfigureMockRestServiceServer}
  * annotation can be used.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Stephane Nicoll
  * @author Phillip Webb

--- a/module/spring-boot-webclient-test/src/main/java/org/springframework/boot/webclient/test/autoconfigure/WebClientTest.java
+++ b/module/spring-boot-webclient-test/src/main/java/org/springframework/boot/webclient/test/autoconfigure/WebClientTest.java
@@ -50,9 +50,6 @@ import org.springframework.web.client.RestClient.Builder;
  * <ul>
  * <li>{@code JacksonModule}, if Jackson is available</li>
  * </ul>
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Andy Wilkinson
  * @since 4.0.0

--- a/module/spring-boot-webflux-test/src/main/java/org/springframework/boot/webflux/test/autoconfigure/WebFluxTest.java
+++ b/module/spring-boot-webflux-test/src/main/java/org/springframework/boot/webflux/test/autoconfigure/WebFluxTest.java
@@ -78,9 +78,6 @@ import org.springframework.test.web.reactive.server.WebTestClient;
  * you should consider {@link SpringBootTest @SpringBootTest} combined with
  * {@link AutoConfigureWebTestClient @AutoConfigureWebTestClient} rather than this
  * annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Stephane Nicoll
  * @author Artsiom Yudovin

--- a/module/spring-boot-webmvc-test/src/main/java/org/springframework/boot/webmvc/test/autoconfigure/WebMvcTest.java
+++ b/module/spring-boot-webmvc-test/src/main/java/org/springframework/boot/webmvc/test/autoconfigure/WebMvcTest.java
@@ -84,9 +84,6 @@ import org.springframework.test.web.servlet.MockMvc;
  * If you are looking to load your full application configuration and use MockMVC, you
  * should consider {@link SpringBootTest @SpringBootTest} combined with
  * {@link AutoConfigureMockMvc @AutoConfigureMockMvc} rather than this annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Phillip Webb
  * @author Artsiom Yudovin

--- a/module/spring-boot-webservices-test/src/main/java/org/springframework/boot/webservices/test/autoconfigure/client/WebServiceClientTest.java
+++ b/module/spring-boot-webservices-test/src/main/java/org/springframework/boot/webservices/test/autoconfigure/client/WebServiceClientTest.java
@@ -47,9 +47,6 @@ import org.springframework.ws.test.client.MockWebServiceServer;
  * If you are testing a bean that doesn't use {@link WebServiceTemplateBuilder} but
  * instead injects a {@link WebServiceTemplate} directly, you can add
  * {@code @AutoConfigureWebServiceClient(registerWebServiceTemplate=true)}.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
  *
  * @author Dmytro Nosan
  * @since 2.3.0


### PR DESCRIPTION
Since Spring Framework 7 has deprecated JUnit 4 support with removal planned for 7.1 or 7.2, this commit removes outdated JUnit 4 references from test slice annotation javadocs and reference documentation.

Removes mentions of @RunWith(SpringRunner.class) from:
- All @...Test annotation javadocs (18 annotations)
- Reference documentation (testing guide, Kotlin guide)

Fixes gh-47228

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
