### PR TITLE
Remove redundant assertion

### DIFF
--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/ValueObjectBinderTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/ValueObjectBinderTests.java
@@ -342,7 +342,7 @@ class ValueObjectBinderTests {
 		RecordPropertiesWithOptionalInNestedRecord bound = this.binder.bindOrCreate("foo",
 				Bindable.of(RecordPropertiesWithOptionalInNestedRecord.class));
 		assertThat(bound.nested()).isNotNull();
-		assertThat(bound.nested().property1()).isNotNull().isEmpty();
+		assertThat(bound.nested().property1()).isEmpty();
 		assertThat(bound.nested().property2()).isEqualTo("str");
 	}
 


### PR DESCRIPTION
`isNotNull()` is enforced in `isEmpty()`.
