### PR TITLE
Fix incorrect indefinite articles in Javadoc

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/launch/Archive.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-loader/src/main/java/org/springframework/boot/loader/launch/Archive.java
@@ -98,7 +98,7 @@ public interface Archive extends AutoCloseable {
 	 * Factory method to create an appropriate {@link Archive} from the given
 	 * {@link Class} target.
 	 * @param target a target class that will be used to find the archive code source
-	 * @return an new {@link Archive} instance
+	 * @return a new {@link Archive} instance
 	 * @throws Exception if the archive cannot be created
 	 */
 	static Archive create(Class<?> target) throws Exception {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonMixinModuleEntriesBeanRegistrationAotProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/jackson/JsonMixinModuleEntriesBeanRegistrationAotProcessor.java
@@ -37,7 +37,7 @@ import org.springframework.javapoet.CodeBlock;
 
 /**
  * {@link BeanRegistrationAotProcessor} that replaces any {@link JsonMixinModuleEntries}
- * by an hard-coded equivalent. This has the effect of disabling scanning at runtime.
+ * by a hard-coded equivalent. This has the effect of disabling scanning at runtime.
  *
  * @author Stephane Nicoll
  */

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/json/JsonWriter.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/json/JsonWriter.java
@@ -391,7 +391,7 @@ public interface JsonWriter<T> {
 
 		/**
 		 * Only include this member when an extracted value is not {@code null}.
-		 * @param extractor an function used to extract the value to test
+		 * @param extractor a function used to extract the value to test
 		 * @return a {@link Member} which may be configured further
 		 */
 		public Member<T> whenNotNull(Function<T, ?> extractor) {


### PR DESCRIPTION
Fix incorrect indefinite articles: "an new", "an function",
"a existing", and "an hard-coded".