### PR TITLE
Add @ConditionalOnWebApplication to NettyReactiveWebServerAutoConfiguration

### DIFF
--- a/module/spring-boot-reactor-netty/src/main/java/org/springframework/boot/reactor/netty/autoconfigure/NettyReactiveWebServerAutoConfiguration.java
+++ b/module/spring-boot-reactor-netty/src/main/java/org/springframework/boot/reactor/netty/autoconfigure/NettyReactiveWebServerAutoConfiguration.java
@@ -23,6 +23,8 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.reactor.netty.NettyReactiveWebServerFactory;
 import org.springframework.boot.reactor.netty.NettyRouteProvider;
@@ -42,10 +44,12 @@ import org.springframework.http.client.ReactorResourceFactory;
  * server.
  *
  * @author Andy Wilkinson
+ * @author Daeho Kwon
  * @since 4.0.0
  */
 @AutoConfiguration
 @ConditionalOnClass({ ReactiveHttpInputMessage.class, HttpServer.class })
+@ConditionalOnWebApplication(type = Type.REACTIVE)
 @EnableConfigurationProperties(NettyServerProperties.class)
 @Import({ ReactiveWebServerConfiguration.class, ReactorResourceFactoryConfiguration.class })
 public final class NettyReactiveWebServerAutoConfiguration {

--- a/module/spring-boot-reactor-netty/src/test/java/org/springframework/boot/reactor/netty/autoconfigure/NettyReactiveWebServerAutoConfigurationTests.java
+++ b/module/spring-boot-reactor-netty/src/test/java/org/springframework/boot/reactor/netty/autoconfigure/NettyReactiveWebServerAutoConfigurationTests.java
@@ -19,10 +19,13 @@ package org.springframework.boot.reactor.netty.autoconfigure;
 import org.junit.jupiter.api.Test;
 import reactor.netty.http.server.HttpServer;
 
+import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.reactor.netty.NettyReactiveWebServerFactory;
 import org.springframework.boot.reactor.netty.NettyServerCustomizer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.boot.web.server.autoconfigure.reactive.AbstractReactiveWebServerAutoConfigurationTests;
+import org.springframework.boot.web.server.reactive.ReactiveWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -39,6 +42,7 @@ import static org.mockito.Mockito.mock;
  * @author Raheela Aslam
  * @author Madhura Bhave
  * @author Scott Frederick
+ * @author Daeho Kwon
  */
 // @DirtiesUrlFactories
 class NettyReactiveWebServerAutoConfigurationTests extends AbstractReactiveWebServerAutoConfigurationTests {
@@ -65,6 +69,13 @@ class NettyReactiveWebServerAutoConfigurationTests extends AbstractReactiveWebSe
 				assertThat(factory.getServerCustomizers()).contains(customizer);
 				then(customizer).should().apply(any(HttpServer.class));
 			});
+	}
+
+	@Test
+	void autoConfigurationDoesNotApplyToNonWebApplication() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(NettyReactiveWebServerAutoConfiguration.class))
+			.run((context) -> assertThat(context).doesNotHaveBean(ReactiveWebServerFactory.class));
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
This PR addresses #49693.

`NettyReactiveWebServerAutoConfiguration` is missing a `@ConditionalOnWebApplication(type = Type.REACTIVE)` condition, unlike other reactive web server auto-configurations such as `JettyReactiveWebServerAutoConfiguration`.

Closes #49693
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
