### PR TITLE
Docs/docker: clarify manual cleanup for shared docker services

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/docker-compose.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/docker-compose.adoc
@@ -38,3 +38,7 @@ If you want to share services between multiple applications, create the `compose
 You should also set configprop:spring.docker.compose.lifecycle-management[] to `start-only`, as it defaults to `start-and-stop` and stopping one application would shut down the shared services for the other still running applications as well.
 Setting it to `start-only` won't stop the shared services on application stop, but a caveat is that if you shut down all applications, the services remain running.
 You can stop the services manually by running `docker compose stop` on the command line in the directory which contains the `compose.yaml` file.
+
+[NOTE]
+====
+While `docker compose stop` halts containers, `docker compose down` stops and removes the containers, networks, and any anonymous volumes defined in the `compose.yaml` file.


### PR DESCRIPTION
Description
This PR enhances the Docker Compose "How-to" guide by clarifying how to properly clean up shared services.

Changes:

Added a [NOTE] block to the sharing-services section.

Clarified that while docker compose stop halts containers, docker compose down should be used to fully remove containers, networks, and anonymous volumes.

Why this is useful: The current documentation mentions start-only lifecycle management for shared services and notes that services remain running after the application stops. While it suggests docker compose stop for manual cleanup, beginners often encounter "stale" container issues if networks and volumes aren't also cleared. Explicitly mentioning docker compose down provides a completer and more modern workflow for local development.