### PR TITLE
Check getter annotation in LombokPropertyDescriptor.isMarkedAsNested

### DIFF
--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/LombokPropertyDescriptor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/LombokPropertyDescriptor.java
@@ -71,7 +71,8 @@ class LombokPropertyDescriptor extends PropertyDescriptor {
 
 	@Override
 	protected boolean isMarkedAsNested(MetadataGenerationEnvironment environment) {
-		return environment.getNestedConfigurationPropertyAnnotation(getField()) != null;
+		return environment.getNestedConfigurationPropertyAnnotation(getField()) != null
+				|| environment.getNestedConfigurationPropertyAnnotation(getGetter()) != null;
 	}
 
 	@Override
@@ -136,5 +137,5 @@ class LombokPropertyDescriptor extends PropertyDescriptor {
 		Object value = values.get("value");
 		return (value == null || value.toString().equals(LOMBOK_ACCESS_LEVEL_PUBLIC));
 	}
-
+	
 }


### PR DESCRIPTION
Follow-up to gh-49734 and gh-50096.

**`LombokPropertyDescriptor.isMarkedAsNested`** only checked the field for
**`@NestedConfigurationProperty`**, ignoring the getter. This means if
someone places `@NestedConfigurationProperty` on the getter of a Lombok
property the annotation is silently ignored and nested configuration
metadata is not generated.

**`ConstructorParameterPropertyDescriptor`** and
**`RecordParameterPropertyDescriptor`** both check field + getter.
**`LombokPropertyDescriptor`** now does the same.

Fixes gh-50121