### PR TITLE
Call to 'replaceAll()' with a non-regex pattern can be replaced with 'replace()'

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/ssl/PemCertificateParser.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/ssl/PemCertificateParser.java
@@ -92,7 +92,7 @@ final class PemCertificateParser {
 	}
 
 	private static byte[] decodeBase64(String content) {
-		byte[] bytes = content.replaceAll("\r", "").replaceAll("\n", "").getBytes();
+		byte[] bytes = content.replace("\r", "").replace("\n", "").getBytes();
 		return Base64.getDecoder().decode(bytes);
 	}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/ssl/PemPrivateKeyParser.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/ssl/PemPrivateKeyParser.java
@@ -240,7 +240,7 @@ final class PemPrivateKeyParser {
 		}
 
 		private static byte[] decodeBase64(String content) {
-			byte[] contentBytes = content.replaceAll("\r", "").replaceAll("\n", "").getBytes();
+			byte[] contentBytes = content.replace("\r", "").replace("\n", "").getBytes();
 			return Base64.getDecoder().decode(contentBytes);
 		}
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/LifecycleTests.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/LifecycleTests.java
@@ -482,7 +482,7 @@ class LifecycleTests {
 		return (invocation) -> {
 			ContainerConfig config = invocation.getArgument(0, ContainerConfig.class);
 			ArrayNode command = getCommand(config);
-			String name = command.get(0).asText().substring(1).replaceAll("/", "-");
+			String name = command.get(0).asText().substring(1).replace('/', '-');
 			this.configs.put(name, config);
 			if (invocation.getArguments().length > 2) {
 				this.content.put(name, invocation.getArgument(2, ContainerContent.class));

--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ssl/PemFileWriter.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ssl/PemFileWriter.java
@@ -181,7 +181,7 @@ public class PemFileWriter {
 	Path writeFile(String name, String... contents) throws IOException {
 		Path path = Paths.get(this.tempDir.toString(), name);
 		for (String content : contents) {
-			Files.write(path, content.replaceAll(EXAMPLE_SECRET_QUALIFIER, "").getBytes(), StandardOpenOption.CREATE,
+			Files.write(path, content.replace(EXAMPLE_SECRET_QUALIFIER, "").getBytes(), StandardOpenOption.CREATE,
 					StandardOpenOption.APPEND);
 		}
 		return path;

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/PemCertificateParser.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/PemCertificateParser.java
@@ -92,7 +92,7 @@ final class PemCertificateParser {
 	}
 
 	private static byte[] decodeBase64(String content) {
-		byte[] bytes = content.replaceAll("\r", "").replaceAll("\n", "").getBytes();
+		byte[] bytes = content.replace("\r", "").replace("\n", "").getBytes();
 		return Base64.getDecoder().decode(bytes);
 	}
 

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/PemPrivateKeyParser.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/ssl/pem/PemPrivateKeyParser.java
@@ -240,7 +240,7 @@ final class PemPrivateKeyParser {
 		}
 
 		private static byte[] decodeBase64(String content) {
-			byte[] contentBytes = content.replaceAll("\r", "").replaceAll("\n", "").getBytes();
+			byte[] contentBytes = content.replace("\r", "").replace("\n", "").getBytes();
 			return Base64.getDecoder().decode(contentBytes);
 		}
 


### PR DESCRIPTION
It will improve performance.
