### PR TITLE
Add time, locale, and work dir data to ProcessInfo

### DIFF
--- a/core/spring-boot/src/test/java/org/springframework/boot/info/ProcessInfoTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/info/ProcessInfoTests.java
@@ -44,6 +44,12 @@ class ProcessInfoTests {
 		assertThat(processInfo.getPid()).isEqualTo(ProcessHandle.current().pid());
 		assertThat(processInfo.getParentPid())
 			.isEqualTo(ProcessHandle.current().parent().map(ProcessHandle::pid).orElse(null));
+		assertThat(processInfo.getUptime()).isPositive();
+		assertThat(processInfo.getStartTime()).isInThePast();
+		assertThat(processInfo.getCurrentTime()).isAfter(processInfo.getStartTime());
+		assertThat(processInfo.getTimezone()).isNotNull();
+		assertThat(processInfo.getLocale()).isNotNull();
+		assertThat(processInfo.getWorkingDirectory()).isNotBlank();
 	}
 
 	@Test

--- a/documentation/spring-boot-actuator-docs/src/test/java/org/springframework/boot/actuate/docs/info/InfoEndpointDocumentationTests.java
+++ b/documentation/spring-boot-actuator-docs/src/test/java/org/springframework/boot/actuate/docs/info/InfoEndpointDocumentationTests.java
@@ -103,6 +103,14 @@ class InfoEndpointDocumentationTests extends MockMvcEndpointDocumentationTests {
 				fieldWithPath("pid").description("Process ID.").type(JsonFieldType.NUMBER),
 				fieldWithPath("parentPid").description("Parent Process ID (or -1).").type(JsonFieldType.NUMBER),
 				fieldWithPath("owner").description("Process owner.").type(JsonFieldType.STRING),
+				fieldWithPath("uptime").description("Process uptime.").type(JsonFieldType.STRING),
+				fieldWithPath("startTime").description("Process start time.").type(JsonFieldType.STRING),
+				fieldWithPath("currentTime").description("Current time known by the process.")
+					.type(JsonFieldType.STRING),
+				fieldWithPath("timezone").description("Process timezone.").type(JsonFieldType.STRING),
+				fieldWithPath("locale").description("Process locale.").type(JsonFieldType.STRING),
+				fieldWithPath("workingDirectory").description("Working directory of the process.")
+					.type(JsonFieldType.STRING),
 				fieldWithPath("cpus").description("Number of CPUs available to the process.")
 					.type(JsonFieldType.NUMBER),
 				fieldWithPath("memory").description("Memory information."),


### PR DESCRIPTION
This information can be useful during troubleshooting and learning more about the workload that is running in a certain environment. The new fields are:
- uptime
- startTime
- currentTime
- timezone
- locale
- workingDirectory

At first sight, these seem to belong to `ProcessInfo` to me but please let me know if you have alternative ideas about their placement.