### PR TITLE
Remove superfluous semi-colon from read timeout configuration example for HTTP service interface clients

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/io/rest-client.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/io/rest-client.adoc
@@ -386,7 +386,7 @@ spring:
     serviceclient:
       echo:
         base-url: "https://echo.zuplo.io"
-        read-timeout: 2s;
+        read-timeout: 2s
         apiversion:
           default: 1.0.0
           insert:


### PR DESCRIPTION
Remove extraneous semicolon from `read-timeout` value in rest.client.adoc

`read-timeout: 2s;` → `read-timeout: 2s`

Fixes #49305 