### PR TITLE
Document that use of non idiomatic format for '@Value' still apply for environment variables

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/external-config.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/external-config.adoc
@@ -1380,7 +1380,7 @@ If you do want to use javadoc:org.springframework.beans.factory.annotation.Value
 This will allow Spring Boot to use the same logic as it does when xref:features/external-config.adoc#features.external-config.typesafe-configuration-properties.relaxed-binding[relaxed binding] javadoc:org.springframework.boot.context.properties.ConfigurationProperties[format=annotation].
 
 For example, `@Value("${demo.item-price}")` will pick up `demo.item-price` and `demo.itemPrice` forms from the `application.properties` file, as well as `DEMO_ITEMPRICE` from the system environment.
-If you used `@Value("${demo.itemPrice}")` instead, `demo.item-price` and `DEMO_ITEMPRICE` would not be considered.
+If you used `@Value("${demo.itemPrice}")` instead, `demo.item-price` would not be considered; however, `DEMO_ITEMPRICE` from the environment would still be considered.
 ====
 
 If you define a set of configuration keys for your own components, we recommend you group them in a POJO annotated with javadoc:org.springframework.boot.context.properties.ConfigurationProperties[format=annotation].


### PR DESCRIPTION
This patch makes a small change to the documentation for External Configuration regarding how `@Value` behaves with camelCase variables and environment variables.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
I created a [demo application](https://github.com/linkian209/spring-property-test/tree/a3a639ca62078df2d7a13506982ba8f48d6ee380) that illustrates that variables that are defined using camelCase and injected using `@Value` not in the canonical form will pickup values from environment variables.