### PR TITLE
Add structured logging stacktrace hash field

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/StandardStackTracePrinter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/StandardStackTracePrinter.java
@@ -278,6 +278,35 @@ public final class StandardStackTracePrinter implements StackTracePrinter {
 				this.frameFilter, this.formatter, this.frameFormatter, frameHasher);
 	}
 
+	/**
+	 * Compute a hash for the given throwable using the default frame hasher and return it
+	 * as a zero-padded 8-character hex string.
+	 * @param throwable the throwable to hash
+	 * @return the hash as a hex string, or {@code null} if the throwable is {@code null}
+	 * @since 4.0.0
+	 */
+	public static @Nullable String hashAsHexString(@Nullable Throwable throwable) {
+		return hashAsHexString(throwable, DEFAULT_FRAME_HASHER);
+	}
+
+	/**
+	 * Compute a hash for the given throwable using the specified frame hasher and return
+	 * it as a zero-padded 8-character hex string.
+	 * @param throwable the throwable to hash
+	 * @param frameHasher the function used to hash individual stack trace elements
+	 * @return the hash as a hex string, or {@code null} if the throwable is {@code null}
+	 * @since 4.0.0
+	 */
+	public static @Nullable String hashAsHexString(@Nullable Throwable throwable,
+			ToIntFunction<StackTraceElement> frameHasher) {
+		if (throwable == null) {
+			return null;
+		}
+		StackTrace stackTrace = new StackTrace(throwable);
+		int hash = stackTrace.hash(new HashSet<>(), frameHasher);
+		return String.format("%08x", hash);
+	}
+
 	private StandardStackTracePrinter withOption(Option option) {
 		EnumSet<Option> options = EnumSet.copyOf(this.options);
 		options.add(option);

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/ElasticCommonSchemaStructuredLogFormatter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/ElasticCommonSchemaStructuredLogFormatter.java
@@ -33,6 +33,7 @@ import org.springframework.boot.logging.structured.ContextPairs;
 import org.springframework.boot.logging.structured.ContextPairs.Pairs;
 import org.springframework.boot.logging.structured.ElasticCommonSchemaProperties;
 import org.springframework.boot.logging.structured.JsonWriterStructuredLogFormatter;
+import org.springframework.boot.logging.structured.StackTraceHashFieldConfiguration;
 import org.springframework.boot.logging.structured.StructuredLogFormatter;
 import org.springframework.boot.logging.structured.StructuredLoggingJsonMembersCustomizer;
 import org.springframework.core.env.Environment;
@@ -48,13 +49,15 @@ import org.springframework.util.ObjectUtils;
 class ElasticCommonSchemaStructuredLogFormatter extends JsonWriterStructuredLogFormatter<LogEvent> {
 
 	ElasticCommonSchemaStructuredLogFormatter(Environment environment, @Nullable StackTracePrinter stackTracePrinter,
-			ContextPairs contextPairs, StructuredLoggingJsonMembersCustomizer.Builder<?> customizerBuilder) {
-		super((members) -> jsonMembers(environment, stackTracePrinter, contextPairs, members),
+			@Nullable StackTraceHashFieldConfiguration hashFieldConfiguration, ContextPairs contextPairs,
+			StructuredLoggingJsonMembersCustomizer.Builder<?> customizerBuilder) {
+		super((members) -> jsonMembers(environment, stackTracePrinter, hashFieldConfiguration, contextPairs, members),
 				customizerBuilder.nested().build());
 	}
 
 	private static void jsonMembers(Environment environment, @Nullable StackTracePrinter stackTracePrinter,
-			ContextPairs contextPairs, JsonWriter.Members<LogEvent> members) {
+			@Nullable StackTraceHashFieldConfiguration hashFieldConfiguration, ContextPairs contextPairs,
+			JsonWriter.Members<LogEvent> members) {
 		Extractor extractor = new Extractor(stackTracePrinter);
 		members.add("@timestamp", LogEvent::getInstant).as(ElasticCommonSchemaStructuredLogFormatter::asTimestamp);
 		members.add("log").usingMembers((log) -> {
@@ -76,6 +79,11 @@ class ElasticCommonSchemaStructuredLogFormatter extends JsonWriterStructuredLogF
 				error.add("message", Throwable::getMessage);
 				error.add("stack_trace", extractor::stackTrace);
 			}));
+		if (hashFieldConfiguration != null) {
+			members.add(hashFieldConfiguration.getFieldName(), LogEvent::getThrown)
+				.whenNotNull()
+				.as(hashFieldConfiguration::computeHash);
+		}
 		members.add("tags", LogEvent::getMarker)
 			.whenNotNull()
 			.as(ElasticCommonSchemaStructuredLogFormatter::getMarkers)

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/GraylogExtendedLogFormatStructuredLogFormatter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/GraylogExtendedLogFormatStructuredLogFormatter.java
@@ -41,6 +41,7 @@ import org.springframework.boot.logging.structured.ContextPairs;
 import org.springframework.boot.logging.structured.ContextPairs.Joiner;
 import org.springframework.boot.logging.structured.GraylogExtendedLogFormatProperties;
 import org.springframework.boot.logging.structured.JsonWriterStructuredLogFormatter;
+import org.springframework.boot.logging.structured.StackTraceHashFieldConfiguration;
 import org.springframework.boot.logging.structured.StructuredLogFormatter;
 import org.springframework.boot.logging.structured.StructuredLoggingJsonMembersCustomizer;
 import org.springframework.core.env.Environment;
@@ -74,13 +75,16 @@ class GraylogExtendedLogFormatStructuredLogFormatter extends JsonWriterStructure
 	private static final Set<String> ADDITIONAL_FIELD_ILLEGAL_KEYS = Set.of("id", "_id");
 
 	GraylogExtendedLogFormatStructuredLogFormatter(Environment environment,
-			@Nullable StackTracePrinter stackTracePrinter, ContextPairs contextPairs,
+			@Nullable StackTracePrinter stackTracePrinter,
+			@Nullable StackTraceHashFieldConfiguration hashFieldConfiguration, ContextPairs contextPairs,
 			@Nullable StructuredLoggingJsonMembersCustomizer<?> customizer) {
-		super((members) -> jsonMembers(environment, stackTracePrinter, contextPairs, members), customizer);
+		super((members) -> jsonMembers(environment, stackTracePrinter, hashFieldConfiguration, contextPairs, members),
+				customizer);
 	}
 
 	private static void jsonMembers(Environment environment, @Nullable StackTracePrinter stackTracePrinter,
-			ContextPairs contextPairs, JsonWriter.Members<LogEvent> members) {
+			@Nullable StackTraceHashFieldConfiguration hashFieldConfiguration, ContextPairs contextPairs,
+			JsonWriter.Members<LogEvent> members) {
 		Extractor extractor = new Extractor(stackTracePrinter);
 		members.add("version", "1.1");
 		members.add("short_message", LogEvent::getMessage)
@@ -103,6 +107,11 @@ class GraylogExtendedLogFormatStructuredLogFormatter extends JsonWriterStructure
 		members.add()
 			.whenNotNull(getThrown)
 			.usingMembers((thrownMembers) -> throwableMembers(thrownMembers, extractor));
+		if (hashFieldConfiguration != null) {
+			members.add(hashFieldConfiguration.getFieldName(), LogEvent::getThrown)
+				.whenNotNull()
+				.as(hashFieldConfiguration::computeHash);
+		}
 	}
 
 	private static String getMessageText(Message message) {

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/LogstashStructuredLogFormatter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/LogstashStructuredLogFormatter.java
@@ -35,6 +35,7 @@ import org.springframework.boot.logging.StackTracePrinter;
 import org.springframework.boot.logging.structured.CommonStructuredLogFormat;
 import org.springframework.boot.logging.structured.ContextPairs;
 import org.springframework.boot.logging.structured.JsonWriterStructuredLogFormatter;
+import org.springframework.boot.logging.structured.StackTraceHashFieldConfiguration;
 import org.springframework.boot.logging.structured.StructuredLogFormatter;
 import org.springframework.boot.logging.structured.StructuredLoggingJsonMembersCustomizer;
 import org.springframework.util.CollectionUtils;
@@ -47,12 +48,14 @@ import org.springframework.util.CollectionUtils;
  */
 class LogstashStructuredLogFormatter extends JsonWriterStructuredLogFormatter<LogEvent> {
 
-	LogstashStructuredLogFormatter(@Nullable StackTracePrinter stackTracePrinter, ContextPairs contextPairs,
+	LogstashStructuredLogFormatter(@Nullable StackTracePrinter stackTracePrinter,
+			@Nullable StackTraceHashFieldConfiguration hashFieldConfiguration, ContextPairs contextPairs,
 			@Nullable StructuredLoggingJsonMembersCustomizer<?> customizer) {
-		super((members) -> jsonMembers(stackTracePrinter, contextPairs, members), customizer);
+		super((members) -> jsonMembers(stackTracePrinter, hashFieldConfiguration, contextPairs, members), customizer);
 	}
 
-	private static void jsonMembers(@Nullable StackTracePrinter stackTracePrinter, ContextPairs contextPairs,
+	private static void jsonMembers(@Nullable StackTracePrinter stackTracePrinter,
+			@Nullable StackTraceHashFieldConfiguration hashFieldConfiguration, ContextPairs contextPairs,
 			JsonWriter.Members<LogEvent> members) {
 		Extractor extractor = new Extractor(stackTracePrinter);
 		members.add("@timestamp", LogEvent::getInstant).as(LogstashStructuredLogFormatter::asTimestamp);
@@ -72,6 +75,11 @@ class LogstashStructuredLogFormatter extends JsonWriterStructuredLogFormatter<Lo
 			.as(LogstashStructuredLogFormatter::getMarkers)
 			.whenNot(collectionIsEmpty);
 		members.add("stack_trace", LogEvent::getThrown).whenNotNull().as(extractor::stackTrace);
+		if (hashFieldConfiguration != null) {
+			members.add(hashFieldConfiguration.getFieldName(), LogEvent::getThrown)
+				.whenNotNull()
+				.as(hashFieldConfiguration::computeHash);
+		}
 	}
 
 	private static String asTimestamp(Instant instant) {

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/StructuredLogLayout.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/StructuredLogLayout.java
@@ -32,6 +32,7 @@ import org.apache.logging.log4j.core.layout.AbstractStringLayout;
 import org.springframework.boot.logging.StackTracePrinter;
 import org.springframework.boot.logging.structured.CommonStructuredLogFormat;
 import org.springframework.boot.logging.structured.ContextPairs;
+import org.springframework.boot.logging.structured.StackTraceHashFieldConfiguration;
 import org.springframework.boot.logging.structured.StructuredLogFormatter;
 import org.springframework.boot.logging.structured.StructuredLogFormatterFactory;
 import org.springframework.boot.logging.structured.StructuredLogFormatterFactory.CommonFormatters;
@@ -117,35 +118,42 @@ final class StructuredLogLayout extends AbstractStringLayout {
 		private ElasticCommonSchemaStructuredLogFormatter createEcsFormatter(Instantiator<?> instantiator) {
 			Environment environment = instantiator.getArg(Environment.class);
 			StackTracePrinter stackTracePrinter = instantiator.getArg(StackTracePrinter.class);
+			StackTraceHashFieldConfiguration hashFieldConfiguration = instantiator
+				.getArg(StackTraceHashFieldConfiguration.class);
 			ContextPairs contextPairs = instantiator.getArg(ContextPairs.class);
 			StructuredLoggingJsonMembersCustomizer.Builder<?> jsonMembersCustomizerBuilder = instantiator
 				.getArg(StructuredLoggingJsonMembersCustomizer.Builder.class);
 			Assert.state(environment != null, "'environment' must not be null");
 			Assert.state(contextPairs != null, "'contextPairs' must not be null");
 			Assert.state(jsonMembersCustomizerBuilder != null, "'jsonMembersCustomizerBuilder' must not be null");
-			return new ElasticCommonSchemaStructuredLogFormatter(environment, stackTracePrinter, contextPairs,
-					jsonMembersCustomizerBuilder);
+			return new ElasticCommonSchemaStructuredLogFormatter(environment, stackTracePrinter, hashFieldConfiguration,
+					contextPairs, jsonMembersCustomizerBuilder);
 		}
 
 		private GraylogExtendedLogFormatStructuredLogFormatter createGraylogFormatter(Instantiator<?> instantiator) {
 			Environment environment = instantiator.getArg(Environment.class);
 			StackTracePrinter stackTracePrinter = instantiator.getArg(StackTracePrinter.class);
+			StackTraceHashFieldConfiguration hashFieldConfiguration = instantiator
+				.getArg(StackTraceHashFieldConfiguration.class);
 			ContextPairs contextPairs = instantiator.getArg(ContextPairs.class);
 			StructuredLoggingJsonMembersCustomizer<?> jsonMembersCustomizer = instantiator
 				.getArg(StructuredLoggingJsonMembersCustomizer.class);
 			Assert.state(environment != null, "'environment' must not be null");
 			Assert.state(contextPairs != null, "'contextPairs' must not be null");
-			return new GraylogExtendedLogFormatStructuredLogFormatter(environment, stackTracePrinter, contextPairs,
-					jsonMembersCustomizer);
+			return new GraylogExtendedLogFormatStructuredLogFormatter(environment, stackTracePrinter,
+					hashFieldConfiguration, contextPairs, jsonMembersCustomizer);
 		}
 
 		private LogstashStructuredLogFormatter createLogstashFormatter(Instantiator<?> instantiator) {
 			StackTracePrinter stackTracePrinter = instantiator.getArg(StackTracePrinter.class);
+			StackTraceHashFieldConfiguration hashFieldConfiguration = instantiator
+				.getArg(StackTraceHashFieldConfiguration.class);
 			ContextPairs contextPairs = instantiator.getArg(ContextPairs.class);
 			StructuredLoggingJsonMembersCustomizer<?> jsonMembersCustomizer = instantiator
 				.getArg(StructuredLoggingJsonMembersCustomizer.class);
 			Assert.state(contextPairs != null, "'contextPairs' must not be null");
-			return new LogstashStructuredLogFormatter(stackTracePrinter, contextPairs, jsonMembersCustomizer);
+			return new LogstashStructuredLogFormatter(stackTracePrinter, hashFieldConfiguration, contextPairs,
+					jsonMembersCustomizer);
 		}
 
 	}

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/ElasticCommonSchemaStructuredLogFormatter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/ElasticCommonSchemaStructuredLogFormatter.java
@@ -36,6 +36,7 @@ import org.springframework.boot.logging.structured.CommonStructuredLogFormat;
 import org.springframework.boot.logging.structured.ContextPairs;
 import org.springframework.boot.logging.structured.ElasticCommonSchemaProperties;
 import org.springframework.boot.logging.structured.JsonWriterStructuredLogFormatter;
+import org.springframework.boot.logging.structured.StackTraceHashFieldConfiguration;
 import org.springframework.boot.logging.structured.StructuredLogFormatter;
 import org.springframework.boot.logging.structured.StructuredLoggingJsonMembersCustomizer;
 import org.springframework.core.env.Environment;
@@ -53,15 +54,16 @@ class ElasticCommonSchemaStructuredLogFormatter extends JsonWriterStructuredLogF
 			(pair) -> pair.value);
 
 	ElasticCommonSchemaStructuredLogFormatter(Environment environment, @Nullable StackTracePrinter stackTracePrinter,
-			ContextPairs contextPairs, ThrowableProxyConverter throwableProxyConverter,
+			@Nullable StackTraceHashFieldConfiguration hashFieldConfiguration, ContextPairs contextPairs,
+			ThrowableProxyConverter throwableProxyConverter,
 			StructuredLoggingJsonMembersCustomizer.Builder<?> customizerBuilder) {
-		super((members) -> jsonMembers(environment, stackTracePrinter, contextPairs, throwableProxyConverter, members),
-				customizerBuilder.nested().build());
+		super((members) -> jsonMembers(environment, stackTracePrinter, hashFieldConfiguration, contextPairs,
+				throwableProxyConverter, members), customizerBuilder.nested().build());
 	}
 
 	private static void jsonMembers(Environment environment, @Nullable StackTracePrinter stackTracePrinter,
-			ContextPairs contextPairs, ThrowableProxyConverter throwableProxyConverter,
-			JsonWriter.Members<ILoggingEvent> members) {
+			@Nullable StackTraceHashFieldConfiguration hashFieldConfiguration, ContextPairs contextPairs,
+			ThrowableProxyConverter throwableProxyConverter, JsonWriter.Members<ILoggingEvent> members) {
 		Extractor extractor = new Extractor(stackTracePrinter, throwableProxyConverter);
 		members.add("@timestamp", ILoggingEvent::getInstant);
 		members.add("log").usingMembers((log) -> {
@@ -87,11 +89,23 @@ class ElasticCommonSchemaStructuredLogFormatter extends JsonWriterStructuredLogF
 				error.add("stack_trace", extractor::stackTrace);
 			});
 		});
+		if (hashFieldConfiguration != null) {
+			members.add(hashFieldConfiguration.getFieldName(), (event) -> event)
+				.whenNotNull(getThrowableProxy)
+				.as((event) -> hashFieldConfiguration.computeHash(extractThrowable(event)));
+		}
 		members.add("tags", ILoggingEvent::getMarkerList)
 			.whenNotNull()
 			.as(ElasticCommonSchemaStructuredLogFormatter::getMarkers)
 			.whenNotEmpty();
 		members.add("ecs").usingMembers((ecs) -> ecs.add("version", "8.11"));
+	}
+
+	private static @Nullable Throwable extractThrowable(ILoggingEvent event) {
+		if (event.getThrowableProxy() instanceof ch.qos.logback.classic.spi.ThrowableProxy throwableProxy) {
+			return throwableProxy.getThrowable();
+		}
+		return null;
 	}
 
 	private static Set<String> getMarkers(List<Marker> markers) {

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/GraylogExtendedLogFormatStructuredLogFormatter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/GraylogExtendedLogFormatStructuredLogFormatter.java
@@ -40,6 +40,7 @@ import org.springframework.boot.logging.structured.ContextPairs;
 import org.springframework.boot.logging.structured.ContextPairs.Joiner;
 import org.springframework.boot.logging.structured.GraylogExtendedLogFormatProperties;
 import org.springframework.boot.logging.structured.JsonWriterStructuredLogFormatter;
+import org.springframework.boot.logging.structured.StackTraceHashFieldConfiguration;
 import org.springframework.boot.logging.structured.StructuredLogFormatter;
 import org.springframework.boot.logging.structured.StructuredLoggingJsonMembersCustomizer;
 import org.springframework.core.env.Environment;
@@ -75,16 +76,17 @@ class GraylogExtendedLogFormatStructuredLogFormatter extends JsonWriterStructure
 	private static final Set<String> ADDITIONAL_FIELD_ILLEGAL_KEYS = Set.of("id", "_id");
 
 	GraylogExtendedLogFormatStructuredLogFormatter(Environment environment,
-			@Nullable StackTracePrinter stackTracePrinter, ContextPairs contextPairs,
+			@Nullable StackTracePrinter stackTracePrinter,
+			@Nullable StackTraceHashFieldConfiguration hashFieldConfiguration, ContextPairs contextPairs,
 			ThrowableProxyConverter throwableProxyConverter,
 			@Nullable StructuredLoggingJsonMembersCustomizer<?> customizer) {
-		super((members) -> jsonMembers(environment, stackTracePrinter, contextPairs, throwableProxyConverter, members),
-				customizer);
+		super((members) -> jsonMembers(environment, stackTracePrinter, hashFieldConfiguration, contextPairs,
+				throwableProxyConverter, members), customizer);
 	}
 
 	private static void jsonMembers(Environment environment, @Nullable StackTracePrinter stackTracePrinter,
-			ContextPairs contextPairs, ThrowableProxyConverter throwableProxyConverter,
-			JsonWriter.Members<ILoggingEvent> members) {
+			@Nullable StackTraceHashFieldConfiguration hashFieldConfiguration, ContextPairs contextPairs,
+			ThrowableProxyConverter throwableProxyConverter, JsonWriter.Members<ILoggingEvent> members) {
 		Extractor extractor = new Extractor(stackTracePrinter, throwableProxyConverter);
 		members.add("version", "1.1");
 		members.add("short_message", ILoggingEvent::getFormattedMessage)
@@ -106,6 +108,18 @@ class GraylogExtendedLogFormatStructuredLogFormatter extends JsonWriterStructure
 		members.add()
 			.whenNotNull(getThrowableProxy)
 			.usingMembers((throwableMembers) -> throwableMembers(throwableMembers, extractor));
+		if (hashFieldConfiguration != null) {
+			members.add(hashFieldConfiguration.getFieldName(), (event) -> event)
+				.whenNotNull(getThrowableProxy)
+				.as((event) -> hashFieldConfiguration.computeHash(extractThrowable(event)));
+		}
+	}
+
+	private static @Nullable Throwable extractThrowable(ILoggingEvent event) {
+		if (event.getThrowableProxy() instanceof ch.qos.logback.classic.spi.ThrowableProxy throwableProxy) {
+			return throwableProxy.getThrowable();
+		}
+		return null;
 	}
 
 	private static String getMessageText(String formattedMessage) {

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogstashStructuredLogFormatter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogstashStructuredLogFormatter.java
@@ -39,6 +39,7 @@ import org.springframework.boot.logging.StackTracePrinter;
 import org.springframework.boot.logging.structured.CommonStructuredLogFormat;
 import org.springframework.boot.logging.structured.ContextPairs;
 import org.springframework.boot.logging.structured.JsonWriterStructuredLogFormatter;
+import org.springframework.boot.logging.structured.StackTraceHashFieldConfiguration;
 import org.springframework.boot.logging.structured.StructuredLogFormatter;
 import org.springframework.boot.logging.structured.StructuredLoggingJsonMembersCustomizer;
 
@@ -53,13 +54,16 @@ class LogstashStructuredLogFormatter extends JsonWriterStructuredLogFormatter<IL
 	private static final PairExtractor<KeyValuePair> keyValuePairExtractor = PairExtractor.of((pair) -> pair.key,
 			(pair) -> pair.value);
 
-	LogstashStructuredLogFormatter(@Nullable StackTracePrinter stackTracePrinter, ContextPairs contextPairs,
+	LogstashStructuredLogFormatter(@Nullable StackTracePrinter stackTracePrinter,
+			@Nullable StackTraceHashFieldConfiguration hashFieldConfiguration, ContextPairs contextPairs,
 			ThrowableProxyConverter throwableProxyConverter,
 			@Nullable StructuredLoggingJsonMembersCustomizer<?> customizer) {
-		super((members) -> jsonMembers(stackTracePrinter, contextPairs, throwableProxyConverter, members), customizer);
+		super((members) -> jsonMembers(stackTracePrinter, hashFieldConfiguration, contextPairs, throwableProxyConverter,
+				members), customizer);
 	}
 
-	private static void jsonMembers(@Nullable StackTracePrinter stackTracePrinter, ContextPairs contextPairs,
+	private static void jsonMembers(@Nullable StackTracePrinter stackTracePrinter,
+			@Nullable StackTraceHashFieldConfiguration hashFieldConfiguration, ContextPairs contextPairs,
 			ThrowableProxyConverter throwableProxyConverter, JsonWriter.Members<ILoggingEvent> members) {
 		Extractor extractor = new Extractor(stackTracePrinter, throwableProxyConverter);
 		members.add("@timestamp", ILoggingEvent::getInstant).as(LogstashStructuredLogFormatter::asTimestamp);
@@ -80,6 +84,18 @@ class LogstashStructuredLogFormatter extends JsonWriterStructuredLogFormatter<IL
 		Function<@Nullable ILoggingEvent, @Nullable Object> getThrowableProxy = (event) -> (event != null)
 				? event.getThrowableProxy() : null;
 		members.add("stack_trace", (event) -> event).whenNotNull(getThrowableProxy).as(extractor::stackTrace);
+		if (hashFieldConfiguration != null) {
+			members.add(hashFieldConfiguration.getFieldName(), (event) -> event)
+				.whenNotNull(getThrowableProxy)
+				.as((event) -> hashFieldConfiguration.computeHash(extractThrowable(event)));
+		}
+	}
+
+	private static @Nullable Throwable extractThrowable(ILoggingEvent event) {
+		if (event.getThrowableProxy() instanceof ch.qos.logback.classic.spi.ThrowableProxy throwableProxy) {
+			return throwableProxy.getThrowable();
+		}
+		return null;
 	}
 
 	private static String asTimestamp(Instant instant) {

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/StructuredLogEncoder.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/StructuredLogEncoder.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.boot.logging.StackTracePrinter;
 import org.springframework.boot.logging.structured.CommonStructuredLogFormat;
 import org.springframework.boot.logging.structured.ContextPairs;
+import org.springframework.boot.logging.structured.StackTraceHashFieldConfiguration;
 import org.springframework.boot.logging.structured.StructuredLogFormatter;
 import org.springframework.boot.logging.structured.StructuredLogFormatterFactory;
 import org.springframework.boot.logging.structured.StructuredLogFormatterFactory.CommonFormatters;
@@ -92,6 +93,8 @@ public class StructuredLogEncoder extends EncoderBase<ILoggingEvent> {
 	private StructuredLogFormatter<ILoggingEvent> createEcsFormatter(Instantiator<?> instantiator) {
 		Environment environment = instantiator.getArg(Environment.class);
 		StackTracePrinter stackTracePrinter = instantiator.getArg(StackTracePrinter.class);
+		StackTraceHashFieldConfiguration hashFieldConfiguration = instantiator
+			.getArg(StackTraceHashFieldConfiguration.class);
 		ContextPairs contextPairs = instantiator.getArg(ContextPairs.class);
 		ThrowableProxyConverter throwableProxyConverter = instantiator.getArg(ThrowableProxyConverter.class);
 		StructuredLoggingJsonMembersCustomizer.Builder<?> jsonMembersCustomizerBuilder = instantiator
@@ -100,13 +103,15 @@ public class StructuredLogEncoder extends EncoderBase<ILoggingEvent> {
 		Assert.state(contextPairs != null, "'contextPairs' must not be null");
 		Assert.state(throwableProxyConverter != null, "'throwableProxyConverter' must not be null");
 		Assert.state(jsonMembersCustomizerBuilder != null, "'jsonMembersCustomizerBuilder' must not be null");
-		return new ElasticCommonSchemaStructuredLogFormatter(environment, stackTracePrinter, contextPairs,
-				throwableProxyConverter, jsonMembersCustomizerBuilder);
+		return new ElasticCommonSchemaStructuredLogFormatter(environment, stackTracePrinter, hashFieldConfiguration,
+				contextPairs, throwableProxyConverter, jsonMembersCustomizerBuilder);
 	}
 
 	private StructuredLogFormatter<ILoggingEvent> createGraylogFormatter(Instantiator<?> instantiator) {
 		Environment environment = instantiator.getArg(Environment.class);
 		StackTracePrinter stackTracePrinter = instantiator.getArg(StackTracePrinter.class);
+		StackTraceHashFieldConfiguration hashFieldConfiguration = instantiator
+			.getArg(StackTraceHashFieldConfiguration.class);
 		ContextPairs contextPairs = instantiator.getArg(ContextPairs.class);
 		ThrowableProxyConverter throwableProxyConverter = instantiator.getArg(ThrowableProxyConverter.class);
 		StructuredLoggingJsonMembersCustomizer<?> jsonMembersCustomizer = instantiator
@@ -114,20 +119,22 @@ public class StructuredLogEncoder extends EncoderBase<ILoggingEvent> {
 		Assert.state(environment != null, "'environment' must not be null");
 		Assert.state(contextPairs != null, "'contextPairs' must not be null");
 		Assert.state(throwableProxyConverter != null, "'throwableProxyConverter' must not be null");
-		return new GraylogExtendedLogFormatStructuredLogFormatter(environment, stackTracePrinter, contextPairs,
-				throwableProxyConverter, jsonMembersCustomizer);
+		return new GraylogExtendedLogFormatStructuredLogFormatter(environment, stackTracePrinter,
+				hashFieldConfiguration, contextPairs, throwableProxyConverter, jsonMembersCustomizer);
 	}
 
 	private StructuredLogFormatter<ILoggingEvent> createLogstashFormatter(Instantiator<?> instantiator) {
 		StackTracePrinter stackTracePrinter = instantiator.getArg(StackTracePrinter.class);
+		StackTraceHashFieldConfiguration hashFieldConfiguration = instantiator
+			.getArg(StackTraceHashFieldConfiguration.class);
 		ContextPairs contextPairs = instantiator.getArg(ContextPairs.class);
 		ThrowableProxyConverter throwableProxyConverter = instantiator.getArg(ThrowableProxyConverter.class);
 		StructuredLoggingJsonMembersCustomizer<?> jsonMembersCustomizer = instantiator
 			.getArg(StructuredLoggingJsonMembersCustomizer.class);
 		Assert.state(contextPairs != null, "'contextPairs' must not be null");
 		Assert.state(throwableProxyConverter != null, "'throwableProxyConverter' must not be null");
-		return new LogstashStructuredLogFormatter(stackTracePrinter, contextPairs, throwableProxyConverter,
-				jsonMembersCustomizer);
+		return new LogstashStructuredLogFormatter(stackTracePrinter, hashFieldConfiguration, contextPairs,
+				throwableProxyConverter, jsonMembersCustomizer);
 	}
 
 	@Override

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/StackTraceHashFieldConfiguration.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/StackTraceHashFieldConfiguration.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.logging.structured;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.boot.logging.StandardStackTracePrinter;
+
+/**
+ * Configuration for emitting stack trace hashes as a dedicated structured field.
+ *
+ * @author [Venkata Naga Sai Srikanth Gollapudi]
+ * @since 4.0
+ */
+public class StackTraceHashFieldConfiguration {
+
+	private final String fieldName;
+
+	StackTraceHashFieldConfiguration(String fieldName) {
+		this.fieldName = fieldName;
+	}
+
+	/**
+	 * Return the field name to use for the stack trace hash.
+	 * @return the field name
+	 */
+	public String getFieldName() {
+		return this.fieldName;
+	}
+
+	/**
+	 * Compute the hash for the given throwable.
+	 * @param throwable the throwable to hash
+	 * @return the hash as a hex string, or {@code null} if the throwable is {@code null}
+	 */
+	public @Nullable String computeHash(@Nullable Throwable throwable) {
+		return StandardStackTracePrinter.hashAsHexString(throwable);
+	}
+
+}

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/StackTraceHashGenerate.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/StackTraceHashGenerate.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.logging.structured;
+
+/**
+ * The mode for generating stack trace hashes in structured logging.
+ *
+ * @author [Venkata Naga Sai Srikanth Gollapudi]
+ * @since 4.0
+ */
+public enum StackTraceHashGenerate {
+
+	/**
+	 * Include the hash inline as part of the stack trace string. This preserves the
+	 * existing behavior where the hash is prefixed to the stack trace text.
+	 */
+	INLINE,
+
+	/**
+	 * Include the hash as a separate structured JSON field. The field name can be
+	 * customized using the {@code field-name} property, otherwise a sensible default is
+	 * used for the selected logging format.
+	 */
+	AS_FIELD
+
+}

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/StructuredLogFormatterFactory.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/StructuredLogFormatterFactory.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.boot.json.JsonWriter.Members;
 import org.springframework.boot.logging.StackTracePrinter;
 import org.springframework.boot.logging.structured.StructuredLoggingJsonProperties.Context;
+import org.springframework.boot.logging.structured.StructuredLoggingJsonProperties.StackTrace;
 import org.springframework.boot.util.Instantiator;
 import org.springframework.boot.util.Instantiator.AvailableParameters;
 import org.springframework.boot.util.Instantiator.FailureHandler;
@@ -94,6 +95,8 @@ public class StructuredLogFormatterFactory<E> {
 			allAvailableParameters.add(StructuredLoggingJsonMembersCustomizer.Builder.class,
 					new JsonMembersCustomizerBuilder(properties));
 			allAvailableParameters.add(StackTracePrinter.class, (type) -> getStackTracePrinter(properties));
+			allAvailableParameters.add(StackTraceHashFieldConfiguration.class,
+					(type) -> getStackTraceHashFieldConfiguration(properties));
 			allAvailableParameters.add(ContextPairs.class, (type) -> getContextPairs(properties));
 			if (availableParameters != null) {
 				availableParameters.accept(allAvailableParameters);
@@ -105,6 +108,23 @@ public class StructuredLogFormatterFactory<E> {
 
 	private @Nullable StackTracePrinter getStackTracePrinter(@Nullable StructuredLoggingJsonProperties properties) {
 		return (properties != null && properties.stackTrace() != null) ? properties.stackTrace().createPrinter() : null;
+	}
+
+	private @Nullable StackTraceHashFieldConfiguration getStackTraceHashFieldConfiguration(
+			@Nullable StructuredLoggingJsonProperties properties) {
+		if (properties == null || properties.stackTrace() == null) {
+			return null;
+		}
+		StackTrace stackTrace = properties.stackTrace();
+		StackTraceHashGenerate generate = stackTrace.effectiveHashGenerate();
+		if (generate != StackTraceHashGenerate.AS_FIELD) {
+			return null;
+		}
+		String fieldName = stackTrace.effectiveHashFieldName();
+		if (fieldName == null) {
+			fieldName = "stack_trace_hash";
+		}
+		return new StackTraceHashFieldConfiguration(fieldName);
 	}
 
 	private ContextPairs getContextPairs(@Nullable StructuredLoggingJsonProperties properties) {

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/StructuredLoggingJsonProperties.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/StructuredLoggingJsonProperties.java
@@ -40,6 +40,7 @@ import org.springframework.boot.logging.StandardStackTracePrinter;
 import org.springframework.boot.util.Instantiator;
 import org.springframework.core.env.Environment;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Properties that can be used to customize structured logging JSON.
@@ -96,11 +97,13 @@ record StructuredLoggingJsonProperties(Set<String> include, Set<String> exclude,
 	 * @param maxLength the maximum length to print
 	 * @param maxThrowableDepth the maximum throwable depth to print
 	 * @param includeCommonFrames whether common frames should be included
-	 * @param includeHashes whether stack trace hashes should be included
+	 * @param includeHashes whether stack trace hashes should be included (deprecated, use
+	 * {@code hash} instead)
+	 * @param hash hash generation properties
 	 */
 	record StackTrace(@Nullable String printer, @Nullable Root root, @Nullable Integer maxLength,
-			@Nullable Integer maxThrowableDepth, @Nullable Boolean includeCommonFrames,
-			@Nullable Boolean includeHashes) {
+			@Nullable Integer maxThrowableDepth, @Nullable Boolean includeCommonFrames, @Nullable Boolean includeHashes,
+			@Nullable Hash hash) {
 
 		@Nullable StackTracePrinter createPrinter() {
 			String name = sanitizePrinter();
@@ -130,8 +133,37 @@ record StructuredLoggingJsonProperties(Set<String> include, Set<String> exclude,
 		}
 
 		private boolean hasAnyOtherProperty() {
-			return Stream.of(root(), maxLength(), maxThrowableDepth(), includeCommonFrames(), includeHashes())
+			return Stream.of(root(), maxLength(), maxThrowableDepth(), includeCommonFrames(), includeHashes(), hash())
 				.anyMatch(Objects::nonNull);
+		}
+
+		/**
+		 * Return the effective hash generate mode, considering both the deprecated
+		 * {@code includeHashes} property and the new {@code hash} property.
+		 * @return the effective {@link StackTraceHashGenerate} or {@code null} if no hash
+		 * generation is configured
+		 */
+		@Nullable StackTraceHashGenerate effectiveHashGenerate() {
+			if (hash() != null && hash().generate() != null) {
+				return hash().generate();
+			}
+			if (Boolean.TRUE.equals(includeHashes())) {
+				return StackTraceHashGenerate.INLINE;
+			}
+			return null;
+		}
+
+		/**
+		 * Return the effective hash field name considering the {@code hash} property.
+		 * @return the configured field name or {@code null} if not set
+		 */
+		@Nullable String effectiveHashFieldName() {
+			return (hash() != null) ? hash().fieldName() : null;
+		}
+
+		private boolean shouldIncludeInlineHashes() {
+			StackTraceHashGenerate generate = effectiveHashGenerate();
+			return generate == StackTraceHashGenerate.INLINE;
 		}
 
 		private StandardStackTracePrinter createStandardPrinter() {
@@ -143,7 +175,9 @@ record StructuredLoggingJsonProperties(Set<String> include, Set<String> exclude,
 				.to(printer, StandardStackTracePrinter::withMaximumThrowableDepth);
 			printer = map.from(this::includeCommonFrames)
 				.to(printer, apply(StandardStackTracePrinter::withCommonFrames));
-			printer = map.from(this::includeHashes).to(printer, apply(StandardStackTracePrinter::withHashes));
+			if (shouldIncludeInlineHashes()) {
+				printer = printer.withHashes();
+			}
 			return printer;
 		}
 
@@ -158,6 +192,24 @@ record StructuredLoggingJsonProperties(Set<String> include, Set<String> exclude,
 		enum Root {
 
 			LAST, FIRST
+
+		}
+
+		/**
+		 * Properties to configure stack trace hash generation.
+		 *
+		 * @param generate the hash generation mode ({@code inline} or {@code as-field})
+		 * @param fieldName the name of the JSON field when using {@code as-field} mode.
+		 * If not set, a sensible default will be used for the selected logging format
+		 */
+		record Hash(@Nullable StackTraceHashGenerate generate, @Nullable String fieldName) {
+
+			@Nullable String resolveFieldName(@Nullable String defaultFieldName) {
+				if (StringUtils.hasText(this.fieldName)) {
+					return this.fieldName;
+				}
+				return defaultFieldName;
+			}
 
 		}
 

--- a/core/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -370,7 +370,7 @@
       "deprecation": {
         "level": "warning",
         "replacement": "logging.structured.json.stacktrace.hash.generate",
-        "since": "3.6.0"
+        "since": "4.0.0"
       }
     },
     {

--- a/core/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -356,7 +356,22 @@
     {
       "name": "logging.structured.json.stacktrace.include-hashes",
       "type": "java.lang.Boolean",
-      "description": "Whether stack trace hashes should be included."
+      "description": "Whether stack trace hashes should be included.",
+      "deprecation": {
+        "level": "warning",
+        "replacement": "logging.structured.json.stacktrace.hash.generate",
+        "since": "3.6.0"
+      }
+    },
+    {
+      "name": "logging.structured.json.stacktrace.hash.generate",
+      "type": "org.springframework.boot.logging.structured.StackTraceHashGenerate",
+      "description": "How stack trace hashes should be generated. Use 'inline' to include the hash in the stack trace text or 'as-field' to emit the hash as a separate structured field."
+    },
+    {
+      "name": "logging.structured.json.stacktrace.hash.field-name",
+      "type": "java.lang.String",
+      "description": "The name of the JSON field to use when the hash generate mode is 'as-field'. Defaults to 'stack_trace_hash' if not set."
     },
     {
       "name": "logging.structured.json.stacktrace.max-length",
@@ -807,7 +822,7 @@
         }
       ]
     },
- 	{
+    {
       "name": "logging.structured.json.stacktrace.printer",
       "values": [
         {

--- a/core/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -349,6 +349,16 @@
       "description": "Mapping between member paths and an alternative name that should be used in structured logging JSON"
     },
     {
+      "name": "logging.structured.json.stacktrace.hash.field-name",
+      "type": "java.lang.String",
+      "description": "The name of the JSON field to use when the hash generate mode is 'as-field'. Defaults to 'stack_trace_hash' if not set."
+    },
+    {
+      "name": "logging.structured.json.stacktrace.hash.generate",
+      "type": "org.springframework.boot.logging.structured.StackTraceHashGenerate",
+      "description": "How stack trace hashes should be generated. Use 'inline' to include the hash in the stack trace text or 'as-field' to emit the hash as a separate structured field."
+    },
+    {
       "name": "logging.structured.json.stacktrace.include-common-frames",
       "type": "java.lang.Boolean",
       "description": "Whether common frames should be included."
@@ -362,16 +372,6 @@
         "replacement": "logging.structured.json.stacktrace.hash.generate",
         "since": "3.6.0"
       }
-    },
-    {
-      "name": "logging.structured.json.stacktrace.hash.generate",
-      "type": "org.springframework.boot.logging.structured.StackTraceHashGenerate",
-      "description": "How stack trace hashes should be generated. Use 'inline' to include the hash in the stack trace text or 'as-field' to emit the hash as a separate structured field."
-    },
-    {
-      "name": "logging.structured.json.stacktrace.hash.field-name",
-      "type": "java.lang.String",
-      "description": "The name of the JSON field to use when the hash generate mode is 'as-field'. Defaults to 'stack_trace_hash' if not set."
     },
     {
       "name": "logging.structured.json.stacktrace.max-length",

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/ElasticCommonSchemaStructuredLogFormatterTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/ElasticCommonSchemaStructuredLogFormatterTests.java
@@ -55,7 +55,7 @@ class ElasticCommonSchemaStructuredLogFormatterTests extends AbstractStructuredL
 		this.environment.setProperty("logging.structured.ecs.service.environment", "test");
 		this.environment.setProperty("logging.structured.ecs.service.node-name", "node-1");
 		this.environment.setProperty("spring.application.pid", "1");
-		this.formatter = new ElasticCommonSchemaStructuredLogFormatter(this.environment, null,
+		this.formatter = new ElasticCommonSchemaStructuredLogFormatter(this.environment, null, null,
 				TestContextPairs.include(), this.customizerBuilder);
 	}
 
@@ -116,7 +116,7 @@ class ElasticCommonSchemaStructuredLogFormatterTests extends AbstractStructuredL
 	@SuppressWarnings("unchecked")
 	void shouldFormatExceptionUsingStackTracePrinter() {
 		this.formatter = new ElasticCommonSchemaStructuredLogFormatter(this.environment, new SimpleStackTracePrinter(),
-				TestContextPairs.include(), this.customizerBuilder);
+				null, TestContextPairs.include(), this.customizerBuilder);
 		MutableLogEvent event = createEvent();
 		event.setThrown(new RuntimeException("Boom"));
 		Map<String, Object> deserialized = deserialize(this.formatter.format(event));

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/GraylogExtendedLogFormatStructuredLogFormatterTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/GraylogExtendedLogFormatStructuredLogFormatterTests.java
@@ -53,7 +53,7 @@ class GraylogExtendedLogFormatStructuredLogFormatterTests extends AbstractStruct
 		this.environment.setProperty("logging.structured.gelf.host", "name");
 		this.environment.setProperty("logging.structured.gelf.service.version", "1.0.0");
 		this.environment.setProperty("spring.application.pid", "1");
-		this.formatter = new GraylogExtendedLogFormatStructuredLogFormatter(this.environment, null,
+		this.formatter = new GraylogExtendedLogFormatStructuredLogFormatter(this.environment, null, null,
 				TestContextPairs.include(), this.customizer);
 	}
 
@@ -153,7 +153,7 @@ class GraylogExtendedLogFormatStructuredLogFormatterTests extends AbstractStruct
 	@Test
 	void shouldFormatExceptionUsingStackTracePrinter() {
 		this.formatter = new GraylogExtendedLogFormatStructuredLogFormatter(this.environment,
-				new SimpleStackTracePrinter(), TestContextPairs.include(), this.customizer);
+				new SimpleStackTracePrinter(), null, TestContextPairs.include(), this.customizer);
 		MutableLogEvent event = createEvent();
 		event.setThrown(new RuntimeException("Boom"));
 		String json = this.formatter.format(event);

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/LogstashStructuredLogFormatterTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/LogstashStructuredLogFormatterTests.java
@@ -29,7 +29,9 @@ import org.apache.logging.log4j.message.MapMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.logging.structured.StackTraceHashFieldConfiguration;
 import org.springframework.boot.logging.structured.TestContextPairs;
+import org.springframework.boot.logging.structured.TestStackTraceHashFieldConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -47,7 +49,7 @@ class LogstashStructuredLogFormatterTests extends AbstractStructuredLoggingTests
 
 	@BeforeEach
 	void setUp() {
-		this.formatter = new LogstashStructuredLogFormatter(null, TestContextPairs.include(), this.customizer);
+		this.formatter = new LogstashStructuredLogFormatter(null, null, TestContextPairs.include(), this.customizer);
 	}
 
 	@Test
@@ -91,8 +93,8 @@ class LogstashStructuredLogFormatterTests extends AbstractStructuredLoggingTests
 
 	@Test
 	void shouldFormatExceptionWithStackTracePrinter() {
-		this.formatter = new LogstashStructuredLogFormatter(new SimpleStackTracePrinter(), TestContextPairs.include(),
-				this.customizer);
+		this.formatter = new LogstashStructuredLogFormatter(new SimpleStackTracePrinter(), null,
+				TestContextPairs.include(), this.customizer);
 		MutableLogEvent event = createEvent();
 		event.setThrown(new RuntimeException("Boom"));
 		String json = this.formatter.format(event);
@@ -114,6 +116,31 @@ class LogstashStructuredLogFormatterTests extends AbstractStructuredLoggingTests
 		assertThat(deserialized).containsExactlyInAnyOrderEntriesOf(
 				map("@timestamp", timestamp, "@version", "1", "message", expectedMessage, "logger_name",
 						"org.example.Test", "thread_name", "main", "level", "INFO", "level_value", 400));
+	}
+
+	@Test
+	void shouldFormatExceptionWithHashAsField() {
+		StackTraceHashFieldConfiguration hashConfig = TestStackTraceHashFieldConfiguration.of("my_stack_hash");
+		this.formatter = new LogstashStructuredLogFormatter(null, hashConfig, TestContextPairs.include(),
+				this.customizer);
+		MutableLogEvent event = createEvent();
+		event.setThrown(new RuntimeException("Boom"));
+		String json = this.formatter.format(event);
+		Map<String, Object> deserialized = deserialize(json);
+		assertThat(deserialized).containsKey("my_stack_hash");
+		assertThat((String) deserialized.get("my_stack_hash")).matches("[0-9a-f]{8}");
+		assertThat(deserialized).containsKey("stack_trace");
+	}
+
+	@Test
+	void shouldNotIncludeHashFieldWhenNoException() {
+		StackTraceHashFieldConfiguration hashConfig = TestStackTraceHashFieldConfiguration.of("my_stack_hash");
+		this.formatter = new LogstashStructuredLogFormatter(null, hashConfig, TestContextPairs.include(),
+				this.customizer);
+		MutableLogEvent event = createEvent();
+		String json = this.formatter.format(event);
+		Map<String, Object> deserialized = deserialize(json);
+		assertThat(deserialized).doesNotContainKey("my_stack_hash");
 	}
 
 }

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/ElasticCommonSchemaStructuredLogFormatterTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/ElasticCommonSchemaStructuredLogFormatterTests.java
@@ -57,7 +57,7 @@ class ElasticCommonSchemaStructuredLogFormatterTests extends AbstractStructuredL
 		this.environment.setProperty("logging.structured.ecs.service.environment", "test");
 		this.environment.setProperty("logging.structured.ecs.service.node-name", "node-1");
 		this.environment.setProperty("spring.application.pid", "1");
-		this.formatter = new ElasticCommonSchemaStructuredLogFormatter(this.environment, null,
+		this.formatter = new ElasticCommonSchemaStructuredLogFormatter(this.environment, null, null,
 				TestContextPairs.include(), getThrowableProxyConverter(), this.customizerBuilder);
 	}
 
@@ -121,7 +121,7 @@ class ElasticCommonSchemaStructuredLogFormatterTests extends AbstractStructuredL
 	@SuppressWarnings("unchecked")
 	void shouldFormatExceptionUsingStackTracePrinter() {
 		this.formatter = new ElasticCommonSchemaStructuredLogFormatter(this.environment, new SimpleStackTracePrinter(),
-				TestContextPairs.include(), getThrowableProxyConverter(), this.customizerBuilder);
+				null, TestContextPairs.include(), getThrowableProxyConverter(), this.customizerBuilder);
 		LoggingEvent event = createEvent();
 		event.setMDCPropertyMap(Collections.emptyMap());
 		event.setThrowableProxy(new ThrowableProxy(new RuntimeException("Boom")));

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/GraylogExtendedLogFormatStructuredLogFormatterTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/GraylogExtendedLogFormatStructuredLogFormatterTests.java
@@ -56,7 +56,7 @@ class GraylogExtendedLogFormatStructuredLogFormatterTests extends AbstractStruct
 		this.environment.setProperty("logging.structured.gelf.host", "name");
 		this.environment.setProperty("logging.structured.gelf.service.version", "1.0.0");
 		this.environment.setProperty("spring.application.pid", "1");
-		this.formatter = new GraylogExtendedLogFormatStructuredLogFormatter(this.environment, null,
+		this.formatter = new GraylogExtendedLogFormatStructuredLogFormatter(this.environment, null, null,
 				TestContextPairs.include(), getThrowableProxyConverter(), this.customizer);
 	}
 
@@ -159,7 +159,7 @@ class GraylogExtendedLogFormatStructuredLogFormatterTests extends AbstractStruct
 	@Test
 	void shouldFormatExceptionUsingStackTracePrinter() {
 		this.formatter = new GraylogExtendedLogFormatStructuredLogFormatter(this.environment,
-				new SimpleStackTracePrinter(), TestContextPairs.include(), getThrowableProxyConverter(),
+				new SimpleStackTracePrinter(), null, TestContextPairs.include(), getThrowableProxyConverter(),
 				this.customizer);
 		LoggingEvent event = createEvent();
 		event.setMDCPropertyMap(Collections.emptyMap());

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogstashStructuredLogFormatterTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogstashStructuredLogFormatterTests.java
@@ -29,7 +29,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Marker;
 
+import org.springframework.boot.logging.structured.StackTraceHashFieldConfiguration;
 import org.springframework.boot.logging.structured.TestContextPairs;
+import org.springframework.boot.logging.structured.TestStackTraceHashFieldConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -48,7 +50,7 @@ class LogstashStructuredLogFormatterTests extends AbstractStructuredLoggingTests
 	@BeforeEach
 	void setUp() {
 		super.setUp();
-		this.formatter = new LogstashStructuredLogFormatter(null, TestContextPairs.include(),
+		this.formatter = new LogstashStructuredLogFormatter(null, null, TestContextPairs.include(),
 				getThrowableProxyConverter(), this.customizer);
 	}
 
@@ -95,8 +97,8 @@ class LogstashStructuredLogFormatterTests extends AbstractStructuredLoggingTests
 
 	@Test
 	void shouldFormatExceptionWithStackTracePrinter() {
-		this.formatter = new LogstashStructuredLogFormatter(new SimpleStackTracePrinter(), TestContextPairs.include(),
-				getThrowableProxyConverter(), this.customizer);
+		this.formatter = new LogstashStructuredLogFormatter(new SimpleStackTracePrinter(), null,
+				TestContextPairs.include(), getThrowableProxyConverter(), this.customizer);
 		LoggingEvent event = createEvent();
 		event.setThrowableProxy(new ThrowableProxy(new RuntimeException("Boom")));
 		event.setMDCPropertyMap(Collections.emptyMap());
@@ -104,6 +106,33 @@ class LogstashStructuredLogFormatterTests extends AbstractStructuredLoggingTests
 		Map<String, Object> deserialized = deserialize(json);
 		String stackTrace = (String) deserialized.get("stack_trace");
 		assertThat(stackTrace).isEqualTo("stacktrace:RuntimeException");
+	}
+
+	@Test
+	void shouldFormatExceptionWithHashAsField() {
+		StackTraceHashFieldConfiguration hashConfig = TestStackTraceHashFieldConfiguration.of("my_stack_hash");
+		this.formatter = new LogstashStructuredLogFormatter(null, hashConfig, TestContextPairs.include(),
+				getThrowableProxyConverter(), this.customizer);
+		LoggingEvent event = createEvent();
+		event.setThrowableProxy(new ThrowableProxy(new RuntimeException("Boom")));
+		event.setMDCPropertyMap(Collections.emptyMap());
+		String json = this.formatter.format(event);
+		Map<String, Object> deserialized = deserialize(json);
+		assertThat(deserialized).containsKey("my_stack_hash");
+		assertThat((String) deserialized.get("my_stack_hash")).matches("[0-9a-f]{8}");
+		assertThat(deserialized).containsKey("stack_trace");
+	}
+
+	@Test
+	void shouldNotIncludeHashFieldWhenNoException() {
+		StackTraceHashFieldConfiguration hashConfig = TestStackTraceHashFieldConfiguration.of("my_stack_hash");
+		this.formatter = new LogstashStructuredLogFormatter(null, hashConfig, TestContextPairs.include(),
+				getThrowableProxyConverter(), this.customizer);
+		LoggingEvent event = createEvent();
+		event.setMDCPropertyMap(Collections.emptyMap());
+		String json = this.formatter.format(event);
+		Map<String, Object> deserialized = deserialize(json);
+		assertThat(deserialized).doesNotContainKey("my_stack_hash");
 	}
 
 }

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/StructuredLogEncoderTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/StructuredLogEncoderTests.java
@@ -114,6 +114,88 @@ class StructuredLogEncoderTests extends AbstractStructuredLoggingTests {
 	}
 
 	@Test
+	void shouldSupportLogstashWithHashAsField() {
+		this.environment.setProperty("logging.structured.json.stacktrace.hash.generate", "as-field");
+		this.environment.setProperty("logging.structured.json.stacktrace.hash.field-name", "my_hash");
+		StructuredLogEncoder hashEncoder = new StructuredLogEncoder();
+		hashEncoder.setContext(this.loggerContext);
+		hashEncoder.setFormat("logstash");
+		hashEncoder.start();
+		LoggingEvent event = createEvent(new RuntimeException("Boom!"));
+		event.setMDCPropertyMap(Collections.emptyMap());
+		String json = new String(hashEncoder.encode(event), StandardCharsets.UTF_8);
+		Map<String, Object> deserialized = deserialize(json);
+		assertThat(deserialized).containsKey("my_hash");
+		assertThat(deserialized.get("my_hash")).isInstanceOf(String.class);
+		assertThat((String) deserialized.get("my_hash")).matches("[0-9a-f]{8}");
+		hashEncoder.stop();
+	}
+
+	@Test
+	void shouldSupportLogstashWithHashAsFieldDefaultFieldName() {
+		this.environment.setProperty("logging.structured.json.stacktrace.hash.generate", "as-field");
+		StructuredLogEncoder hashEncoder = new StructuredLogEncoder();
+		hashEncoder.setContext(this.loggerContext);
+		hashEncoder.setFormat("logstash");
+		hashEncoder.start();
+		LoggingEvent event = createEvent(new RuntimeException("Boom!"));
+		event.setMDCPropertyMap(Collections.emptyMap());
+		String json = new String(hashEncoder.encode(event), StandardCharsets.UTF_8);
+		Map<String, Object> deserialized = deserialize(json);
+		assertThat(deserialized).containsKey("stack_trace_hash");
+		assertThat((String) deserialized.get("stack_trace_hash")).matches("[0-9a-f]{8}");
+		hashEncoder.stop();
+	}
+
+	@Test
+	void shouldNotIncludeHashFieldWhenNoException() {
+		this.environment.setProperty("logging.structured.json.stacktrace.hash.generate", "as-field");
+		StructuredLogEncoder hashEncoder = new StructuredLogEncoder();
+		hashEncoder.setContext(this.loggerContext);
+		hashEncoder.setFormat("logstash");
+		hashEncoder.start();
+		LoggingEvent event = createEvent();
+		event.setMDCPropertyMap(Collections.emptyMap());
+		String json = new String(hashEncoder.encode(event), StandardCharsets.UTF_8);
+		Map<String, Object> deserialized = deserialize(json);
+		assertThat(deserialized).doesNotContainKey("stack_trace_hash");
+		hashEncoder.stop();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void shouldSupportEcsWithHashAsField() {
+		this.environment.setProperty("logging.structured.json.stacktrace.hash.generate", "as-field");
+		StructuredLogEncoder hashEncoder = new StructuredLogEncoder();
+		hashEncoder.setContext(this.loggerContext);
+		hashEncoder.setFormat("ecs");
+		hashEncoder.start();
+		LoggingEvent event = createEvent(new RuntimeException("Boom!"));
+		event.setMDCPropertyMap(Collections.emptyMap());
+		String json = new String(hashEncoder.encode(event), StandardCharsets.UTF_8);
+		Map<String, Object> deserialized = deserialize(json);
+		assertThat(deserialized).containsKey("stack_trace_hash");
+		assertThat((String) deserialized.get("stack_trace_hash")).matches("[0-9a-f]{8}");
+		hashEncoder.stop();
+	}
+
+	@Test
+	void shouldSupportGelfWithHashAsField() {
+		this.environment.setProperty("logging.structured.json.stacktrace.hash.generate", "as-field");
+		StructuredLogEncoder hashEncoder = new StructuredLogEncoder();
+		hashEncoder.setContext(this.loggerContext);
+		hashEncoder.setFormat("gelf");
+		hashEncoder.start();
+		LoggingEvent event = createEvent(new RuntimeException("Boom!"));
+		event.setMDCPropertyMap(Collections.emptyMap());
+		String json = new String(hashEncoder.encode(event), StandardCharsets.UTF_8);
+		Map<String, Object> deserialized = deserialize(json);
+		assertThat(deserialized).containsKey("stack_trace_hash");
+		assertThat((String) deserialized.get("stack_trace_hash")).matches("[0-9a-f]{8}");
+		hashEncoder.stop();
+	}
+
+	@Test
 	void shouldSupportGelfCommonFormat() {
 		this.encoder.setFormat("gelf");
 		this.encoder.start();

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/structured/StructuredLoggingJsonPropertiesTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/structured/StructuredLoggingJsonPropertiesTests.java
@@ -33,6 +33,7 @@ import org.springframework.boot.logging.StandardStackTracePrinter;
 import org.springframework.boot.logging.TestException;
 import org.springframework.boot.logging.structured.StructuredLoggingJsonProperties.Context;
 import org.springframework.boot.logging.structured.StructuredLoggingJsonProperties.StackTrace;
+import org.springframework.boot.logging.structured.StructuredLoggingJsonProperties.StackTrace.Hash;
 import org.springframework.boot.logging.structured.StructuredLoggingJsonProperties.StackTrace.Root;
 import org.springframework.boot.logging.structured.StructuredLoggingJsonProperties.StructuredLoggingJsonPropertiesRuntimeHints;
 import org.springframework.mock.env.MockEnvironment;
@@ -68,8 +69,22 @@ class StructuredLoggingJsonPropertiesTests {
 		environment.setProperty("logging.structured.json.stacktrace.include-hashes", "true");
 		StructuredLoggingJsonProperties properties = StructuredLoggingJsonProperties.get(environment);
 		assertThat(properties).isNotNull();
-		assertThat(properties.stackTrace())
-			.isEqualTo(new StructuredLoggingJsonProperties.StackTrace("standard", Root.FIRST, 1024, 5, true, true));
+		assertThat(properties.stackTrace()).isEqualTo(
+				new StructuredLoggingJsonProperties.StackTrace("standard", Root.FIRST, 1024, 5, true, true, null));
+	}
+
+	@Test
+	void getWhenHasHashPropertiesBindsFromEnvironment() {
+		MockEnvironment environment = new MockEnvironment();
+		setupJsonProperties(environment);
+		environment.setProperty("logging.structured.json.stacktrace.hash.generate", "as-field");
+		environment.setProperty("logging.structured.json.stacktrace.hash.field-name", "my_hash");
+		StructuredLoggingJsonProperties properties = StructuredLoggingJsonProperties.get(environment);
+		assertThat(properties).isNotNull();
+		assertThat(properties.stackTrace()).isNotNull();
+		assertThat(properties.stackTrace().hash()).isNotNull();
+		assertThat(properties.stackTrace().hash().generate()).isEqualTo(StackTraceHashGenerate.AS_FIELD);
+		assertThat(properties.stackTrace().hash().fieldName()).isEqualTo("my_hash");
 	}
 
 	private void setupJsonProperties(MockEnvironment environment) {
@@ -98,7 +113,10 @@ class StructuredLoggingJsonPropertiesTests {
 			.accepts(hints);
 		assertThat(RuntimeHintsPredicates.reflection()
 			.onConstructorInvocation(StackTrace.class.getDeclaredConstructor(String.class, Root.class, Integer.class,
-					Integer.class, Boolean.class, Boolean.class)))
+					Integer.class, Boolean.class, Boolean.class, Hash.class)))
+			.accepts(hints);
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onConstructorInvocation(Hash.class.getDeclaredConstructor(StackTraceHashGenerate.class, String.class)))
 			.accepts(hints);
 		assertThat(RuntimeHintsPredicates.reflection()
 			.onConstructorInvocation(Context.class.getDeclaredConstructor(boolean.class, String.class))).accepts(hints);
@@ -115,44 +133,44 @@ class StructuredLoggingJsonPropertiesTests {
 
 		@Test
 		void createPrinterWhenEmptyReturnsNull() {
-			StackTrace properties = new StackTrace(null, null, null, null, null, null);
+			StackTrace properties = new StackTrace(null, null, null, null, null, null, null);
 			assertThat(properties.createPrinter()).isNull();
 		}
 
 		@Test
 		void createPrinterWhenNoPrinterAndNotEmptyReturnsStandard() {
-			StackTrace properties = new StackTrace(null, Root.LAST, null, null, null, null);
+			StackTrace properties = new StackTrace(null, Root.LAST, null, null, null, null, null);
 			assertThat(properties.createPrinter()).isInstanceOf(StandardStackTracePrinter.class);
 		}
 
 		@Test
 		void createPrinterWhenLoggingSystemReturnsNull() {
-			StackTrace properties = new StackTrace("logging-system", null, null, null, null, null);
+			StackTrace properties = new StackTrace("logging-system", null, null, null, null, null, null);
 			assertThat(properties.createPrinter()).isNull();
 		}
 
 		@Test
 		void createPrinterWhenLoggingSystemRelaxedReturnsNull() {
-			StackTrace properties = new StackTrace("LoggingSystem", null, null, null, null, null);
+			StackTrace properties = new StackTrace("LoggingSystem", null, null, null, null, null, null);
 			assertThat(properties.createPrinter()).isNull();
 		}
 
 		@Test
 		void createPrinterWhenStandardReturnsStandardPrinter() {
-			StackTrace properties = new StackTrace("standard", null, null, null, null, null);
+			StackTrace properties = new StackTrace("standard", null, null, null, null, null, null);
 			assertThat(properties.createPrinter()).isInstanceOf(StandardStackTracePrinter.class);
 		}
 
 		@Test
 		void createPrinterWhenStandardRelaxedReturnsStandardPrinter() {
-			StackTrace properties = new StackTrace("STANDARD", null, null, null, null, null);
+			StackTrace properties = new StackTrace("STANDARD", null, null, null, null, null, null);
 			assertThat(properties.createPrinter()).isInstanceOf(StandardStackTracePrinter.class);
 		}
 
 		@Test
 		void createPrinterWhenStandardAppliesCustomizations() {
 			Exception exception = TestException.create();
-			StackTrace properties = new StackTrace(null, Root.FIRST, 300, 2, true, false);
+			StackTrace properties = new StackTrace(null, Root.FIRST, 300, 2, true, false, null);
 			StandardStackTracePrinter printer = (StandardStackTracePrinter) properties.createPrinter();
 			assertThat(printer).isNotNull();
 			printer = printer.withLineSeparator("\n");
@@ -168,7 +186,7 @@ class StructuredLoggingJsonPropertiesTests {
 		@Test
 		void createPrinterWhenStandardWithHashesPrintsHash() {
 			Exception exception = TestException.create();
-			StackTrace properties = new StackTrace(null, null, null, null, null, true);
+			StackTrace properties = new StackTrace(null, null, null, null, null, true, null);
 			StackTracePrinter printer = properties.createPrinter();
 			assertThat(printer).isNotNull();
 			String actual = printer.printStackTraceToString(exception);
@@ -178,7 +196,8 @@ class StructuredLoggingJsonPropertiesTests {
 		@Test
 		void createPrinterWhenClassNameCreatesPrinter() {
 			Exception exception = TestException.create();
-			StackTrace properties = new StackTrace(TestStackTracePrinter.class.getName(), null, null, null, true, null);
+			StackTrace properties = new StackTrace(TestStackTracePrinter.class.getName(), null, null, null, true, null,
+					null);
 			StackTracePrinter printer = properties.createPrinter();
 			assertThat(printer).isNotNull();
 			assertThat(printer.printStackTraceToString(exception)).isEqualTo("java.lang.RuntimeException: exception");
@@ -188,7 +207,7 @@ class StructuredLoggingJsonPropertiesTests {
 		void createPrinterWhenClassNameInjectsConfiguredPrinter() {
 			Exception exception = TestException.create();
 			StackTrace properties = new StackTrace(TestStackTracePrinterCustomized.class.getName(), Root.FIRST, 300, 2,
-					true, null);
+					true, null, null);
 			StackTracePrinter printer = properties.createPrinter();
 			assertThat(printer).isNotNull();
 			String actual = TestException.withoutLineNumbers(printer.printStackTraceToString(exception));
@@ -197,26 +216,87 @@ class StructuredLoggingJsonPropertiesTests {
 
 		@Test
 		void hasCustomPrinterShouldReturnFalseWhenPrinterIsEmpty() {
-			StackTrace stackTrace = new StackTrace("", null, null, null, null, null);
+			StackTrace stackTrace = new StackTrace("", null, null, null, null, null, null);
 			assertThat(stackTrace.hasCustomPrinter()).isFalse();
 		}
 
 		@Test
 		void hasCustomPrinterShouldReturnFalseWhenPrinterHasLoggingSystem() {
-			StackTrace stackTrace = new StackTrace("loggingsystem", null, null, null, null, null);
+			StackTrace stackTrace = new StackTrace("loggingsystem", null, null, null, null, null, null);
 			assertThat(stackTrace.hasCustomPrinter()).isFalse();
 		}
 
 		@Test
 		void hasCustomPrinterShouldReturnFalseWhenPrinterHasStandard() {
-			StackTrace stackTrace = new StackTrace("standard", null, null, null, null, null);
+			StackTrace stackTrace = new StackTrace("standard", null, null, null, null, null, null);
 			assertThat(stackTrace.hasCustomPrinter()).isFalse();
 		}
 
 		@Test
 		void hasCustomPrinterShouldReturnTrueWhenPrinterHasCustom() {
-			StackTrace stackTrace = new StackTrace("custom-printer", null, null, null, null, null);
+			StackTrace stackTrace = new StackTrace("custom-printer", null, null, null, null, null, null);
 			assertThat(stackTrace.hasCustomPrinter()).isTrue();
+		}
+
+		@Test
+		void effectiveHashGenerateWhenHashGenerateIsSetReturnsIt() {
+			Hash hash = new Hash(StackTraceHashGenerate.AS_FIELD, null);
+			StackTrace stackTrace = new StackTrace(null, null, null, null, null, null, hash);
+			assertThat(stackTrace.effectiveHashGenerate()).isEqualTo(StackTraceHashGenerate.AS_FIELD);
+		}
+
+		@Test
+		void effectiveHashGenerateWhenIncludeHashesTrueAndNoHashReturnsInline() {
+			StackTrace stackTrace = new StackTrace(null, null, null, null, null, true, null);
+			assertThat(stackTrace.effectiveHashGenerate()).isEqualTo(StackTraceHashGenerate.INLINE);
+		}
+
+		@Test
+		void effectiveHashGenerateWhenNothingSetReturnsNull() {
+			StackTrace stackTrace = new StackTrace(null, null, null, null, null, null, null);
+			assertThat(stackTrace.effectiveHashGenerate()).isNull();
+		}
+
+		@Test
+		void effectiveHashGenerateWhenHashGenerateOverridesIncludeHashes() {
+			Hash hash = new Hash(StackTraceHashGenerate.AS_FIELD, null);
+			StackTrace stackTrace = new StackTrace(null, null, null, null, null, true, hash);
+			assertThat(stackTrace.effectiveHashGenerate()).isEqualTo(StackTraceHashGenerate.AS_FIELD);
+		}
+
+		@Test
+		void effectiveHashFieldNameWhenHashHasFieldNameReturnsIt() {
+			Hash hash = new Hash(StackTraceHashGenerate.AS_FIELD, "my_hash");
+			StackTrace stackTrace = new StackTrace(null, null, null, null, null, null, hash);
+			assertThat(stackTrace.effectiveHashFieldName()).isEqualTo("my_hash");
+		}
+
+		@Test
+		void effectiveHashFieldNameWhenNoHashReturnsNull() {
+			StackTrace stackTrace = new StackTrace(null, null, null, null, null, null, null);
+			assertThat(stackTrace.effectiveHashFieldName()).isNull();
+		}
+
+		@Test
+		void createPrinterWhenHashGenerateInlinePrintsHash() {
+			Exception exception = TestException.create();
+			Hash hash = new Hash(StackTraceHashGenerate.INLINE, null);
+			StackTrace properties = new StackTrace(null, null, null, null, null, null, hash);
+			StackTracePrinter printer = properties.createPrinter();
+			assertThat(printer).isNotNull();
+			String actual = printer.printStackTraceToString(exception);
+			assertThat(actual).containsPattern("<#[0-9a-z]{8}>");
+		}
+
+		@Test
+		void createPrinterWhenHashGenerateAsFieldDoesNotPrintInlineHash() {
+			Exception exception = TestException.create();
+			Hash hash = new Hash(StackTraceHashGenerate.AS_FIELD, null);
+			StackTrace properties = new StackTrace(null, null, null, null, null, null, hash);
+			StackTracePrinter printer = properties.createPrinter();
+			assertThat(printer).isNotNull();
+			String actual = printer.printStackTraceToString(exception);
+			assertThat(actual).doesNotContainPattern("<#[0-9a-z]{8}>");
 		}
 
 	}

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/structured/TestStackTraceHashFieldConfiguration.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/structured/TestStackTraceHashFieldConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.logging.structured;
+
+/**
+ * Test access to {@link StackTraceHashFieldConfiguration}.
+ *
+ * @author [Venkata Naga Sai Srikanth Gollapudi]
+ * @since 4.0
+ */
+public final class TestStackTraceHashFieldConfiguration {
+
+	private TestStackTraceHashFieldConfiguration() {
+	}
+
+	public static StackTraceHashFieldConfiguration of(String fieldName) {
+		return new StackTraceHashFieldConfiguration(fieldName);
+	}
+
+}

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/logging.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/logging.adoc
@@ -191,17 +191,17 @@ The following table shows how the `logging.*` properties can be used together:
 | Specific file (for example, `my.log`)
 | _(none)_
 | Writes to the location specified by `logging.file.name`.
-  The location can be absolute or relative to the current directory.
+The location can be absolute or relative to the current directory.
 
 | _(none)_
 | Specific directory (for example, `/var/log`)
 | Writes `spring.log` to the directory specified by `logging.file.path`.
-  The directory can be absolute or relative to the current directory.
+The directory can be absolute or relative to the current directory.
 
 | Specific file
 | Specific directory
 | Writes to the location specified by `logging.file.name` and ignores `logging.file.path`.
-  The location can be absolute or relative to the current directory.
+The location can be absolute or relative to the current directory.
 |===
 
 Log files rotate when they reach 10 MB and, as with console output, `ERROR`-level, `WARN`-level, and `INFO`-level messages are logged by default.
@@ -737,11 +737,14 @@ To do this, you can use one or more of the following properties:
 | configprop:logging.structured.json.stacktrace.include-common-frames[]
 | If common frames should be included or removed
 
-| configprop:logging.structured.json.stacktrace.include-hashes[]
-| If a hash of the stack trace should be included
+| configprop:logging.structured.json.stacktrace.hash.generate[]
+| How stack trace hashes should be generated. Use `inline` to include the hash in the stack trace text or `as-field` to emit the hash as a separate structured JSON field.
+
+| configprop:logging.structured.json.stacktrace.hash.field-name[]
+| The name of the JSON field to use when the hash generate mode is `as-field`. Defaults to `stack_trace_hash` if not set.
 |===
 
-For example, the following will use root first stack traces, limit their length, and include hashes.
+For example, the following will use root first stack traces and limit their length:
 
 [configprops,yaml]
 ----
@@ -752,8 +755,59 @@ logging:
         root: first
         max-length: 1024
         include-common-frames: true
-        include-hashes: true
 ----
+
+
+
+[[features.logging.structured.customizing-stack-traces.hashes]]
+==== Stack Trace Hashes
+
+Stack trace hashes are useful for grouping common exceptions.
+You can configure how hashes are generated using the configprop:logging.structured.json.stacktrace.hash.generate[] property.
+
+When set to `inline`, the hash is prefixed to the stack trace text (e.g. `<#351b6441> java.lang.RuntimeException: ...`).
+When set to `as-field`, the hash is emitted as a separate structured JSON field, making it easy to filter and aggregate in log analysis tools.
+
+The following will include the hash inline within the stack trace text:
+
+[configprops,yaml]
+----
+logging:
+  structured:
+    json:
+      stacktrace:
+        hash:
+          generate: inline
+----
+
+The following will emit the hash as a separate JSON field named `stack_trace_hash`:
+
+[configprops,yaml]
+----
+logging:
+  structured:
+    json:
+      stacktrace:
+        hash:
+          generate: as-field
+----
+
+You can also customize the field name:
+
+[configprops,yaml]
+----
+logging:
+  structured:
+    json:
+      stacktrace:
+        hash:
+          generate: as-field
+          field-name: my_stack_hash
+----
+
+NOTE: The configprop:logging.structured.json.stacktrace.include-hashes[] property is deprecated.
+Use configprop:logging.structured.json.stacktrace.hash.generate[] instead.
+Setting `include-hashes: true` is equivalent to `hash.generate: inline`.
 
 [TIP]
 ====


### PR DESCRIPTION
**Summary**

This PR adds support for emitting the stacktrace hash as a separate structured logging field, in addition to the existing inline format.

**Details**

Currently, when logging.structured.json.stacktrace.include-hashes is enabled, the hash is prefixed inline within the stack_trace field. While this is useful, it makes it harder to filter and group logs based on the hash value.

This change introduces new configuration properties:

```
logging.structured.stacktrace.hash.generate=inline | as-field
logging.structured.stacktrace.hash.field-name=stack_trace_hash
```

- `inline` preserves the existing behavior (default for backward compatibility)
- `as-field` emits the hash as a separate structured field
- `field-name` allows customization of the output field name

**Backward Compatibility**

- The existing property logging.structured.json.stacktrace.include-hashes is still supported in a deprecated form
- When set, it maps to the equivalent inline behavior
- The new properties take precedence if both are configured

**Example**

With:

`logging.structured.stacktrace.hash.generate=as-field`

Output:

```
{
  "stack_trace": "...",
  "stack_trace_hash": "351b6441"
}
```

**Testing**

- Added tests for:
- Inline mode (existing behavior)
- As-field mode
- Custom field name
- Deprecated property compatibility and precedence

Related Issue

Closes #49639