### PR TITLE
Add auto-configuration for JmsClient.Builder

### DIFF
--- a/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/autoconfigure/JmsClientConfigurations.java
+++ b/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/autoconfigure/JmsClientConfigurations.java
@@ -22,6 +22,7 @@ import io.micrometer.observation.ObservationRegistry;
 import jakarta.jms.ConnectionFactory;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
@@ -30,6 +31,7 @@ import org.springframework.boot.jms.autoconfigure.JmsProperties.DeliveryMode;
 import org.springframework.boot.jms.autoconfigure.JmsProperties.Template;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 import org.springframework.jms.core.JmsClient;
 import org.springframework.jms.core.JmsMessageOperations;
 import org.springframework.jms.core.JmsMessagingTemplate;
@@ -120,10 +122,18 @@ abstract class JmsClientConfigurations {
 	static class JmsClientConfiguration {
 
 		@Bean
+		@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 		@ConditionalOnMissingBean
 		@ConditionalOnSingleCandidate(JmsTemplate.class)
-		JmsClient jmsClient(JmsTemplate jmsTemplate) {
-			return JmsClient.create(jmsTemplate);
+		JmsClient.Builder jmsClientBuilder(JmsTemplate jmsTemplate) {
+			return JmsClient.builder(jmsTemplate);
+		}
+
+		@Bean
+		@ConditionalOnMissingBean
+		@ConditionalOnSingleCandidate(JmsClient.Builder.class)
+		JmsClient jmsClient(JmsClient.Builder jmsClientBuilder) {
+			return jmsClientBuilder.build();
 		}
 
 	}

--- a/module/spring-boot-jms/src/test/java/org/springframework/boot/jms/autoconfigure/JmsAutoConfigurationTests.java
+++ b/module/spring-boot-jms/src/test/java/org/springframework/boot/jms/autoconfigure/JmsAutoConfigurationTests.java
@@ -74,6 +74,7 @@ class JmsAutoConfigurationTests {
 		new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(JmsAutoConfiguration.class))
 			.run((context) -> assertThat(context).doesNotHaveBean(JmsTemplate.class)
 				.doesNotHaveBean(JmsMessagingTemplate.class)
+				.doesNotHaveBean(JmsClient.Builder.class)
 				.doesNotHaveBean(JmsClient.class)
 				.doesNotHaveBean(DefaultJmsListenerContainerFactoryConfigurer.class)
 				.doesNotHaveBean(SimpleJmsListenerContainerFactoryConfigurer.class)
@@ -86,6 +87,7 @@ class JmsAutoConfigurationTests {
 			ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
 			assertThat(context).hasSingleBean(JmsTemplate.class)
 				.hasSingleBean(JmsMessagingTemplate.class)
+				.hasSingleBean(JmsClient.Builder.class)
 				.hasSingleBean(JmsClient.class);
 			JmsTemplate jmsTemplate = context.getBean(JmsTemplate.class);
 			assertThat(jmsTemplate.getConnectionFactory()).isEqualTo(connectionFactory);
@@ -106,6 +108,13 @@ class JmsAutoConfigurationTests {
 		this.contextRunner.withUserConfiguration(TestConfiguration5.class)
 			.run((context) -> assertThat(context.getBean(JmsMessagingTemplate.class).getDefaultDestinationName())
 				.isEqualTo("fooBar"));
+	}
+
+	@Test
+	void testJmsClientBuilderBackOff() {
+		JmsClient.Builder userJmsClientBuilder = mock(JmsClient.Builder.class);
+		this.contextRunner.withBean("userJmsClientBuilder", JmsClient.Builder.class, () -> userJmsClientBuilder)
+			.run((context) -> assertThat(context.getBean(JmsClient.Builder.class)).isEqualTo(userJmsClientBuilder));
 	}
 
 	@Test


### PR DESCRIPTION
This commit adds auto-configuration for `JmsClient.Builder` prototype bean in order to enable reuse of preconfigured instances for further customization (for example, message conversion), similar to usages of `JsonMapper.Builder`, `RestClient.Builder` and others that follow the same pattern.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
