### PR TITLE
Check getter for @NestedConfigurationProperty on record accessors

### DIFF
--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/RecordParameterPropertyDescriptor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/RecordParameterPropertyDescriptor.java
@@ -54,7 +54,8 @@ class RecordParameterPropertyDescriptor extends ParameterPropertyDescriptor {
 
 	@Override
 	protected boolean isMarkedAsNested(MetadataGenerationEnvironment environment) {
-		return environment.getNestedConfigurationPropertyAnnotation(this.recordComponent) != null;
+		return environment.getNestedConfigurationPropertyAnnotation(this.recordComponent) != null
+				|| environment.getNestedConfigurationPropertyAnnotation(getGetter()) != null;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes gh-50096

RecordParameterPropertyDescriptor.isMarkedAsNested now checks both the record component and the getter method for @NestedConfigurationProperty, matching the behavior of JavaBeanPropertyDescriptor and ConstructorParameterPropertyDescriptor.

This ensures consistency across all property descriptor types and allows @NestedConfigurationProperty to work correctly when placed on record accessor methods.

**Changes:**
- Updated RecordParameterPropertyDescriptor.isMarkedAsNested() to check both record component and getter
- Follows the same pattern as ConstructorParameterPropertyDescriptor (fixed in gh-49734)
- Maintains consistency with JavaBeanPropertyDescriptor behavior

**Test Results:**
All PropertyDescriptor tests pass.