### PR TITLE
test: optimize DefaultTimeZoneOffsetTests comment and method name

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/DefaultTimeZoneOffsetTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/DefaultTimeZoneOffsetTests.java
@@ -33,10 +33,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class DefaultTimeZoneOffsetTests {
 
-	// gh-21005
-
+	/**
+	 * gh-21005: 验证不同时区下调用 DefaultTimeZoneOffset.removeFrom(long) 方法返回值转换为 DOS 时间后结果一致。
+	 * 核心目的：确保跨时区场景下时间偏移计算的一致性，避免因时区差异导致 DOS 时间计算错误。
+	 */
 	@Test
-	void removeFromWithLongInDifferentTimeZonesReturnsSameValue() {
+	void removeFrom_shouldReturnSameDosTimeAcrossDifferentTimeZones() {
 		long time = OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant().toEpochMilli();
 		TimeZone timeZone1 = TimeZone.getTimeZone("GMT");
 		TimeZone timeZone2 = TimeZone.getTimeZone("GMT+8");
@@ -50,8 +52,12 @@ class DefaultTimeZoneOffsetTests {
 		assertThat(dosTime1).isEqualTo(dosTime2).isEqualTo(dosTime3);
 	}
 
+	/**
+	 * 验证调用 DefaultTimeZoneOffset.removeFrom(long) 方法在指定时区下返回正确的偏移后时间。
+	 * 测试场景：使用 GMT+8 时区，验证移除时区偏移后的结果不等于原始时间，且等于预期值。
+	 */
 	@Test
-	void removeFromWithFileTimeReturnsFileTime() {
+	void removeFrom_withFileTime_shouldReturnCorrectValueInTimeZone() {
 		long time = OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant().toEpochMilli();
 		long result = new DefaultTimeZoneOffset(TimeZone.getTimeZone("GMT+8")).removeFrom(time);
 		assertThat(result).isNotEqualTo(time).isEqualTo(946656000000L);


### PR DESCRIPTION
## Description
Optimize the readability of `DefaultTimeZoneOffsetTests` in gradle plugin module:
- Add detailed Javadoc for two test methods to clarify test intent
- Optimize method names for better readability (gh-21005)
- Keep test logic unchanged, only improve maintainability

## Note
Local build environment encountered 403 Forbidden error when accessing Spring remote build cache, leading to failure of `buildSrc` module tests. The modified code is pure documentation optimization with no functional changes, and the target test class (`DefaultTimeZoneOffsetTests`) has been verified to compile successfully. CI is relied on for full test validation.

## Type of change
- [x] Documentation (correction or update to documentation)
- [x] Code style update (formatting, renaming)

## Checklist
- [x] My code follows the code style of this project (Spring JavaFormat)
- [x] I have added Javadoc for all new/modified methods
- [x] My commit message includes a Signed-off-by trailer
- [x] No core logic changes, only readability improvement
