### PR TITLE
fix: upgrade handlebars to 4.7.9 (CVE-2026-33937)

### DIFF
--- a/antora/package-lock.json
+++ b/antora/package-lock.json
@@ -12,7 +12,8 @@
         "@springio/antora-extensions": "1.14.10",
         "@springio/antora-xref-extension": "1.0.0-alpha.5",
         "@springio/antora-zip-contents-collector-extension": "1.0.0-alpha.10",
-        "@springio/asciidoctor-extensions": "1.0.0-alpha.18"
+        "@springio/asciidoctor-extensions": "1.0.0-alpha.18",
+        "handlebars": "^4.7.9"
       }
     },
     "node_modules/@antora/asciidoc-loader": {
@@ -1928,9 +1929,10 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",

--- a/antora/package.json
+++ b/antora/package.json
@@ -3,14 +3,15 @@
     "antora": "node npm/antora.js"
   },
   "dependencies": {
+    "@antora/atlas-extension": "1.0.0-alpha.5",
     "@antora/cli": "3.2.0-alpha.11",
     "@antora/site-generator": "3.2.0-alpha.11",
-    "@antora/atlas-extension": "1.0.0-alpha.5",
+    "@asciidoctor/tabs": "1.0.0-beta.6",
     "@springio/antora-extensions": "1.14.10",
     "@springio/antora-xref-extension": "1.0.0-alpha.5",
     "@springio/antora-zip-contents-collector-extension": "1.0.0-alpha.10",
-    "@asciidoctor/tabs": "1.0.0-beta.6",
-    "@springio/asciidoctor-extensions": "1.0.0-alpha.18"
+    "@springio/asciidoctor-extensions": "1.0.0-alpha.18",
+    "handlebars": "^4.7.9"
   },
   "config": {
     "ui-bundle-url": "https://github.com/spring-io/antora-ui-spring/releases/download/v0.4.26/ui-bundle.zip"


### PR DESCRIPTION
## Summary
Upgrade handlebars from 4.7.8 to 4.7.9 to fix CVE-2026-33937.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-33937 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-33937` |
| **File** | `antora/package-lock.json` |

**Description**: handlebars.js: Handlebars: Remote Code Execution via crafted Abstract Syntax Tree object in compile()

## Changes
- `antora/package.json`
- `antora/package-lock.json`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
