### PR TITLE
EnversRevisionRepositoriesRegistrar should reuse @EnableEnversRepositories rather than configuring the JPA counterpart

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jpa/EnversRevisionRepositoriesRegistrar.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/jpa/EnversRevisionRepositoriesRegistrar.java
@@ -17,8 +17,7 @@
 package org.springframework.boot.autoconfigure.data.jpa;
 
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
-import org.springframework.data.envers.repository.support.EnversRevisionRepositoryFactoryBean;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.envers.repository.config.EnableEnversRepositories;
 
 /**
  * {@link ImportBeanDefinitionRegistrar} used to auto-configure Spring Data Envers
@@ -30,11 +29,11 @@ class EnversRevisionRepositoriesRegistrar extends JpaRepositoriesRegistrar {
 
 	@Override
 	protected Class<?> getConfiguration() {
-		return EnableJpaRepositoriesConfiguration.class;
+		return EnableEnversRepositoriesConfiguration.class;
 	}
 
-	@EnableJpaRepositories(repositoryFactoryBeanClass = EnversRevisionRepositoryFactoryBean.class)
-	private static final class EnableJpaRepositoriesConfiguration {
+	@EnableEnversRepositories
+	private static final class EnableEnversRepositoriesConfiguration {
 
 	}
 


### PR DESCRIPTION
This is a small follow-up to #22610, as in that PR I somehow missed using `@EnableEnversRepositories` also in the registrar... 🙃