### PR TITLE
Add customizers for OtlpHttpLogRecordExporterBuilder and OtlpGrpcLogRecordExporterBuilder

### DIFF
--- a/module/spring-boot-opentelemetry/src/main/java/org/springframework/boot/opentelemetry/autoconfigure/logging/otlp/OtlpGrpcLogRecordExporterBuilderCustomizer.java
+++ b/module/spring-boot-opentelemetry/src/main/java/org/springframework/boot/opentelemetry/autoconfigure/logging/otlp/OtlpGrpcLogRecordExporterBuilderCustomizer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.opentelemetry.autoconfigure.logging.otlp;
+
+import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize the
+ * {@link OtlpGrpcLogRecordExporterBuilder} whilst retaining default auto-configuration.
+ *
+ * @author Joaquin Santana
+ * @since 4.1.0
+ */
+@FunctionalInterface
+public interface OtlpGrpcLogRecordExporterBuilderCustomizer {
+
+	/**
+	 * Customize the {@link OtlpGrpcLogRecordExporterBuilder}.
+	 * @param builder the builder to customize
+	 */
+	void customize(OtlpGrpcLogRecordExporterBuilder builder);
+
+}

--- a/module/spring-boot-opentelemetry/src/main/java/org/springframework/boot/opentelemetry/autoconfigure/logging/otlp/OtlpHttpLogRecordExporterBuilderCustomizer.java
+++ b/module/spring-boot-opentelemetry/src/main/java/org/springframework/boot/opentelemetry/autoconfigure/logging/otlp/OtlpHttpLogRecordExporterBuilderCustomizer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.opentelemetry.autoconfigure.logging.otlp;
+
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder;
+
+/**
+ * Callback interface that can be implemented by beans wishing to customize the
+ * {@link OtlpHttpLogRecordExporterBuilder} whilst retaining default auto-configuration.
+ *
+ * @author Joaquin Santana
+ * @since 4.1.0
+ */
+@FunctionalInterface
+public interface OtlpHttpLogRecordExporterBuilderCustomizer {
+
+	/**
+	 * Customize the {@link OtlpHttpLogRecordExporterBuilder}.
+	 * @param builder the builder to customize
+	 */
+	void customize(OtlpHttpLogRecordExporterBuilder builder);
+
+}

--- a/module/spring-boot-opentelemetry/src/main/java/org/springframework/boot/opentelemetry/autoconfigure/logging/otlp/OtlpLoggingConfigurations.java
+++ b/module/spring-boot-opentelemetry/src/main/java/org/springframework/boot/opentelemetry/autoconfigure/logging/otlp/OtlpLoggingConfigurations.java
@@ -88,7 +88,8 @@ final class OtlpLoggingConfigurations {
 		@ConditionalOnProperty(name = "management.opentelemetry.logging.export.otlp.transport", havingValue = "http",
 				matchIfMissing = true)
 		OtlpHttpLogRecordExporter otlpHttpLogRecordExporter(OtlpLoggingProperties properties,
-				OtlpLoggingConnectionDetails connectionDetails, ObjectProvider<MeterProvider> meterProvider) {
+				OtlpLoggingConnectionDetails connectionDetails, ObjectProvider<MeterProvider> meterProvider,
+				ObjectProvider<OtlpHttpLogRecordExporterBuilderCustomizer> customizers) {
 			OtlpHttpLogRecordExporterBuilder builder = OtlpHttpLogRecordExporter.builder()
 				.setEndpoint(connectionDetails.getUrl(Transport.HTTP))
 				.setTimeout(properties.getTimeout())
@@ -96,13 +97,15 @@ final class OtlpLoggingConfigurations {
 				.setCompression(properties.getCompression().name().toLowerCase(Locale.US));
 			properties.getHeaders().forEach(builder::addHeader);
 			meterProvider.ifAvailable(builder::setMeterProvider);
+			customizers.orderedStream().forEach((customizer) -> customizer.customize(builder));
 			return builder.build();
 		}
 
 		@Bean
 		@ConditionalOnProperty(name = "management.opentelemetry.logging.export.otlp.transport", havingValue = "grpc")
 		OtlpGrpcLogRecordExporter otlpGrpcLogRecordExporter(OtlpLoggingProperties properties,
-				OtlpLoggingConnectionDetails connectionDetails, ObjectProvider<MeterProvider> meterProvider) {
+				OtlpLoggingConnectionDetails connectionDetails, ObjectProvider<MeterProvider> meterProvider,
+				ObjectProvider<OtlpGrpcLogRecordExporterBuilderCustomizer> customizers) {
 			OtlpGrpcLogRecordExporterBuilder builder = OtlpGrpcLogRecordExporter.builder()
 				.setEndpoint(connectionDetails.getUrl(Transport.GRPC))
 				.setTimeout(properties.getTimeout())
@@ -110,6 +113,7 @@ final class OtlpLoggingConfigurations {
 				.setCompression(properties.getCompression().name().toLowerCase(Locale.US));
 			properties.getHeaders().forEach(builder::addHeader);
 			meterProvider.ifAvailable(builder::setMeterProvider);
+			customizers.orderedStream().forEach((customizer) -> customizer.customize(builder));
 			return builder.build();
 		}
 


### PR DESCRIPTION
Introduce interfaces to allow customization of the OTLP HTTP and gRPC log record exporters while maintaining default auto-configuration. This enhancement enables users to modify exporter settings through custom beans.

closes https://github.com/spring-projects/spring-boot/issues/48994

