### PR TITLE
Detect duplicate @Name annotations in configuration properties

### DIFF
--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptorResolver.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptorResolver.java
@@ -31,8 +31,10 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
+import javax.tools.Diagnostic;
 
 import org.springframework.boot.configurationprocessor.ConfigurationPropertiesSourceResolver.SourceMetadata;
+import org.springframework.boot.configurationprocessor.metadata.InvalidConfigurationMetadataException;
 
 /**
  * Resolve {@link PropertyDescriptor} instances.
@@ -149,8 +151,13 @@ class PropertyDescriptorResolver {
 	}
 
 	private void register(Map<String, PropertyDescriptor> candidates, PropertyDescriptor descriptor) {
-		if (!candidates.containsKey(descriptor.getName()) && isCandidate(descriptor)) {
-			candidates.put(descriptor.getName(), descriptor);
+		if (isCandidate(descriptor)) {
+			PropertyDescriptor existing = candidates.putIfAbsent(descriptor.getName(), descriptor);
+			if (existing != null) {
+				throw new InvalidConfigurationMetadataException(
+						"Multiple properties with the same name '%s' detected".formatted(descriptor.getName()),
+						Diagnostic.Kind.ERROR);
+			}
 		}
 	}
 

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/NameAnnotationPropertiesTests.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/NameAnnotationPropertiesTests.java
@@ -21,11 +21,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.configurationprocessor.metadata.ConfigurationMetadata;
 import org.springframework.boot.configurationprocessor.metadata.Metadata;
 import org.springframework.boot.configurationsample.name.ConstructorParameterNameAnnotationProperties;
+import org.springframework.boot.configurationsample.name.DuplicateNameAnnotationProperties;
 import org.springframework.boot.configurationsample.name.JavaBeanNameAnnotationProperties;
 import org.springframework.boot.configurationsample.name.LombokNameAnnotationProperties;
 import org.springframework.boot.configurationsample.name.RecordComponentNameAnnotationProperties;
+import org.springframework.core.test.tools.CompilationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * Metadata generation tests for using {@code @Name}.
@@ -85,6 +88,13 @@ class NameAnnotationPropertiesTests extends AbstractMetadataGenerationTests {
 				.fromSource(LombokNameAnnotationProperties.class)
 				.withDefaultValue("Whether default mode is enabled.")
 				.withDefaultValue(true));
+	}
+
+	@Test
+	void duplicateNameAnnotationPropertiesShouldFailCompilation() {
+		assertThatExceptionOfType(CompilationException.class)
+			.isThrownBy(() -> compile(DuplicateNameAnnotationProperties.class))
+			.withMessageContaining("Multiple properties with the same name");
 	}
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/name/DuplicateNameAnnotationProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/name/DuplicateNameAnnotationProperties.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.configurationsample.name;
+
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestName;
+
+/**
+ * Java bean properties with duplicate {@code @Name} values that should fail.
+ *
+ * @author Pavel Anisimov
+ */
+@TestConfigurationProperties("named")
+public class DuplicateNameAnnotationProperties {
+
+	@TestName("sameName")
+	private String first;
+
+	@TestName("sameName")
+	private String second;
+
+	public String getFirst() {
+		return this.first;
+	}
+
+	public void setFirst(String first) {
+		this.first = first;
+	}
+
+	public String getSecond() {
+		return this.second;
+	}
+
+	public void setSecond(String second) {
+		this.second = second;
+	}
+
+}


### PR DESCRIPTION
This changes `PropertyDescriptorResolver` to throw an `InvalidConfigurationMetadataException` when multiple properties resolve to the same name (e.g., via duplicate `@Name` annotations). Previously, the processor silently dropped all but the first property, producing incomplete metadata without any warning.

The `register` method now uses `putIfAbsent` and checks the return value — if a property with the same name was already registered, it raises a compilation error with a clear message identifying the conflict.

Also adds a test case (`DuplicateNameAnnotationProperties`) that verifies the expected compilation failure.

Closes #49565

Signed-off-by: Pavel Anisimov <mango766@users.noreply.github.com>