### PR TITLE
WebFlux Cloud Foundry links endpoint includes query string from received request in resolved links

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/CloudFoundryWebFluxEndpointHandlerMapping.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/CloudFoundryWebFluxEndpointHandlerMapping.java
@@ -49,6 +49,7 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.reactive.result.method.RequestMappingInfoHandlerMapping;
 import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * A custom {@link RequestMappingInfoHandlerMapping} that makes web endpoints available on
@@ -110,8 +111,9 @@ class CloudFoundryWebFluxEndpointHandlerMapping extends AbstractWebFluxEndpointH
 						return new ResponseEntity<>(securityResponse.getStatus());
 					}
 					AccessLevel accessLevel = exchange.getAttribute(AccessLevel.REQUEST_ATTRIBUTE);
+					String requestUri = UriComponentsBuilder.fromUri(request.getURI()).replaceQuery(null).toUriString();
 					Map<String, Link> links = CloudFoundryWebFluxEndpointHandlerMapping.this.linksResolver
-						.resolveLinks(request.getURI().toString());
+						.resolveLinks(requestUri);
 					return new ResponseEntity<>(
 							Collections.singletonMap("_links", getAccessibleLinks(accessLevel, links)), HttpStatus.OK);
 				});

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/CloudFoundryWebFluxEndpointIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/CloudFoundryWebFluxEndpointIntegrationTests.java
@@ -146,45 +146,25 @@ class CloudFoundryWebFluxEndpointIntegrationTests {
 			.jsonPath("_links.length()")
 			.isEqualTo(5)
 			.jsonPath("_links.self.href")
-			.isNotEmpty()
+			.value(isLinkTo("/cfApplication"))
 			.jsonPath("_links.self.templated")
 			.isEqualTo(false)
 			.jsonPath("_links.info.href")
-			.isNotEmpty()
+			.value(isLinkTo("/cfApplication/info"))
 			.jsonPath("_links.info.templated")
 			.isEqualTo(false)
 			.jsonPath("_links.env.href")
-			.isNotEmpty()
+			.value(isLinkTo("/cfApplication/env"))
 			.jsonPath("_links.env.templated")
 			.isEqualTo(false)
 			.jsonPath("_links.test.href")
-			.isNotEmpty()
+			.value(isLinkTo("/cfApplication/test"))
 			.jsonPath("_links.test.templated")
 			.isEqualTo(false)
 			.jsonPath("_links.test-part.href")
-			.isNotEmpty()
+			.value(isLinkTo("/cfApplication/test/{part}"))
 			.jsonPath("_links.test-part.templated")
 			.isEqualTo(true)));
-	}
-
-	@Test
-	void linksToOtherEndpointsWithQueryStringShouldNotContainQueryInHref() {
-		given(this.tokenValidator.validate(any())).willReturn(Mono.empty());
-		given(this.securityService.getAccessLevel(any(), eq("app-id"))).willReturn(Mono.just(AccessLevel.FULL));
-		this.contextRunner.run(withWebTestClient((client) -> client.get()
-			.uri("/cfApplication?x=1")
-			.accept(MediaType.APPLICATION_JSON)
-			.header("Authorization", "bearer " + mockAccessToken())
-			.exchange()
-			.expectStatus()
-			.isOk()
-			.expectBody()
-			.jsonPath("_links.self.href")
-			.value((href) -> assertThat((String) href).doesNotContain("?").endsWith("/cfApplication"))
-			.jsonPath("_links.info.href")
-			.value((href) -> assertThat((String) href).doesNotContain("?").endsWith("/cfApplication/info"))
-			.jsonPath("_links.env.href")
-			.value((href) -> assertThat((String) href).doesNotContain("?").endsWith("/cfApplication/env"))));
 	}
 
 	@Test
