### PR TITLE
Detect duplicate @Name annotations in configuration properties

### DIFF
--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptorResolver.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptorResolver.java
@@ -31,7 +31,8 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
-
+import javax.tools.Diagnostic;
+import org.springframework.boot.configurationprocessor.metadata.InvalidConfigurationMetadataException;
 import org.springframework.boot.configurationprocessor.ConfigurationPropertiesSourceResolver.SourceMetadata;
 
 /**
@@ -149,9 +150,14 @@ class PropertyDescriptorResolver {
 	}
 
 	private void register(Map<String, PropertyDescriptor> candidates, PropertyDescriptor descriptor) {
-		if (!candidates.containsKey(descriptor.getName()) && isCandidate(descriptor)) {
-			candidates.put(descriptor.getName(), descriptor);
-		}
+    if (isCandidate(descriptor)) {
+        PropertyDescriptor existing = candidates.putIfAbsent(descriptor.getName(), descriptor);
+        if (existing != null) {
+            throw new InvalidConfigurationMetadataException(
+                "Multiple properties with the same name '" + descriptor.getName() + "' detected", 
+                Diagnostic.Kind.ERROR);
+        }
+    }
 	}
 
 	private boolean isCandidate(PropertyDescriptor descriptor) {

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/NameAnnotationPropertiesTests.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/NameAnnotationPropertiesTests.java
@@ -24,8 +24,10 @@ import org.springframework.boot.configurationsample.name.ConstructorParameterNam
 import org.springframework.boot.configurationsample.name.JavaBeanNameAnnotationProperties;
 import org.springframework.boot.configurationsample.name.LombokNameAnnotationProperties;
 import org.springframework.boot.configurationsample.name.RecordComponentNameAnnotationProperties;
-
+import org.springframework.boot.configurationsample.name.DuplicateNameAnnotationProperties;
 import static org.assertj.core.api.Assertions.assertThat;
+import org.springframework.core.test.tools.CompilationException;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * Metadata generation tests for using {@code @Name}.
@@ -86,5 +88,13 @@ class NameAnnotationPropertiesTests extends AbstractMetadataGenerationTests {
 				.withDefaultValue("Whether default mode is enabled.")
 				.withDefaultValue(true));
 	}
+
+	@Test
+	void duplicateNameAnnotationPropertiesShouldFailCompilation() {
+		assertThatExceptionOfType(CompilationException.class)
+			.isThrownBy(() -> compile(DuplicateNameAnnotationProperties.class))
+			.withMessageContaining("Multiple properties with the same name");
+	}
+
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/name/DuplicateNameAnnotationProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/name/DuplicateNameAnnotationProperties.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.configurationsample.name;
+
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestName;
+
+/**
+ * Java bean properties with duplicate {@code @Name} values that should fail.
+ *
+ * @author Pratap Chandra Deo
+ */
+@TestConfigurationProperties("named")
+public class DuplicateNameAnnotationProperties {
+
+	@TestName("sameName")
+	private String first;
+
+	@TestName("sameName")
+	private String second;
+
+	public String getFirst() {
+		return this.first;
+	}
+
+	public void setFirst(String first) {
+		this.first = first;
+	}
+
+	public String getSecond() {
+		return this.second;
+	}
+
+	public void setSecond(String second) {
+		this.second = second;
+	}
+
+}


### PR DESCRIPTION
This change updates `PropertyDescriptorResolver` to detect duplicate property names in `@ConfigurationProperties`, especially when multiple fields use the same `@Name` annotation.

Previously, duplicate names were silently ignored after the first occurrence, leading to incomplete metadata without any warning.

Now, the `register` method uses `putIfAbsent` and throws an `InvalidConfigurationMetadataException` when a duplicate is detected, with a clear error message.

Also adds a test case (`DuplicateNameAnnotationProperties`) to verify the expected compilation failure.

Closes #49565

Signed-off-by: Pratap Chandra Deo <pratapchandradeo@gmail.com>