### PR TITLE
Add support for configuration-file-format option in spring init

### DIFF
--- a/cli/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/InitCommand.java
+++ b/cli/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/InitCommand.java
@@ -87,6 +87,7 @@ public class InitCommand extends OptionParsingCommand {
 			options.put("--packageName", "--package-name");
 			options.put("--javaVersion", "--java-version");
 			options.put("--bootVersion", "--boot-version");
+			options.put("--configurationFileFormat", "--configuration-file-format");
 			CAMEL_CASE_OPTIONS = Collections.unmodifiableMap(options);
 		}
 
@@ -140,6 +141,9 @@ public class InitCommand extends OptionParsingCommand {
 		private OptionSpec<String> bootVersion;
 
 		@SuppressWarnings("NullAway.Init")
+		private OptionSpec<String> configurationFileFormat;
+
+		@SuppressWarnings("NullAway.Init")
 		private OptionSpec<String> dependencies;
 
 		@SuppressWarnings("NullAway.Init")
@@ -157,7 +161,7 @@ public class InitCommand extends OptionParsingCommand {
 		@Override
 		protected void options() {
 			this.target = option(Arrays.asList("target"), "URL of the service to use").withRequiredArg()
-				.defaultsTo(ProjectGenerationRequest.DEFAULT_SERVICE_URL);
+					.defaultsTo(ProjectGenerationRequest.DEFAULT_SERVICE_URL);
 			this.listCapabilities = option(Arrays.asList("list"),
 					"List the capabilities of the service. Use it to discover the "
 							+ "dependencies and the types that are available");
@@ -167,37 +171,40 @@ public class InitCommand extends OptionParsingCommand {
 
 		private void projectGenerationOptions() {
 			this.groupId = option(Arrays.asList("group-id", "g"), "Project coordinates (for example 'org.test')")
-				.withRequiredArg();
+					.withRequiredArg();
 			this.artifactId = option(Arrays.asList("artifact-id", "a"),
 					"Project coordinates; infer archive name (for example 'test')")
-				.withRequiredArg();
+					.withRequiredArg();
 			this.version = option(Arrays.asList("version", "v"), "Project version (for example '0.0.1-SNAPSHOT')")
-				.withRequiredArg();
+					.withRequiredArg();
 			this.name = option(Arrays.asList("name", "n"), "Project name; infer application name").withRequiredArg();
 			this.description = option("description", "Project description").withRequiredArg();
 			this.packageName = option(Arrays.asList("package-name"), "Package name").withRequiredArg();
 			this.type = option(Arrays.asList("type", "t"),
 					"Project type. Not normally needed if you use --build "
 							+ "and/or --format. Check the capabilities of the service (--list) for more details")
-				.withRequiredArg();
+					.withRequiredArg();
 			this.packaging = option(Arrays.asList("packaging", "p"), "Project packaging (for example 'jar')")
-				.withRequiredArg();
+					.withRequiredArg();
 			this.build = option("build", "Build system to use (for example 'maven' or 'gradle')").withRequiredArg()
-				.defaultsTo("gradle");
+					.defaultsTo("gradle");
 			this.format = option("format", "Format of the generated content (for example 'build' for a build file, "
 					+ "'project' for a project archive)")
-				.withRequiredArg()
-				.defaultsTo("project");
+					.withRequiredArg()
+					.defaultsTo("project");
 			this.javaVersion = option(Arrays.asList("java-version", "j"), "Language level (for example '1.8')")
-				.withRequiredArg();
+					.withRequiredArg();
 			this.language = option(Arrays.asList("language", "l"), "Programming language  (for example 'java')")
-				.withRequiredArg();
+					.withRequiredArg();
 			this.bootVersion = option(Arrays.asList("boot-version", "b"),
 					"Spring Boot version (for example '1.2.0.RELEASE')")
-				.withRequiredArg();
+					.withRequiredArg();
 			this.dependencies = option(Arrays.asList("dependencies", "d"),
 					"Comma-separated list of dependency identifiers to include in the generated project")
-				.withRequiredArg();
+					.withRequiredArg();
+			this.configurationFileFormat = option(Arrays.asList("configuration-file-format"),
+					"Configuration file format (for example 'properties' or 'yaml')")
+					.withRequiredArg();
 		}
 
 		private void otherOptions() {
@@ -281,6 +288,9 @@ public class InitCommand extends OptionParsingCommand {
 			}
 			if (options.has(this.description)) {
 				request.setDescription(options.valueOf(this.description));
+			}
+			if (options.has(this.configurationFileFormat)) {
+				request.setConfigurationFileFormat(options.valueOf(this.configurationFileFormat));
 			}
 			request.setExtract(options.has(this.extract));
 			if (nonOptionArguments.size() == 1) {

--- a/cli/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/ProjectGenerationRequest.java
+++ b/cli/spring-boot-cli/src/main/java/org/springframework/boot/cli/command/init/ProjectGenerationRequest.java
@@ -72,6 +72,8 @@ class ProjectGenerationRequest {
 
 	private @Nullable String bootVersion;
 
+	private @Nullable String configurationFileFormat;
+
 	private final List<String> dependencies = new ArrayList<>();
 
 	/**
@@ -290,6 +292,19 @@ class ProjectGenerationRequest {
 	}
 
 	/**
+	 * The configuration file format to use or {@code null} if it should not be customized.
+	 * @return the configuration file format or {@code null}
+	 */
+	@Nullable String getConfigurationFileFormat() {
+		return this.configurationFileFormat;
+	}
+
+	void setConfigurationFileFormat(@Nullable String configurationFileFormat) {
+		this.configurationFileFormat = configurationFileFormat;
+	}
+
+
+	/**
 	 * The identifiers of the dependencies to include in the project.
 	 * @return the dependency identifiers
 	 */
@@ -352,6 +367,9 @@ class ProjectGenerationRequest {
 			}
 			if (this.bootVersion != null) {
 				builder.setParameter("bootVersion", this.bootVersion);
+			}
+			if (this.configurationFileFormat != null) {
+				builder.setParameter("configurationFileFormat", this.configurationFileFormat);
 			}
 
 			return builder.build();

--- a/cli/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/init/InitCommandTests.java
+++ b/cli/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/init/InitCommandTests.java
@@ -409,8 +409,28 @@ class InitCommandTests extends AbstractHttpClientMockTests {
 	void userAgent() throws Exception {
 		this.command.run("--list", "--target=https://fake-service");
 		then(this.http).should()
-			.executeOpen(any(HttpHost.class), assertArg((request) -> assertThat(
-					request.getHeaders("User-Agent")[0].getValue().startsWith("SpringBootCli/"))), isNull());
+				.executeOpen(any(HttpHost.class), assertArg((request) -> assertThat(
+						request.getHeaders("User-Agent")[0].getValue().startsWith("SpringBootCli/"))), isNull());
+	}
+
+	@Test
+	void parseConfigurationFileFormatOption() throws Exception {
+		this.handler.disableProjectGeneration();
+
+		this.command.run("--configuration-file-format=yaml");
+
+		assertThat(this.handler.lastRequest).isNotNull();
+		assertThat(this.handler.lastRequest.getConfigurationFileFormat()).isEqualTo("yaml");
+	}
+
+	@Test
+	void parseConfigurationFileFormatCamelCaseOption() throws Exception {
+		this.handler.disableProjectGeneration();
+
+		this.command.run("--configurationFileFormat=yaml");
+
+		assertThat(this.handler.lastRequest).isNotNull();
+		assertThat(this.handler.lastRequest.getConfigurationFileFormat()).isEqualTo("yaml");
 	}
 
 	private void withUserDir(File userDir, ThrowingRunnable action) throws Exception {

--- a/cli/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/init/ProjectGenerationRequestTests.java
+++ b/cli/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/init/ProjectGenerationRequestTests.java
@@ -58,21 +58,21 @@ class ProjectGenerationRequestTests {
 		this.request.setServiceUrl(customServerUrl);
 		this.request.getDependencies().add("security");
 		assertThat(this.request.generateUrl(createDefaultMetadata()))
-			.isEqualTo(new URI(customServerUrl + "/starter.zip?dependencies=security&type=test-type"));
+				.isEqualTo(new URI(customServerUrl + "/starter.zip?dependencies=security&type=test-type"));
 	}
 
 	@Test
 	void customBootVersion() {
 		this.request.setBootVersion("1.2.0.RELEASE");
 		assertThat(this.request.generateUrl(createDefaultMetadata()))
-			.isEqualTo(createDefaultUrl("?type=test-type&bootVersion=1.2.0.RELEASE"));
+				.isEqualTo(createDefaultUrl("?type=test-type&bootVersion=1.2.0.RELEASE"));
 	}
 
 	@Test
 	void singleDependency() {
 		this.request.getDependencies().add("web");
 		assertThat(this.request.generateUrl(createDefaultMetadata()))
-			.isEqualTo(createDefaultUrl("?dependencies=web&type=test-type"));
+				.isEqualTo(createDefaultUrl("?dependencies=web&type=test-type"));
 	}
 
 	@Test
@@ -80,21 +80,21 @@ class ProjectGenerationRequestTests {
 		this.request.getDependencies().add("web");
 		this.request.getDependencies().add("data-jpa");
 		assertThat(this.request.generateUrl(createDefaultMetadata()))
-			.isEqualTo(createDefaultUrl("?dependencies=web%2Cdata-jpa&type=test-type"));
+				.isEqualTo(createDefaultUrl("?dependencies=web%2Cdata-jpa&type=test-type"));
 	}
 
 	@Test
 	void customJavaVersion() {
 		this.request.setJavaVersion("1.8");
 		assertThat(this.request.generateUrl(createDefaultMetadata()))
-			.isEqualTo(createDefaultUrl("?type=test-type&javaVersion=1.8"));
+				.isEqualTo(createDefaultUrl("?type=test-type&javaVersion=1.8"));
 	}
 
 	@Test
 	void customPackageName() {
 		this.request.setPackageName("demo.foo");
 		assertThat(this.request.generateUrl(createDefaultMetadata()))
-			.isEqualTo(createDefaultUrl("?packageName=demo.foo&type=test-type"));
+				.isEqualTo(createDefaultUrl("?packageName=demo.foo&type=test-type"));
 	}
 
 	@Test
@@ -111,14 +111,14 @@ class ProjectGenerationRequestTests {
 	void customPackaging() {
 		this.request.setPackaging("war");
 		assertThat(this.request.generateUrl(createDefaultMetadata()))
-			.isEqualTo(createDefaultUrl("?type=test-type&packaging=war"));
+				.isEqualTo(createDefaultUrl("?type=test-type&packaging=war"));
 	}
 
 	@Test
 	void customLanguage() {
 		this.request.setLanguage("groovy");
 		assertThat(this.request.generateUrl(createDefaultMetadata()))
-			.isEqualTo(createDefaultUrl("?type=test-type&language=groovy"));
+				.isEqualTo(createDefaultUrl("?type=test-type&language=groovy"));
 	}
 
 	@Test
@@ -128,29 +128,29 @@ class ProjectGenerationRequestTests {
 		this.request.setVersion("1.0.1-SNAPSHOT");
 		this.request.setDescription("Spring Boot Test");
 		assertThat(this.request.generateUrl(createDefaultMetadata()))
-			.isEqualTo(createDefaultUrl("?groupId=org.acme&artifactId=sample&version=1.0.1-SNAPSHOT"
-					+ "&description=Spring%20Boot%20Test&type=test-type"));
+				.isEqualTo(createDefaultUrl("?groupId=org.acme&artifactId=sample&version=1.0.1-SNAPSHOT"
+						+ "&description=Spring%20Boot%20Test&type=test-type"));
 	}
 
 	@Test
 	void outputCustomizeArtifactId() {
 		this.request.setOutput("my-project");
 		assertThat(this.request.generateUrl(createDefaultMetadata()))
-			.isEqualTo(createDefaultUrl("?artifactId=my-project&type=test-type"));
+				.isEqualTo(createDefaultUrl("?artifactId=my-project&type=test-type"));
 	}
 
 	@Test
 	void outputArchiveCustomizeArtifactId() {
 		this.request.setOutput("my-project.zip");
 		assertThat(this.request.generateUrl(createDefaultMetadata()))
-			.isEqualTo(createDefaultUrl("?artifactId=my-project&type=test-type"));
+				.isEqualTo(createDefaultUrl("?artifactId=my-project&type=test-type"));
 	}
 
 	@Test
 	void outputArchiveWithDotsCustomizeArtifactId() {
 		this.request.setOutput("my.nice.project.zip");
 		assertThat(this.request.generateUrl(createDefaultMetadata()))
-			.isEqualTo(createDefaultUrl("?artifactId=my.nice.project&type=test-type"));
+				.isEqualTo(createDefaultUrl("?artifactId=my.nice.project&type=test-type"));
 	}
 
 	@Test
@@ -158,7 +158,7 @@ class ProjectGenerationRequestTests {
 		this.request.setOutput("my-project");
 		this.request.setArtifactId("my-id");
 		assertThat(this.request.generateUrl(createDefaultMetadata()))
-			.isEqualTo(createDefaultUrl("?artifactId=my-id&type=test-type"));
+				.isEqualTo(createDefaultUrl("?artifactId=my-id&type=test-type"));
 	}
 
 	@Test
@@ -166,7 +166,7 @@ class ProjectGenerationRequestTests {
 		InitializrServiceMetadata metadata = readMetadata();
 		setBuildAndFormat("does-not-exist", null);
 		assertThatExceptionOfType(ReportableException.class).isThrownBy(() -> this.request.generateUrl(metadata))
-			.withMessageContaining("does-not-exist");
+				.withMessageContaining("does-not-exist");
 	}
 
 	@Test
@@ -174,8 +174,8 @@ class ProjectGenerationRequestTests {
 		InitializrServiceMetadata metadata = readMetadata("types-conflict");
 		setBuildAndFormat("gradle", null);
 		assertThatExceptionOfType(ReportableException.class).isThrownBy(() -> this.request.generateUrl(metadata))
-			.withMessageContaining("gradle-project")
-			.withMessageContaining("gradle-project-2");
+				.withMessageContaining("gradle-project")
+				.withMessageContaining("gradle-project-2");
 	}
 
 	@Test
@@ -197,14 +197,30 @@ class ProjectGenerationRequestTests {
 	void invalidType() {
 		this.request.setType("does-not-exist");
 		assertThatExceptionOfType(ReportableException.class)
-			.isThrownBy(() -> this.request.generateUrl(createDefaultMetadata()));
+				.isThrownBy(() -> this.request.generateUrl(createDefaultMetadata()));
 	}
 
 	@Test
 	void noTypeAndNoDefault() {
 		assertThatExceptionOfType(ReportableException.class)
-			.isThrownBy(() -> this.request.generateUrl(readMetadata("types-conflict")))
-			.withMessageContaining("no default is defined");
+				.isThrownBy(() -> this.request.generateUrl(readMetadata("types-conflict")))
+				.withMessageContaining("no default is defined");
+	}
+
+	@Test
+	void configurationFileFormatIsAddedToUrl() {
+		this.request.setConfigurationFileFormat("yaml");
+
+		URI uri = this.request.generateUrl(createDefaultMetadata());
+
+		assertThat(uri).isEqualTo(createDefaultUrl("?type=test-type&configurationFileFormat=yaml"));
+	}
+
+	@Test
+	void configurationFileFormatNotAddedWhenNull() {
+		URI uri = this.request.generateUrl(createDefaultMetadata());
+
+		assertThat(uri.toString()).doesNotContain("configurationFileFormat");
 	}
 
 	private static URI createUrl(String actionAndParam) {


### PR DESCRIPTION
This PR adds support for the `--configuration-file-format` option in the `spring init` CLI command.

### Changes
- Add CLI option parsing for `configuration-file-format`
- Support both kebab-case (`--configuration-file-format`) and camelCase (`--configurationFileFormat`)
- Extend `ProjectGenerationRequest` to include the new parameter
- Include the parameter in generated URL requests
- Add tests for CLI parsing and URL generation

### Motivation
Spring Initializr supports selecting the configuration file format (e.g., `yaml` or `properties`), but the Spring Boot CLI currently does not expose this option. This change brings parity with Initializr capabilities.

Closes gh-49960