### PR TITLE
Incorrect default value for management.httpexchanges.recording.include in configuration metadata

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -264,9 +264,9 @@
     {
       "name": "management.httpexchanges.recording.include",
       "defaultValue": [
+        "time-taken",
         "request-headers",
-        "response-headers",
-        "errors"
+        "response-headers"
       ]
     },
     {


### PR DESCRIPTION
## Description
The configuration metadata for `management.httpexchanges.recording.include` was inconsistent with the actual default values in the code. 

### Changes:
- Removed `errors` from `defaultValue` (not present in `Include` enum).
- Added `time-taken` to `defaultValue` (defined in `Include.defaultIncludes()`).
- Aligned metadata with `org.springframework.boot.actuate.web.exchanges.Include`.

Fixes #49952
