### PR TITLE
Module spring-boot-resttestclient is missing from spring-boot-starter-test-classic

### DIFF
--- a/module/spring-boot-test-classic-modules/build.gradle
+++ b/module/spring-boot-test-classic-modules/build.gradle
@@ -85,6 +85,9 @@ dependencies {
 	api(project(":module:spring-boot-restclient-test")) {
 		transitive = false
 	}
+	api(project(":module:spring-boot-resttestclient")) {
+		transitive = false
+	}
 	api(project(":module:spring-boot-rsocket-test")) {
 		transitive = false
 	}


### PR DESCRIPTION
Fixes #

Adds `spring-boot-resttestclient` to` spring-boot-test-classic-modules`.

`spring-boot-starter-test-classic` depends on `spring-boot-test-classic-modules`, but the missing `spring-boot-resttestclient` module meant that TestRestTemplate was no longer available when using the starter in 4.0.x.

This change restores the expected dependency so that upgrading from` 3.5.x` to` 4.0.x` is smoother and TestRestTemplate remains available when using spring-boot-starter-test-classic.

Closes #50006 