### PR TITLE
EndpointRequest links matcher unnecessarily matches HTTP methods other than GET 

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/reactive/EndpointRequest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/reactive/EndpointRequest.java
@@ -316,6 +316,8 @@ public final class EndpointRequest {
 
 		/**
 		 * Restricts the matcher to only consider requests with a particular http method.
+		 * <p>
+		 * The links endpoint, if included, is always matched using {@code GET}.
 		 * @param httpMethod the http method to include
 		 * @return a copy of the matcher further restricted to only match requests with
 		 * the specified http method
@@ -373,9 +375,9 @@ public final class EndpointRequest {
 			String linksPath = getLinksPath(properties.getBasePath());
 			if (linksPath != null) {
 				List<ServerWebExchangeMatcher> linksMatchers = new ArrayList<>();
-				linksMatchers.add(new PathPatternParserServerWebExchangeMatcher(linksPath));
+				linksMatchers.add(new PathPatternParserServerWebExchangeMatcher(linksPath, HttpMethod.GET));
 				if (!linksPath.endsWith("/")) {
-					linksMatchers.add(new PathPatternParserServerWebExchangeMatcher(linksPath + "/"));
+					linksMatchers.add(new PathPatternParserServerWebExchangeMatcher(linksPath + "/", HttpMethod.GET));
 				}
 				return new OrServerWebExchangeMatcher(linksMatchers);
 			}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/reactive/EndpointRequest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/reactive/EndpointRequest.java
@@ -119,7 +119,7 @@ public final class EndpointRequest {
 	 * @return the configured {@link ServerWebExchangeMatcher}
 	 */
 	public static LinksServerWebExchangeMatcher toLinks() {
-		return new LinksServerWebExchangeMatcher();
+		return new LinksServerWebExchangeMatcher(null);
 	}
 
 	/**
@@ -335,7 +335,7 @@ public final class EndpointRequest {
 			List<ServerWebExchangeMatcher> delegateMatchers = getDelegateMatchers(paths, this.httpMethod);
 			String linksPath = getLinksPath(endpoints.getBasePath());
 			if (this.includeLinks && linksPath != null) {
-				delegateMatchers.add(new LinksServerWebExchangeMatcher());
+				delegateMatchers.add(new LinksServerWebExchangeMatcher(this.httpMethod));
 			}
 			if (delegateMatchers.isEmpty()) {
 				return EMPTY_MATCHER;
@@ -364,8 +364,11 @@ public final class EndpointRequest {
 	 */
 	public static final class LinksServerWebExchangeMatcher extends AbstractWebExchangeMatcher<WebEndpointProperties> {
 
-		private LinksServerWebExchangeMatcher() {
+		private final HttpMethod httpMethod;
+
+		private LinksServerWebExchangeMatcher(HttpMethod httpMethod) {
 			super(WebEndpointProperties.class);
+			this.httpMethod = httpMethod;
 		}
 
 		@Override
@@ -373,9 +376,9 @@ public final class EndpointRequest {
 			String linksPath = getLinksPath(properties.getBasePath());
 			if (linksPath != null) {
 				List<ServerWebExchangeMatcher> linksMatchers = new ArrayList<>();
-				linksMatchers.add(new PathPatternParserServerWebExchangeMatcher(linksPath));
+				linksMatchers.add(new PathPatternParserServerWebExchangeMatcher(linksPath, this.httpMethod));
 				if (!linksPath.endsWith("/")) {
-					linksMatchers.add(new PathPatternParserServerWebExchangeMatcher(linksPath + "/"));
+					linksMatchers.add(new PathPatternParserServerWebExchangeMatcher(linksPath + "/", this.httpMethod));
 				}
 				return new OrServerWebExchangeMatcher(linksMatchers);
 			}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
@@ -227,9 +227,9 @@ public final class EndpointRequest {
 		protected List<RequestMatcher> getLinksMatchers(RequestMatcherFactory requestMatcherFactory,
 				RequestMatcherProvider matcherProvider, String linksPath) {
 			List<RequestMatcher> linksMatchers = new ArrayList<>();
-			linksMatchers.add(requestMatcherFactory.antPath(matcherProvider, null, linksPath));
+			linksMatchers.add(requestMatcherFactory.antPath(matcherProvider, HttpMethod.GET, linksPath));
 			if (!linksPath.endsWith("/")) {
-				linksMatchers.add(requestMatcherFactory.antPath(matcherProvider, null, linksPath, "/"));
+				linksMatchers.add(requestMatcherFactory.antPath(matcherProvider, HttpMethod.GET, linksPath, "/"));
 			}
 			return linksMatchers;
 		}
@@ -350,6 +350,8 @@ public final class EndpointRequest {
 
 		/**
 		 * Restricts the matcher to only consider requests with a particular HTTP method.
+		 * <p>
+		 * The links endpoint, if included, is always matched using {@code GET}.
 		 * @param httpMethod the HTTP method to include
 		 * @return a copy of the matcher further restricted to only match requests with
 		 * the specified HTTP method

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
@@ -225,11 +225,11 @@ public final class EndpointRequest {
 		}
 
 		protected List<RequestMatcher> getLinksMatchers(RequestMatcherFactory requestMatcherFactory,
-				RequestMatcherProvider matcherProvider, String linksPath) {
+				RequestMatcherProvider matcherProvider, HttpMethod httpMethod, String linksPath) {
 			List<RequestMatcher> linksMatchers = new ArrayList<>();
-			linksMatchers.add(requestMatcherFactory.antPath(matcherProvider, null, linksPath));
+			linksMatchers.add(requestMatcherFactory.antPath(matcherProvider, httpMethod, linksPath));
 			if (!linksPath.endsWith("/")) {
-				linksMatchers.add(requestMatcherFactory.antPath(matcherProvider, null, linksPath, "/"));
+				linksMatchers.add(requestMatcherFactory.antPath(matcherProvider, httpMethod, linksPath, "/"));
 			}
 			return linksMatchers;
 		}
@@ -375,7 +375,8 @@ public final class EndpointRequest {
 			String basePath = endpoints.getBasePath();
 			String linksPath = getLinksPath(context, basePath);
 			if (this.includeLinks && linksPath != null) {
-				delegateMatchers.addAll(getLinksMatchers(requestMatcherFactory, matcherProvider, linksPath));
+				delegateMatchers
+					.addAll(getLinksMatchers(requestMatcherFactory, matcherProvider, this.httpMethod, linksPath));
 			}
 			if (delegateMatchers.isEmpty()) {
 				return EMPTY_MATCHER;
@@ -411,7 +412,7 @@ public final class EndpointRequest {
 			String linksPath = getLinksPath(context, properties.getBasePath());
 			if (linksPath != null) {
 				return new OrRequestMatcher(
-						getLinksMatchers(requestMatcherFactory, getRequestMatcherProvider(context), linksPath));
+						getLinksMatchers(requestMatcherFactory, getRequestMatcherProvider(context), null, linksPath));
 			}
 			return EMPTY_MATCHER;
 		}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/reactive/EndpointRequestTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/reactive/EndpointRequestTests.java
@@ -76,6 +76,15 @@ class EndpointRequestTests {
 	}
 
 	@Test
+	void toAnyEndpointWithHttpMethodShouldUseGetForLinks() {
+		ServerWebExchangeMatcher matcher = EndpointRequest.toAnyEndpoint().withHttpMethod(HttpMethod.POST);
+		assertMatcher(matcher, "/actuator").matches(HttpMethod.GET, "/actuator");
+		assertMatcher(matcher, "/actuator").doesNotMatch(HttpMethod.POST, "/actuator");
+		assertMatcher(matcher, "/actuator").matches(HttpMethod.GET, "/actuator/");
+		assertMatcher(matcher, "/actuator").doesNotMatch(HttpMethod.POST, "/actuator/");
+	}
+
+	@Test
 	void toAnyEndpointShouldMatchEndpointPathWithTrailingSlash() {
 		ServerWebExchangeMatcher matcher = EndpointRequest.toAnyEndpoint();
 		assertMatcher(matcher).matches("/actuator/foo/");
@@ -140,8 +149,10 @@ class EndpointRequestTests {
 		ServerWebExchangeMatcher matcher = EndpointRequest.toLinks();
 		assertMatcher(matcher).doesNotMatch("/actuator/foo");
 		assertMatcher(matcher).doesNotMatch("/actuator/bar");
-		assertMatcher(matcher).matches("/actuator");
-		assertMatcher(matcher).matches("/actuator/");
+		assertMatcher(matcher).matches(HttpMethod.GET, "/actuator");
+		assertMatcher(matcher).doesNotMatch(HttpMethod.POST, "/actuator");
+		assertMatcher(matcher).matches(HttpMethod.GET, "/actuator/");
+		assertMatcher(matcher).doesNotMatch(HttpMethod.POST, "/actuator/");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/reactive/EndpointRequestTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/reactive/EndpointRequestTests.java
@@ -73,6 +73,10 @@ class EndpointRequestTests {
 		ServerWebExchangeMatcher matcher = EndpointRequest.toAnyEndpoint().withHttpMethod(HttpMethod.POST);
 		assertMatcher(matcher, "/actuator").matches(HttpMethod.POST, "/actuator/foo");
 		assertMatcher(matcher, "/actuator").doesNotMatch(HttpMethod.GET, "/actuator/foo");
+		assertMatcher(matcher, "/actuator").matches(HttpMethod.POST, "/actuator");
+		assertMatcher(matcher, "/actuator").doesNotMatch(HttpMethod.GET, "/actuator");
+		assertMatcher(matcher, "/actuator").matches(HttpMethod.POST, "/actuator/");
+		assertMatcher(matcher, "/actuator").doesNotMatch(HttpMethod.GET, "/actuator/");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
@@ -64,7 +64,7 @@ class EndpointRequestTests {
 		assertMatcher(matcher, "/actuator").matches("/actuator/foo/zoo/");
 		assertMatcher(matcher, "/actuator").matches("/actuator/bar");
 		assertMatcher(matcher, "/actuator").matches("/actuator/bar/baz");
-		assertMatcher(matcher, "/actuator").matches("/actuator");
+		assertMatcher(matcher, "/actuator").matches(HttpMethod.GET, "/actuator");
 	}
 
 	@Test
@@ -76,11 +76,21 @@ class EndpointRequestTests {
 	}
 
 	@Test
+	void toAnyEndpointWithHttpMethodShouldUseGetForLinks() {
+		EndpointRequest.EndpointRequestMatcher matcher = EndpointRequest.toAnyEndpoint()
+			.withHttpMethod(HttpMethod.POST);
+		assertMatcher(matcher, "/actuator").matches(HttpMethod.GET, "/actuator");
+		assertMatcher(matcher, "/actuator").doesNotMatch(HttpMethod.POST, "/actuator");
+		assertMatcher(matcher, "/actuator").matches(HttpMethod.GET, "/actuator/");
+		assertMatcher(matcher, "/actuator").doesNotMatch(HttpMethod.POST, "/actuator/");
+	}
+
+	@Test
 	void toAnyEndpointShouldMatchEndpointPathWithTrailingSlash() {
 		RequestMatcher matcher = EndpointRequest.toAnyEndpoint();
 		assertMatcher(matcher, "/actuator").matches("/actuator/foo/");
 		assertMatcher(matcher, "/actuator").matches("/actuator/bar/");
-		assertMatcher(matcher, "/actuator").matches("/actuator/");
+		assertMatcher(matcher, "/actuator").matches(HttpMethod.GET, "/actuator/");
 	}
 
 	@Test
@@ -97,7 +107,7 @@ class EndpointRequestTests {
 		RequestMatcher matcher = EndpointRequest.toAnyEndpoint();
 		RequestMatcherAssert assertMatcher = assertMatcher(matcher, mockPathMappedEndpoints(""), null,
 				WebServerNamespace.MANAGEMENT);
-		assertMatcher.matches("/");
+		assertMatcher.matches(HttpMethod.GET, "/");
 		assertMatcher.matches("/foo");
 	}
 
@@ -112,7 +122,7 @@ class EndpointRequestTests {
 		RequestMatcher matcher = EndpointRequest.toAnyEndpoint();
 		assertMatcher(matcher, "/actuator").matches("/actuator/foo");
 		assertMatcher(matcher, "/actuator").matches("/actuator/bar");
-		assertMatcher(matcher, "/actuator").matches("/actuator");
+		assertMatcher(matcher, "/actuator").matches(HttpMethod.GET, "/actuator");
 		assertMatcher(matcher, "/actuator").doesNotMatch("/actuator/baz");
 	}
 
@@ -147,8 +157,10 @@ class EndpointRequestTests {
 		RequestMatcher matcher = EndpointRequest.toLinks();
 		assertMatcher(matcher).doesNotMatch("/actuator/foo");
 		assertMatcher(matcher).doesNotMatch("/actuator/bar");
-		assertMatcher(matcher).matches("/actuator");
-		assertMatcher(matcher).matches("/actuator/");
+		assertMatcher(matcher).matches(HttpMethod.GET, "/actuator");
+		assertMatcher(matcher).doesNotMatch(HttpMethod.POST, "/actuator");
+		assertMatcher(matcher).matches(HttpMethod.GET, "/actuator/");
+		assertMatcher(matcher).doesNotMatch(HttpMethod.POST, "/actuator/");
 	}
 
 	@Test
@@ -165,7 +177,7 @@ class EndpointRequestTests {
 		RequestMatcher matcher = EndpointRequest.toLinks();
 		RequestMatcherAssert assertMatcher = assertMatcher(matcher, mockPathMappedEndpoints(""), null,
 				WebServerNamespace.MANAGEMENT);
-		assertMatcher.matches("/");
+		assertMatcher.matches(HttpMethod.GET, "/");
 		assertMatcher.doesNotMatch("/foo");
 	}
 
@@ -180,7 +192,7 @@ class EndpointRequestTests {
 		assertMatcher(matcher, pathMappedEndpoints).doesNotMatch("/actuator/foo");
 		assertMatcher(matcher, pathMappedEndpoints).doesNotMatch("/actuator/baz");
 		assertMatcher(matcher).matches("/actuator/bar");
-		assertMatcher(matcher).matches("/actuator");
+		assertMatcher(matcher).matches(HttpMethod.GET, "/actuator");
 	}
 
 	@Test
@@ -195,7 +207,7 @@ class EndpointRequestTests {
 		RequestMatcher matcher = EndpointRequest.toAnyEndpoint().excluding("foo");
 		assertMatcher(matcher).doesNotMatch("/actuator/foo");
 		assertMatcher(matcher).matches("/actuator/bar");
-		assertMatcher(matcher).matches("/actuator");
+		assertMatcher(matcher).matches(HttpMethod.GET, "/actuator");
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequestTests.java
@@ -73,6 +73,10 @@ class EndpointRequestTests {
 			.withHttpMethod(HttpMethod.POST);
 		assertMatcher(matcher, "/actuator").matches(HttpMethod.POST, "/actuator/foo");
 		assertMatcher(matcher, "/actuator").doesNotMatch(HttpMethod.GET, "/actuator/foo");
+		assertMatcher(matcher, "/actuator").matches(HttpMethod.POST, "/actuator");
+		assertMatcher(matcher, "/actuator").doesNotMatch(HttpMethod.GET, "/actuator");
+		assertMatcher(matcher, "/actuator").matches(HttpMethod.POST, "/actuator/");
+		assertMatcher(matcher, "/actuator").doesNotMatch(HttpMethod.GET, "/actuator/");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Hardcode the links matcher to `GET` (per the team decision in this PR's discussion).
- Document the behaviour on `EndpointServerWebExchangeMatcher.withHttpMethod(...)` and `EndpointRequestMatcher.withHttpMethod(...)`.

## Test plan
- `toAnyEndpointWithHttpMethodShouldUseGetForLinks` (servlet + reactive)
- `toLinksShouldOnlyMatchLinks` strengthened with explicit `GET`/`POST` assertions