### PR TITLE
Typo in JdbcSessionAutoConfiguration Javadoc

### DIFF
--- a/module/spring-boot-session-jdbc/src/main/java/org/springframework/boot/session/jdbc/autoconfigure/JdbcSessionAutoConfiguration.java
+++ b/module/spring-boot-session-jdbc/src/main/java/org/springframework/boot/session/jdbc/autoconfigure/JdbcSessionAutoConfiguration.java
@@ -47,7 +47,7 @@ import org.springframework.session.jdbc.config.annotation.SpringSessionDataSourc
 import org.springframework.session.jdbc.config.annotation.web.http.JdbcHttpSessionConfiguration;
 
 /**
- * {@link EnableAutoConfiguration Auto-configuraion} for Spring Session JDBC.
+ * {@link EnableAutoConfiguration Auto-configuration} for Spring Session JDBC.
  *
  * @author Eddú Meléndez
  * @author Stephane Nicoll


### PR DESCRIPTION
The Javadoc on `JdbcSessionAutoConfiguration` has "Auto-configuraion" instead of "Auto-configuration".