### PR TITLE
Using @AutoConfigureWebTestClient prevents separate configuration of spring.test.webtestclient.timeout from taking effect

### DIFF
--- a/module/spring-boot-webtestclient/src/main/java/org/springframework/boot/webtestclient/autoconfigure/AutoConfigureWebTestClient.java
+++ b/module/spring-boot-webtestclient/src/main/java/org/springframework/boot/webtestclient/autoconfigure/AutoConfigureWebTestClient.java
@@ -26,12 +26,14 @@ import java.time.Duration;
 
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.context.PropertyMapping;
+import org.springframework.boot.test.context.PropertyMapping.Skip;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 /**
  * Annotation that can be applied to a test class to enable a {@link WebTestClient}.
  *
  * @author Stephane Nicoll
+ * @author Jay Choi
  * @since 4.0.0
  * @see WebTestClientAutoConfiguration
  */
@@ -48,6 +50,7 @@ public @interface AutoConfigureWebTestClient {
 	 * {@link Duration#parse(CharSequence)}).
 	 * @return the web client timeout
 	 */
+	@PropertyMapping(skip = Skip.ON_DEFAULT_VALUE)
 	String timeout() default "";
 
 }

--- a/module/spring-boot-webtestclient/src/test/java/org/springframework/boot/webtestclient/autoconfigure/WebTestClientTimeoutSpringBootTestIntegrationTests.java
+++ b/module/spring-boot-webtestclient/src/test/java/org/springframework/boot/webtestclient/autoconfigure/WebTestClientTimeoutSpringBootTestIntegrationTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.webtestclient.autoconfigure;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.config.EnableWebFlux;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SpringBootTest @SpringBootTest} with
+ * {@link AutoConfigureWebTestClient @AutoConfigureWebTestClient} timeout property
+ * binding.
+ *
+ * @author Jay Choi
+ */
+@SpringBootTest(properties = { "spring.main.web-application-type=reactive",
+		"spring.test.webtestclient.timeout=30s" }, classes = ExampleWebTestClientApplication.class)
+@AutoConfigureWebTestClient
+@EnableWebFlux
+class WebTestClientTimeoutSpringBootTestIntegrationTests {
+
+	@Autowired
+	private WebTestClient webClient;
+
+	@Test
+	void timeoutFromPropertyShouldBeApplied() {
+		assertThat(this.webClient).hasFieldOrPropertyWithValue("responseTimeout", Duration.ofSeconds(30));
+	}
+
+}


### PR DESCRIPTION
Add `@PropertyMapping(skip = Skip.ON_DEFAULT_VALUE)` to the timeout attribute of `@AutoConfigureWebTestClient` so that external property sources such as `application.properties` are not blocked by the default empty string value.

Closes gh-49331

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
