### PR TITLE
Fix EndpointRequest.toLinks() when base-path is '/'

### DIFF
--- a/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointProperties.java
+++ b/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointProperties.java
@@ -67,7 +67,7 @@ public class WebEndpointProperties {
 	}
 
 	private String cleanBasePath(String basePath) {
-		if (StringUtils.hasText(basePath) && basePath.endsWith("/")) {
+		if (StringUtils.hasText(basePath) && basePath.endsWith("/") && basePath.length() > 1) {
 			return basePath.substring(0, basePath.length() - 1);
 		}
 		return basePath;

--- a/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointPropertiesTests.java
+++ b/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointPropertiesTests.java
@@ -38,7 +38,7 @@ class WebEndpointPropertiesTests {
 	void basePathShouldBeCleaned() {
 		WebEndpointProperties properties = new WebEndpointProperties();
 		properties.setBasePath("/");
-		assertThat(properties.getBasePath()).isEmpty();
+		assertThat(properties.getBasePath()).isEqualTo("/");
 		properties.setBasePath("/actuator/");
 		assertThat(properties.getBasePath()).isEqualTo("/actuator");
 	}

--- a/module/spring-boot-security/src/test/java/org/springframework/boot/security/autoconfigure/actuate/web/reactive/EndpointRequestTests.java
+++ b/module/spring-boot-security/src/test/java/org/springframework/boot/security/autoconfigure/actuate/web/reactive/EndpointRequestTests.java
@@ -146,6 +146,24 @@ class EndpointRequestTests {
 	}
 
 	@Test
+	void toLinksShouldMatchWhenBasePathIsSlash() {
+		ServerWebExchangeMatcher matcher = EndpointRequest.toLinks();
+		RequestMatcherAssert assertMatcher = assertMatcher(matcher, "/");
+		assertMatcher.matches("/");
+		assertMatcher.doesNotMatch("/foo");
+		assertMatcher.doesNotMatch("/bar");
+	}
+
+	@Test
+	void toAnyEndpointWhenBasePathIsSlashShouldMatchLinks() {
+		ServerWebExchangeMatcher matcher = EndpointRequest.toAnyEndpoint();
+		RequestMatcherAssert assertMatcher = assertMatcher(matcher, "/");
+		assertMatcher.matches("/");
+		assertMatcher.matches("/foo");
+		assertMatcher.matches("/bar");
+	}
+
+	@Test
 	void excludeByClassShouldNotMatchExcluded() {
 		ServerWebExchangeMatcher matcher = EndpointRequest.toAnyEndpoint()
 			.excluding(FooEndpoint.class, BazServletEndpoint.class);
@@ -260,7 +278,7 @@ class EndpointRequestTests {
 	@Test
 	void toAnyEndpointWhenEndpointPathMappedToRootIsExcludedShouldNotMatchRoot() {
 		ServerWebExchangeMatcher matcher = EndpointRequest.toAnyEndpoint().excluding("root");
-		RequestMatcherAssert assertMatcher = assertMatcher(matcher, new PathMappedEndpoints("/", () -> List
+		RequestMatcherAssert assertMatcher = assertMatcher(matcher, new PathMappedEndpoints("", () -> List
 			.of(mockEndpoint(EndpointId.of("root"), "/"), mockEndpoint(EndpointId.of("alpha"), "alpha"))));
 		assertMatcher.doesNotMatch("/");
 		assertMatcher.matches("/alpha");
@@ -271,7 +289,7 @@ class EndpointRequestTests {
 	void toEndpointWhenEndpointPathMappedToRootShouldMatchRoot() {
 		ServerWebExchangeMatcher matcher = EndpointRequest.to("root");
 		RequestMatcherAssert assertMatcher = assertMatcher(matcher,
-				new PathMappedEndpoints("/", () -> List.of(mockEndpoint(EndpointId.of("root"), "/"))));
+				new PathMappedEndpoints("", () -> List.of(mockEndpoint(EndpointId.of("root"), "/"))));
 		assertMatcher.matches("/");
 	}
 

--- a/module/spring-boot-security/src/test/java/org/springframework/boot/security/autoconfigure/actuate/web/servlet/EndpointRequestTests.java
+++ b/module/spring-boot-security/src/test/java/org/springframework/boot/security/autoconfigure/actuate/web/servlet/EndpointRequestTests.java
@@ -152,6 +152,24 @@ class EndpointRequestTests {
 	}
 
 	@Test
+	void toLinksShouldMatchWhenBasePathIsSlash() {
+		RequestMatcher matcher = EndpointRequest.toLinks();
+		RequestMatcherAssert assertMatcher = assertMatcher(matcher, "/");
+		assertMatcher.matches("/");
+		assertMatcher.doesNotMatch("/foo");
+		assertMatcher.doesNotMatch("/bar");
+	}
+
+	@Test
+	void toAnyEndpointWhenBasePathIsSlashShouldMatchLinks() {
+		RequestMatcher matcher = EndpointRequest.toAnyEndpoint();
+		RequestMatcherAssert assertMatcher = assertMatcher(matcher, "/");
+		assertMatcher.matches("/");
+		assertMatcher.matches("/foo");
+		assertMatcher.matches("/bar");
+	}
+
+	@Test
 	void excludeByClassShouldNotMatchExcluded() {
 		RequestMatcher matcher = EndpointRequest.toAnyEndpoint().excluding(FooEndpoint.class, BazServletEndpoint.class);
 		List<ExposableEndpoint<?>> endpoints = new ArrayList<>();


### PR DESCRIPTION
## Summary

Fixes #34834

When `management.endpoints.web.base-path` is set to `'/'`, `EndpointRequest.toLinks()` never matches, causing security configuration like `EndpointRequest.toLinks().permitAll()` to fail.

## Root Cause

`WebEndpointProperties.cleanBasePath("/")` strips the trailing slash, producing an empty string (`""`). Downstream, `LinksRequestMatcher` and `LinksServerWebExchangeMatcher` check `StringUtils.hasText(basePath)`, which returns `false` for `""`, so they return `EMPTY_MATCHER` (which always evaluates to `false`).

## Fix

Updated `cleanBasePath` to only strip trailing slashes from multi-segment paths (e.g., `/actuator/` → `/actuator`), preserving `"/"` as a valid base path.

### Changes
- **`WebEndpointProperties.cleanBasePath`**: Added `basePath.length() > 1` guard to prevent stripping `"/"` to `""`
- **`WebEndpointPropertiesTests`**: Updated assertion for `setBasePath("/")`
- **Servlet `EndpointRequestTests`**: Added `toLinksShouldMatchWhenBasePathIsSlash` and `toAnyEndpointWhenBasePathIsSlashShouldMatchLinks`
- **Reactive `EndpointRequestTests`**: Added equivalent tests and fixed inconsistent `PathMappedEndpoints` base path usage