### PR TITLE
Enable ansi support by default on Windows 11+

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiOutput.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/ansi/AnsiOutput.java
@@ -47,13 +47,13 @@ public abstract class AnsiOutput {
 
 	private static final String OPERATING_SYSTEM_NAME = System.getProperty("os.name");
 
+	private static final List<String> WINDOWS_ANSI_COMPATIBLE = List.of("Windows 11", "Windows Server 2025");
+
 	private static final String ENCODE_START = "\033[";
 
 	private static final String ENCODE_END = "m";
 
 	private static final String RESET = "0;" + AnsiColor.DEFAULT;
-
-	private static final List<String> WINDOWS_ANSI_COMPATIBLE = List.of("Windows 11", "Windows Server 2025");
 
 	/**
 	 * Sets if ANSI output is enabled.
@@ -175,7 +175,7 @@ public abstract class AnsiOutput {
 					}
 				}
 			}
-			if (isWindows(OPERATING_SYSTEM_NAME)) {
+			if (OPERATING_SYSTEM_NAME.toLowerCase(Locale.ENGLISH).contains("win")) {
 				return WINDOWS_ANSI_COMPATIBLE.contains(OPERATING_SYSTEM_NAME);
 			}
 			return true;
@@ -183,10 +183,6 @@ public abstract class AnsiOutput {
 		catch (Throwable ex) {
 			return false;
 		}
-	}
-
-	static boolean isWindows(String osName) {
-		return osName.toLowerCase(Locale.ENGLISH).contains("win");
 	}
 
 	/**

--- a/core/spring-boot/src/test/java/org/springframework/boot/ansi/AnsiOutputTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/ansi/AnsiOutputTests.java
@@ -16,25 +16,18 @@
 
 package org.springframework.boot.ansi;
 
-import java.util.stream.Stream;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import org.springframework.boot.ansi.AnsiOutput.Enabled;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for {@link AnsiOutput}.
  *
  * @author Phillip Webb
- * @author Philemon Hilscher
  */
 class AnsiOutputTests {
 
@@ -53,29 +46,6 @@ class AnsiOutputTests {
 		String encoded = AnsiOutput.toString("A", AnsiColor.RED, AnsiStyle.BOLD, "B", AnsiStyle.NORMAL, "D",
 				AnsiColor.GREEN, "E", AnsiStyle.FAINT, "F");
 		assertThat(encoded).isEqualTo("A[31;1mB[0mD[32mE[2mF[0;39m");
-	}
-
-	private static Stream<Arguments> provideOsNames() {
-		return Stream.of(
-				Arguments.of("", false),
-				Arguments.of("Windows NT 3.51", true),
-				Arguments.of("Windows 7", true),
-				Arguments.of("Windows 8", true),
-				Arguments.of("Windows 8.1", true),
-				Arguments.of("Windows 10", true),
-				Arguments.of("Windows 11", true),
-				Arguments.of("Windows Server 2025", true),
-				Arguments.of("Linux", false),
-				Arguments.of("Mac OS X", false),
-				Arguments.of("Mac OS", false)
-		);
-	}
-
-	@ParameterizedTest
-	@MethodSource("provideOsNames")
-	void testDetectIfIsWindows(String osName, boolean expected) {
-		boolean actual = AnsiOutput.isWindows(osName);
-		assertEquals(expected, actual);
 	}
 
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

# Enhancement proposal

Windows supports console ANSI output since build 10586 (End of 2015). Therefore I thought it would make sense to update the ANSI support detection in Spring Boot.

The only slight issue I noticed is that the JDK does not return the build number for Windows systems which in result cannot be checked. https://github.com/openjdk/jdk/blob/master/src/java.base/windows/native/libjava/java_props_md.c#L502

So with this change only the earliest versions of Windows 10 until 2016 (which are no longer supported anyway) would give out a wrong result whether they support ANSI.

Now I need your feedback. Is this acceptable? Should I add more test cases?

Thanks in advance. :)