### PR TITLE
Register ServerHttpObservationFilter in Management context

### DIFF
--- a/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/actuate/web/WebMvcEndpointChildContextConfiguration.java
+++ b/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/actuate/web/WebMvcEndpointChildContextConfiguration.java
@@ -16,7 +16,12 @@
 
 package org.springframework.boot.webmvc.autoconfigure.actuate.web;
 
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import jakarta.servlet.DispatcherType;
+
 import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
 import org.springframework.boot.actuate.autoconfigure.web.ManagementContextType;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -24,18 +29,25 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.boot.autoconfigure.condition.SearchStrategy;
 import org.springframework.boot.autoconfigure.web.WebProperties;
+import org.springframework.boot.micrometer.observation.autoconfigure.ObservationProperties;
 import org.springframework.boot.servlet.filter.OrderedRequestContextFilter;
 import org.springframework.boot.web.error.ErrorPage;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.boot.web.server.servlet.ConfigurableServletWebServerFactory;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.webmvc.autoconfigure.DispatcherServletAutoConfiguration;
 import org.springframework.boot.webmvc.autoconfigure.DispatcherServletRegistrationBean;
 import org.springframework.boot.webmvc.error.ErrorAttributes;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
+import org.springframework.http.server.observation.DefaultServerRequestObservationConvention;
+import org.springframework.http.server.observation.ServerRequestObservationConvention;
 import org.springframework.web.context.request.RequestContextListener;
 import org.springframework.web.filter.RequestContextFilter;
+import org.springframework.web.filter.ServerHttpObservationFilter;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
@@ -106,6 +118,29 @@ class WebMvcEndpointChildContextConfiguration {
 	@ConditionalOnMissingBean({ RequestContextListener.class, RequestContextFilter.class })
 	RequestContextFilter requestContextFilter() {
 		return new OrderedRequestContextFilter();
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass({ Observation.class, ObservationProperties.class })
+	@ConditionalOnBean({ ObservationRegistry.class, ObservationProperties.class })
+	static class ObservationFilterConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean(value = ServerHttpObservationFilter.class,
+				parameterizedContainer = FilterRegistrationBean.class, search = SearchStrategy.CURRENT)
+		FilterRegistrationBean<ServerHttpObservationFilter> managementWebMvcObservationFilter(
+				ObservationRegistry registry, ObjectProvider<ServerRequestObservationConvention> customConvention,
+				ObservationProperties observationProperties) {
+			String name = observationProperties.getHttp().getServer().getRequests().getName();
+			ServerRequestObservationConvention convention = customConvention
+				.getIfAvailable(() -> new DefaultServerRequestObservationConvention(name));
+			ServerHttpObservationFilter filter = new ServerHttpObservationFilter(registry, convention);
+			FilterRegistrationBean<ServerHttpObservationFilter> registration = new FilterRegistrationBean<>(filter);
+			registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 1);
+			registration.setDispatcherTypes(DispatcherType.REQUEST, DispatcherType.ASYNC);
+			return registration;
+		}
+
 	}
 
 	/**

--- a/module/spring-boot-webmvc/src/test/java/org/springframework/boot/webmvc/autoconfigure/actuate/web/WebMvcEndpointChildContextConfigurationTests.java
+++ b/module/spring-boot-webmvc/src/test/java/org/springframework/boot/webmvc/autoconfigure/actuate/web/WebMvcEndpointChildContextConfigurationTests.java
@@ -16,15 +16,18 @@
 
 package org.springframework.boot.webmvc.autoconfigure.actuate.web;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
-
+import org.springframework.boot.micrometer.observation.autoconfigure.ObservationProperties;
 import org.springframework.boot.servlet.filter.OrderedRequestContextFilter;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.webmvc.autoconfigure.DispatcherServletPath;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.context.request.RequestContextListener;
 import org.springframework.web.filter.RequestContextFilter;
+import org.springframework.web.filter.ServerHttpObservationFilter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -69,6 +72,33 @@ class WebMvcEndpointChildContextConfigurationTests {
 			.run((context) -> assertThat(context.getBean(DispatcherServletPath.class).getPath()).isEqualTo("/"));
 	}
 
+	@Test
+	void contextShouldConfigureObservationFilterWhenObservationRegistryPresent() {
+		this.contextRunner
+			.withUserConfiguration(ObservationTestConfig.class, WebMvcEndpointChildContextConfiguration.class)
+			.run((context) -> {
+				assertThat(context).hasSingleBean(FilterRegistrationBean.class);
+				FilterRegistrationBean<?> registration = context.getBean(FilterRegistrationBean.class);
+				assertThat(registration.getFilter()).isInstanceOf(ServerHttpObservationFilter.class);
+			});
+	}
+
+	@Test
+	void contextShouldNotConfigureObservationFilterWhenObservationRegistryMissing() {
+		this.contextRunner.withUserConfiguration(WebMvcEndpointChildContextConfiguration.class).run((context) -> {
+			assertThat(context).doesNotHaveBean(ServerHttpObservationFilter.class);
+			assertThat(context).doesNotHaveBean(FilterRegistrationBean.class);
+		});
+	}
+
+	@Test
+	void contextShouldNotConfigureObservationFilterWhenExistingFilterPresent() {
+		this.contextRunner
+			.withUserConfiguration(ObservationTestConfig.class, ExistingObservationFilterConfig.class,
+					WebMvcEndpointChildContextConfiguration.class)
+			.run((context) -> assertThat(context).doesNotHaveBean(FilterRegistrationBean.class));
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	static class ExistingConfig {
 
@@ -85,6 +115,31 @@ class WebMvcEndpointChildContextConfigurationTests {
 		@Bean
 		RequestContextListener testRequestContextListener() {
 			return new RequestContextListener();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ObservationTestConfig {
+
+		@Bean
+		ObservationRegistry observationRegistry() {
+			return ObservationRegistry.create();
+		}
+
+		@Bean
+		ObservationProperties observationProperties() {
+			return new ObservationProperties();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ExistingObservationFilterConfig {
+
+		@Bean
+		ServerHttpObservationFilter testServerHttpObservationFilter() {
+			return new ServerHttpObservationFilter(ObservationRegistry.create());
 		}
 
 	}


### PR DESCRIPTION
Fixes - https://github.com/spring-projects/spring-boot/issues/31811

This PR registers the `ServerHttpObservationFilter` in the Management context, enabling HTTP observations (metrics and traces) for management endpoints in Spring MVC.

Since this is a long-standing issue, this change provides a pragmatic fix that resolves the problem for the time being without affecting the main application context.