### PR TITLE
Upgrade to ActiveMQ 6.2.3

### DIFF
--- a/platform/spring-boot-dependencies/build.gradle
+++ b/platform/spring-boot-dependencies/build.gradle
@@ -31,11 +31,7 @@ bom {
 			]
 		}
 	}
-	library("ActiveMQ", "6.2.1") {
-		prohibit {
-			versionRange "[6.2.2]"
-			because "it contains a regression on Windows (https://github.com/apache/activemq/issues/1830)"
-		}
+	library("ActiveMQ", "6.2.3") {
 		group("org.apache.activemq") {
 			modules = [
 				"activemq-console",


### PR DESCRIPTION
Version 6.2.3 fixes the Windows regression that was discovered in version 6.2.2. 

See #49768 and https://github.com/apache/activemq/issues/1830
