### PR TITLE
Replace dependsOn with source set configuration

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/dsl/SpringBootExtension.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/dsl/SpringBootExtension.java
@@ -93,8 +93,11 @@ public class SpringBootExtension {
 		TaskProvider<BuildInfo> bootBuildInfo = tasks.register("bootBuildInfo", BuildInfo.class,
 				this::configureBuildInfoTask);
 		this.project.getPlugins().withType(JavaPlugin.class, (plugin) -> {
-			SourceSetContainer sourceSets = this.project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets();
-			sourceSets.named(SourceSet.MAIN_SOURCE_SET_NAME).configure((sourceSet) -> sourceSet.getResources().srcDirs(bootBuildInfo));
+			SourceSetContainer sourceSets = this.project.getExtensions()
+				.getByType(JavaPluginExtension.class)
+				.getSourceSets();
+			sourceSets.named(SourceSet.MAIN_SOURCE_SET_NAME)
+				.configure((sourceSet) -> sourceSet.getResources().srcDirs(bootBuildInfo));
 			bootBuildInfo.configure((buildInfo) -> buildInfo.getProperties()
 				.getArtifact()
 				.convention(this.project.provider(this::determineArtifactBaseName)));


### PR DESCRIPTION
Fixes the use of `dependsOn` in the spring boot gradle plugin. See [Best Practices for Tasks - Avoid DependsOn](https://docs.gradle.org/current/userguide/best_practices_tasks.html#avoid_depends_on)

Unfortunately Gradle isn't smart enough to know that a dependsOn allows other tasks that might use sourceset outputs as their inputs, we should use Gradle's implicit input/output tracking instead.

Without this, if one uses for example a task that uses the main output resources, such as Google's protobuf gradle plugin, and another task that shares resources like test fixtures or additional test suites, you'll end up with issues with undefined dependencies.

```
3: Task failed with an exception.
-----------
* What went wrong:
A problem was found with the configuration of task ':app:extractIncludeIntegrationTestProto' (type 'ProtobufExtract').
  - Gradle detected a problem with the following location: '/Users/cwalker/source/spring-boot-build-info-issue/app/build/resources/main'.
    
    Reason: Task ':app:extractIncludeIntegrationTestProto' uses this output of task ':app:bootBuildInfo' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':app:bootBuildInfo' as an input of ':app:extractIncludeIntegrationTestProto'.
      2. Declare an explicit dependency on ':app:bootBuildInfo' from ':app:extractIncludeIntegrationTestProto' using Task#dependsOn.
      3. Declare an explicit dependency on ':app:bootBuildInfo' from ':app:extractIncludeIntegrationTestProto' using Task#mustRunAfter.
```