### PR TITLE
Improve performance of structure logging 'ContextPairs' nested name splitting

### DIFF
--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/structured/ContextPairsTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/structured/ContextPairsTests.java
@@ -121,6 +121,19 @@ class ContextPairsTests {
 	}
 
 	@Test
+	void nestedWhenNameEndsWithDelimiterDropsTrailingDelimiter() {
+		ContextPairs contextPairs = new ContextPairs(true, null);
+		Map<String, String> map = new LinkedHashMap<>();
+		map.put("a1.b1.", "A1B1");
+		Map<String, Object> actual = apply(contextPairs.nested((pairs) -> pairs.addMapEntries((item) -> map)));
+		Map<String, Object> expected = new LinkedHashMap<>();
+		Map<String, Object> a1 = new LinkedHashMap<>();
+		expected.put("a1", a1);
+		a1.put("b1", "A1B1");
+		assertThat(actual).isEqualTo(expected);
+	}
+
+	@Test
 	void nestedWhenDuplicateInParentThrowsException() {
 		ContextPairs contextPairs = new ContextPairs(true, null);
 		Map<String, String> map = new LinkedHashMap<>();


### PR DESCRIPTION
`ContextPairs` builds nested pairs by splitting each name on ".". The current implementation uses `String.split("\\.")`, which is regex-based and allocates an array and list per name.

Here I replaced the regex split with a manual dot delimited scan that reduces allocations and avoids regex overhead while preserving existing behavior. 

A test has been added.