### PR TITLE
Add SSL bundle support for LDAP connections  

### DIFF
--- a/module/spring-boot-ldap/src/dockerTest/java/org/springframework/boot/ldap/autoconfigure/LdapSslDockerTests.java
+++ b/module/spring-boot-ldap/src/dockerTest/java/org/springframework/boot/ldap/autoconfigure/LdapSslDockerTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.ldap.autoconfigure;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.ssl.SslAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.ldap.core.LdapTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Docker-based integration tests for LDAP SSL configuration.
+ *
+ * @author Massimo Deiana
+ */
+@Testcontainers
+class LdapSslDockerTests {
+
+	private static final String LDAP_IMAGE = "osixia/openldap:1.5.0";
+
+	@Container
+	static final GenericContainer<?> ldapContainer = new GenericContainer<>(LDAP_IMAGE)
+		.withEnv("LDAP_ORGANISATION", "Example Inc")
+		.withEnv("LDAP_DOMAIN", "example.org")
+		.withEnv("LDAP_ADMIN_PASSWORD", "admin")
+		.withEnv("LDAP_TLS", "true")
+		.withEnv("LDAP_TLS_VERIFY_CLIENT", "never")
+		.withExposedPorts(389, 636)
+		.waitingFor(Wait.forLogMessage(".*slapd starting.*", 1).withStartupTimeout(Duration.ofMinutes(2)));
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(LdapAutoConfiguration.class, SslAutoConfiguration.class));
+
+	@Test
+	void ldapConnectionWithoutSsl() {
+		this.contextRunner
+			.withPropertyValues("spring.ldap.urls=ldap://localhost:" + ldapContainer.getMappedPort(389),
+					"spring.ldap.base=dc=example,dc=org", "spring.ldap.username=cn=admin,dc=example,dc=org",
+					"spring.ldap.password=admin")
+			.run((context) -> {
+				assertThat(context).hasSingleBean(LdapTemplate.class);
+				LdapTemplate ldapTemplate = context.getBean(LdapTemplate.class);
+				Object result = ldapTemplate.lookup("");
+				assertThat(result).isNotNull();
+			});
+	}
+
+	@Test
+	void ldapConnectionWithStartTlsConfiguration() {
+		this.contextRunner
+			.withPropertyValues("spring.ldap.urls=ldap://localhost:" + ldapContainer.getMappedPort(389),
+					"spring.ldap.base=dc=example,dc=org", "spring.ldap.username=cn=admin,dc=example,dc=org",
+					"spring.ldap.password=admin")
+			.run((context) -> {
+				assertThat(context).hasSingleBean(LdapTemplate.class);
+				LdapTemplate ldapTemplate = context.getBean(LdapTemplate.class);
+				Object result = ldapTemplate.lookup("");
+				assertThat(result).isNotNull();
+			});
+	}
+
+}

--- a/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/autoconfigure/LdapAutoConfiguration.java
+++ b/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/autoconfigure/LdapAutoConfiguration.java
@@ -17,9 +17,17 @@
 package org.springframework.boot.ldap.autoconfigure;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSocketFactory;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -27,17 +35,25 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.boot.ldap.autoconfigure.LdapProperties.Ssl;
 import org.springframework.boot.ldap.autoconfigure.LdapProperties.Template;
+import org.springframework.boot.ldap.ssl.SslBundleSocketFactoryRegistry;
+import org.springframework.boot.ssl.SslBundle;
+import org.springframework.boot.ssl.SslBundles;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.ldap.convert.ConverterUtils;
 import org.springframework.ldap.core.ContextSource;
 import org.springframework.ldap.core.LdapOperations;
 import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.ldap.core.support.DefaultTlsDirContextAuthenticationStrategy;
 import org.springframework.ldap.core.support.DirContextAuthenticationStrategy;
 import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.ldap.odm.core.ObjectDirectoryMapper;
 import org.springframework.ldap.odm.core.impl.DefaultObjectDirectoryMapper;
