### PR TITLE
Ordering of 'spring.config.import' is inconsistent when defined in environment or system properties

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataEnvironment.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataEnvironment.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.context.config;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -59,6 +60,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Nan Chiu
  */
 class ConfigDataEnvironment {
 
@@ -199,7 +201,8 @@ class ConfigDataEnvironment {
 
 	private List<ConfigDataEnvironmentContributor> getInitialImportContributors(Binder binder) {
 		List<ConfigDataEnvironmentContributor> initialContributors = new ArrayList<>();
-		addInitialImportContributors(initialContributors, bindLocations(binder, IMPORT_PROPERTY, EMPTY_LOCATIONS));
+		addInitialImportPropertyContributors(initialContributors,
+				bindLocations(binder, IMPORT_PROPERTY, EMPTY_LOCATIONS));
 		addInitialImportContributors(initialContributors,
 				bindLocations(binder, ADDITIONAL_LOCATION_PROPERTY, EMPTY_LOCATIONS));
 		addInitialImportContributors(initialContributors,
@@ -209,6 +212,15 @@ class ConfigDataEnvironment {
 
 	private ConfigDataLocation[] bindLocations(Binder binder, String propertyName, ConfigDataLocation[] other) {
 		return binder.bind(propertyName, CONFIG_DATA_LOCATION_ARRAY).orElse(other);
+	}
+
+	private void addInitialImportPropertyContributors(List<ConfigDataEnvironmentContributor> initialContributors,
+			ConfigDataLocation[] locations) {
+		List<ConfigDataEnvironmentContributor> initialPropertiesContributors = new ArrayList<>();
+		addInitialImportContributors(initialPropertiesContributors, locations);
+		initialContributors.add(ConfigDataEnvironmentContributor.ofInitialImportProperty(
+			initialPropertiesContributors, this.environment.getConversionService(), Arrays.asList(locations))
+		);
 	}
 
 	private void addInitialImportContributors(List<ConfigDataEnvironmentContributor> initialContributors,

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataEnvironmentContributor.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/config/ConfigDataEnvironmentContributor.java
@@ -56,6 +56,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Nan Chiu
  */
 class ConfigDataEnvironmentContributor implements Iterable<ConfigDataEnvironmentContributor> {
 
@@ -414,6 +415,27 @@ class ConfigDataEnvironmentContributor implements Iterable<ConfigDataEnvironment
 	}
 
 	/**
+	 * Factory method to create a {@link Kind#INITIAL_IMPORT_PROPERTY initial import property}
+	 * contributor. This contributor is a container that wraps initial imports from
+	 * {@code spring.config.import} property, allowing profile-specific imports to take
+	 * precedence over the imported locations.
+	 * @param contributors the contributors created from the import locations
+	 * @param conversionService the conversion service to use
+	 * @param locations the original import locations from the property
+	 * @return a new {@link ConfigDataEnvironmentContributor} instance
+	 */
+	static ConfigDataEnvironmentContributor ofInitialImportProperty(
+			List<ConfigDataEnvironmentContributor> contributors,
+			ConversionService conversionService,
+			List<ConfigDataLocation> locations) {
+		Map<ImportPhase, List<ConfigDataEnvironmentContributor>> children = new LinkedHashMap<>();
+		ConfigDataProperties properties = new ConfigDataProperties(locations, null);
+		children.put(ImportPhase.BEFORE_PROFILE_ACTIVATION, Collections.unmodifiableList(contributors));
+		return new ConfigDataEnvironmentContributor(Kind.INITIAL_IMPORT_PROPERTY, null, null, false, null, null, properties, null, children,
+				conversionService);
+	}
+
+	/**
 	 * Factory method to create a contributor that wraps an {@link Kind#EXISTING existing}
 	 * property source. The contributor provides access to existing properties, but
 	 * doesn't actively import any additional contributors.
@@ -487,6 +509,11 @@ class ConfigDataEnvironmentContributor implements Iterable<ConfigDataEnvironment
 		 * An initial import that needs to be processed.
 		 */
 		INITIAL_IMPORT,
+
+		/**
+		 * A container contributor that wraps initial imports from spring.config.import property.
+		 */
+		INITIAL_IMPORT_PROPERTY,
 
 		/**
 		 * An existing property source that contributes properties but no imports.

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentContributorTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentContributorTests.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.mock;
  * @author Phillip Webb
  * @author Madhura Bhave
  * @author Scott Frederick
+ * @author Nan Chiu
  */
 class ConfigDataEnvironmentContributorTests {
 
@@ -301,6 +302,21 @@ class ConfigDataEnvironmentContributorTests {
 		assertThat(contributor.getPropertySource()).isNull();
 		assertThat(contributor.getConfigurationPropertySource()).isNull();
 		assertThat(contributor.getChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION)).isEmpty();
+	}
+
+	@Test
+	void ofInitialImportPropertyCreatedInitialImportPropertyContributor() {
+		ConfigDataEnvironmentContributor innerContributor = ConfigDataEnvironmentContributor.ofInitialImport(TEST_LOCATION,
+				this.conversionService);
+		ConfigDataEnvironmentContributor contributor = ConfigDataEnvironmentContributor.ofInitialImportProperty(
+				Collections.singletonList(innerContributor), this.conversionService, Arrays.asList(TEST_LOCATION));
+		assertThat(contributor.getKind()).isEqualTo(Kind.INITIAL_IMPORT_PROPERTY);
+		assertThat(contributor.getResource()).isNull();
+		assertThat(contributor.getImports()).containsExactly(TEST_LOCATION);
+		assertThat(contributor.isActive(this.activationContext)).isTrue();
+		assertThat(contributor.getPropertySource()).isNull();
+		assertThat(contributor.getConfigurationPropertySource()).isNull();
+		assertThat(contributor.getChildren(ImportPhase.BEFORE_PROFILE_ACTIVATION)).containsExactly(innerContributor);
 	}
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
@@ -79,6 +79,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
  *
  * @author Madhura Bhave
  * @author Phillip Webb
+ * @author Nan Chiu
  */
 class ConfigDataEnvironmentPostProcessorIntegrationTests {
 
@@ -330,6 +331,25 @@ class ConfigDataEnvironmentPostProcessorIntegrationTests {
 		assertThat(environment.getActiveProfiles()).containsExactly("myprofile");
 		String property = environment.getProperty("my.property");
 		assertThat(property).isEqualTo("frommyprofilepropertiesfile");
+	}
+
+	@Test
+	@WithResource(name = "testproperties-1.properties", content = """
+			my.property=fromtestproperties-1.properties
+			""")
+	@WithResource(name = "testproperties-1-myprofile.properties", content = """
+			my.property=fromtestproperties-1-myprofile.properties
+			""")
+	@WithResource(name = "testproperties-2.properties", content = """
+			my.property=fromtestproperties-2.properties
+			""")
+	void runWhenHasImportPropertyWithProfileSpecificFileTakesPrecedence() {
+		ConfigurableApplicationContext context = this.application.run(
+				"--spring.config.import=classpath:testproperties-1.properties,classpath:testproperties-2.properties",
+				"--spring.profiles.active=myprofile");
+		ConfigurableEnvironment environment = context.getEnvironment();
+		String property = environment.getProperty("my.property");
+		assertThat(property).isEqualTo("fromtestproperties-1-myprofile.properties");
 	}
 
 	@Test


### PR DESCRIPTION
### Description
When `spring.config.import` is defined in `application.properties` or `application.yml`, imported config data contributors are ordered consistently with profile-specific variants according to the `PROFILE_SPECIFIC` option introduced in #25766 https://github.com/spring-projects/spring-boot/commit/5774ea3f0c81de9776fc06cfbcb7c7d055f26333#diff-f66c18c64b5580ffa30cf0f1dad18db0dba9a1859b3f48902c6d7835cff0cc6e

However, when `spring.config.import` is defined via:

- Java system properties
- Environment variables

the resulting contributor ordering differs.

### Reproducible Scenario

Directory structure:

```
/mock
 ├── test1.properties
 ├── test1-myprofile.properties
 ├── test2.properties
```

When configured in `application.properties`:

```
spring.config.import=classpath:mock/test1.properties,classpath:mock/test2.properties
spring.profiles.active=myprofile
```

The resulting precedence order is:

```
test1.properties
test2.properties
test1-myprofile.properties
```

However, when configured via environment variables:

```
SPRING_CONFIG_IMPORT=classpath:mock/test1.properties,classpath:mock/test2.properties
SPRING_PROFILES_ACTIVE=myprofile
```

The resulting precedence order becomes:

```
test1.properties
test1-myprofile.properties
test2.properties
```

This behavior is inconsistent the expected import ordering semantics described in #25766 (Support profile specific ConfigData imports)



### Proposed Fix

This PR wraps contributors originating from environment and system property-based `spring.config.import` definitions in a dedicated contributor wrapper.

This ensures consistent treatment with file-based imports.