### PR TITLE
Remove redundant properties from additional-spring-configuration-metadata.json

### DIFF
--- a/module/spring-boot-jackson/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/module/spring-boot-jackson/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,10 +1,6 @@
 {
   "properties": [
     {
-      "name": "spring.jackson.constructor-detector",
-      "defaultValue": "default"
-    },
-    {
       "name": "spring.jackson.datatype.enum",
       "description": "Jackson on/off features for enums."
     },

--- a/module/spring-boot-jackson2/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/module/spring-boot-jackson2/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,10 +1,6 @@
 {
   "properties": [
     {
-      "name": "spring.jackson2.constructor-detector",
-      "defaultValue": "default"
-    },
-    {
       "name": "spring.jackson2.datatype.enum",
       "description": "Jackson on/off features for enums."
     }


### PR DESCRIPTION
Which can be inferred from `@ConfigurationProperties` classes.