### PR TITLE
Streamline references to BindMethod

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBean.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBean.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.boot.context.properties.bind.BindConstructorProvider;
+import org.springframework.boot.context.properties.bind.BindMethod;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.ApplicationContext;
@@ -57,12 +58,6 @@ import org.springframework.validation.annotation.Validated;
  * @see #get(ApplicationContext, Object, String)
  */
 public final class ConfigurationPropertiesBean {
-
-	private static final org.springframework.boot.context.properties.bind.BindMethod JAVA_BEAN_BIND_METHOD = //
-			org.springframework.boot.context.properties.bind.BindMethod.JAVA_BEAN;
-
-	private static final org.springframework.boot.context.properties.bind.BindMethod VALUE_OBJECT_BIND_METHOD = //
-			org.springframework.boot.context.properties.bind.BindMethod.VALUE_OBJECT;
 
 	private final String name;
 
@@ -201,9 +196,9 @@ public final class ConfigurationPropertiesBean {
 		}
 		bindTarget = bindTarget.withBindMethod(BindMethodAttribute.get(applicationContext, beanName));
 		if (bindTarget.getBindMethod() == null && factoryMethod != null) {
-			bindTarget = bindTarget.withBindMethod(JAVA_BEAN_BIND_METHOD);
+			bindTarget = bindTarget.withBindMethod(BindMethod.JAVA_BEAN);
 		}
-		if (bindTarget.getBindMethod() != VALUE_OBJECT_BIND_METHOD) {
+		if (bindTarget.getBindMethod() != BindMethod.VALUE_OBJECT) {
 			bindTarget = bindTarget.withExistingValue(bean);
 		}
 		return create(beanName, bean, bindTarget);
@@ -232,9 +227,9 @@ public final class ConfigurationPropertiesBean {
 
 	static ConfigurationPropertiesBean forValueObject(Class<?> beanType, String beanName) {
 		Bindable<Object> bindTarget = createBindTarget(null, beanType, null);
-		Assert.state(bindTarget != null && deduceBindMethod(bindTarget) == VALUE_OBJECT_BIND_METHOD,
+		Assert.state(bindTarget != null && deduceBindMethod(bindTarget) == BindMethod.VALUE_OBJECT,
 				() -> "Bean '" + beanName + "' is not a @ConfigurationProperties value object");
-		return create(beanName, null, bindTarget.withBindMethod(VALUE_OBJECT_BIND_METHOD));
+		return create(beanName, null, bindTarget.withBindMethod(BindMethod.VALUE_OBJECT));
 	}
 
 	private static Bindable<Object> createBindTarget(Object bean, Class<?> beanType, Method factoryMethod) {
@@ -284,7 +279,7 @@ public final class ConfigurationPropertiesBean {
 	 * @param type the source type
 	 * @return the bind method to use
 	 */
-	static org.springframework.boot.context.properties.bind.BindMethod deduceBindMethod(Class<?> type) {
+	static BindMethod deduceBindMethod(Class<?> type) {
 		return deduceBindMethod(BindConstructorProvider.DEFAULT.getBindConstructor(type, false));
 	}
 
@@ -293,13 +288,12 @@ public final class ConfigurationPropertiesBean {
 	 * @param bindable the source bindable
 	 * @return the bind method to use
 	 */
-	static org.springframework.boot.context.properties.bind.BindMethod deduceBindMethod(Bindable<Object> bindable) {
+	static BindMethod deduceBindMethod(Bindable<Object> bindable) {
 		return deduceBindMethod(BindConstructorProvider.DEFAULT.getBindConstructor(bindable, false));
 	}
 
-	private static org.springframework.boot.context.properties.bind.BindMethod deduceBindMethod(
-			Constructor<?> bindConstructor) {
-		return (bindConstructor != null) ? VALUE_OBJECT_BIND_METHOD : JAVA_BEAN_BIND_METHOD;
+	private static BindMethod deduceBindMethod(Constructor<?> bindConstructor) {
+		return (bindConstructor != null) ? BindMethod.VALUE_OBJECT : BindMethod.JAVA_BEAN;
 	}
 
 }


### PR DESCRIPTION
Previously, bind methods were represented as scattered constants. This PR centralizes and refactors these occurrences to use the BindMethod enum. This refactoring streamlines the internal API for property binding and provides a more robust way to manage different binding strategies within the org.springframework.boot.context.properties package.