### PR TITLE
Upgrade to Pulsar 4.2.0

### DIFF
--- a/platform/spring-boot-dependencies/build.gradle
+++ b/platform/spring-boot-dependencies/build.gradle
@@ -1898,7 +1898,7 @@ bom {
 			releaseNotes("https://github.com/prometheus/client_java/releases/tag/parent-{version}")
 		}
 	}
-	library("Pulsar", "4.1.3") {
+	library("Pulsar", "4.2.0") {
 		group("org.apache.pulsar") {
 			bom("pulsar-bom")
 		}

--- a/test-support/spring-boot-docker-test-support/src/main/java/org/springframework/boot/testsupport/container/TestImage.java
+++ b/test-support/spring-boot-docker-test-support/src/main/java/org/springframework/boot/testsupport/container/TestImage.java
@@ -238,9 +238,10 @@ public enum TestImage {
 	/**
 	 * A container image suitable for testing Pulsar.
 	 */
-	PULSAR("apachepulsar/pulsar", "3.3.3", () -> PulsarContainer.class,
+	PULSAR("apachepulsar/pulsar", "4.2.0", () -> PulsarContainer.class,
 			(container) -> ((PulsarContainer) container).withStartupAttempts(2)
-				.withStartupTimeout(Duration.ofMinutes(3))),
+				.withStartupTimeout(Duration.ofMinutes(3))
+				.withEnv("PULSAR_PREFIX_advertisedAddress", "localhost")),
 
 	/**
 	 * A container image suitable for testing Pulsar using the deprecated


### PR DESCRIPTION
This commit updates the managed version of Pulsar from `4.1.3` to `4.2.0` and the test image version from `3.3.3` to `4.2.0`.

Since Pulsar `4.2.0` standalone mode advertises the container's FQDN (the container ID) instead of localhost. The Pulsar client reconnects to the advertised address during servicediscovery, but is unable to reach the FQDN. Therefore, this also sets the `advertisedAddress` on the Pulsar testcontainers used by the tests.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
