### PR TITLE
Java and Kotlin samples of an environment post processor are inconsistent

### DIFF
--- a/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/application/customizetheenvironmentorapplicationcontext/MyEnvironmentPostProcessor.kt
+++ b/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/howto/application/customizetheenvironmentorapplicationcontext/MyEnvironmentPostProcessor.kt
@@ -37,7 +37,7 @@ class MyEnvironmentPostProcessor : EnvironmentPostProcessor {
 	}
 
 	private fun loadYaml(path: Resource): PropertySource<*> {
-		Assert.isTrue(path.exists()) { "Resource $path does not exist" }
+		Assert.isTrue(path.exists()) { "'path' [$path] must exist" }
 		return try {
 			loader.load("custom-resource", path)[0]
 		} catch (ex: IOException) {


### PR DESCRIPTION
The Java and Kotlin files differ in message. This PR addresses that.

https://github.com/spring-projects/spring-boot/blob/d102bb69b37b8bac09db3dcce8b7cf8ab2081a04/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/howto/application/customizetheenvironmentorapplicationcontext/MyEnvironmentPostProcessor.java#L42