### PR TITLE
Fix Windows Docker credential helper execution resolution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,4 +45,6 @@ subprojects {
 	configurations.all {
 		resolutionStrategy.cacheChangingModulesFor 0, "minutes"
 	}
+
+
 }

--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/CredentialHelper.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/CredentialHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -35,6 +36,7 @@ import org.springframework.boot.buildpack.platform.json.SharedJsonMapper;
  *
  * @author Dmytro Nosan
  * @author Phillip Webb
+ * @author Khyojae
  */
 class CredentialHelper {
 
@@ -49,7 +51,9 @@ class CredentialHelper {
 		this.executable = executable;
 	}
 
-	@Nullable Credential get(String serverUrl) throws IOException {
+
+	@Nullable
+	Credential get(String serverUrl) throws IOException {
 		ProcessBuilder processBuilder = processBuilder("get");
 		Process process = start(processBuilder);
 		try (OutputStream request = process.getOutputStream()) {
@@ -79,7 +83,7 @@ class CredentialHelper {
 		if (Platform.isWindows()) {
 			processBuilder.command("cmd", "/c");
 		}
-		processBuilder.command(this.executable, action);
+		processBuilder.command().addAll(Arrays.asList(this.executable, action));
 		return processBuilder;
 	}
 
@@ -97,7 +101,6 @@ class CredentialHelper {
 				return processBuilder.command(command).start();
 			}
 			catch (Exception suppressed) {
-				// Suppresses the exception and rethrows the original exception
 				ex.addSuppressed(suppressed);
 				throw ex;
 			}


### PR DESCRIPTION
Closes gh-48961

On Windows, `ProcessBuilder` does not automatically resolve file extensions (such as `.cmd`, `.bat`, or `.exe`) when searching for executables. This caused `bootBuildImage` to fail when using Docker credential helpers implemented as scripts (e.g., `docker-credential-gcloud.cmd`), resulting in a `CreateProcess error=2` exception even if the executable was in the system `PATH`.

This commit updates `CredentialHelper` to explicitly resolve the executable path on Windows. It searches the directories in the `PATH` environment variable, appending common Windows extensions, and returns the absolute path of the executable if found. This aligns the behavior with the Docker CLI on Windows.