@@ -216,11 +196,11 @@ class CloudFoundryWebFluxEndpointIntegrationTests {
 			.jsonPath("_links.length()")
 			.isEqualTo(2)
 			.jsonPath("_links.self.href")
-			.isNotEmpty()
+			.value(isLinkTo("/cfApplication"))
 			.jsonPath("_links.self.templated")
 			.isEqualTo(false)
 			.jsonPath("_links.info.href")
-			.isNotEmpty()
+			.value(isLinkTo("/cfApplication/info"))
 			.jsonPath("_links.info.templated")
 			.isEqualTo(false)
 			.jsonPath("_links.env")
@@ -232,9 +212,31 @@ class CloudFoundryWebFluxEndpointIntegrationTests {
 	}
 
 	@Test
+	void whenRequestHasAQueryStringLinksToOtherEndpointsDoNotHaveAQueryString() {
+		given(this.tokenValidator.validate(any())).willReturn(Mono.empty());
+		given(this.securityService.getAccessLevel(any(), eq("app-id"))).willReturn(Mono.just(AccessLevel.RESTRICTED));
+		this.contextRunner.run(withWebTestClient((client) -> client.get()
+			.uri("/cfApplication?x=1")
+			.accept(MediaType.APPLICATION_JSON)
+			.header("Authorization", "bearer " + mockAccessToken())
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody()
+			.jsonPath("_links.self.href")
+			.value(isLinkTo("/cfApplication"))
+			.jsonPath("_links.info.href")
+			.value(isLinkTo("/cfApplication/info"))));
+	}
+
+	@Test
 	void unknownEndpointsAreForbidden() {
 		this.contextRunner.run(withWebTestClient(
 				(client) -> client.get().uri("/cfApplication/unknown").exchange().expectStatus().isForbidden()));
+	}
+
+	private Consumer<Object> isLinkTo(String target) {
+		return (href) -> assertThat(href).asString().doesNotContain("?").endsWith(target);
 	}
 
 	private ContextConsumer<AssertableReactiveWebApplicationContext> withWebTestClient(

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/CloudFoundryWebFluxEndpointIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/reactive/CloudFoundryWebFluxEndpointIntegrationTests.java
@@ -61,6 +61,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.cors.CorsConfiguration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -164,6 +165,26 @@ class CloudFoundryWebFluxEndpointIntegrationTests {
 			.isNotEmpty()
 			.jsonPath("_links.test-part.templated")
 			.isEqualTo(true)));
+	}
+
+	@Test
+	void linksToOtherEndpointsWithQueryStringShouldNotContainQueryInHref() {
+		given(this.tokenValidator.validate(any())).willReturn(Mono.empty());
+		given(this.securityService.getAccessLevel(any(), eq("app-id"))).willReturn(Mono.just(AccessLevel.FULL));
+		this.contextRunner.run(withWebTestClient((client) -> client.get()
+			.uri("/cfApplication?x=1")
+			.accept(MediaType.APPLICATION_JSON)
+			.header("Authorization", "bearer " + mockAccessToken())
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody()
+			.jsonPath("_links.self.href")
+			.value((href) -> assertThat((String) href).doesNotContain("?").endsWith("/cfApplication"))
+			.jsonPath("_links.info.href")
+			.value((href) -> assertThat((String) href).doesNotContain("?").endsWith("/cfApplication/info"))
+			.jsonPath("_links.env.href")
+			.value((href) -> assertThat((String) href).doesNotContain("?").endsWith("/cfApplication/env"))));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundryMvcWebEndpointIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundryMvcWebEndpointIntegrationTests.java
@@ -58,6 +58,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -133,23 +134,23 @@ class CloudFoundryMvcWebEndpointIntegrationTests {
 					.jsonPath("_links.length()")
 					.isEqualTo(5)
 					.jsonPath("_links.self.href")
-					.isNotEmpty()
+					.value(isLinkTo("/cfApplication"))
 					.jsonPath("_links.self.templated")
 					.isEqualTo(false)
 					.jsonPath("_links.info.href")
-					.isNotEmpty()
+					.value(isLinkTo("/cfApplication/info"))
 					.jsonPath("_links.info.templated")
 					.isEqualTo(false)
 					.jsonPath("_links.env.href")
-					.isNotEmpty()
+					.value(isLinkTo("/cfApplication/env"))
 					.jsonPath("_links.env.templated")
 					.isEqualTo(false)
 					.jsonPath("_links.test.href")
-					.isNotEmpty()
+					.value(isLinkTo("/cfApplication/test"))
 					.jsonPath("_links.test.templated")
 					.isEqualTo(false)
 					.jsonPath("_links.test-part.href")
-					.isNotEmpty()
+					.value(isLinkTo("/cfApplication/test/{part}"))
 					.jsonPath("_links.test-part.templated")
 					.isEqualTo(true));
 	}
