### PR TITLE
Fix typo in Javadoc for SpringBootTestAnnotation

### DIFF
--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestAnnotation.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestAnnotation.java
@@ -30,7 +30,7 @@ import org.springframework.test.context.TestContextAnnotationUtils;
 
 /**
  * {@link ContextCustomizer} to track attributes of
- * {@link SpringBootTest @SptringBootTest} that are taken into account when evaluating a
+ * {@link SpringBootTest @SpringBootTest} that are taken into account when evaluating a
  * {@link MergedContextConfiguration} to determine if a context can be shared between
  * tests.
  *


### PR DESCRIPTION
This PR fixes a minor typo in the Javadoc.