### PR TITLE
ErrorPageRegistrarBeanPostProcessor is not auto-configured in war deployments and the ErrorPageCustomizer is not applied 

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/web/servlet/support/ErrorPageFilterConfiguration.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/web/servlet/support/ErrorPageFilterConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.boot.web.servlet.support;
 
 import jakarta.servlet.DispatcherType;
 
+import org.springframework.boot.web.error.ErrorPageRegistrarBeanPostProcessor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,6 +27,7 @@ import org.springframework.context.annotation.Configuration;
  * Configuration for {@link ErrorPageFilter}.
  *
  * @author Andy Wilkinson
+ * @author Jay Choi
  */
 @Configuration(proxyBeanMethods = false)
 class ErrorPageFilterConfiguration {
@@ -41,6 +43,11 @@ class ErrorPageFilterConfiguration {
 		registration.setOrder(filter.getOrder());
 		registration.setDispatcherTypes(DispatcherType.REQUEST, DispatcherType.ASYNC);
 		return registration;
+	}
+
+	@Bean
+	static ErrorPageRegistrarBeanPostProcessor errorPageRegistrarBeanPostProcessor() {
+		return new ErrorPageRegistrarBeanPostProcessor();
 	}
 
 }

--- a/core/spring-boot/src/test/java/org/springframework/boot/web/servlet/support/SpringBootServletInitializerTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/web/servlet/support/SpringBootServletInitializerTests.java
@@ -41,6 +41,7 @@ import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEven
 import org.springframework.boot.context.logging.LoggingApplicationListener;
 import org.springframework.boot.testsupport.system.CapturedOutput;
 import org.springframework.boot.testsupport.system.OutputCaptureExtension;
+import org.springframework.boot.web.error.ErrorPageRegistrarBeanPostProcessor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -66,6 +67,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Jay Choi
  */
 @ExtendWith(OutputCaptureExtension.class)
 class SpringBootServletInitializerTests {
@@ -132,6 +134,21 @@ class SpringBootServletInitializerTests {
 			assertThat(context).isNotNull();
 			Map<String, ErrorPageFilter> errorPageFilterBeans = context.getBeansOfType(ErrorPageFilter.class);
 			assertThat(errorPageFilterBeans).isEmpty();
+		}
+	}
+
+	@Test
+	void errorPageRegistrarBeanPostProcessorIsRegistered() {
+		ServletContext servletContext = mock(ServletContext.class);
+		given(servletContext.addFilter(any(), any(Filter.class))).willReturn(mock(Dynamic.class));
+		given(servletContext.getInitParameterNames()).willReturn(Collections.emptyEnumeration());
+		given(servletContext.getAttributeNames()).willReturn(Collections.emptyEnumeration());
+		try (AbstractApplicationContext context = (AbstractApplicationContext) new WithErrorPageFilter()
+			.createRootApplicationContext(servletContext)) {
+			assertThat(context).isNotNull();
+			Map<String, ErrorPageRegistrarBeanPostProcessor> beans = context
+				.getBeansOfType(ErrorPageRegistrarBeanPostProcessor.class);
+			assertThat(beans).hasSize(1);
 		}
 	}
 


### PR DESCRIPTION
Closes gh-49148

In Spring Boot 4, `ErrorPageRegistrarBeanPostProcessor` is only registered in `ServletWebServerConfiguration`, which is not active in WAR deployments. This causes exceptions to bypass Spring's error handling and expose the servlet container's default error page.

This commit registers `ErrorPageRegistrarBeanPostProcessor` as a static `@Bean` in `ErrorPageFilterConfiguration`, which is loaded exclusively in WAR mode via `SpringBootServletInitializer`