### PR TITLE
changing ambiguous variable naming in BasicJsonParser.java

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
@@ -170,7 +170,7 @@ public class BasicJsonParser extends AbstractJsonParser {
 
 	private static final class Tracking {
 
-		private final int[] counts = new int[Tracked.rawSplit().length];
+		private final int[] counts = new int[Tracked.values().length];
 
 		boolean in(Tracked... tracked) {
 			return Arrays.stream(tracked).mapToInt(this::get).anyMatch((i) -> i > 0);


### PR DESCRIPTION
in parseMapInternal, inside the for loop that handles tokens from tokenize(json), there is a variable named "values" that should have a different name. Semantically, it holds the trimmed strings of the key and the value of the JSON pair, but someone reading the code might think it only holds the value of the pair.
This pull request changes the variable name to "rawSplit", because it was built off the untrimmed String array named "split" and because after that it is seperated into variables called rawKey and rawValue.