### PR TITLE
Treat invalid pattern as bad request in EnvironmentEndpoint

### DIFF
--- a/module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/env/EnvironmentEndpoint.java
+++ b/module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/env/EnvironmentEndpoint.java
@@ -23,11 +23,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.boot.actuate.endpoint.InvalidEndpointRequestException;
 import org.springframework.boot.actuate.endpoint.OperationResponseBody;
 import org.springframework.boot.actuate.endpoint.SanitizableData;
 import org.springframework.boot.actuate.endpoint.Sanitizer;
@@ -87,9 +89,19 @@ public class EnvironmentEndpoint {
 
 	EnvironmentDescriptor getEnvironmentDescriptor(@Nullable String pattern, boolean showUnsanitized) {
 		if (StringUtils.hasText(pattern)) {
-			return getEnvironmentDescriptor(Pattern.compile(pattern).asPredicate(), showUnsanitized);
+			return getEnvironmentDescriptor(getPatternPredicate(pattern), showUnsanitized);
 		}
 		return getEnvironmentDescriptor((name) -> true, showUnsanitized);
+	}
+
+	private Predicate<String> getPatternPredicate(String pattern) {
+		try {
+			return Pattern.compile(pattern).asPredicate();
+		}
+		catch (PatternSyntaxException ex) {
+			throw new InvalidEndpointRequestException("Pattern '" + pattern + "' is not a valid regular expression",
+					ex.getMessage());
+		}
 	}
 
 	private EnvironmentDescriptor getEnvironmentDescriptor(Predicate<String> propertyNamePredicate,

--- a/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/env/EnvironmentEndpointTests.java
+++ b/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/env/EnvironmentEndpointTests.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.actuate.endpoint.InvalidEndpointRequestException;
 import org.springframework.boot.actuate.endpoint.Show;
 import org.springframework.boot.actuate.env.EnvironmentEndpoint.EnvironmentDescriptor;
 import org.springframework.boot.actuate.env.EnvironmentEndpoint.EnvironmentEntryDescriptor;
@@ -50,6 +51,7 @@ import org.springframework.core.io.InputStreamSource;
 import org.springframework.mock.env.MockPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * Tests for {@link EnvironmentEndpoint}.
@@ -87,6 +89,14 @@ class EnvironmentEndpointTests {
 		PropertySourceDescriptor two = sources.get("two");
 		assertThat(two).isNotNull();
 		assertThat(two.getProperties()).containsOnlyKeys("my.key");
+	}
+
+	@Test
+	void invalidPatternThrowsInvalidEndpointRequestException() {
+		ConfigurableEnvironment environment = emptyEnvironment();
+		EnvironmentEndpoint endpoint = new EnvironmentEndpoint(environment, Collections.emptyList(), Show.ALWAYS);
+		assertThatExceptionOfType(InvalidEndpointRequestException.class).isThrownBy(() -> endpoint.environment("["))
+			.withMessageContaining("Pattern '[' is not a valid regular expression");
 	}
 
 	@Test


### PR DESCRIPTION
Closes #49884                                                                                                                                                                      
                                                                                                                                                                                     
  ## Summary                                                                                                                                                                         
                                                                                                                                                                                     
  `EnvironmentEndpoint` passes the user-supplied `pattern` directly to `Pattern.compile()` when filtering property names. An invalid regex (e.g., `GET /actuator/env?pattern=[`)     
  raises a `PatternSyntaxException` which is not translated into the actuator's standard bad-request path.
                                                                                                                                                                                     
  This PR wraps `PatternSyntaxException` in an `InvalidEndpointRequestException`, ensuring a proper 400 Bad Request response. This follows the same pattern used in                  
  `MetricsEndpoint.parseTag()` for handling invalid user input.
                                                                                                                                                                                     
  ## Changes                                                                                                                                                                         
   
  - Added `getPatternPredicate()` method that catches `PatternSyntaxException` and throws `InvalidEndpointRequestException`                                                          
  - Added test to verify invalid patterns throw `InvalidEndpointRequestException`
                                                                                                                                                                                              
