### PR TITLE
Skip running checks during IntelliJ IDEA sync

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -187,4 +187,11 @@ eclipse {
 	}
 }
 
-jar.dependsOn check
+if (isRegularBuild(providers)) {
+	jar.dependsOn(check)
+}
+
+static boolean isRegularBuild(ProviderFactory providers) {
+	def isIdeSync = providers.systemProperty("idea.sync.active")
+	return !isIdeSync.isPresent()
+}


### PR DESCRIPTION
Introduce conditional logic for making the `jar` task depend on `check` in `buildSrc`. This ensures that verification tasks do not run when the `idea.sync.active` system property is present.

This prevents IntelliJ IDEA syncs from failing due to formatting issues or failing tests. A successful sync ensures developers retain full IDE functionality (like code completion and navigation) needed to easily resolve those very issues.

Checks will still run as part of regular build tasks and cause the build to fail if there are issues.