### PR TITLE
Refactor LocalServerPortTests for type consistency and clarity

### DIFF
--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/web/server/LocalServerPortTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/web/server/LocalServerPortTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.test.web.server;
 
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -37,20 +36,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(properties = "local.server.port=8181")
 class LocalServerPortTests {
 
-	@Value("${local.server.port}")
-	private @Nullable String fromValue;
+    @Value("${local.server.port}")
+    private int fromValue;
 
-	@LocalServerPort
-	private @Nullable String fromAnnotation;
+    @LocalServerPort
+    private int fromAnnotation;
 
-	@Test
-	void testLocalServerPortAnnotation() {
-		assertThat(this.fromAnnotation).isNotNull().isEqualTo(this.fromValue);
-	}
+    @Test
+    void localServerPortShouldMatchPropertyValue() {
+        assertThat(this.fromAnnotation).isEqualTo(this.fromValue);
+    }
 
-	@Configuration(proxyBeanMethods = false)
-	static class Config {
-
-	}
+    @Configuration(proxyBeanMethods = false)
+    static class Config {
+    
+    }
 
 }


### PR DESCRIPTION


- Changed @LocalServerPort and @Value injection fields from String to int
  to align with typical usage of local.server.port as a numeric value.
- Removed unnecessary @Nullable annotations since values are guaranteed
  in the test context.
- Renamed test method to `localServerPortShouldMatchPropertyValue` for
  improved readability and intent clarity.
- Kept inner Config class minimal, ready for future bean definitions.