### PR TITLE
Kafka documentation refers to deprecated JSON serializer and deserializer classes

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/messaging/kafka.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/messaging/kafka.adoc
@@ -116,27 +116,27 @@ spring:
 
 This sets the common `prop.one` Kafka property to `first` (applies to producers, consumers, admins, and streams), the `prop.two` admin property to `second`, the `prop.three` consumer property to `third`, the `prop.four` producer property to `fourth` and the `prop.five` streams property to `fifth`.
 
-You can also configure the Spring Kafka javadoc:org.springframework.kafka.support.serializer.JsonDeserializer[] as follows:
+You can also configure the Spring Kafka javadoc:org.springframework.kafka.support.serializer.JacksonJsonDeserializer[] as follows:
 
 [configprops,yaml]
 ----
 spring:
   kafka:
     consumer:
-      value-deserializer: "org.springframework.kafka.support.serializer.JsonDeserializer"
+      value-deserializer: "org.springframework.kafka.support.serializer.JacksonJsonDeserializer"
       properties:
         "[spring.json.value.default.type]": "com.example.Invoice"
         "[spring.json.trusted.packages]": "com.example.main,com.example.another"
 ----
 
-Similarly, you can disable the javadoc:org.springframework.kafka.support.serializer.JsonSerializer[] default behavior of sending type information in headers:
+Similarly, you can disable the javadoc:org.springframework.kafka.support.serializer.JacksonJsonSerializer[] default behavior of sending type information in headers:
 
 [configprops,yaml]
 ----
 spring:
   kafka:
     producer:
-      value-serializer: "org.springframework.kafka.support.serializer.JsonSerializer"
+      value-serializer: "org.springframework.kafka.support.serializer.JacksonJsonSerializer"
       properties:
         "[spring.json.add.type.headers]": false
 ----


### PR DESCRIPTION
Updated the Kafka reference documentation to replace deprecated classes 
with their recommended replacements:

- `JsonSerializer` → `JacksonJsonSerializer`
- `JsonDeserializer` → `JacksonJsonDeserializer`

`JsonSerializer` and `JsonDeserializer` are deprecated in favor of the Jackson-specific variants. Using the deprecated classes requires an explicit `jackson-databind` dependency.

Ref:
- https://github.com/spring-projects/spring-kafka/blob/30d242b8ed333daf6cbe4631c73820f46b8e3639/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java#L59
- https://github.com/spring-projects/spring-kafka/blob/30d242b8ed333daf6cbe4631c73820f46b8e3639/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java#L66