### PR TITLE
Support spring.webflux.default-html-escape property for application-wide HTML escaping configuration

### DIFF
--- a/module/spring-boot-webflux/src/main/java/org/springframework/boot/webflux/autoconfigure/HttpHandlerAutoConfiguration.java
+++ b/module/spring-boot-webflux/src/main/java/org/springframework/boot/webflux/autoconfigure/HttpHandlerAutoConfiguration.java
@@ -64,10 +64,13 @@ public final class HttpHandlerAutoConfiguration {
 		@Bean
 		HttpHandler httpHandler(ObjectProvider<WebFluxProperties> propsProvider,
 				ObjectProvider<WebHttpHandlerBuilderCustomizer> handlerBuilderCustomizers) {
+			WebFluxProperties properties = propsProvider.getIfAvailable();
 			WebHttpHandlerBuilder handlerBuilder = WebHttpHandlerBuilder.applicationContext(this.applicationContext);
+			if (properties != null) {
+				handlerBuilder.defaultHtmlEscape(properties.getDefaultHtmlEscape());
+			}
 			handlerBuilderCustomizers.orderedStream().forEach((customizer) -> customizer.customize(handlerBuilder));
 			HttpHandler httpHandler = handlerBuilder.build();
-			WebFluxProperties properties = propsProvider.getIfAvailable();
 			if (properties != null && StringUtils.hasText(properties.getBasePath())) {
 				Map<String, HttpHandler> handlersMap = Collections.singletonMap(properties.getBasePath(), httpHandler);
 				return new ContextPathCompositeHandler(handlersMap);

--- a/module/spring-boot-webflux/src/main/java/org/springframework/boot/webflux/autoconfigure/WebFluxAutoConfiguration.java
+++ b/module/spring-boot-webflux/src/main/java/org/springframework/boot/webflux/autoconfigure/WebFluxAutoConfiguration.java
@@ -304,11 +304,6 @@ public final class WebFluxAutoConfiguration {
 				.forEach((mediaType, parameterName) -> configurer.useMediaTypeParameter(mediaType, parameterName));
 		}
 
-		@Bean
-		WebHttpHandlerBuilderCustomizer defaultHtmlEscapeCustomizer() {
-			return (builder) -> builder.defaultHtmlEscape(this.webFluxProperties.getDefaultHtmlEscape());
-		}
-
 	}
 
 	/**

--- a/module/spring-boot-webflux/src/test/java/org/springframework/boot/webflux/autoconfigure/HttpHandlerAutoConfigurationTests.java
+++ b/module/spring-boot-webflux/src/test/java/org/springframework/boot/webflux/autoconfigure/HttpHandlerAutoConfigurationTests.java
@@ -18,6 +18,8 @@ package org.springframework.boot.webflux.autoconfigure;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Mono;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -35,6 +37,7 @@ import org.springframework.web.reactive.DispatcherHandler;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import org.springframework.web.server.WebHandler;
+import org.springframework.web.server.adapter.HttpWebHandlerAdapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
@@ -97,6 +100,29 @@ class HttpHandlerAutoConfigurationTests {
 				assertThat(httpHandler).isInstanceOf(ContextPathCompositeHandler.class)
 					.extracting("handlerMap", InstanceOfAssertFactories.map(String.class, HttpHandler.class))
 					.containsKey("/something");
+			});
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	void shouldConfigureDefaultHtmlEscape(boolean enabled) {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(WebFluxAutoConfiguration.class))
+			.withPropertyValues("spring.webflux.default-html-escape=" + enabled)
+			.run((context) -> {
+				assertThat(context).hasSingleBean(HttpHandler.class);
+				assertThat(context.getBean(HttpHandler.class)).isInstanceOfSatisfying(HttpWebHandlerAdapter.class,
+						(adapter) -> assertThat(adapter.getDefaultHtmlEscape()).isEqualTo(enabled));
+			});
+	}
+
+	@Test
+	void shouldNotConfigureDefaultHtmlEscaperWithoutWebFluxAutoConfiguration() {
+		this.contextRunner.withUserConfiguration(CustomWebHandler.class)
+			.withPropertyValues("spring.webflux.default-html-escape=true")
+			.run((context) -> {
+				assertThat(context).hasSingleBean(HttpHandler.class);
+				assertThat(context.getBean(HttpHandler.class)).isInstanceOfSatisfying(HttpWebHandlerAdapter.class,
+						(adapter) -> assertThat(adapter.getDefaultHtmlEscape()).isNull());
 			});
 	}
 

--- a/module/spring-boot-webflux/src/test/java/org/springframework/boot/webflux/autoconfigure/WebFluxAutoConfigurationTests.java
+++ b/module/spring-boot-webflux/src/test/java/org/springframework/boot/webflux/autoconfigure/WebFluxAutoConfigurationTests.java
@@ -120,7 +120,6 @@ import org.springframework.web.reactive.result.method.annotation.ResponseEntityE
 import org.springframework.web.reactive.result.view.ViewResolutionResultHandler;
 import org.springframework.web.reactive.result.view.ViewResolver;
 import org.springframework.web.server.ServerWebExchange;
-import org.springframework.web.server.WebHandler;
 import org.springframework.web.server.WebSession;
 import org.springframework.web.server.adapter.WebHttpHandlerBuilder;
 import org.springframework.web.server.i18n.AcceptHeaderLocaleContextResolver;
@@ -460,39 +459,6 @@ class WebFluxAutoConfigurationTests {
 	void hiddenHttpMethodFilterCanBeEnabled() {
 		this.contextRunner.withPropertyValues("spring.webflux.hiddenmethod.filter.enabled=true")
 			.run((context) -> assertThat(context).hasSingleBean(OrderedHiddenHttpMethodFilter.class));
-	}
-
-	@Test
-	void defaultHtmlEscapeIsNotConfiguredByDefault() {
-		this.contextRunner.run((context) -> {
-			WebHttpHandlerBuilderCustomizer customizer = context.getBean("defaultHtmlEscapeCustomizer",
-					WebHttpHandlerBuilderCustomizer.class);
-			WebHttpHandlerBuilder builder = WebHttpHandlerBuilder.webHandler(mock(WebHandler.class));
-			customizer.customize(builder);
-			assertThat(builder.getDefaultHtmlEscape()).isNull();
-		});
-	}
-
-	@Test
-	void defaultHtmlEscapeCanBeEnabled() {
-		this.contextRunner.withPropertyValues("spring.webflux.default-html-escape=true").run((context) -> {
-			WebHttpHandlerBuilderCustomizer customizer = context.getBean("defaultHtmlEscapeCustomizer",
-					WebHttpHandlerBuilderCustomizer.class);
-			WebHttpHandlerBuilder builder = WebHttpHandlerBuilder.webHandler(mock(WebHandler.class));
-			customizer.customize(builder);
-			assertThat(builder.getDefaultHtmlEscape()).isTrue();
-		});
-	}
-
-	@Test
-	void defaultHtmlEscapeCanBeDisabled() {
-		this.contextRunner.withPropertyValues("spring.webflux.default-html-escape=false").run((context) -> {
-			WebHttpHandlerBuilderCustomizer customizer = context.getBean("defaultHtmlEscapeCustomizer",
-					WebHttpHandlerBuilderCustomizer.class);
-			WebHttpHandlerBuilder builder = WebHttpHandlerBuilder.webHandler(mock(WebHandler.class));
-			customizer.customize(builder);
-			assertThat(builder.getDefaultHtmlEscape()).isFalse();
-		});
 	}
 
 	@Test


### PR DESCRIPTION
Adds `spring.webflux.default-html-escape` property to allow configuring application-wide HTML escaping in WebFlux applications.

This builds on the programmatic support added to Spring Framework 7.0.6 (spring-projects/spring-framework#36400) by exposing the setting as a property, giving WebFlux applications the same property-based configuration experience that Spring MVC applications have always had.

With this change, WebFlux applications can configure HTML escaping globally via application.properties:
properties `spring.webflux.default-html-escape=true`


Closes #49623