### PR TITLE
Upgrade to Thymeleaf Layout Dialect 4.0.0

### DIFF
--- a/module/spring-boot-thymeleaf/src/test/java/org/springframework/boot/thymeleaf/autoconfigure/ThymeleafReactiveAutoConfigurationTests.java
+++ b/module/spring-boot-thymeleaf/src/test/java/org/springframework/boot/thymeleaf/autoconfigure/ThymeleafReactiveAutoConfigurationTests.java
@@ -261,7 +261,7 @@ class ThymeleafReactiveAutoConfigurationTests {
 
 		@Bean
 		LayoutDialect layoutDialect() {
-			return new LayoutDialect(new GroupingStrategy());
+			return new LayoutDialect().withSortingStrategy(new GroupingStrategy());
 		}
 
 	}

--- a/module/spring-boot-thymeleaf/src/test/java/org/springframework/boot/thymeleaf/autoconfigure/ThymeleafServletAutoConfigurationTests.java
+++ b/module/spring-boot-thymeleaf/src/test/java/org/springframework/boot/thymeleaf/autoconfigure/ThymeleafServletAutoConfigurationTests.java
@@ -374,7 +374,7 @@ class ThymeleafServletAutoConfigurationTests {
 
 		@Bean
 		LayoutDialect layoutDialect() {
-			return new LayoutDialect(new GroupingStrategy());
+			return new LayoutDialect().withSortingStrategy(new GroupingStrategy());
 		}
 
 	}

--- a/platform/spring-boot-dependencies/build.gradle
+++ b/platform/spring-boot-dependencies/build.gradle
@@ -2732,7 +2732,7 @@ bom {
 			]
 		}
 	}
-	library("Thymeleaf Layout Dialect", "3.4.0") {
+	library("Thymeleaf Layout Dialect", "4.0.0") {
 		group("nz.net.ultraq.thymeleaf") {
 			modules = [
 				"thymeleaf-layout-dialect"


### PR DESCRIPTION
Hi there 👋  I'm the developer of the [thymeleaf-layout-dialect](https://github.com/ultraq/thymeleaf-layout-dialect), a managed dependency in Spring Boot.  With the recent release of Spring Boot 4.0.3, a patch version of Groovy 5 was included which unfortunately introduced a backwards compatibility issue for projects built against Groovy 4, which the layout dialect was, and as a result I've been getting pinged a bit about the bug.

I've repeated the advice of downgrading Groovy 5 to the last good version as in #49277, but I've also just released a new version of the layout dialect which targets Groovy 5 and no longer has the backwards-compatibility issue.  It is a major version bump from the one currently managed by Spring Boot though (going from 3.4.0 to 4.0.0), and so despite this PR basically being just a version bump which is discouraged as per Spring Boot's PR template, I'm wondering if you'd be open to including this in the upcoming Spring Boot 4.1.0?

The breaking changes between layout dialect 3.4.0 and 4.0.0 are to align with Spring Boot 4's own build targets and dependencies (so going from Java 8 to 17, and Groovy 4 to 5), and the removal of deprecated code.  Some more details are on the [release page](https://github.com/ultraq/thymeleaf-layout-dialect/releases/tag/4.0.0), but that's the gist of it.
