### PR TITLE
Docker credential helpers with file extensions cannot be executed on Windows

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/CredentialHelper.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/CredentialHelper.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -78,7 +79,7 @@ class CredentialHelper {
 		if (Platform.isWindows()) {
 			processBuilder.command("cmd", "/c");
 		}
-		processBuilder.command(this.executable, action);
+		processBuilder.command().addAll(Arrays.asList(this.executable, action));
 		return processBuilder;
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/configuration/CredentialHelperTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/configuration/CredentialHelperTests.java
@@ -38,10 +38,20 @@ class CredentialHelperTests {
 
 	@BeforeAll
 	static void setUp() throws Exception {
-		String executableName = "docker-credential-test" + ((Platform.isWindows()) ? ".bat" : ".sh");
-		String executable = new ClassPathResource(executableName, CredentialHelperTests.class).getFile()
-			.getAbsolutePath();
-		helper = new CredentialHelper(executable);
+		helper = new CredentialHelper(getExecutableName());
+	}
+
+	private static String getExecutableName() throws Exception {
+		if (Platform.isWindows()) {
+			String executablePath = geExecutableAbsolutePath("docker-credential-test.bat");
+			// cmd /c must resolve automatically .bat suffix
+			return executablePath.substring(0, executablePath.lastIndexOf(".bat"));
+		}
+		return geExecutableAbsolutePath("docker-credential-test.sh");
+	}
+
+	private static String geExecutableAbsolutePath(String executableName) throws Exception {
+		return new ClassPathResource(executableName, CredentialHelperTests.class).getFile().getAbsolutePath();
 	}
 
 	@Test


### PR DESCRIPTION
See https://github.com/spring-projects/spring-boot/issues/48961