### PR TITLE
Javadoc of JettyHttpClientBuilder refers to the wrong type

### DIFF
--- a/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/JettyHttpClientBuilder.java
+++ b/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/JettyHttpClientBuilder.java
@@ -75,10 +75,10 @@ public final class JettyHttpClientBuilder {
 	}
 
 	/**
-	 * Return a new {@link JettyClientHttpRequestFactoryBuilder} that applies additional
+	 * Return a new {@link JettyHttpClientBuilder} that applies additional
 	 * customization to the underlying {@link HttpClient}.
 	 * @param customizer the customizer to apply
-	 * @return a new {@link JettyClientHttpRequestFactoryBuilder} instance
+	 * @return a new {@link JettyHttpClientBuilder} instance
 	 */
 	public JettyHttpClientBuilder withCustomizer(Consumer<HttpClient> customizer) {
 		Assert.notNull(customizer, "'customizer' must not be null");
@@ -87,10 +87,10 @@ public final class JettyHttpClientBuilder {
 	}
 
 	/**
-	 * Return a new {@link JettyClientHttpRequestFactoryBuilder} that uses the given
+	 * Return a new {@link JettyHttpClientBuilder} that uses the given
 	 * factory to create the {@link HttpClientTransport}.
 	 * @param httpClientTransportFactory the {@link HttpClientTransport} factory to use
-	 * @return a new {@link JettyClientHttpRequestFactoryBuilder} instance
+	 * @return a new {@link JettyHttpClientBuilder} instance
 	 * @since 4.0.0
 	 */
 	public JettyHttpClientBuilder withHttpClientTransportFactory(
@@ -101,10 +101,10 @@ public final class JettyHttpClientBuilder {
 	}
 
 	/**
-	 * Return a new {@link JettyClientHttpRequestFactoryBuilder} that applies additional
+	 * Return a new {@link JettyHttpClientBuilder} that applies additional
 	 * customization to the underlying {@link HttpClientTransport}.
 	 * @param httpClientTransportCustomizer the customizer to apply
-	 * @return a new {@link JettyClientHttpRequestFactoryBuilder} instance
+	 * @return a new {@link JettyHttpClientBuilder} instance
 	 */
 	public JettyHttpClientBuilder withHttpClientTransportCustomizer(
 			Consumer<HttpClientTransport> httpClientTransportCustomizer) {
@@ -115,10 +115,10 @@ public final class JettyHttpClientBuilder {
 	}
 
 	/**
-	 * Return a new {@link JettyClientHttpRequestFactoryBuilder} that applies additional
+	 * Return a new {@link JettyHttpClientBuilder} that applies additional
 	 * customization to the underlying {@link ClientConnector}.
 	 * @param clientConnectorCustomizerCustomizer the customizer to apply
-	 * @return a new {@link JettyClientHttpRequestFactoryBuilder} instance
+	 * @return a new {@link JettyHttpClientBuilder} instance
 	 */
 	public JettyHttpClientBuilder withClientConnectorCustomizerCustomizer(
 			Consumer<ClientConnector> clientConnectorCustomizerCustomizer) {

--- a/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/ReactorHttpClientBuilder.java
+++ b/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/ReactorHttpClientBuilder.java
@@ -37,7 +37,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.function.ThrowingConsumer;
 
 /**
- * Builder that can be used to create a Rector Netty {@link HttpClient}.
+ * Builder that can be used to create a Reactor Netty {@link HttpClient}.
  *
  * @author Phillip Webb
  * @author Andy Wilkinson


### PR DESCRIPTION
Fix 'Rector' typo in `ReactorHttpClientBuilder` class Javadoc and correct `JettyHttpClientBuilder` method Javadoc that incorrectly referenced `JettyClientHttpRequestFactoryBuilder` instead of `JettyHttpClientBuilder`.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
