### PR TITLE
Improve macOS executable fallback for Homebrew paths

### DIFF
--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/CredentialHelper.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/configuration/CredentialHelper.java
@@ -41,6 +41,10 @@ class CredentialHelper {
 
 	private static final String USR_LOCAL_BIN = "/usr/local/bin/";
 
+	private static final String OPT_HOMEBREW_BIN = "/opt/homebrew/bin/";
+
+	private static final String[] MAC_OS_BIN_DIRECTORIES = { OPT_HOMEBREW_BIN, USR_LOCAL_BIN };
+
 	private static final Set<String> CREDENTIAL_NOT_FOUND_MESSAGES = Set.of("credentials not found in native keychain",
 			"no credentials server URL", "no credentials username");
 
@@ -92,17 +96,27 @@ class CredentialHelper {
 			if (!Platform.isMac()) {
 				throw ex;
 			}
-			try {
-				List<String> command = new ArrayList<>(processBuilder.command());
-				command.set(0, USR_LOCAL_BIN + command.get(0));
-				return processBuilder.command(command).start();
+			String executableName = getExecutableName(processBuilder.command().get(0));
+			for (String binDirectory : MAC_OS_BIN_DIRECTORIES) {
+				try {
+					List<String> command = new ArrayList<>(processBuilder.command());
+					if (command.get(0).startsWith(binDirectory)) {
+						continue;
+					}
+					command.set(0, binDirectory + executableName);
+					return processBuilder.command(command).start();
+				}
+				catch (Exception suppressed) {
+					ex.addSuppressed(suppressed);
+				}
 			}
-			catch (Exception suppressed) {
-				// Suppresses the exception and rethrows the original exception
-				ex.addSuppressed(suppressed);
-				throw ex;
-			}
+			throw ex;
 		}
+	}
+
+	private String getExecutableName(String executable) {
+		int lastSlash = executable.lastIndexOf('/');
+		return (lastSlash != -1) ? executable.substring(lastSlash + 1) : executable;
 	}
 
 	private static boolean isCredentialsNotFoundError(String message) {

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/configuration/CredentialHelperTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/configuration/CredentialHelperTests.java
@@ -102,14 +102,16 @@ class CredentialHelperTests {
 	void getWhenExecutableDoesNotExistErrorThrowsException() {
 		String executable = "docker-credential-%s".formatted(UUID.randomUUID().toString());
 		assertThatIOException().isThrownBy(() -> new CredentialHelper(executable).get("invalid.example.com"))
-			.withMessageContaining(executable)
-			.satisfies((ex) -> {
-				if (Platform.isMac()) {
-					assertThat(ex.getMessage()).doesNotContain("/usr/local/bin/");
-					assertThat(ex.getSuppressed()).allSatisfy((suppressed) -> assertThat(suppressed)
-						.hasMessageContaining("/usr/local/bin/" + executable));
-				}
-			});
+				.withMessageContaining(executable)
+				.satisfies((ex) -> {
+					if (Platform.isMac()) {
+						assertThat(ex.getMessage()).doesNotContain("/usr/local/bin/");
+						assertThat(ex.getSuppressed()).anySatisfy(
+								(suppressed) -> assertThat(suppressed).hasMessageContaining("/opt/homebrew/bin/" + executable));
+						assertThat(ex.getSuppressed()).anySatisfy(
+								(suppressed) -> assertThat(suppressed).hasMessageContaining("/usr/local/bin/" + executable));
+					}
+				});
 	}
 
 }

--- a/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/ProcessRunner.java
+++ b/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/ProcessRunner.java
@@ -44,6 +44,10 @@ class ProcessRunner {
 
 	private static final String USR_LOCAL_BIN = "/usr/local/bin";
 
+	private static final String OPT_HOMEBREW_BIN = "/opt/homebrew/bin";
+
+	private static final String[] MAC_OS_BIN_DIRECTORIES = { OPT_HOMEBREW_BIN, USR_LOCAL_BIN };
+
 	private static final boolean MAC_OS = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("mac");
 
 	private static final Log logger = LogFactory.getLog(ProcessRunner.class);
@@ -108,14 +112,31 @@ class ProcessRunner {
 		}
 		catch (IOException ex) {
 			String path = processBuilder.environment().get("PATH");
-			if (MAC_OS && path != null && !path.contains(USR_LOCAL_BIN)
-					&& !command[0].startsWith(USR_LOCAL_BIN + "/")) {
-				String[] localCommand = command.clone();
-				localCommand[0] = USR_LOCAL_BIN + "/" + localCommand[0];
-				return startProcess(localCommand);
+			if (MAC_OS && path != null) {
+				String commandName = getCommandName(command[0]);
+				for (String binDirectory : MAC_OS_BIN_DIRECTORIES) {
+					if (path.contains(binDirectory) || command[0].startsWith(binDirectory + "/")) {
+						continue;
+					}
+					String[] localCommand = command.clone();
+					localCommand[0] = binDirectory + "/" + commandName;
+					ProcessBuilder localProcessBuilder = new ProcessBuilder(localCommand);
+					localProcessBuilder.directory(this.workingDirectory);
+					try {
+						return localProcessBuilder.start();
+					}
+					catch (IOException suppressed) {
+						ex.addSuppressed(suppressed);
+					}
+				}
 			}
 			throw new ProcessStartException(command, ex);
 		}
+	}
+
+	private String getCommandName(String command) {
+		int lastSlash = command.lastIndexOf('/');
+		return (lastSlash != -1) ? command.substring(lastSlash + 1) : command;
 	}
 
 	private int waitForProcess(Process process) {

--- a/test-support/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/process/DisabledIfProcessUnavailableCondition.java
+++ b/test-support/spring-boot-test-support/src/main/java/org/springframework/boot/testsupport/process/DisabledIfProcessUnavailableCondition.java
@@ -43,6 +43,10 @@ class DisabledIfProcessUnavailableCondition implements ExecutionCondition {
 
 	private static final String USR_LOCAL_BIN = "/usr/local/bin";
 
+	private static final String OPT_HOMEBREW_BIN = "/opt/homebrew/bin";
+
+	private static final String[] MAC_OS_BIN_DIRECTORIES = { OPT_HOMEBREW_BIN, USR_LOCAL_BIN };
+
 	private static final boolean MAC_OS = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("mac");
 
 	@Override
@@ -68,23 +72,41 @@ class DisabledIfProcessUnavailableCondition implements ExecutionCondition {
 	private void check(String[] command) {
 		ProcessBuilder processBuilder = new ProcessBuilder(command);
 		try {
-			Process process = processBuilder.start();
-			Assert.state(process.waitFor(30, TimeUnit.SECONDS), "Process did not exit within 30 seconds");
-			Assert.state(process.exitValue() == 0, () -> "Process exited with %d".formatted(process.exitValue()));
-			process.destroy();
+			check(processBuilder);
 		}
 		catch (Exception ex) {
 			String path = processBuilder.environment().get("PATH");
-			if (MAC_OS && path != null && !path.contains(USR_LOCAL_BIN)
-					&& !command[0].startsWith(USR_LOCAL_BIN + "/")) {
-				String[] localCommand = command.clone();
-				localCommand[0] = USR_LOCAL_BIN + "/" + localCommand[0];
-				check(localCommand);
-				return;
+			if (MAC_OS && path != null) {
+				String commandName = getCommandName(command[0]);
+				for (String binDirectory : MAC_OS_BIN_DIRECTORIES) {
+					if (path.contains(binDirectory) || command[0].startsWith(binDirectory + "/")) {
+						continue;
+					}
+					String[] localCommand = command.clone();
+					localCommand[0] = binDirectory + "/" + commandName;
+					try {
+						check(new ProcessBuilder(localCommand));
+						return;
+					}
+					catch (Exception ignored) {
+					}
+				}
 			}
 			throw new RuntimeException(
 					"Unable to start process '%s'".formatted(StringUtils.arrayToDelimitedString(command, " ")));
 		}
+	}
+
+	private void check(ProcessBuilder processBuilder) throws Exception {
+		Process process = processBuilder.start();
+		Assert.state(process.waitFor(30, TimeUnit.SECONDS), "Process did not exit within 30 seconds");
+		Assert.state(process.exitValue() == 0, () -> "Process exited with %d".formatted(process.exitValue()));
+		process.destroy();
+	}
+
+	private String getCommandName(String command) {
+		int lastSlash = command.lastIndexOf('/');
+		return (lastSlash != -1) ? command.substring(lastSlash + 1) : command;
 	}
 
 }


### PR DESCRIPTION
## Summary
Improve macOS process startup fallback by supporting both Homebrew bin locations:
- `/opt/homebrew/bin` (Apple Silicon default)
- `/usr/local/bin` (legacy/common)

## Problem
Some macOS code paths retried process startup using only `/usr/local/bin`.
On Apple Silicon, executables are often installed under `/opt/homebrew/bin`,
so process startup could fail in restricted `PATH` environments.

## Changes
- Added `OPT_HOMEBREW_BIN` fallback alongside existing `USR_LOCAL_BIN`.
- Updated fallback handling in:
  - `core/spring-boot-docker-compose` `ProcessRunner`
  - `test-support` `DisabledIfProcessUnavailableCondition`
  - `buildpack` `CredentialHelper`
- Updated `CredentialHelperTests` to assert both fallback candidates are attempted.

## Why this is safe
- macOS-only behavior change (guarded by OS checks)
- Windows/Linux behavior unchanged
- Existing `/usr/local/bin` fallback preserved

## Verification
Executed with JDK 25:
- `:buildpack:spring-boot-buildpack-platform:test --tests org.springframework.boot.buildpack.platform.docker.configuration.CredentialHelperTests`
- `:test-support:spring-boot-test-support:test --tests org.springframework.boot.testsupport.process.DisabledIfProcessUnavailableTests`
- `:core:spring-boot-docker-compose:test --tests org.springframework.boot.docker.compose.core.ProcessRunnerTests`
- `:core:spring-boot-docker-compose:checkstyleMain`
- `:test-support:spring-boot-test-support:checkstyleMain`
- `:buildpack:spring-boot-buildpack-platform:checkstyleMain`

All passed.