### PR TITLE
Add more ANSI styles to the logging color converter

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/ColorConverter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/ColorConverter.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
@@ -35,6 +36,7 @@ import org.apache.logging.log4j.core.pattern.PatternFormatter;
 import org.apache.logging.log4j.core.pattern.PatternParser;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.boot.ansi.AnsiBackground;
 import org.springframework.boot.ansi.AnsiColor;
 import org.springframework.boot.ansi.AnsiElement;
 import org.springframework.boot.ansi.AnsiOutput;
@@ -42,8 +44,8 @@ import org.springframework.boot.ansi.AnsiStyle;
 
 /**
  * Log4j2 {@link LogEventPatternConverter} to color output using the {@link AnsiOutput}
- * class. A single option 'styling' can be provided to the converter, or if not specified
- * color styling will be picked based on the logging level.
+ * class. One or more options can be provided to the converter to set the color and style,
+ * or if not specified color styling will be picked based on the logging level.
  *
  * @author Vladimir Tsanev
  * @since 1.3.0
@@ -59,7 +61,13 @@ public final class ColorConverter extends LogEventPatternConverter {
 		Arrays.stream(AnsiColor.values())
 			.filter((color) -> color != AnsiColor.DEFAULT)
 			.forEach((color) -> ansiElements.put(color.name().toLowerCase(Locale.ROOT), color));
+		Arrays.stream(AnsiBackground.values())
+			.filter((bg) -> bg != AnsiBackground.DEFAULT)
+			.forEach((bg) -> ansiElements.put("bg_" + bg.name().toLowerCase(Locale.ROOT), bg));
+		ansiElements.put("bold", AnsiStyle.BOLD);
 		ansiElements.put("faint", AnsiStyle.FAINT);
+		ansiElements.put("italic", AnsiStyle.ITALIC);
+		ansiElements.put("underline", AnsiStyle.UNDERLINE);
 		ELEMENTS = Collections.unmodifiableMap(ansiElements);
 	}
 
@@ -75,12 +83,12 @@ public final class ColorConverter extends LogEventPatternConverter {
 
 	private final List<PatternFormatter> formatters;
 
-	private final @Nullable AnsiElement styling;
+	private final AnsiElement @Nullable [] stylings;
 
-	private ColorConverter(List<PatternFormatter> formatters, @Nullable AnsiElement styling) {
+	private ColorConverter(List<PatternFormatter> formatters, AnsiElement @Nullable [] stylings) {
 		super("style", "style");
 		this.formatters = formatters;
-		this.styling = styling;
+		this.stylings = stylings;
 	}
 
 	@Override
@@ -100,18 +108,25 @@ public final class ColorConverter extends LogEventPatternConverter {
 			formatter.format(event, buf);
 		}
 		if (!buf.isEmpty()) {
-			AnsiElement element = this.styling;
-			if (element == null) {
-				// Assume highlighting
-				element = LEVELS.get(event.getLevel().intLevel());
-				element = (element != null) ? element : AnsiColor.GREEN;
+			if (this.stylings != null && this.stylings.length > 0) {
+				appendAnsiString(toAppendTo, buf.toString(), this.stylings);
 			}
-			appendAnsiString(toAppendTo, buf.toString(), element);
+			else {
+				// Assume highlighting
+				AnsiElement element = LEVELS.get(event.getLevel().intLevel());
+				element = (element != null) ? element : AnsiColor.GREEN;
+				appendAnsiString(toAppendTo, buf.toString(), element);
+			}
 		}
 	}
 
-	private void appendAnsiString(StringBuilder toAppendTo, String in, AnsiElement element) {
-		toAppendTo.append(AnsiOutput.toString(element, in));
+	private void appendAnsiString(StringBuilder toAppendTo, String in, AnsiElement... elements) {
+		Object[] args = new Object[elements.length + 1];
+		for (int i = 0; i < elements.length; i++) {
+			args[i] = elements[i];
+		}
+		args[elements.length] = in;
+		toAppendTo.append(AnsiOutput.toString(args));
 	}
 
 	/**
@@ -131,8 +146,11 @@ public final class ColorConverter extends LogEventPatternConverter {
 		}
 		PatternParser parser = PatternLayout.createPatternParser(config);
 		List<PatternFormatter> formatters = parser.parse(options[0]);
-		AnsiElement element = (options.length != 1) ? ELEMENTS.get(options[1]) : null;
-		return new ColorConverter(formatters, element);
+		AnsiElement[] elements = Arrays.stream(options, 1, options.length)
+			.map(ELEMENTS::get)
+			.filter(Objects::nonNull)
+			.toArray(AnsiElement[]::new);
+		return new ColorConverter(formatters, (elements.length > 0) ? elements : null);
 	}
 
 }

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/ColorConverter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/ColorConverter.java
@@ -19,13 +19,16 @@ package org.springframework.boot.logging.logback;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.pattern.CompositeConverter;
 
+import org.springframework.boot.ansi.AnsiBackground;
 import org.springframework.boot.ansi.AnsiColor;
 import org.springframework.boot.ansi.AnsiElement;
 import org.springframework.boot.ansi.AnsiOutput;
@@ -33,8 +36,8 @@ import org.springframework.boot.ansi.AnsiStyle;
 
 /**
  * Logback {@link CompositeConverter} to color output using the {@link AnsiOutput} class.
- * A single 'color' option can be provided to the converter, or if not specified color
- * will be picked based on the logging level.
+ * One or more options can be provided to the converter to set the color and style, or if
+ * not specified color will be picked based on the logging level.
  *
  * @author Phillip Webb
  * @since 1.0.0
@@ -48,7 +51,13 @@ public class ColorConverter extends CompositeConverter<ILoggingEvent> {
 		Arrays.stream(AnsiColor.values())
 			.filter((color) -> color != AnsiColor.DEFAULT)
 			.forEach((color) -> ansiElements.put(color.name().toLowerCase(Locale.ROOT), color));
+		Arrays.stream(AnsiBackground.values())
+			.filter((bg) -> bg != AnsiBackground.DEFAULT)
+			.forEach((bg) -> ansiElements.put("bg_" + bg.name().toLowerCase(Locale.ROOT), bg));
+		ansiElements.put("bold", AnsiStyle.BOLD);
 		ansiElements.put("faint", AnsiStyle.FAINT);
+		ansiElements.put("italic", AnsiStyle.ITALIC);
+		ansiElements.put("underline", AnsiStyle.UNDERLINE);
 		ELEMENTS = Collections.unmodifiableMap(ansiElements);
 	}
 
@@ -63,17 +72,29 @@ public class ColorConverter extends CompositeConverter<ILoggingEvent> {
 
 	@Override
 	protected String transform(ILoggingEvent event, String in) {
-		AnsiElement color = ELEMENTS.get(getFirstOption());
-		if (color == null) {
-			// Assume highlighting
-			color = LEVELS.get(event.getLevel().toInteger());
-			color = (color != null) ? color : AnsiColor.GREEN;
+		List<String> options = getOptionList();
+		if (options != null && !options.isEmpty()) {
+			AnsiElement[] elements = options.stream()
+				.map(ELEMENTS::get)
+				.filter(Objects::nonNull)
+				.toArray(AnsiElement[]::new);
+			if (elements.length > 0) {
+				return toAnsiString(in, elements);
+			}
 		}
+		// Assume highlighting
+		AnsiElement color = LEVELS.get(event.getLevel().toInteger());
+		color = (color != null) ? color : AnsiColor.GREEN;
 		return toAnsiString(in, color);
 	}
 
-	protected String toAnsiString(String in, AnsiElement element) {
-		return AnsiOutput.toString(element, in);
+	protected String toAnsiString(String in, AnsiElement... elements) {
+		Object[] args = new Object[elements.length + 1];
+		for (int i = 0; i < elements.length; i++) {
+			args[i] = elements[i];
+		}
+		args[elements.length] = in;
+		return AnsiOutput.toString(args);
 	}
 
 	static String getName(AnsiElement element) {

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/ColorConverterTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/ColorConverterTests.java
@@ -174,6 +174,50 @@ class ColorConverterTests {
 	}
 
 	@Test
+	void bold() {
+		StringBuilder output = new StringBuilder();
+		newConverter("bold").format(this.event, output);
+		assertThat(output).hasToString("\033[1min\033[0;39m");
+	}
+
+	@Test
+	void italic() {
+		StringBuilder output = new StringBuilder();
+		newConverter("italic").format(this.event, output);
+		assertThat(output).hasToString("\033[3min\033[0;39m");
+	}
+
+	@Test
+	void underline() {
+		StringBuilder output = new StringBuilder();
+		newConverter("underline").format(this.event, output);
+		assertThat(output).hasToString("\033[4min\033[0;39m");
+	}
+
+	@Test
+	void bgRed() {
+		StringBuilder output = new StringBuilder();
+		newConverter("bg_red").format(this.event, output);
+		assertThat(output).hasToString("\033[41min\033[0;39m");
+	}
+
+	@Test
+	void bgBrightGreen() {
+		StringBuilder output = new StringBuilder();
+		newConverter("bg_bright_green").format(this.event, output);
+		assertThat(output).hasToString("\033[102min\033[0;39m");
+	}
+
+	@Test
+	void boldAndRed() {
+		StringBuilder output = new StringBuilder();
+		ColorConverter converter = ColorConverter.newInstance(null, new String[] { this.in, "bold", "red" });
+		assertThat(converter).isNotNull();
+		converter.format(this.event, output);
+		assertThat(output).hasToString("\033[1;31min\033[0;39m");
+	}
+
+	@Test
 	void highlightFatal() {
 		this.event.setLevel(Level.FATAL);
 		StringBuilder output = new StringBuilder();

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/ColorConverterTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/ColorConverterTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.logging.logback;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import ch.qos.logback.classic.Level;
@@ -168,6 +169,48 @@ class ColorConverterTests {
 		this.converter.setOptionList(Collections.singletonList("bright_cyan"));
 		String out = this.converter.transform(this.event, this.in);
 		assertThat(out).isEqualTo("\033[96min\033[0;39m");
+	}
+
+	@Test
+	void bold() {
+		this.converter.setOptionList(Collections.singletonList("bold"));
+		String out = this.converter.transform(this.event, this.in);
+		assertThat(out).isEqualTo("\033[1min\033[0;39m");
+	}
+
+	@Test
+	void italic() {
+		this.converter.setOptionList(Collections.singletonList("italic"));
+		String out = this.converter.transform(this.event, this.in);
+		assertThat(out).isEqualTo("\033[3min\033[0;39m");
+	}
+
+	@Test
+	void underline() {
+		this.converter.setOptionList(Collections.singletonList("underline"));
+		String out = this.converter.transform(this.event, this.in);
+		assertThat(out).isEqualTo("\033[4min\033[0;39m");
+	}
+
+	@Test
+	void bgRed() {
+		this.converter.setOptionList(Collections.singletonList("bg_red"));
+		String out = this.converter.transform(this.event, this.in);
+		assertThat(out).isEqualTo("\033[41min\033[0;39m");
+	}
+
+	@Test
+	void bgBrightGreen() {
+		this.converter.setOptionList(Collections.singletonList("bg_bright_green"));
+		String out = this.converter.transform(this.event, this.in);
+		assertThat(out).isEqualTo("\033[102min\033[0;39m");
+	}
+
+	@Test
+	void boldAndRed() {
+		this.converter.setOptionList(Arrays.asList("bold", "red"));
+		String out = this.converter.transform(this.event, this.in);
+		assertThat(out).isEqualTo("\033[1;31min\033[0;39m");
 	}
 
 	@Test


### PR DESCRIPTION
## Problem

`%clr` in both Logback and Log4j2 `ColorConverter` only supported foreground colors and `faint` as style options. Styles like `bold`, `italic`, `underline`, and background colors (`bg_*`) were defined in `AnsiStyle` and `AnsiBackground` but were never exposed to the converter. Additionally, only a single option could be applied at a time, making it impossible to combine styles (e.g., bold red text).

## Changes

- **Expanded `ELEMENTS` map** in both `logback/ColorConverter` and `log4j2/ColorConverter` to include:
  - `bold`, `italic`, `underline` from `AnsiStyle`
  - All background colors with `bg_` prefix (e.g., `bg_red`, `bg_bright_green`) from `AnsiBackground`
- **Support for multiple options** per `%clr` converter so styles can be combined. For example:
  - Logback: `%clr(%msg){bold,red}`
  - Log4j2: `%clr{%msg}{bold}{red}`
- Updated `toAnsiString` / `appendAnsiString` to accept varargs `AnsiElement` and compose them using the existing `AnsiOutput.toString(Object...)` mechanism.
- Added tests for all new options and multi-option combinations in both `ColorConverterTests`.

## Related Issue

Closes #49262