### PR TITLE
Check getter annotation in RecordParameterPropertyDescriptor.isMarkedAsNested

### DIFF
--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/RecordParameterPropertyDescriptor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/RecordParameterPropertyDescriptor.java
@@ -56,5 +56,4 @@ class RecordParameterPropertyDescriptor extends ParameterPropertyDescriptor {
 	protected String resolveDescription(MetadataGenerationEnvironment environment) {
 		return environment.getTypeUtils().getJavaDoc(this.recordComponent);
 	}
-
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/RecordParameterPropertyDescriptor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/RecordParameterPropertyDescriptor.java
@@ -48,7 +48,8 @@ class RecordParameterPropertyDescriptor extends ParameterPropertyDescriptor {
 
 	@Override
 	protected boolean isMarkedAsNested(MetadataGenerationEnvironment environment) {
-		return environment.getNestedConfigurationPropertyAnnotation(this.recordComponent) != null;
+		return environment.getNestedConfigurationPropertyAnnotation(this.recordComponent) != null
+				|| environment.getNestedConfigurationPropertyAnnotation(getGetter()) != null;
 	}
 
 	@Override


### PR DESCRIPTION
While going through issue #50096 I noticed that **`RecordParameterPropertyDescriptor.isMarkedAsNested`** only checks the record component for the **`@NestedConfigurationProperty`** annotation and completely ignores the getter.

### This creates a problem:
if someone places **`@NestedConfigurationProperty`** on the getter of a record property it gets silently ignored and the nested configuration metadata is not generated. That behavior is clearly unintended.

What stood out is that **`ConstructorParameterPropertyDescriptor`** previously had the exact same issue which was already addressed in gh-49734. In that fix, the logic was updated to check both the constructor parameter and the getter. However, the same update was not applied to **`RecordParameterPropertyDescriptor`,** leading to inconsistent behavior.

To resolve this I applied the same approach here. The **`isMarkedAsNested`** method now checks both the record component and the corresponding getter aligning its behavior with **`ConstructorParameterPropertyDescriptor`.**

The change itself is minimal just an additional condition in the return statement

### Before:
**return environment.getNestedConfigurationPropertyAnnotation(this.recordComponent) != null;**

### After:
**return environment.getNestedConfigurationPropertyAnnotation(this.recordComponent) != null
|| environment.getNestedConfigurationPropertyAnnotation(getGetter()) != null;**

Fixes gh-50096.
