### PR TITLE
Whitespace can be incorrectly removed when spring-boot-configuration-processor runs on multi-line javadoc

### DIFF
--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeUtils.java
@@ -272,8 +272,11 @@ class TypeUtils {
 		char lastChar = '.';
 		for (int i = 0; i < javadoc.length(); i++) {
 			char ch = javadoc.charAt(i);
+			if (ch == '\r' || ch == '\n') {
+				ch = ' ';
+			}
 			boolean repeatedSpace = ch == ' ' && lastChar == ' ';
-			if (ch != '\r' && ch != '\n' && !repeatedSpace) {
+			if (!repeatedSpace) {
 				result.append(ch);
 				lastChar = ch;
 			}


### PR DESCRIPTION
When using multiline markdown javadoc comments in Java 25 the description generated in `META-INF/spring-configuration-metadata.json` by `spring-boot-configuration-processor` is missing whitespaces.

The following javadoc comment

```
/// foo
/// bar
```

results in

```
"description": "foobar"
```

This pull request fixes this.