### PR TITLE
Add test for nested @Import handling in SpringBootTest

### DIFF
--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/NestedImportTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/NestedImportTests.java
@@ -1,0 +1,35 @@
+package org.springframework.boot.test.context;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+@Import(NestedImportTests.ConfigA.class)
+class NestedImportTests {
+
+	@Nested
+	@SpringBootTest
+	@Import(ConfigB.class)
+	class Inner extends NestedImportTests {
+
+		@Autowired(required = false)
+		ConfigA configA;
+
+		@Test
+		void shouldLoadOuterImport() {
+			assertThat(this.configA).isNotNull();
+		}
+	}
+
+	@Configuration
+	static class ConfigA {}
+
+	@Configuration
+	static class ConfigB {}
+}


### PR DESCRIPTION
Fixes #49860

This PR adds a test that demonstrates that `@Import` annotations
declared on an enclosing test class are not applied to nested
test classes.

Currently, nested test classes override configuration instead of
merging with enclosing classes, causing outer `@Import` to be ignored.

This test highlights the issue and can serve as a basis for further
discussion or fixes.