### PR TITLE
500 response from env endpoint when supplied pattern is invalid

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/env/EnvironmentEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/env/EnvironmentEndpoint.java
@@ -89,18 +89,18 @@ public class EnvironmentEndpoint {
 
 	EnvironmentDescriptor getEnvironmentDescriptor(String pattern, boolean showUnsanitized) {
 		if (StringUtils.hasText(pattern)) {
-			return getEnvironmentDescriptor(getPatternPredicate(pattern), showUnsanitized);
+			return getEnvironmentDescriptor(parsePattern(pattern).asPredicate(), showUnsanitized);
 		}
 		return getEnvironmentDescriptor((name) -> true, showUnsanitized);
 	}
 
-	private Predicate<String> getPatternPredicate(String pattern) {
+	private Pattern parsePattern(String pattern) {
 		try {
-			return Pattern.compile(pattern).asPredicate();
+			return Pattern.compile(pattern);
 		}
 		catch (PatternSyntaxException ex) {
-			throw new InvalidEndpointRequestException("Pattern '" + pattern + "' is not a valid regular expression",
-					ex.getMessage());
+			throw new InvalidEndpointRequestException("Failed to parse regular expression: " + pattern,
+					"Invalid regular expression", ex);
 		}
 	}
 

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/env/EnvironmentEndpointTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/env/EnvironmentEndpointTests.java
@@ -23,6 +23,7 @@ import java.math.BigInteger;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.PatternSyntaxException;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -72,14 +73,6 @@ class EnvironmentEndpointTests {
 	}
 
 	@Test
-	void invalidPatternThrowsInvalidEndpointRequestException() {
-		ConfigurableEnvironment environment = emptyEnvironment();
-		EnvironmentEndpoint endpoint = new EnvironmentEndpoint(environment, Collections.emptyList(), Show.ALWAYS);
-		assertThatExceptionOfType(InvalidEndpointRequestException.class).isThrownBy(() -> endpoint.environment("["))
-			.withMessageContaining("Pattern '[' is not a valid regular expression");
-	}
-
-	@Test
 	void basicResponse() {
 		ConfigurableEnvironment environment = emptyEnvironment();
 		environment.getPropertySources().addLast(singleKeyPropertySource("one", "my.key", "first"));
@@ -124,6 +117,15 @@ class EnvironmentEndpointTests {
 			assertThat(systemProperties.get("system.service").getValue()).isEqualTo("123456");
 			return null;
 		});
+	}
+
+	@Test
+	void responseWhenPatternIsInvalidThrowsInvalidEndpointRequestException() {
+		ConfigurableEnvironment environment = emptyEnvironment();
+		EnvironmentEndpoint endpoint = new EnvironmentEndpoint(environment, Collections.emptyList(), Show.ALWAYS);
+		assertThatExceptionOfType(InvalidEndpointRequestException.class).isThrownBy(() -> endpoint.environment("["))
+			.withMessageContaining("Failed to parse regular expression: [")
+			.withCauseInstanceOf(PatternSyntaxException.class);
 	}
 
 	@Test


### PR DESCRIPTION
`EnvironmentEndpoint` passes the user-supplied pattern directly to
`Pattern.compile(...)`. An invalid regex throws `PatternSyntaxException`
which is not handled by the actuator web layer, resulting in a `500`
response instead of `400`.

Wrap `PatternSyntaxException` in `InvalidEndpointRequestException` so
that the standard actuator bad-request path is used.

Closes gh-49884
