### PR TITLE
Fixing slight naming confusion in BasicJsonParser.java

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
@@ -29,7 +29,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Really basic JSON parser for when you have nothing else available. Comes with some
- * limitations with respect to the JSON specification (e.g. only supports String rawSplit),
+ * limitations with respect to the JSON specification (e.g. only supports String values),
  * so users will probably prefer to have a library handle things instead (Jackson or Snake
  * YAML are supported).
  *


### PR DESCRIPTION
in parseMapInternal, inside the for loop that handles tokens from tokenize(json), there is a variable named "values" that should have a different name. Semantically, it holds the trimmed strings of the key and the value of the JSON pair,  but someone reading the code might think it only holds the value of the pair.
This pull request changes the variable name to "rawSplit", because it was built off the untrimmed String array named "split" and because after that it is seperated into variables called rawKey and rawValue.