### PR TITLE
Harmonize ObservationConvention parameters in gRPC support

### DIFF
--- a/module/spring-boot-grpc-client/src/main/java/org/springframework/boot/grpc/client/autoconfigure/GrpcClientObservationAutoConfiguration.java
+++ b/module/spring-boot-grpc-client/src/main/java/org/springframework/boot/grpc/client/autoconfigure/GrpcClientObservationAutoConfiguration.java
@@ -53,9 +53,9 @@ public final class GrpcClientObservationAutoConfiguration {
 	@GlobalClientInterceptor
 	@ConditionalOnMissingBean
 	ObservationGrpcClientInterceptor grpcClientObservationInterceptor(ObservationRegistry observationRegistry,
-			ObjectProvider<GrpcClientObservationConvention> convention) {
+			ObjectProvider<GrpcClientObservationConvention> customConvention) {
 		ObservationGrpcClientInterceptor interceptor = new ObservationGrpcClientInterceptor(observationRegistry);
-		convention.ifAvailable(interceptor::setCustomConvention);
+		customConvention.ifAvailable(interceptor::setCustomConvention);
 		return interceptor;
 	}
 

--- a/module/spring-boot-grpc-server/src/main/java/org/springframework/boot/grpc/server/autoconfigure/GrpcServerObservationAutoConfiguration.java
+++ b/module/spring-boot-grpc-server/src/main/java/org/springframework/boot/grpc/server/autoconfigure/GrpcServerObservationAutoConfiguration.java
@@ -58,9 +58,9 @@ public final class GrpcServerObservationAutoConfiguration {
 	@GlobalServerInterceptor
 	@ConditionalOnMissingBean
 	ObservationGrpcServerInterceptor grpcServerObservationInterceptor(ObservationRegistry observationRegistry,
-			ObjectProvider<GrpcServerObservationConvention> convention) {
+			ObjectProvider<GrpcServerObservationConvention> customConvention) {
 		ObservationGrpcServerInterceptor interceptor = new ObservationGrpcServerInterceptor(observationRegistry);
-		convention.ifAvailable(interceptor::setCustomConvention);
+		customConvention.ifAvailable(interceptor::setCustomConvention);
 		return interceptor;
 	}
 


### PR DESCRIPTION
Let's rename `GrpcClientObservationConvention` to `convention` to maintain style and consistency with `GrpcServerObservationAutoConfiguration`

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
