### PR TITLE
Fix ReactiveOAuth2ResourceServerAutoConfiguration to only trigger on reactive web applications

### DIFF
--- a/module/spring-boot-security-oauth2-resource-server/src/main/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/reactive/ReactiveOAuth2ResourceServerAutoConfiguration.java
+++ b/module/spring-boot-security-oauth2-resource-server/src/main/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/reactive/ReactiveOAuth2ResourceServerAutoConfiguration.java
@@ -21,6 +21,7 @@ import reactor.core.publisher.Mono;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.security.autoconfigure.ReactiveUserDetailsServiceAutoConfiguration;
 import org.springframework.boot.security.autoconfigure.actuate.web.reactive.ReactiveManagementWebSecurityAutoConfiguration;
@@ -39,6 +40,7 @@ import org.springframework.security.oauth2.server.resource.authentication.Bearer
 @AutoConfiguration(before = { ReactiveManagementWebSecurityAutoConfiguration.class,
 		ReactiveWebSecurityAutoConfiguration.class, ReactiveUserDetailsServiceAutoConfiguration.class })
 @ConditionalOnClass({ Mono.class, BearerTokenAuthenticationToken.class })
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
 @EnableConfigurationProperties(OAuth2ResourceServerProperties.class)
 @Import({ ReactiveJwtDecoderConfiguration.class, ReactiveJwtConverterConfiguration.class,
 		ReactiveOpaqueTokenIntrospectionClientConfiguration.class })


### PR DESCRIPTION
## Problem

When using `spring-boot-starter-security-oauth2-resource-server` alongside starters that include Project Reactor (e.g., `spring-boot-starter-data-redis`), the `ReactiveOAuth2ResourceServerAutoConfiguration` is triggered unintentionally, causing `NoClassDefFoundError` for `WebClient` in Servlet-based applications.

## Root Cause

The current condition `@ConditionalOnClass({ Mono.class, BearerTokenAuthenticationToken.class })` is insufficient because `Mono.class` presence alone does not indicate a reactive web application - libraries like Lettuce (via Redis starter) pull in reactor-core for internal async logic.

## Fix

Adds `@ConditionalOnWebApplication(type = Type.REACTIVE)` to ensure the autoconfiguration only triggers for actual reactive web applications.

Fixes #49807