### PR TITLE
Reuse reactive CloudFoundry UAA URL across calls

### DIFF
--- a/module/spring-boot-cloudfoundry/src/main/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/SecurityService.java
+++ b/module/spring-boot-cloudfoundry/src/main/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/SecurityService.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.client.HttpClient;
@@ -55,7 +54,7 @@ class SecurityService {
 
 	private final String cloudControllerUrl;
 
-	private volatile @Nullable String uaaUrl;
+	private final Mono<String> uaaUrl;
 
 	SecurityService(WebClient.Builder webClientBuilder, String cloudControllerUrl, boolean skipSslValidation) {
 		Assert.notNull(webClientBuilder, "'webClientBuilder' must not be null");
@@ -65,6 +64,18 @@ class SecurityService {
 		}
 		this.webClient = webClientBuilder.build();
 		this.cloudControllerUrl = cloudControllerUrl;
+		this.uaaUrl = this.webClient.get()
+			.uri(this.cloudControllerUrl + "/info")
+			.retrieve()
+			.bodyToMono(Map.class)
+			.map((response) -> {
+				String tokenEndpoint = (String) response.get("token_endpoint");
+				Assert.state(tokenEndpoint != null, "No 'token_endpoint' found in response");
+				return tokenEndpoint;
+			})
+			.cacheInvalidateIf((token) -> false)
+			.onErrorMap((ex) -> new CloudFoundryAuthorizationException(Reason.SERVICE_UNAVAILABLE,
+					"Unable to fetch token keys from UAA."));
 	}
 
 	protected ReactorClientHttpConnector buildTrustAllSslConnector() {
@@ -152,23 +163,7 @@ class SecurityService {
 	 * @return the UAA url Mono
 	 */
 	Mono<String> getUaaUrl() {
-		String uaaUrl = this.uaaUrl;
-		if (uaaUrl != null) {
-			return Mono.just(uaaUrl);
-		}
-		return this.webClient.get()
-			.uri(this.cloudControllerUrl + "/info")
-			.retrieve()
-			.bodyToMono(Map.class)
-			.map((response) -> {
-				String tokenEndpoint = (String) response.get("token_endpoint");
-				Assert.state(tokenEndpoint != null, "No 'token_endpoint' found in response");
-				this.uaaUrl = tokenEndpoint;
-				return tokenEndpoint;
-			})
-			.cache()
-			.onErrorMap((ex) -> new CloudFoundryAuthorizationException(Reason.SERVICE_UNAVAILABLE,
-					"Unable to fetch token keys from UAA."));
+		return this.uaaUrl;
 	}
 
 }

--- a/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/SecurityServiceTests.java
+++ b/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/SecurityServiceTests.java
@@ -213,6 +213,10 @@ class SecurityServiceTests {
 			.consumeNextWith((uaaUrl) -> assertThat(uaaUrl).isEqualTo(UAA_URL))
 			.expectComplete()
 			.verify();
+		prepareResponse((response) -> {
+			response.setBody("{\"token_endpoint\":\"" + UAA_URL + "\"}");
+			response.setHeader("Content-Type", "application/json");
+		});
 		StepVerifier.create(this.securityService.getUaaUrl())
 			.consumeNextWith((uaaUrl) -> assertThat(uaaUrl).isEqualTo(UAA_URL))
 			.expectComplete()


### PR DESCRIPTION
Reactive `SecurityService#getUaaUrl()` creates a new `Mono` pipeline on each
invocation, so the resolved UAA URL is not reused across calls.

This can matter during token validation. On a token key cache miss,
`TokenValidator.validate()` can reach `getUaaUrl()` twice in a single flow:
once through `fetchTokenKeys()` and once through `validateIssuer()`. As a
result, the reactive path can issue duplicate `/info` requests.

The servlet counterpart stores the resolved UAA URL and reuses it on later
calls. The existing reactive test named
`getUaaUrlShouldCallCloudControllerInfoOnlyOnce` only calls `getUaaUrl()` once,
while the servlet test with the same name calls it twice and verifies that only
one request is made.

This change stores the resolved UAA URL after a successful `/info` lookup and
adds regression tests that verify reuse after success and retry after failure.

Testing:
- `./gradlew :module:spring-boot-cloudfoundry:test --tests 'org.springframework.boot.cloudfoundry.autoconfigure.actuate.endpoint.reactive.SecurityServiceTests'`