### PR TITLE
Add auto-configuration for OTLP exemplars

### DIFF
--- a/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/export/otlp/OtlpMetricsExportAutoConfiguration.java
+++ b/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/export/otlp/OtlpMetricsExportAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp;
 
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.registry.otlp.ExemplarContextProvider;
 import io.micrometer.registry.otlp.OtlpConfig;
 import io.micrometer.registry.otlp.OtlpMeterRegistry;
 import io.micrometer.registry.otlp.OtlpMetricsSender;
@@ -80,23 +81,29 @@ public final class OtlpMetricsExportAutoConfiguration {
 	@ConditionalOnMissingBean
 	@ConditionalOnThreading(Threading.PLATFORM)
 	OtlpMeterRegistry otlpMeterRegistry(OtlpConfig otlpConfig, Clock clock,
-			ObjectProvider<OtlpMetricsSender> metricsSender) {
-		return builder(otlpConfig, clock, metricsSender).build();
+			ObjectProvider<OtlpMetricsSender> metricsSender,
+			ObjectProvider<ExemplarContextProvider> exemplarContextProvider) {
+		return builder(otlpConfig, clock, metricsSender, exemplarContextProvider).build();
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnThreading(Threading.VIRTUAL)
 	OtlpMeterRegistry otlpMeterRegistryVirtualThreads(OtlpConfig otlpConfig, Clock clock,
-			ObjectProvider<OtlpMetricsSender> metricsSender) {
+			ObjectProvider<OtlpMetricsSender> metricsSender,
+			ObjectProvider<ExemplarContextProvider> exemplarContextProvider) {
 		VirtualThreadTaskExecutor executor = new VirtualThreadTaskExecutor("otlp-meter-registry-");
-		return builder(otlpConfig, clock, metricsSender).threadFactory(executor.getVirtualThreadFactory()).build();
+		return builder(otlpConfig, clock, metricsSender, exemplarContextProvider)
+			.threadFactory(executor.getVirtualThreadFactory())
+			.build();
 	}
 
 	private OtlpMeterRegistry.Builder builder(OtlpConfig otlpConfig, Clock clock,
-			ObjectProvider<OtlpMetricsSender> metricsSender) {
+			ObjectProvider<OtlpMetricsSender> metricsSender,
+			ObjectProvider<ExemplarContextProvider> exemplarContextProvider) {
 		OtlpMeterRegistry.Builder builder = OtlpMeterRegistry.builder(otlpConfig).clock(clock);
 		metricsSender.ifAvailable(builder::metricsSender);
+		exemplarContextProvider.ifAvailable(builder::exemplarContextProvider);
 		return builder;
 	}
 

--- a/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/autoconfigure/export/otlp/OtlpMetricsExportAutoConfigurationTests.java
+++ b/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/autoconfigure/export/otlp/OtlpMetricsExportAutoConfigurationTests.java
@@ -19,6 +19,7 @@ package org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp;
 import java.util.concurrent.ScheduledExecutorService;
 
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.registry.otlp.ExemplarContextProvider;
 import io.micrometer.registry.otlp.OtlpConfig;
 import io.micrometer.registry.otlp.OtlpMeterRegistry;
 import io.micrometer.registry.otlp.OtlpMetricsSender;
@@ -143,11 +144,37 @@ class OtlpMetricsExportAutoConfigurationTests {
 	}
 
 	@Test
+	void allowsCustomExemplarContextProviderToBeUsed() {
+		this.contextRunner
+			.withUserConfiguration(BaseConfiguration.class, CustomExemplarContextProviderConfiguration.class)
+			.run(this::assertHasCustomExemplarContextProvider);
+	}
+
+	@Test
 	@EnabledForJreRange(min = JRE.JAVA_21)
 	void allowsCustomMetricsSenderToBeUsedWithVirtualThreads() {
 		this.contextRunner.withUserConfiguration(BaseConfiguration.class, CustomMetricsSenderConfiguration.class)
 			.withPropertyValues("spring.threads.virtual.enabled=true")
 			.run(this::assertHasCustomMetricsSender);
+	}
+
+	@Test
+	@EnabledForJreRange(min = JRE.JAVA_21)
+	void allowsCustomExemplarContextProviderToBeUsedWithVirtualThreads() {
+		this.contextRunner
+			.withUserConfiguration(BaseConfiguration.class, CustomExemplarContextProviderConfiguration.class)
+			.withPropertyValues("spring.threads.virtual.enabled=true")
+			.run(this::assertHasCustomExemplarContextProvider);
+	}
+
+	@Test
+	void exemplarContextProviderShouldBeMissingIfNoExemplarContextProviderBeanPresent() {
+		this.contextRunner.withUserConfiguration(BaseConfiguration.class).run((context) -> {
+			assertThat(context).doesNotHaveBean(ExemplarContextProvider.class);
+			assertThat(context).hasSingleBean(OtlpMeterRegistry.class);
+			OtlpMeterRegistry registry = context.getBean(OtlpMeterRegistry.class);
+			assertThat(registry).extracting("exemplarSamplerFactory").isNull();
+		});
 	}
 
 	@Test
@@ -162,6 +189,15 @@ class OtlpMetricsExportAutoConfigurationTests {
 		OtlpMeterRegistry registry = context.getBean(OtlpMeterRegistry.class);
 		assertThat(registry).extracting("metricsSender")
 			.satisfies((sender) -> assertThat(sender).isSameAs(CustomMetricsSenderConfiguration.customMetricsSender));
+	}
+
+	private void assertHasCustomExemplarContextProvider(AssertableApplicationContext context) {
+		assertThat(context).hasSingleBean(OtlpMeterRegistry.class);
+		OtlpMeterRegistry registry = context.getBean(OtlpMeterRegistry.class);
+		assertThat(registry).extracting("exemplarSamplerFactory")
+			.extracting("exemplarContextProvider")
+			.satisfies((sender) -> assertThat(sender)
+				.isSameAs(CustomExemplarContextProviderConfiguration.customExemplarContextProvider));
 	}
 
 	@Configuration(proxyBeanMethods = false)
@@ -215,6 +251,18 @@ class OtlpMetricsExportAutoConfigurationTests {
 		@Bean
 		OtlpMetricsSender customMetricsSender() {
 			return customMetricsSender;
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomExemplarContextProviderConfiguration {
+
+		static ExemplarContextProvider customExemplarContextProvider = () -> null;
+
+		@Bean
+		ExemplarContextProvider customExemplarContextProvider() {
+			return customExemplarContextProvider;
 		}
 
 	}

--- a/module/spring-boot-micrometer-tracing-brave/build.gradle
+++ b/module/spring-boot-micrometer-tracing-brave/build.gradle
@@ -40,8 +40,10 @@ dependencies {
 	testImplementation(project(":core:spring-boot-test"))
 	testImplementation(project(":test-support:spring-boot-test-support"))
 	testImplementation(project(":module:spring-boot-micrometer-metrics"))
+	testImplementation(project(":module:spring-boot-opentelemetry"))
 	testImplementation("io.micrometer:micrometer-registry-prometheus")
 	testImplementation("io.prometheus:prometheus-metrics-exposition-formats")
+	testImplementation("io.micrometer:micrometer-registry-otlp")
 
 	testRuntimeOnly("ch.qos.logback:logback-classic")
 }

--- a/module/spring-boot-micrometer-tracing-brave/src/test/java/org/springframework/boot/micrometer/tracing/brave/autoconfigure/OtlpExemplarsAutoConfigurationTests.java
+++ b/module/spring-boot-micrometer-tracing-brave/src/test/java/org/springframework/boot/micrometer/tracing/brave/autoconfigure/OtlpExemplarsAutoConfigurationTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.micrometer.tracing.brave.autoconfigure;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.Observation.Context;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.registry.otlp.ExemplarContextProvider;
+import io.micrometer.registry.otlp.OtlpMeterRegistry;
+import io.micrometer.registry.otlp.OtlpMetricsSender;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.TracingAwareMeterObservationHandler;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration;
+import org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp.OtlpMetricsExportAutoConfiguration;
+import org.springframework.boot.micrometer.observation.autoconfigure.ObservationAutoConfiguration;
+import org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration;
+import org.springframework.boot.micrometer.tracing.autoconfigure.otlp.OtlpExemplarsAutoConfiguration;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link OtlpExemplarsAutoConfiguration}.
+ *
+ * @author Jonatan Ivanov
+ */
+class OtlpExemplarsAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withPropertyValues("management.tracing.sampling.probability=1.0",
+				"management.metrics.distribution.percentiles-histogram.all=true",
+				"management.metrics.use-global-registry=false")
+		.withConfiguration(
+				AutoConfigurations.of(MetricsAutoConfiguration.class, OtlpMetricsExportAutoConfiguration.class,
+						OtlpExemplarsAutoConfiguration.class, ObservationAutoConfiguration.class,
+						BraveAutoConfiguration.class, MicrometerTracingAutoConfiguration.class));
+
+	@Test
+	void shouldNotSupplyBeansIfOtlpSupportIsMissing() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader("io.micrometer.registry.otlp"))
+			.run((context) -> assertThat(context).doesNotHaveBean(ExemplarContextProvider.class));
+	}
+
+	@Test
+	void shouldNotSupplyBeansIfMicrometerTracingIsMissing() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader("io.micrometer.tracing"))
+			.run((context) -> assertThat(context).doesNotHaveBean(ExemplarContextProvider.class));
+	}
+
+	@Test
+	void shouldSupplyCustomBeans() {
+		this.contextRunner.withUserConfiguration(CustomConfiguration.class)
+			.run((context) -> assertThat(context).hasSingleBean(ExemplarContextProvider.class)
+				.getBean(ExemplarContextProvider.class)
+				.isSameAs(CustomConfiguration.CONTEXT_PROVIDER));
+	}
+
+	@Test
+	void otlpOutputShouldContainExemplars() {
+		this.contextRunner.withUserConfiguration(TracingConfiguration.class).run((context) -> {
+			assertThat(context).hasSingleBean(ExemplarContextProvider.class);
+			ObservationRegistry observationRegistry = context.getBean(ObservationRegistry.class);
+			Observation.start("test.observation", observationRegistry).stop();
+			OtlpMeterRegistry otlpMeterRegistry = context.getBean(OtlpMeterRegistry.class);
+			TestOtlpMetricsSender metricsSender = context.getBean(TestOtlpMetricsSender.class);
+			otlpMeterRegistry.close();
+
+			assertThat(metricsSender.getOtlpRequest()).containsOnlyOnce("name: \"test.observation\"")
+				.containsOnlyOnce("exemplars")
+				.containsOnlyOnce("span_id")
+				.containsOnlyOnce("trace_id");
+		});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	private static final class CustomConfiguration {
+
+		static final ExemplarContextProvider CONTEXT_PROVIDER = mock(ExemplarContextProvider.class);
+
+		@Bean
+		ExemplarContextProvider customContextProvider() {
+			return CONTEXT_PROVIDER;
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class TracingConfiguration {
+
+		@Bean
+		TracingAwareMeterObservationHandler<Context> tracingAwareMeterObservationHandler(MeterRegistry meterRegistry,
+				Tracer tracer) {
+			DefaultMeterObservationHandler delegate = new DefaultMeterObservationHandler(meterRegistry);
+			return new TracingAwareMeterObservationHandler<>(delegate, tracer);
+		}
+
+		@Bean
+		TestOtlpMetricsSender testOtlpMetricsSender() {
+			return new TestOtlpMetricsSender();
+		}
+
+	}
+
+	static class TestOtlpMetricsSender implements OtlpMetricsSender {
+
+		private String request = "";
+
+		@Override
+		public void send(Request request) throws Exception {
+			this.request = request.toString();
+		}
+
+		String getOtlpRequest() {
+			return this.request;
+		}
+
+	}
+
+}

--- a/module/spring-boot-micrometer-tracing/build.gradle
+++ b/module/spring-boot-micrometer-tracing/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	optional(project(":core:spring-boot-autoconfigure"))
 	optional(project(":module:spring-boot-micrometer-metrics"))
 	optional("io.prometheus:prometheus-metrics-tracer-common")
+	optional("io.micrometer:micrometer-registry-otlp")
 	optional("org.aspectj:aspectjweaver")
 
 	testImplementation(project(":core:spring-boot-test"))

--- a/module/spring-boot-micrometer-tracing/src/main/java/org/springframework/boot/micrometer/tracing/autoconfigure/otlp/OtlpExemplarsAutoConfiguration.java
+++ b/module/spring-boot-micrometer-tracing/src/main/java/org/springframework/boot/micrometer/tracing/autoconfigure/otlp/OtlpExemplarsAutoConfiguration.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.micrometer.tracing.autoconfigure.otlp;
+
+import io.micrometer.registry.otlp.ExemplarContextProvider;
+import io.micrometer.registry.otlp.OtlpExemplarContext;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.lang.Contract;
+import org.springframework.util.function.SingletonSupplier;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for OTLP (OpenTelemetry Protocol)
+ * Exemplars with Micrometer Tracing.
+ *
+ * @author Jonatan Ivanov
+ * @since 4.1.0
+ */
+@AutoConfiguration(
+		beforeName = "org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp.OtlpMetricsExportAutoConfiguration",
+		after = MicrometerTracingAutoConfiguration.class)
+@ConditionalOnBean(Tracer.class)
+@ConditionalOnClass({ Tracer.class, ExemplarContextProvider.class })
+public final class OtlpExemplarsAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	ExemplarContextProvider exemplarContextProvider(ObjectProvider<Tracer> tracerProvider) {
+		return new LazyTracingExemplarContextProvider(tracerProvider);
+	}
+
+	/**
+	 * Since the MeterRegistry can depend on the {@link Tracer} (Exemplars) and the
+	 * {@link Tracer} can depend on the MeterRegistry (recording metrics), this
+	 * {@link ExemplarContextProvider} breaks the cycle by lazily loading the
+	 * {@link Tracer}.
+	 */
+	static class LazyTracingExemplarContextProvider implements ExemplarContextProvider {
+
+		private final SingletonSupplier<Tracer> tracer;
+
+		LazyTracingExemplarContextProvider(ObjectProvider<Tracer> tracerProvider) {
+			this.tracer = SingletonSupplier.of(tracerProvider::getObject);
+		}
+
+		@Override
+		public @Nullable OtlpExemplarContext getExemplarContext() {
+			Span span = this.tracer.obtain().currentSpan();
+			if (isSampled(span)) {
+				TraceContext context = span.context();
+				return new OtlpExemplarContext(context.traceId(), context.spanId());
+			}
+			return null;
+		}
+
+		@Contract("null -> false")
+		private boolean isSampled(@Nullable Span span) {
+			if (span == null) {
+				return false;
+			}
+			Boolean sampled = span.context().sampled();
+			return sampled != null && sampled;
+		}
+
+	}
+
+}

--- a/module/spring-boot-micrometer-tracing/src/main/java/org/springframework/boot/micrometer/tracing/autoconfigure/otlp/package-info.java
+++ b/module/spring-boot-micrometer-tracing/src/main/java/org/springframework/boot/micrometer/tracing/autoconfigure/otlp/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for OTLP (OpenTelemetry Protocol) Exemplars with Micrometer Tracing.
+ */
+@NullMarked
+package org.springframework.boot.micrometer.tracing.autoconfigure.otlp;
+
+import org.jspecify.annotations.NullMarked;

--- a/module/spring-boot-micrometer-tracing/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/module/spring-boot-micrometer-tracing/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
 org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration
 org.springframework.boot.micrometer.tracing.autoconfigure.NoopTracerAutoConfiguration
+org.springframework.boot.micrometer.tracing.autoconfigure.otlp.OtlpExemplarsAutoConfiguration
 org.springframework.boot.micrometer.tracing.autoconfigure.prometheus.PrometheusExemplarsAutoConfiguration

--- a/module/spring-boot-micrometer-tracing/src/test/java/org/springframework/boot/micrometer/tracing/autoconfigure/otlp/LazyTracingExemplarContextProviderTests.java
+++ b/module/spring-boot-micrometer-tracing/src/test/java/org/springframework/boot/micrometer/tracing/autoconfigure/otlp/LazyTracingExemplarContextProviderTests.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.micrometer.tracing.autoconfigure.otlp;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.micrometer.tracing.autoconfigure.otlp.OtlpExemplarsAutoConfiguration.LazyTracingExemplarContextProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link LazyTracingExemplarContextProvider}.
+ *
+ * @author Jonatan Ivanov
+ */
+class LazyTracingExemplarContextProviderTests {
+
+	private final Tracer tracer = mock(Tracer.class);
+
+	private final ObjectProvider<Tracer> objectProvider = new ObjectProvider<>() {
+		@Override
+		public Tracer getObject() throws BeansException {
+			return LazyTracingExemplarContextProviderTests.this.tracer;
+		}
+
+		@Override
+		public Tracer getObject(@Nullable Object... args) throws BeansException {
+			return LazyTracingExemplarContextProviderTests.this.tracer;
+		}
+
+		@Override
+		public Tracer getIfAvailable() throws BeansException {
+			return LazyTracingExemplarContextProviderTests.this.tracer;
+		}
+
+		@Override
+		public Tracer getIfUnique() throws BeansException {
+			return LazyTracingExemplarContextProviderTests.this.tracer;
+		}
+
+	};
+
+	private final LazyTracingExemplarContextProvider contextProvider = new LazyTracingExemplarContextProvider(
+			this.objectProvider);
+
+	@Test
+	void whenCurrentSpanIsNullThenExemplarContextIsNull() {
+		assertThat(this.contextProvider.getExemplarContext()).isNull();
+	}
+
+	@Test
+	void whenCurrentSpanHasSpanIdThenSpanIdIsFromSpan() {
+		Span span = mock(Span.class);
+		given(this.tracer.currentSpan()).willReturn(span);
+		TraceContext traceContext = mock(TraceContext.class);
+		given(traceContext.sampled()).willReturn(true);
+		given(traceContext.spanId()).willReturn("span-id");
+		given(span.context()).willReturn(traceContext);
+		assertThat(this.contextProvider.getExemplarContext()).isNotNull();
+		assertThat(this.contextProvider.getExemplarContext().getSpanId()).isEqualTo("span-id");
+	}
+
+	@Test
+	void whenCurrentSpanHasTraceIdThenTraceIdIsFromSpan() {
+		Span span = mock(Span.class);
+		given(this.tracer.currentSpan()).willReturn(span);
+		TraceContext traceContext = mock(TraceContext.class);
+		given(traceContext.sampled()).willReturn(true);
+		given(traceContext.traceId()).willReturn("trace-id");
+		given(span.context()).willReturn(traceContext);
+		assertThat(this.contextProvider.getExemplarContext()).isNotNull();
+		assertThat(this.contextProvider.getExemplarContext().getTraceId()).isEqualTo("trace-id");
+	}
+
+	@Test
+	void whenCurrentSpanHasNoSpanIdThenSpanIdIsNull() {
+		Span span = mock(Span.class);
+		given(this.tracer.currentSpan()).willReturn(span);
+		TraceContext traceContext = mock(TraceContext.class);
+		given(traceContext.sampled()).willReturn(true);
+		given(span.context()).willReturn(traceContext);
+		assertThat(this.contextProvider.getExemplarContext()).isNotNull();
+		assertThat(this.contextProvider.getExemplarContext().getSpanId()).isNull();
+	}
+
+	@Test
+	void whenCurrentSpanHasNoTraceIdThenTraceIdIsNull() {
+		Span span = mock(Span.class);
+		given(this.tracer.currentSpan()).willReturn(span);
+		TraceContext traceContext = mock(TraceContext.class);
+		given(traceContext.sampled()).willReturn(true);
+		given(span.context()).willReturn(traceContext);
+		assertThat(this.contextProvider.getExemplarContext()).isNotNull();
+		assertThat(this.contextProvider.getExemplarContext().getTraceId()).isNull();
+	}
+
+	@Test
+	void whenCurrentSpanIsSampledThenExemplarContextIsNotNull() {
+		Span span = mock(Span.class);
+		given(this.tracer.currentSpan()).willReturn(span);
+		TraceContext traceContext = mock(TraceContext.class);
+		given(traceContext.sampled()).willReturn(true);
+		given(span.context()).willReturn(traceContext);
+		assertThat(this.contextProvider.getExemplarContext()).isNotNull();
+	}
+
+	@Test
+	void whenCurrentSpanIsNotSampledThenExemplarContextIsNull() {
+		Span span = mock(Span.class);
+		given(this.tracer.currentSpan()).willReturn(span);
+		TraceContext traceContext = mock(TraceContext.class);
+		given(traceContext.sampled()).willReturn(false);
+		given(span.context()).willReturn(traceContext);
+		assertThat(this.contextProvider.getExemplarContext()).isNull();
+	}
+
+	@Test
+	void whenCurrentSpanHasDeferredSamplingThenExemplarContextIsNull() {
+		Span span = mock(Span.class);
+		given(this.tracer.currentSpan()).willReturn(span);
+		TraceContext traceContext = mock(TraceContext.class);
+		given(traceContext.sampled()).willReturn(null);
+		given(span.context()).willReturn(traceContext);
+		assertThat(this.contextProvider.getExemplarContext()).isNull();
+	}
+
+}


### PR DESCRIPTION
Micrometer 1.17.0-M3 introduced exemplars support for OTLP, this is the auto-configuration support for it.
See https://github.com/micrometer-metrics/micrometer/pull/7199