### PR TITLE
Add @ConditionalOnWebApplication to ReactiveOAuth2ResourceServerAutoConfiguration

### DIFF
--- a/module/spring-boot-security-oauth2-resource-server/src/main/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/reactive/ReactiveOAuth2ResourceServerAutoConfiguration.java
+++ b/module/spring-boot-security-oauth2-resource-server/src/main/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/reactive/ReactiveOAuth2ResourceServerAutoConfiguration.java
@@ -21,6 +21,8 @@ import reactor.core.publisher.Mono;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.security.autoconfigure.ReactiveUserDetailsServiceAutoConfiguration;
 import org.springframework.boot.security.autoconfigure.actuate.web.reactive.ReactiveManagementWebSecurityAutoConfiguration;
@@ -39,6 +41,7 @@ import org.springframework.security.oauth2.server.resource.authentication.Bearer
 @AutoConfiguration(before = { ReactiveManagementWebSecurityAutoConfiguration.class,
 		ReactiveWebSecurityAutoConfiguration.class, ReactiveUserDetailsServiceAutoConfiguration.class })
 @ConditionalOnClass({ Mono.class, BearerTokenAuthenticationToken.class })
+@ConditionalOnWebApplication(type = Type.REACTIVE)
 @EnableConfigurationProperties(OAuth2ResourceServerProperties.class)
 @Import({ ReactiveJwtDecoderConfiguration.class, ReactiveJwtConverterConfiguration.class,
 		ReactiveOpaqueTokenIntrospectionClientConfiguration.class })

--- a/module/spring-boot-security-oauth2-resource-server/src/test/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
+++ b/module/spring-boot-security-oauth2-resource-server/src/test/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
@@ -53,6 +53,7 @@ import org.springframework.boot.security.oauth2.server.resource.autoconfigure.Jw
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.assertj.AssertableReactiveWebApplicationContext;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.testsupport.classpath.resources.WithResource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -382,6 +383,17 @@ class ReactiveOAuth2ResourceServerAutoConfigurationTests {
 			.withUserConfiguration(JwtDecoderConfig.class)
 			.withClassLoader(new FilteredClassLoader(ReactiveJwtDecoder.class))
 			.run((context) -> assertThat(context).doesNotHaveBean(BeanIds.SPRING_SECURITY_FILTER_CHAIN));
+	}
+
+	@Test
+	void autoConfigurationShouldBeConditionalOnReactiveWebApplication() {
+		new WebApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(ReactiveOAuth2ResourceServerAutoConfiguration.class))
+			.withPropertyValues("spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://jwk-set-uri.com")
+			.run((context) -> {
+				assertThat(context).doesNotHaveBean(ReactiveJwtDecoder.class);
+				assertThat(context).doesNotHaveBean(ReactiveOpaqueTokenIntrospector.class);
+			});
 	}
 
 	@Test


### PR DESCRIPTION
## Problem

When a Servlet-based application includes dependencies that pull in `reactor-core` (e.g., `spring-boot-starter-data-redis` via Lettuce), `ReactiveOAuth2ResourceServerAutoConfiguration` is triggered incorrectly, causing a `NoClassDefFoundError` for `WebClient` at startup.

## Root Cause

`ReactiveOAuth2ResourceServerAutoConfiguration` only checks for the presence of `Mono.class` and `BearerTokenAuthenticationToken.class` via `@ConditionalOnClass`. Since libraries like Lettuce bring `reactor-core` (and thus `Mono`) onto the classpath for their own async internals, the condition is satisfied even in Servlet-based applications. The imported `ReactiveJwtDecoderConfiguration` then attempts to create a `NimbusReactiveJwtDecoder` which requires `WebClient` from `spring-webflux`, which is not present.

## Fix

- Added `@ConditionalOnWebApplication(type = Type.REACTIVE)` to `ReactiveOAuth2ResourceServerAutoConfiguration` to ensure it only activates for reactive web applications
- This is consistent with `ReactiveOAuth2ResourceServerWebSecurityAutoConfiguration`, which already has this condition

## Tests Added

| Change Point | Test |
|-------------|------|
| Added `@ConditionalOnWebApplication(type = Type.REACTIVE)` | `autoConfigurationShouldBeConditionalOnReactiveWebApplication()` — verifies that no `ReactiveJwtDecoder` or `ReactiveOpaqueTokenIntrospector` beans are created when running in a Servlet web application context |

## Impact

Only affects the activation condition of the reactive OAuth2 resource server auto-configuration. Servlet-based applications will no longer incorrectly trigger this configuration. Reactive web applications are unaffected as the condition is satisfied in that context.

Fixes #49807