### PR TITLE
HTTP method is lost when configuring excludes in EndpointRequest

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/reactive/EndpointRequest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/reactive/EndpointRequest.java
@@ -301,17 +301,17 @@ public final class EndpointRequest {
 		public EndpointServerWebExchangeMatcher excluding(Class<?>... endpoints) {
 			List<Object> excludes = new ArrayList<>(this.excludes);
 			excludes.addAll(Arrays.asList((Object[]) endpoints));
-			return new EndpointServerWebExchangeMatcher(this.includes, excludes, this.includeLinks, null);
+			return new EndpointServerWebExchangeMatcher(this.includes, excludes, this.includeLinks, this.httpMethod);
 		}
 
 		public EndpointServerWebExchangeMatcher excluding(String... endpoints) {
 			List<Object> excludes = new ArrayList<>(this.excludes);
 			excludes.addAll(Arrays.asList((Object[]) endpoints));
-			return new EndpointServerWebExchangeMatcher(this.includes, excludes, this.includeLinks, null);
+			return new EndpointServerWebExchangeMatcher(this.includes, excludes, this.includeLinks, this.httpMethod);
 		}
 
 		public EndpointServerWebExchangeMatcher excludingLinks() {
-			return new EndpointServerWebExchangeMatcher(this.includes, this.excludes, false, null);
+			return new EndpointServerWebExchangeMatcher(this.includes, this.excludes, false, this.httpMethod);
 		}
 
 		/**

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
@@ -335,17 +335,17 @@ public final class EndpointRequest {
 		public EndpointRequestMatcher excluding(Class<?>... endpoints) {
 			List<Object> excludes = new ArrayList<>(this.excludes);
 			excludes.addAll(Arrays.asList((Object[]) endpoints));
-			return new EndpointRequestMatcher(this.includes, excludes, this.includeLinks, null);
+			return new EndpointRequestMatcher(this.includes, excludes, this.includeLinks, this.httpMethod);
 		}
 
 		public EndpointRequestMatcher excluding(String... endpoints) {
 			List<Object> excludes = new ArrayList<>(this.excludes);
 			excludes.addAll(Arrays.asList((Object[]) endpoints));
-			return new EndpointRequestMatcher(this.includes, excludes, this.includeLinks, null);
+			return new EndpointRequestMatcher(this.includes, excludes, this.includeLinks, this.httpMethod);
 		}
 
 		public EndpointRequestMatcher excludingLinks() {
-			return new EndpointRequestMatcher(this.includes, this.excludes, false, null);
+			return new EndpointRequestMatcher(this.includes, this.excludes, false, this.httpMethod);
 		}
 
 		/**

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/reactive/EndpointRequestTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/reactive/EndpointRequestTests.java
@@ -235,6 +235,33 @@ class EndpointRequestTests {
 	}
 
 	@Test
+	void toAnyEndpointWithHttpMethodExcludingShouldPreserveHttpMethod() {
+		ServerWebExchangeMatcher matcher = EndpointRequest.toAnyEndpoint()
+			.withHttpMethod(HttpMethod.POST)
+			.excluding(FooEndpoint.class)
+			.excluding("baz");
+		List<ExposableEndpoint<?>> endpoints = new ArrayList<>();
+		endpoints.add(mockEndpoint(EndpointId.of("foo"), "foo"));
+		endpoints.add(mockEndpoint(EndpointId.of("bar"), "bar"));
+		endpoints.add(mockEndpoint(EndpointId.of("baz"), "baz"));
+		PathMappedEndpoints pathMappedEndpoints = new PathMappedEndpoints("/actuator", () -> endpoints);
+		assertMatcher(matcher, pathMappedEndpoints).matches(HttpMethod.POST, "/actuator/bar");
+		assertMatcher(matcher, pathMappedEndpoints).doesNotMatch(HttpMethod.GET, "/actuator/bar");
+		assertMatcher(matcher, pathMappedEndpoints).doesNotMatch("/actuator/foo");
+		assertMatcher(matcher, pathMappedEndpoints).doesNotMatch("/actuator/baz");
+	}
+
+	@Test
+	void toAnyEndpointWithHttpMethodExcludingLinksShouldPreserveHttpMethod() {
+		ServerWebExchangeMatcher matcher = EndpointRequest.toAnyEndpoint()
+			.withHttpMethod(HttpMethod.POST)
+			.excludingLinks();
+		assertMatcher(matcher).matches(HttpMethod.POST, "/actuator/foo");
+		assertMatcher(matcher).doesNotMatch(HttpMethod.GET, "/actuator/foo");
+		assertMatcher(matcher).doesNotMatch("/actuator");
+	}
+
+	@Test
 	void noEndpointPathsBeansShouldNeverMatch() {
 		ServerWebExchangeMatcher matcher = EndpointRequest.toAnyEndpoint();
 		assertMatcher(matcher, (PathMappedEndpoints) null).doesNotMatch("/actuator/foo");

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
@@ -223,6 +223,31 @@ class EndpointRequestTests {
 	}
 
 	@Test
+	void toAnyEndpointWithHttpMethodExcludingShouldPreserveHttpMethod() {
+		RequestMatcher matcher = EndpointRequest.toAnyEndpoint()
+			.withHttpMethod(HttpMethod.POST)
+			.excluding(FooEndpoint.class)
+			.excluding("baz");
+		List<ExposableEndpoint<?>> endpoints = new ArrayList<>();
+		endpoints.add(mockEndpoint(EndpointId.of("foo"), "foo"));
+		endpoints.add(mockEndpoint(EndpointId.of("bar"), "bar"));
+		endpoints.add(mockEndpoint(EndpointId.of("baz"), "baz"));
+		PathMappedEndpoints pathMappedEndpoints = new PathMappedEndpoints("/actuator", () -> endpoints);
+		assertMatcher(matcher, pathMappedEndpoints).matches(HttpMethod.POST, "/actuator/bar");
+		assertMatcher(matcher, pathMappedEndpoints).doesNotMatch(HttpMethod.GET, "/actuator/bar");
+		assertMatcher(matcher, pathMappedEndpoints).doesNotMatch("/actuator/foo");
+		assertMatcher(matcher, pathMappedEndpoints).doesNotMatch("/actuator/baz");
+	}
+
+	@Test
+	void toAnyEndpointWithHttpMethodExcludingLinksShouldPreserveHttpMethod() {
+		RequestMatcher matcher = EndpointRequest.toAnyEndpoint().withHttpMethod(HttpMethod.POST).excludingLinks();
+		assertMatcher(matcher).matches(HttpMethod.POST, "/actuator/foo");
+		assertMatcher(matcher).doesNotMatch(HttpMethod.GET, "/actuator/foo");
+		assertMatcher(matcher).doesNotMatch("/actuator");
+	}
+
+	@Test
 	void endpointRequestMatcherShouldUseCustomRequestMatcherProvider() {
 		RequestMatcher matcher = EndpointRequest.toAnyEndpoint();
 		RequestMatcher mockRequestMatcher = (request) -> false;


### PR DESCRIPTION
`EndpointRequest.withHttpMethod(...)` restrictions are lost when `excluding(Class<?>...)`, `excluding(String...)`, or
  `excludingLinks()` are chained because each exclusion creates a new matcher without the configured method.

  This change preserves the configured `HttpMethod` in both servlet and reactive matchers and adds regression tests for
  exclusion chaining.

  Testing:
  - `./gradlew :module:spring-boot-security:test --tests
  'org.springframework.boot.security.autoconfigure.actuate.web.servlet.EndpointRequestTests' --tests
  'org.springframework.boot.security.autoconfigure.actuate.web.reactive.EndpointRequestTests'`
  - `./gradlew :module:spring-boot-security:checkFormatTest`