### PR TITLE
fix: use first available executor when applicationTaskExecutor bean is absent

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jpa/JpaRepositoriesAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jpa/JpaRepositoriesAutoConfiguration.java
@@ -95,7 +95,14 @@ public class JpaRepositoriesAutoConfiguration {
 		if (taskExecutors.size() == 1) {
 			return taskExecutors.values().iterator().next();
 		}
-		return taskExecutors.get(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME);
+		AsyncTaskExecutor executor = taskExecutors.get(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME);
+		if (executor != null) {
+			return executor;
+		}
+		// No applicationTaskExecutor bean found; return first available to ensure
+		// bootstrap-mode=deferred actually runs asynchronously instead of silently
+		// falling back to the main thread (see gh-49688)
+		return taskExecutors.values().iterator().next();
 	}
 
 	private static final class BootstrapExecutorCondition extends AnyNestedCondition {


### PR DESCRIPTION
## What

When `spring.data.jpa.repositories.bootstrap-mode=deferred` is configured but no bean named `applicationTaskExecutor` exists, `determineBootstrapExecutor()` returns `null`, silently falling back to the main thread instead of running JPA bootstrap asynchronously.

## Fix

Changed `determineBootstrapExecutor()` to fall back to the first available `AsyncTaskExecutor` when `applicationTaskExecutor` is not present, instead of returning `null`. This ensures `bootstrap-mode=deferred` actually works asynchronously even without a named task executor bean.

## Original behavior

```java
// Returns null when applicationTaskExecutor is absent → deferred mode silently runs on main thread
return taskExecutors.get(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME);
```

## Fixed behavior

```java
AsyncTaskExecutor executor = taskExecutors.get(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME);
if (executor != null) {
    return executor;
}
// No applicationTaskExecutor bean found; return first available to ensure
// bootstrap-mode=deferred actually runs asynchronously instead of silently
// falling back to the main thread (see gh-49688)
return taskExecutors.values().iterator().next();
```

Fixes #49688
