### PR TITLE
Clarify that configuration property default values are not available through the Environment

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/external-config.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/external-config.adoc
@@ -790,9 +790,6 @@ TIP: To use a reserved keyword in the name of a property, such as `my.service.im
 
 NOTE: The properties that map to javadoc:org.springframework.boot.context.properties.ConfigurationProperties[format=annotation] classes available in Spring Boot, which are configured through properties files, YAML files, environment variables, and other mechanisms, are public API but the accessors (getters/setters) of the class itself are not meant to be used directly.
 
-NOTE: Default values defined in javadoc:org.springframework.boot.context.properties.ConfigurationProperties[format=annotation] classes are not reflected in the javadoc:org.springframework.core.env.Environment[].
-If your application code references the same property using javadoc:org.springframework.beans.factory.annotation.Value[format=annotation], javadoc:org.springframework.boot.autoconfigure.condition.ConditionalOnProperty[format=annotation], or its own javadoc:org.springframework.boot.context.properties.ConfigurationProperties[format=annotation] class, it will not see the default value -- only values that are actually present in the javadoc:org.springframework.core.env.Environment[] will be applied.
-
 [NOTE]
 ====
 Such arrangement relies on a default empty constructor and getters and setters are usually mandatory, since binding is through standard Java Beans property descriptors, just like in Spring MVC.
@@ -852,6 +849,18 @@ As such, it is not well-suited to configuration property injection.
 For consistency with properties of other types, if you do declare an javadoc:java.util.Optional[] property and it has no value, `null` rather than an empty javadoc:java.util.Optional[] will be bound.
 
 TIP: To use a reserved keyword in the name of a property, such as `my.service.import`, use the javadoc:org.springframework.boot.context.properties.bind.Name[format=annotation] annotation on the constructor parameter.
+
+
+
+[[features.external-config.typesafe-configuration-properties.default-values]]
+=== Default Values
+
+Default Values defined in configuration properties are not reflected in the javadoc:org.springframework.core.env.Environment[].
+In the examples above, the `enabled` property of `MyProperties` bound to `my.service` is `false` by default.
+
+However,  `my.service.enabled` is not available in the `Environment` with a value of `false` if no such property is set by the user.
+Concretely, this prevents you to use `@Value(${"my.service.enabled"})` or `my.service.enabled` as a placeholder in configuration properties without explicitly providing a default.
+If you need to query the javadoc:org.springframework.core.env.Environment[] for that property, for instance in a javadoc:org.springframework.context.annotation.Condition[] implementation, the default needs to be provided as well.
 
 
 


### PR DESCRIPTION
See gh-49654

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

  Clarify in the documentation that default values defined in                                 
  `@ConfigurationProperties` classes are not reflected in the `Environment`.                  
  This means application code using `@Value`, `@ConditionalOnProperty`,
  or its own `@ConfigurationProperties` will not see those defaults.     