### PR TITLE
Fix minor Javadoc wording errors

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Operation.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/Operation.java
@@ -35,7 +35,7 @@ public interface Operation {
 	 * Invoke the underlying operation using the given {@code context}. Results intended
 	 * to be returned in the body of the response should additionally implement
 	 * {@link OperationResponseBody}.
-	 * @param context the context in to use when invoking the operation
+	 * @param context the context to use when invoking the operation
 	 * @return the result of the operation, may be {@code null}
 	 */
 	Object invoke(InvocationContext context);

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnPropertyCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnPropertyCondition.java
@@ -38,7 +38,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
 /**
- * {@link Condition} that checks if properties are defined in environment.
+ * {@link Condition} that checks if properties are defined in the environment.
  *
  * @author Maciej Walkowiak
  * @author Phillip Webb

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayDataSource.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/flyway/FlywayDataSource.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
- * Qualifier annotation for a DataSource to be injected in to Flyway. If used for a second
+ * Qualifier annotation for a DataSource to be injected into Flyway. If used for a second
  * data source, the other (main) one would normally be marked as {@code @Primary}.
  *
  * @author Dave Syer

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseDataSource.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseDataSource.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
- * Qualifier annotation for a DataSource to be injected in to Liquibase. If used for a
+ * Qualifier annotation for a DataSource to be injected into Liquibase. If used for a
  * second data source, the other (main) one would normally be marked as {@code @Primary}.
  *
  * @author Eddú Meléndez

--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTest.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTest.java
@@ -134,7 +134,7 @@ public @interface SpringBootTest {
 	UseMainMethod useMainMethod() default UseMainMethod.NEVER;
 
 	/**
-	 * An enumeration web environment modes.
+	 * An enumeration of web environment modes.
 	 */
 	enum WebEnvironment {
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata-changelog-generator/src/main/java/org/springframework/boot/configurationmetadata/changelog/Difference.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-configuration-metadata-changelog-generator/src/main/java/org/springframework/boot/configurationmetadata/changelog/Difference.java
@@ -20,7 +20,7 @@ import org.springframework.boot.configurationmetadata.ConfigurationMetadataPrope
 import org.springframework.boot.configurationmetadata.Deprecation.Level;
 
 /**
- * A difference the metadata.
+ * A difference in the metadata.
  *
  * @param type the type of the difference
  * @param oldProperty the old property


### PR DESCRIPTION
Add missing words such as "the", "of", and "in", and replace "in to"
with "into" where appropriate.