@@ -184,11 +185,11 @@ class CloudFoundryMvcWebEndpointIntegrationTests {
 					.jsonPath("_links.length()")
 					.isEqualTo(2)
 					.jsonPath("_links.self.href")
-					.isNotEmpty()
+					.value(isLinkTo("/cfApplication"))
 					.jsonPath("_links.self.templated")
 					.isEqualTo(false)
 					.jsonPath("_links.info.href")
-					.isNotEmpty()
+					.value(isLinkTo("/cfApplication/info"))
 					.jsonPath("_links.info.templated")
 					.isEqualTo(false)
 					.jsonPath("_links.env")
@@ -200,6 +201,24 @@ class CloudFoundryMvcWebEndpointIntegrationTests {
 	}
 
 	@Test
+	void whenRequestHasAQueryStringLinksToOtherEndpointsDoNotHaveAQueryString() {
+		given(this.securityService.getAccessLevel(any(), eq("app-id"))).willReturn(AccessLevel.RESTRICTED);
+		load(TestEndpointConfiguration.class,
+				(client) -> client.get()
+					.uri("/cfApplication?x=1")
+					.accept(MediaType.APPLICATION_JSON)
+					.header("Authorization", "bearer " + mockAccessToken())
+					.exchange()
+					.expectStatus()
+					.isOk()
+					.expectBody()
+					.jsonPath("_links.self.href")
+					.value(isLinkTo("/cfApplication"))
+					.jsonPath("_links.info.href")
+					.value(isLinkTo("/cfApplication/info")));
+	}
+
+	@Test
 	void unknownEndpointsAreForbidden() {
 		load(TestEndpointConfiguration.class,
 				(client) -> client.get()
@@ -208,6 +227,10 @@ class CloudFoundryMvcWebEndpointIntegrationTests {
 					.exchange()
 					.expectStatus()
 					.isForbidden());
+	}
+
+	private Consumer<Object> isLinkTo(String target) {
+		return (href) -> assertThat(href).asString().doesNotContain("?").endsWith(target);
 	}
 
 	private void load(Class<?> configuration, Consumer<WebTestClient> clientConsumer) {

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/annotation/AbstractWebEndpointIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/annotation/AbstractWebEndpointIntegrationTests.java
@@ -162,15 +162,40 @@ public abstract class AbstractWebEndpointIntegrationTests<T extends Configurable
 					.jsonPath("_links.length()")
 					.isEqualTo(3)
 					.jsonPath("_links.self.href")
-					.isNotEmpty()
+					.value(isLinkTo("/endpoints"))
 					.jsonPath("_links.self.templated")
 					.isEqualTo(false)
 					.jsonPath("_links.test.href")
-					.isNotEmpty()
+					.value(isLinkTo("/endpoints/test"))
 					.jsonPath("_links.test.templated")
 					.isEqualTo(false)
 					.jsonPath("_links.test-part.href")
-					.isNotEmpty()
+					.value(isLinkTo("/endpoints/test/{part}"))
+					.jsonPath("_links.test-part.templated")
+					.isEqualTo(true));
+	}
+
+	@Test
+	void whenRequestHasAQueryStringLinksToOtherEndpointsDoNotHaveAQueryString() {
+		load(TestEndpointConfiguration.class,
+				(client) -> client.get()
+					.uri("?a=alpha")
+					.exchange()
+					.expectStatus()
+					.isOk()
+					.expectBody()
+					.jsonPath("_links.length()")
+					.isEqualTo(3)
+					.jsonPath("_links.self.href")
+					.value(isLinkTo("/endpoints"))
+					.jsonPath("_links.self.templated")
+					.isEqualTo(false)
+					.jsonPath("_links.test.href")
+					.value(isLinkTo("/endpoints/test"))
+					.jsonPath("_links.test.templated")
+					.isEqualTo(false)
+					.jsonPath("_links.test-part.href")
+					.value(isLinkTo("/endpoints/test/{part}"))
 					.jsonPath("_links.test-part.templated")
 					.isEqualTo(true));
 	}
@@ -666,6 +691,10 @@ public abstract class AbstractWebEndpointIntegrationTests<T extends Configurable
 	void endpointCanProduceAResponseWithACustomStatus() {
 		load((context) -> context.register(CustomResponseStatusEndpointConfiguration.class),
 				(client) -> client.get().uri("/customstatus").exchange().expectStatus().isEqualTo(234));
+	}
+
+	private Consumer<Object> isLinkTo(String target) {
+		return (href) -> assertThat(href).asString().doesNotContain("?").endsWith(target);
 	}
 
 	protected abstract int getPort(T context);


### PR DESCRIPTION
## Summary

- `CloudFoundryLinksHandler#links` includes the request query string when resolving endpoint links
- This causes generated link hrefs to contain the query (for example, `/cfApplication?x=1/info` instead of `/cfApplication/info`)
- The standard WebFlux sibling uses `UriComponentsBuilder.fromUri(...).replaceQuery(null)` to strip the query, and the Cloud Foundry servlet sibling uses `getRequestURL()` which excludes the query by Servlet spec
- Applied the same `replaceQuery(null)` pattern and added a regression test verifying `self`, `info`, and `env` link hrefs remain query-free

## Test plan

- [x] `CloudFoundryWebFluxEndpointIntegrationTests` passes (including new `linksToOtherEndpointsWithQueryStringShouldNotContainQueryInHref`)
- [x] `checkFormatMain` and `checkFormatTest` pass