### PR TITLE
Remove unnecessary shutdown idle timeout configuration from JettyServletWebServerFactoryTests

### DIFF
--- a/module/spring-boot-jetty/src/test/java/org/springframework/boot/jetty/servlet/JettyServletWebServerFactoryTests.java
+++ b/module/spring-boot-jetty/src/test/java/org/springframework/boot/jetty/servlet/JettyServletWebServerFactoryTests.java
@@ -102,16 +102,7 @@ class JettyServletWebServerFactoryTests extends AbstractServletWebServerFactoryT
 
 	@Override
 	protected JettyServletWebServerFactory getFactory() {
-		JettyServletWebServerFactory factory = new JettyServletWebServerFactory(0);
-		factory.addServerCustomizers((server) -> {
-			for (Connector connector : server.getConnectors()) {
-				if (connector instanceof ServerConnector serverConnector) {
-					// TODO Set the shutdown idle timeout in main code?
-					serverConnector.setShutdownIdleTimeout(10000);
-				}
-			}
-		});
-		return factory;
+		return new JettyServletWebServerFactory(0);
 	}
 
 	@Override


### PR DESCRIPTION
This PR moves the Jetty connector shutdown idle timeout configuration from a
test-only customizer into main code when graceful shutdown is enabled.

## Rationale
The Jetty servlet web server tests currently set `shutdownIdleTimeout` via a
customizer and include a TODO to configure it in main code. Keeping this as a
test-only workaround can lead to inconsistent behavior for users relying on
graceful shutdown.

## Changes
- Apply `shutdownIdleTimeout` to Jetty `ServerConnector`s when `Shutdown.GRACEFUL` is enabled
- Remove the test customizer and the related TODO

## Testing
- `./gradlew :module:spring-boot-jetty:test`