### PR TITLE
Members declared in final classes should not be protected

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/BomResolver.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/BomResolver.java
@@ -199,7 +199,7 @@ class BomResolver {
 
 	private static final class Node {
 
-		protected final XPath xpath;
+		private final XPath xpath;
 
 		private final org.w3c.dom.Node delegate;
 

--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/info/ProjectInfoAutoConfiguration.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/info/ProjectInfoAutoConfiguration.java
@@ -75,7 +75,7 @@ public final class ProjectInfoAutoConfiguration {
 				loadFrom(this.properties.getBuild().getLocation(), "build", this.properties.getBuild().getEncoding()));
 	}
 
-	protected Properties loadFrom(Resource location, String prefix, Charset encoding) throws IOException {
+	private Properties loadFrom(Resource location, String prefix, Charset encoding) throws IOException {
 		prefix = prefix.endsWith(".") ? prefix : prefix + ".";
 		Properties source = loadSource(location, encoding);
 		Properties target = new Properties();

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/util/TestPropertyValues.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/util/TestPropertyValues.java
@@ -310,7 +310,7 @@ public final class TestPropertyValues {
 			return this.sourceClass;
 		}
 
-		protected String applySuffix(String name) {
+		private String applySuffix(String name) {
 			return (this.suffix != null) ? name + "-" + this.suffix : name;
 		}
 

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/ColorConverter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/ColorConverter.java
@@ -110,7 +110,7 @@ public final class ColorConverter extends LogEventPatternConverter {
 		}
 	}
 
-	protected void appendAnsiString(StringBuilder toAppendTo, String in, AnsiElement element) {
+	private void appendAnsiString(StringBuilder toAppendTo, String in, AnsiElement element) {
 		toAppendTo.append(AnsiOutput.toString(element, in));
 	}
 

--- a/loader/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/BuildPropertiesWriter.java
+++ b/loader/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/BuildPropertiesWriter.java
@@ -73,7 +73,7 @@ public final class BuildPropertiesWriter {
 		}
 	}
 
-	protected Properties createBuildInfo(ProjectDetails project) {
+	private Properties createBuildInfo(ProjectDetails project) {
 		Properties properties = CollectionFactory.createSortedProperties(true);
 		addIfHasValue(properties, "build.group", project.getGroup());
 		addIfHasValue(properties, "build.artifact", project.getArtifact());


### PR DESCRIPTION
>> Since final classes cannot be inherited, marking the method as protected may be confusing. It is better to declare such members as private or package-visible instead.

Reported by IDEA, I tried to write `ArchRule` to prohibit such usage, but it's difficult to test methods are overriding super class methods.
Feel free to close if it's not worthy.