### PR TITLE
ApplicationContextAssert documents a non-existent assertion in getFailure()

### DIFF
--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssert.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssert.java
@@ -436,7 +436,7 @@ public class ApplicationContextAssert<C extends ApplicationContext>
 	 * becoming the object under test.
 	 * <p>
 	 * Example: <pre class="code">
-	 * assertThat(context).getFailure().containsMessage("missing bean");
+	 * assertThat(context).getFailure().hasMessageContaining("missing bean");
 	 * </pre>
 	 * @return assertions on the cause of the failure
 	 * @throws AssertionError if the application context started without a failure


### PR DESCRIPTION
This replaces the non-existent `containsMessage()` assertion with [`hasMessageContaining()`](https://www.javadoc.io/doc/org.assertj/assertj-core/3.27.7/org/assertj/core/api/AbstractThrowableAssert.html#hasMessageContaining(java.lang.String)).