+import org.springframework.util.StringUtils;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for LDAP.
@@ -61,7 +77,8 @@ public final class LdapAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	LdapContextSource ldapContextSource(LdapConnectionDetails connectionDetails, LdapProperties properties,
-			ObjectProvider<DirContextAuthenticationStrategy> dirContextAuthenticationStrategy) {
+			ObjectProvider<DirContextAuthenticationStrategy> dirContextAuthenticationStrategy,
+			ObjectProvider<SslBundles> sslBundles) {
 		LdapContextSource source = new LdapContextSource();
 		dirContextAuthenticationStrategy.ifUnique(source::setAuthenticationStrategy);
 		PropertyMapper propertyMapper = PropertyMapper.get();
@@ -73,8 +90,11 @@ public final class LdapAutoConfiguration {
 			.to(source::setReferral);
 		propertyMapper.from(connectionDetails.getBase()).to(source::setBase);
 		propertyMapper.from(connectionDetails.getUrls()).to(source::setUrls);
-		propertyMapper.from(properties.getBaseEnvironment())
-			.to((baseEnvironment) -> source.setBaseEnvironmentProperties(Collections.unmodifiableMap(baseEnvironment)));
+		Map<String, Object> baseEnvironment = new HashMap<>(properties.getBaseEnvironment());
+		configureLdapsSsl(properties, connectionDetails, sslBundles.getIfAvailable(), baseEnvironment);
+		if (!baseEnvironment.isEmpty()) {
+			source.setBaseEnvironmentProperties(Collections.unmodifiableMap(baseEnvironment));
+		}
 		return source;
 	}
 
@@ -102,6 +122,75 @@ public final class LdapAutoConfiguration {
 		propertyMapper.from(template.isIgnoreSizeLimitExceededException())
 			.to(ldapTemplate::setIgnoreSizeLimitExceededException);
 		return ldapTemplate;
+	}
+
+	@Bean
+	SmartInitializingSingleton ldapSslRegistryCleanup() {
+		return SslBundleSocketFactoryRegistry::clear;
+	}
+
+	private void configureLdapsSsl(LdapProperties properties, LdapConnectionDetails connectionDetails,
+			@Nullable SslBundles sslBundles, Map<String, Object> baseEnvironment) {
+		Ssl ssl = properties.getSsl();
+		if (!ssl.isEnabled() || !StringUtils.hasLength(ssl.getBundle())) {
+			return;
+		}
+		if (shouldUseLdapsSocketFactory(ssl, connectionDetails)) {
+			if (sslBundles == null) {
+				throw new IllegalStateException(
+						"SSL bundle '" + ssl.getBundle() + "' is configured but no SslBundles bean is available");
+			}
+			SslBundle bundle = sslBundles.getBundle(ssl.getBundle());
+			SSLSocketFactory socketFactory = bundle.createSslContext().getSocketFactory();
+			SslBundleSocketFactoryRegistry.register(socketFactory);
+			baseEnvironment.put("java.naming.ldap.factory.socket", SslBundleSocketFactoryRegistry.class.getName());
+		}
+	}
+
+	private boolean shouldUseLdapsSocketFactory(Ssl ssl, LdapConnectionDetails connectionDetails) {
+		if (Boolean.TRUE.equals(ssl.getStartTls())) {
+			return false;
+		}
+		if (Boolean.FALSE.equals(ssl.getStartTls())) {
+			return true;
+		}
+		String[] urls = connectionDetails.getUrls();
+		if (urls != null) {
+			for (String url : urls) {
+				if (url != null && url.toLowerCase(Locale.ROOT).startsWith("ldaps://")) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Conditional(OnLdapStartTlsCondition.class)
+	@ConditionalOnMissingBean(DirContextAuthenticationStrategy.class)
+	static class StartTlsConfiguration {
+
+		@Bean
+		DefaultTlsDirContextAuthenticationStrategy tlsDirContextAuthenticationStrategy(LdapProperties properties,
+				ObjectProvider<SslBundles> sslBundles) {
+			Ssl ssl = properties.getSsl();
+			DefaultTlsDirContextAuthenticationStrategy strategy = new DefaultTlsDirContextAuthenticationStrategy();
+			SslBundles bundles = sslBundles.getIfAvailable();
+			if (bundles != null && StringUtils.hasLength(ssl.getBundle())) {
+				SslBundle bundle = bundles.getBundle(ssl.getBundle());
+				SSLSocketFactory socketFactory = bundle.createSslContext().getSocketFactory();
+				strategy.setSslSocketFactory(socketFactory);
+			}
+			if (!ssl.isVerifyHostname()) {
+				strategy.setHostnameVerifier(acceptAllHostnameVerifier());
+			}
+			return strategy;
+		}
+
+		private static HostnameVerifier acceptAllHostnameVerifier() {
+			return (hostname, session) -> true;
+		}
+
 	}
 
 }

--- a/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/autoconfigure/LdapProperties.java
+++ b/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/autoconfigure/LdapProperties.java
@@ -78,6 +78,8 @@ public class LdapProperties {
 
 	private final Template template = new Template();
 
+	private final Ssl ssl = new Ssl();
+
 	public String @Nullable [] getUrls() {
 		return this.urls;
 	}
@@ -132,6 +134,10 @@ public class LdapProperties {
 
 	public Template getTemplate() {
 		return this.template;
+	}
+
+	public Ssl getSsl() {
+		return this.ssl;
 	}
 
 	public String[] determineUrls(Environment environment) {
@@ -195,6 +201,68 @@ public class LdapProperties {
 
 		public void setIgnoreSizeLimitExceededException(Boolean ignoreSizeLimitExceededException) {
 			this.ignoreSizeLimitExceededException = ignoreSizeLimitExceededException;
+		}
+
+	}
+
+	/**
+	 * SSL configuration.
+	 */
+	public static class Ssl {
+
+		/**
+		 * Whether to enable SSL support. Enabled automatically if "bundle" is provided
+		 * unless specified otherwise.
+		 */
+		private @Nullable Boolean enabled;
+
+		/**
+		 * SSL bundle name.
+		 */
+		private @Nullable String bundle;
+
+		/**
+		 * Whether to use StartTLS instead of LDAPS. When not set, automatically
+		 * determined based on URL scheme (ldaps:// uses LDAPS, ldap:// uses StartTLS).
+		 */
+		private @Nullable Boolean startTls;
+
+		/**
+		 * Whether to verify the LDAP server's hostname matches the certificate. Defaults
+		 * to true. Set to false for testing with self-signed certificates.
+		 */
+		private boolean verifyHostname = true;
+
+		public boolean isEnabled() {
+			return (this.enabled != null) ? this.enabled : this.bundle != null;
+		}
+
+		public void setEnabled(@Nullable Boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public @Nullable String getBundle() {
+			return this.bundle;
+		}
+
+		public void setBundle(@Nullable String bundle) {
+			this.bundle = bundle;
+		}
+
+		public @Nullable Boolean getStartTls() {
+			return this.startTls;
+		}
+
+		public void setStartTls(@Nullable Boolean startTls) {
+			this.startTls = startTls;
+		}
+
+		public boolean isVerifyHostname() {
+			return this.verifyHostname;
+		}
+
+		public void setVerifyHostname(boolean verifyHostname) {
+			this.verifyHostname = verifyHostname;
 		}
 
 	}

--- a/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/autoconfigure/OnLdapStartTlsCondition.java
+++ b/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/autoconfigure/OnLdapStartTlsCondition.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.ldap.autoconfigure;
+
+import java.util.Locale;
+
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.StringUtils;
+
+/**
+ * Condition that matches when LDAP StartTLS should be used.
+ * <p>
+ * StartTLS mode is active when:
+ * <ul>
+ * <li>SSL bundle is configured ({@code spring.ldap.ssl.bundle})</li>
+ * <li>SSL is not explicitly disabled ({@code spring.ldap.ssl.enabled != false})</li>
+ * <li>StartTLS is either explicitly enabled ({@code spring.ldap.ssl.start-tls=true}) or
+ * the URL scheme is {@code ldap://} (not {@code ldaps://})</li>
+ * </ul>
+ *
+ * @author Massimo Deiana
+ */
+class OnLdapStartTlsCondition extends SpringBootCondition {
+
+	@Override
+	public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		String bundle = context.getEnvironment().getProperty("spring.ldap.ssl.bundle");
+		if (!StringUtils.hasLength(bundle)) {
+			return ConditionOutcome.noMatch("No SSL bundle configured");
+		}
+		String enabled = context.getEnvironment().getProperty("spring.ldap.ssl.enabled");
+		if ("false".equalsIgnoreCase(enabled)) {
+			return ConditionOutcome.noMatch("SSL is explicitly disabled");
+		}
+		String startTls = context.getEnvironment().getProperty("spring.ldap.ssl.start-tls");
+		if ("false".equalsIgnoreCase(startTls)) {
+			return ConditionOutcome.noMatch("StartTLS is explicitly disabled (using LDAPS mode)");
+		}
+		if ("true".equalsIgnoreCase(startTls)) {
+			return ConditionOutcome.match("StartTLS is explicitly enabled");
+		}
+		String urls = context.getEnvironment().getProperty("spring.ldap.urls");
+		if (urls != null && urls.toLowerCase(Locale.ROOT).contains("ldaps://")) {
+			return ConditionOutcome.noMatch("URL scheme is ldaps://, using LDAPS mode");
+		}
+		return ConditionOutcome.match("SSL bundle configured with ldap:// URL (StartTLS mode)");
+	}
+
+}

--- a/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/ssl/SslBundleSocketFactoryRegistry.java
+++ b/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/ssl/SslBundleSocketFactoryRegistry.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.ldap.ssl;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * Registry-based {@link SSLSocketFactory} for LDAPS connections.
+ * <p>
+ * JNDI requires the {@code java.naming.ldap.factory.socket} property to be a class name,
+ * not an instance. This class provides a workaround by storing {@link SSLSocketFactory}
+ * instances in a {@link ThreadLocal} before context creation.
+ * <p>
+ * Usage:
+ * <ol>
+ * <li>Register the SSLSocketFactory:
+ * {@code SslBundleSocketFactoryRegistry.register(sslSocketFactory)}</li>
+ * <li>Set JNDI property:
+ * {@code env.put("java.naming.ldap.factory.socket", SslBundleSocketFactoryRegistry.class.getName())}</li>
+ * <li>Create LDAP context (uses the registered factory)</li>
+ * <li>Clear registration: {@code SslBundleSocketFactoryRegistry.clear()}</li>
+ * </ol>
+ *
+ * @author Massimo Deiana
+ * @since 4.0.0
+ * @see SSLSocketFactory
+ */
+public class SslBundleSocketFactoryRegistry extends SSLSocketFactory {
+
+	private static final ThreadLocal<SSLSocketFactory> CURRENT_FACTORY = new ThreadLocal<>();
+
+	private final SSLSocketFactory delegate;
+
+	/**
+	 * Default constructor required by JNDI. Retrieves the {@link SSLSocketFactory} from
+	 * the {@link ThreadLocal} registry.
+	 * @throws IllegalStateException if no factory has been registered
+	 */
+	public SslBundleSocketFactoryRegistry() {
+		SSLSocketFactory factory = CURRENT_FACTORY.get();
+		if (factory == null) {
+			throw new IllegalStateException(
+					"No SSLSocketFactory registered. Call SslBundleSocketFactoryRegistry.register() "
+							+ "before creating the LDAP context.");
+		}
+		this.delegate = factory;
+	}
+
+	/**
+	 * Register an {@link SSLSocketFactory} for the current thread. Must be called before
+	 * creating the LDAP context.
+	 * @param factory the SSLSocketFactory to use for LDAPS connections
+	 */
+	public static void register(SSLSocketFactory factory) {
+		CURRENT_FACTORY.set(factory);
+	}
+
+	/**
+	 * Clear the registered {@link SSLSocketFactory} for the current thread. Should be
+	 * called after LDAP context creation to prevent memory leaks.
+	 */
+	public static void clear() {
+		CURRENT_FACTORY.remove();
+	}
+
+	/**
+	 * Returns a new instance that delegates to the registered factory. This method is
+	 * called by JNDI when creating SSL sockets.
+	 * @return a new {@link SslBundleSocketFactoryRegistry} instance
+	 */
+	public static SocketFactory getDefault() {
+		return new SslBundleSocketFactoryRegistry();
+	}
+
+	@Override
+	public String[] getDefaultCipherSuites() {
+		return this.delegate.getDefaultCipherSuites();
+	}
+
+	@Override
+	public String[] getSupportedCipherSuites() {
+		return this.delegate.getSupportedCipherSuites();
+	}
+
+	@Override
+	public Socket createSocket(Socket socket, String host, int port, boolean autoClose) throws IOException {
+		return this.delegate.createSocket(socket, host, port, autoClose);
+	}
+
+	@Override
+	public Socket createSocket(String host, int port) throws IOException {
+		return this.delegate.createSocket(host, port);
+	}
+
+	@Override
+	public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+		return this.delegate.createSocket(host, port, localHost, localPort);
+	}
+
+	@Override
+	public Socket createSocket(InetAddress host, int port) throws IOException {
+		return this.delegate.createSocket(host, port);
+	}
+
+	@Override
+	public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
+			throws IOException {
+		return this.delegate.createSocket(address, port, localAddress, localPort);
+	}
+
+	@Override
+	public Socket createSocket() throws IOException {
+		return this.delegate.createSocket();
+	}
+
+}

--- a/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/ssl/package-info.java
+++ b/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/ssl/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * SSL support classes for Spring LDAP integration.
+ */
+@NullMarked
+package org.springframework.boot.ldap.ssl;
+
+import org.jspecify.annotations.NullMarked;

--- a/module/spring-boot-ldap/src/test/java/org/springframework/boot/ldap/autoconfigure/LdapAutoConfigurationSslTests.java
+++ b/module/spring-boot-ldap/src/test/java/org/springframework/boot/ldap/autoconfigure/LdapAutoConfigurationSslTests.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.ldap.autoconfigure;
+
+import java.util.Hashtable;
+import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.ssl.SslAutoConfiguration;
+import org.springframework.boot.ldap.ssl.SslBundleSocketFactoryRegistry;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.ldap.core.support.DefaultTlsDirContextAuthenticationStrategy;
+import org.springframework.ldap.core.support.DirContextAuthenticationStrategy;
+import org.springframework.ldap.core.support.LdapContextSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for SSL configuration in {@link LdapAutoConfiguration}.
+ *
+ * @author Massimo Deiana
+ */
+class LdapAutoConfigurationSslTests {
+
+	private static final String TEST_KEYSTORE_LOCATION = "classpath:org/springframework/boot/ldap/autoconfigure/embedded/test.jks";
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(LdapAutoConfiguration.class, SslAutoConfiguration.class));
+
+	@Test
+	void whenSslBundleConfiguredWithLdapsUrl_thenSocketFactoryPropertyIsSet() {
+		this.contextRunner
+			.withPropertyValues("spring.ssl.bundle.jks.test.keystore.location=" + TEST_KEYSTORE_LOCATION,
+					"spring.ssl.bundle.jks.test.keystore.password=secret",
+					"spring.ssl.bundle.jks.test.truststore.location=" + TEST_KEYSTORE_LOCATION,
+					"spring.ssl.bundle.jks.test.truststore.password=secret", "spring.ldap.urls=ldaps://localhost:636",
+					"spring.ldap.ssl.bundle=test")
+			.run((context) -> {
+				assertThat(context).hasSingleBean(LdapContextSource.class);
+				LdapContextSource contextSource = context.getBean(LdapContextSource.class);
+				@SuppressWarnings("unchecked")
+				Hashtable<String, Object> baseEnv = (Hashtable<String, Object>) Objects
+					.requireNonNull(ReflectionTestUtils.getField(contextSource, "baseEnv"));
+				assertThat(baseEnv).containsKey("java.naming.ldap.factory.socket");
+				assertThat(baseEnv.get("java.naming.ldap.factory.socket"))
+					.isEqualTo(SslBundleSocketFactoryRegistry.class.getName());
+			});
+	}
+
+	@Test
+	void whenSslBundleConfiguredWithLdapUrl_thenStartTlsStrategyIsCreated() {
+		this.contextRunner
+			.withPropertyValues("spring.ssl.bundle.jks.test.keystore.location=" + TEST_KEYSTORE_LOCATION,
+					"spring.ssl.bundle.jks.test.keystore.password=secret",
+					"spring.ssl.bundle.jks.test.truststore.location=" + TEST_KEYSTORE_LOCATION,
+					"spring.ssl.bundle.jks.test.truststore.password=secret", "spring.ldap.urls=ldap://localhost:389",
+					"spring.ldap.ssl.bundle=test")
+			.run((context) -> {
+				assertThat(context).hasSingleBean(DirContextAuthenticationStrategy.class);
+				assertThat(context.getBean(DirContextAuthenticationStrategy.class))
+					.isInstanceOf(DefaultTlsDirContextAuthenticationStrategy.class);
+			});
+	}
+
+	@Test
+	void whenSslBundleConfiguredWithExplicitStartTls_thenStartTlsStrategyIsCreated() {
+		this.contextRunner
+			.withPropertyValues("spring.ssl.bundle.jks.test.keystore.location=" + TEST_KEYSTORE_LOCATION,
+					"spring.ssl.bundle.jks.test.keystore.password=secret",
+					"spring.ssl.bundle.jks.test.truststore.location=" + TEST_KEYSTORE_LOCATION,
+					"spring.ssl.bundle.jks.test.truststore.password=secret", "spring.ldap.urls=ldap://localhost:389",
+					"spring.ldap.ssl.bundle=test", "spring.ldap.ssl.start-tls=true")
+			.run((context) -> assertThat(context).hasSingleBean(DefaultTlsDirContextAuthenticationStrategy.class));
+	}
+
+	@Test
+	void whenSslBundleConfiguredWithExplicitLdapsMode_thenSocketFactoryIsUsed() {
+		this.contextRunner
+			.withPropertyValues("spring.ssl.bundle.jks.test.keystore.location=" + TEST_KEYSTORE_LOCATION,
+					"spring.ssl.bundle.jks.test.keystore.password=secret",
+					"spring.ssl.bundle.jks.test.truststore.location=" + TEST_KEYSTORE_LOCATION,
+					"spring.ssl.bundle.jks.test.truststore.password=secret", "spring.ldap.urls=ldap://localhost:389",
+					"spring.ldap.ssl.bundle=test", "spring.ldap.ssl.start-tls=false")
+			.run((context) -> {
+				LdapContextSource contextSource = context.getBean(LdapContextSource.class);
+				@SuppressWarnings("unchecked")
+				Hashtable<String, Object> baseEnv = (Hashtable<String, Object>) Objects
+					.requireNonNull(ReflectionTestUtils.getField(contextSource, "baseEnv"));
+				assertThat(baseEnv).containsKey("java.naming.ldap.factory.socket");
+				assertThat(context).doesNotHaveBean(DefaultTlsDirContextAuthenticationStrategy.class);
+			});
+	}
+
+	@Test
+	void whenSslDisabled_thenNoSslConfiguration() {
+		this.contextRunner
+			.withPropertyValues("spring.ssl.bundle.jks.test.keystore.location=" + TEST_KEYSTORE_LOCATION,
+					"spring.ssl.bundle.jks.test.keystore.password=secret", "spring.ldap.urls=ldap://localhost:389",
+					"spring.ldap.ssl.enabled=false", "spring.ldap.ssl.bundle=test")
+			.run((context) -> {
+				LdapContextSource contextSource = context.getBean(LdapContextSource.class);
+				@SuppressWarnings("unchecked")
+				Hashtable<String, Object> baseEnv = (Hashtable<String, Object>) Objects
+					.requireNonNull(ReflectionTestUtils.getField(contextSource, "baseEnv"));
+				assertThat(baseEnv).doesNotContainKey("java.naming.ldap.factory.socket");
+				assertThat(context).doesNotHaveBean(DefaultTlsDirContextAuthenticationStrategy.class);
+			});
+	}
+
+	@Test
+	void whenNoSslBundle_thenNoSslConfiguration() {
+		this.contextRunner.withPropertyValues("spring.ldap.urls=ldap://localhost:389").run((context) -> {
+			LdapContextSource contextSource = context.getBean(LdapContextSource.class);
+			@SuppressWarnings("unchecked")
+			Hashtable<String, Object> baseEnv = (Hashtable<String, Object>) Objects
+				.requireNonNull(ReflectionTestUtils.getField(contextSource, "baseEnv"));
+			assertThat(baseEnv).isEmpty();
+			assertThat(context).doesNotHaveBean(DefaultTlsDirContextAuthenticationStrategy.class);
+		});
+	}
+
+	@Test
+	void whenHostnameVerificationDisabled_thenStrategyHasNoOpVerifier() {
+		this.contextRunner
+			.withPropertyValues("spring.ssl.bundle.jks.test.keystore.location=" + TEST_KEYSTORE_LOCATION,
+					"spring.ssl.bundle.jks.test.keystore.password=secret",
+					"spring.ssl.bundle.jks.test.truststore.location=" + TEST_KEYSTORE_LOCATION,
+					"spring.ssl.bundle.jks.test.truststore.password=secret", "spring.ldap.urls=ldap://localhost:389",
+					"spring.ldap.ssl.bundle=test", "spring.ldap.ssl.verify-hostname=false")
+			.run((context) -> {
+				DefaultTlsDirContextAuthenticationStrategy strategy = context
+					.getBean(DefaultTlsDirContextAuthenticationStrategy.class);
+				Object hostnameVerifier = ReflectionTestUtils.getField(strategy, "hostnameVerifier");
+				assertThat(hostnameVerifier).isNotNull();
+			});
+	}
+
+	@Test
+	void whenHostnameVerificationEnabled_thenStrategyUsesDefaultVerifier() {
+		this.contextRunner
+			.withPropertyValues("spring.ssl.bundle.jks.test.keystore.location=" + TEST_KEYSTORE_LOCATION,
+					"spring.ssl.bundle.jks.test.keystore.password=secret",
+					"spring.ssl.bundle.jks.test.truststore.location=" + TEST_KEYSTORE_LOCATION,
+					"spring.ssl.bundle.jks.test.truststore.password=secret", "spring.ldap.urls=ldap://localhost:389",
+					"spring.ldap.ssl.bundle=test", "spring.ldap.ssl.verify-hostname=true")
+			.run((context) -> {
+				DefaultTlsDirContextAuthenticationStrategy strategy = context
+					.getBean(DefaultTlsDirContextAuthenticationStrategy.class);
+				assertThat(strategy).hasFieldOrPropertyWithValue("hostnameVerifier", null);
+			});
+	}
+
+	@Test
+	void whenInvalidSslBundle_thenFailsWithClearError() {
+		this.contextRunner
+			.withPropertyValues("spring.ldap.urls=ldaps://localhost:636", "spring.ldap.ssl.bundle=nonexistent")
+			.run((context) -> {
+				assertThat(context).hasFailed();
+				assertThat(context).getFailure().hasMessageContaining("nonexistent");
+			});
+	}
+
+	@Test
+	void sslRegistryCleanupBeanIsCreated() {
+		this.contextRunner.withPropertyValues("spring.ldap.urls=ldap://localhost:389")
+			.run((context) -> assertThat(context).hasBean("ldapSslRegistryCleanup"));
+	}
+
+}


### PR DESCRIPTION
This PR adds support for configuring SSL/TLS for LDAP connections using      
  Spring Boot's SSL Bundles infrastructure.                                    
                                                                               
  ## Motivation                                                                
                                                                               
  Currently, there's no way to configure custom keystores/truststores for LDAP 
  connections through Spring Boot's configuration properties. Users needing    
  mutual TLS (mTLS) or custom certificate authorities for LDAP must configure  
  this programmatically. This enhancement brings LDAP in line with other Spring
   Boot modules (Kafka, RabbitMQ, etc.) that already support SSL Bundles.      
                                                                               
  Related discussions in spring-ldap: spring-projects/spring-ldap#494,         
  spring-projects/spring-ldap#545                                              
                                                                               
  ## Changes                                                                   
                                                                               
  Adds new configuration properties under `spring.ldap.ssl`:                   
  - `bundle` - Name of the SSL bundle to use                                   
  - `enabled` - Enable/disable SSL (defaults based on bundle presence)         
  - `start-tls` - Explicitly choose StartTLS or LDAPS mode                     
  - `verify-hostname` - Enable/disable hostname verification for StartTLS      
                                                                               
  The mode (LDAPS vs StartTLS) is automatically detected from the URL scheme   
  when not explicitly configured.                                              
                                                                               
  ## Example                                                                   
                                                                               
  ```yaml                                                                      
  spring:                                                                      
    ldap:                                                                      
      urls: ldaps://ldap.example.com:636                                       
      ssl:                                                                     
        bundle: my-ldap-bundle                                                 
    ssl:                                                                       
      bundle:                                                                  
        jks:                                                                   
          my-ldap-bundle:                                                      
            truststore:                                                        
              location: classpath:truststore.jks                               
              password: secret                                                 
 