### PR TITLE
Add boundary tests for JsonValueWriter max nesting depth

### DIFF
--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/json/JsonValueWriterTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/json/JsonValueWriterTests.java
@@ -300,15 +300,12 @@ class JsonValueWriterTests {
 	void shouldAllowStartingObjectWhenCurrentDepthIsMaxDepth() {
 		StringBuilder out = new StringBuilder();
 		JsonValueWriter writer = new JsonValueWriter(out, 2);
-
 		writer.start(Series.OBJECT);
 		writer.start(Series.OBJECT);
 		writer.start(Series.OBJECT);
-
 		writer.end(Series.OBJECT);
 		writer.end(Series.OBJECT);
 		writer.end(Series.OBJECT);
-
 		assertThat(out).hasToString("{{{}}}");
 	}
 
@@ -316,15 +313,12 @@ class JsonValueWriterTests {
 	void shouldAllowStartingArrayWhenCurrentDepthIsMaxDepth() {
 		StringBuilder out = new StringBuilder();
 		JsonValueWriter writer = new JsonValueWriter(out, 2);
-
 		writer.start(Series.ARRAY);
 		writer.start(Series.ARRAY);
 		writer.start(Series.ARRAY);
-
 		writer.end(Series.ARRAY);
 		writer.end(Series.ARRAY);
 		writer.end(Series.ARRAY);
-
 		assertThat(out).hasToString("[[[]]]");
 	}
 


### PR DESCRIPTION
This change adds boundary tests for JsonValueWriter max nesting depth.

Existing tests verify that exceeding the maximum depth eventually results
in an exception, but they do not assert the exact boundary at which nesting
is still allowed.

The new tests verify that starting a new series when the current depth
equals maxNestingDepth is still allowed, and that an exception is thrown
when attempting to start another series beyond that point.

This helps to better define the current behavior and guard against regressions.