### PR TITLE
NimbusJwtDecoder silently accepts unknown values for spring.security.oauth2.resourceserver.jwt.jws-algorithms

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerJwkConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerJwkConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.Condition
 import org.springframework.boot.autoconfigure.security.oauth2.resource.ConditionalOnPublicKeyJwtDecoder;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -103,7 +104,12 @@ class ReactiveOAuth2ResourceServerJwkConfiguration {
 
 		private void jwsAlgorithms(Set<SignatureAlgorithm> signatureAlgorithms) {
 			for (String algorithm : this.properties.getJwsAlgorithms()) {
-				signatureAlgorithms.add(SignatureAlgorithm.from(algorithm));
+				SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.from(algorithm);
+				if (signatureAlgorithm == null) {
+					throw new InvalidConfigurationPropertyValueException(
+							"spring.security.oauth2.resourceserver.jwt.jws-algorithms", algorithm, "Unknown algorithm");
+				}
+				signatureAlgorithms.add(signatureAlgorithm);
 			}
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.Condition
 import org.springframework.boot.autoconfigure.security.oauth2.resource.ConditionalOnPublicKeyJwtDecoder;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -102,7 +103,12 @@ class OAuth2ResourceServerJwtConfiguration {
 
 		private void jwsAlgorithms(Set<SignatureAlgorithm> signatureAlgorithms) {
 			for (String algorithm : this.properties.getJwsAlgorithms()) {
-				signatureAlgorithms.add(SignatureAlgorithm.from(algorithm));
+				SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.from(algorithm);
+				if (signatureAlgorithm == null) {
+					throw new InvalidConfigurationPropertyValueException(
+							"spring.security.oauth2.resourceserver.jwt.jws-algorithms", algorithm, "Unknown algorithm");
+				}
+				signatureAlgorithms.add(signatureAlgorithm);
 			}
 		}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerJwtConfiguration.java
@@ -54,7 +54,9 @@ import org.springframework.security.oauth2.jwt.SupplierJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
@@ -140,7 +142,7 @@ class OAuth2ResourceServerJwtConfiguration {
 			RSAPublicKey publicKey = (RSAPublicKey) KeyFactory.getInstance("RSA")
 				.generatePublic(new X509EncodedKeySpec(getKeySpec(this.properties.readPublicKey())));
 			NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withPublicKey(publicKey)
-				.signatureAlgorithm(SignatureAlgorithm.from(exactlyOneAlgorithm()))
+				.signatureAlgorithm(exactlyOneAlgorithm())
 				.build();
 			jwtDecoder.setJwtValidator(getValidators(JwtValidators.createDefault()));
 			return jwtDecoder;
@@ -151,15 +153,18 @@ class OAuth2ResourceServerJwtConfiguration {
 			return Base64.getMimeDecoder().decode(keyValue);
 		}
 
-		private String exactlyOneAlgorithm() {
+		private SignatureAlgorithm exactlyOneAlgorithm() {
 			List<String> algorithms = this.properties.getJwsAlgorithms();
-			int count = (algorithms != null) ? algorithms.size() : 0;
-			if (count != 1) {
-				throw new IllegalStateException(
-						"Creating a JWT decoder using a public key requires exactly one JWS algorithm but " + count
-								+ " were configured");
+			Assert.state(algorithms != null && algorithms.size() == 1,
+					() -> "Creating a JWT decoder using a public key requires exactly one JWS algorithm but "
+							+ algorithms.size() + " were configured");
+			SignatureAlgorithm algorithm = SignatureAlgorithm.from(algorithms.get(0));
+			if (algorithm == null) {
+				throw new InvalidConfigurationPropertyValueException(
+						"spring.security.oauth2.resourceserver.jwt.jws-algorithms",
+						StringUtils.collectionToCommaDelimitedString(algorithms), "Unknown algorithm");
 			}
-			return algorithms.get(0);
+			return algorithm;
 		}
 
 		@Bean

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/JwtConverterCustomizationsArgumentsProvider.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/JwtConverterCustomizationsArgumentsProvider.java
@@ -70,10 +70,10 @@ public final class JwtConverterCustomizationsArgumentsProvider implements Argume
 			.claim(customPrincipalClaim, customPrincipalValue);
 		Jwt noAuthoritiesCustomizationsJwt = jwtBuilder.claim("scp", jwtScopes[0] + " " + jwtScopes[1]).build();
 		Jwt customAuthoritiesDelimiterJwt = jwtBuilder.claim("scp", jwtScopes[0] + "~" + jwtScopes[1]).build();
-		Jwt customAuthoritiesClaimJwt = jwtBuilder.claim("scp", null)
+		Jwt customAuthoritiesClaimJwt = jwtBuilder.claim("scp", "value")
 			.claim(customAuthoritiesClaim, jwtScopes[0] + " " + jwtScopes[1])
 			.build();
-		Jwt customAuthoritiesClaimAndDelimiterJwt = jwtBuilder.claim("scp", null)
+		Jwt customAuthoritiesClaimAndDelimiterJwt = jwtBuilder.claim("scp", "value")
 			.claim(customAuthoritiesClaim, jwtScopes[0] + "~" + jwtScopes[1])
 			.build();
 		String[] customPrefixAuthorities = { customPrefix + jwtScopes[0], customPrefix + jwtScopes[1] };

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
@@ -178,6 +178,19 @@ class ReactiveOAuth2ResourceServerAutoConfigurationTests {
 	}
 
 	@Test
+	void autoConfigurationUsingJwkSetUriShouldFailIfJwsAlgorithmIsUnknown() {
+		this.contextRunner
+			.withPropertyValues("spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://jwk-set-uri.com",
+					"spring.security.oauth2.resourceserver.jwt.jws-algorithms=NOT_VALID")
+			.run((context) -> {
+				assertThat(context).hasFailed();
+				assertThat(context.getStartupFailure())
+					.hasRootCauseMessage("Property spring.security.oauth2.resourceserver.jwt.jws-algorithms with value "
+							+ "'NOT_VALID' is invalid: Unknown algorithm");
+			});
+	}
+
+	@Test
 	@WithPublicKeyResource
 	void autoConfigurationUsingPublicKeyValueShouldConfigureResourceServerUsingSingleJwsAlgorithm() {
 		this.contextRunner

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
@@ -49,6 +49,7 @@ import org.mockito.InOrder;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.JwtConverterCustomizationsArgumentsProvider;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
+import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.assertj.AssertableWebApplicationContext;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
@@ -333,7 +334,8 @@ class OAuth2ResourceServerAutoConfigurationTests {
 					"spring.security.oauth2.resourceserver.jwt.jws-algorithms=NOT_VALID")
 			.run((context) -> assertThat(context).hasFailed()
 				.getFailure()
-				.hasMessageContaining("signatureAlgorithm cannot be null"));
+				.hasMessageContaining("Unknown algorithm")
+				.hasRootCauseExactlyInstanceOf(InvalidConfigurationPropertyValueException.class));
 	}
 
 	@Test

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/resource/servlet/OAuth2ResourceServerAutoConfigurationTests.java
@@ -179,6 +179,19 @@ class OAuth2ResourceServerAutoConfigurationTests {
 	}
 
 	@Test
+	void autoConfigurationUsingJwkSetUriShouldFailIfJwsAlgorithmIsUnknown() {
+		this.contextRunner
+			.withPropertyValues("spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://jwk-set-uri.com",
+					"spring.security.oauth2.resourceserver.jwt.jws-algorithms=NOT_VALID")
+			.run((context) -> {
+				assertThat(context).hasFailed();
+				assertThat(context.getStartupFailure())
+					.hasRootCauseMessage("Property spring.security.oauth2.resourceserver.jwt.jws-algorithms with value "
+							+ "'NOT_VALID' is invalid: Unknown algorithm");
+			});
+	}
+
+	@Test
 	@WithPublicKeyResource
 	void autoConfigurationUsingPublicKeyValueShouldConfigureResourceServerUsingSingleJwsAlgorithm() {
 		this.contextRunner

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerJwtAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/security/oauth2/server/servlet/OAuth2AuthorizationServerJwtAutoConfigurationTests.java
@@ -31,6 +31,7 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link OAuth2AuthorizationServerJwtAutoConfiguration}.
@@ -96,7 +97,7 @@ class OAuth2AuthorizationServerJwtAutoConfigurationTests {
 
 		@Bean
 		JwtDecoder jwtDecoder() {
-			return (token) -> null;
+			return mock(JwtDecoder.class);
 		}
 
 	}


### PR DESCRIPTION
`OAuth2ResourceServerJwtConfiguration.jwsAlgorithms(Set)` and its reactive counterpart map each configured value through `SignatureAlgorithm.from(String)` and add the result directly to the set. `SignatureAlgorithm.from` returns `null` for unknown names, so a misconfiguration such as `RS265` (instead of `RS256`) is silently accepted and only surfaces later as a confusing verification-time failure.

Both methods now reject unknown algorithms with an `InvalidConfigurationPropertyValueException`, matching the behaviour already used by `exactlyOneAlgorithm()` for the public-key path.

Closes gh-50116