### PR TITLE
bumping the version of infinispan-bom to latest version supporting spring boot 4 and spring framework 7

### DIFF
--- a/platform/spring-boot-dependencies/build.gradle
+++ b/platform/spring-boot-dependencies/build.gradle
@@ -723,7 +723,7 @@ bom {
 			]
 		}
 	}
-	library("Infinispan", "15.2.6.Final") {
+	library("Infinispan", "16.1.0") {
 		group("org.infinispan") {
 			bom("infinispan-bom")
 		}


### PR DESCRIPTION
The latest version of spring boot as of 4.0.3 is still using infinispan 15.2.6.Final which doesn't support spring's newest versions. 
in this pull request the infinispan version is updated to 16.1.0.
