### PR TITLE
Apply path api version resolver last

### DIFF
--- a/module/spring-boot-webflux/src/main/java/org/springframework/boot/webflux/autoconfigure/WebFluxAutoConfiguration.java
+++ b/module/spring-boot-webflux/src/main/java/org/springframework/boot/webflux/autoconfigure/WebFluxAutoConfiguration.java
@@ -301,9 +301,9 @@ public final class WebFluxAutoConfiguration {
 			PropertyMapper map = PropertyMapper.get();
 			map.from(use::getHeader).whenHasText().to(configurer::useRequestHeader);
 			map.from(use::getQueryParameter).whenHasText().to(configurer::useQueryParam);
-			map.from(use::getPathSegment).to(configurer::usePathSegment);
 			use.getMediaTypeParameter()
 				.forEach((mediaType, parameterName) -> configurer.useMediaTypeParameter(mediaType, parameterName));
+			map.from(use::getPathSegment).to(configurer::usePathSegment);
 		}
 
 	}

--- a/module/spring-boot-webflux/src/test/java/org/springframework/boot/webflux/autoconfigure/WebFluxAutoConfigurationTests.java
+++ b/module/spring-boot-webflux/src/test/java/org/springframework/boot/webflux/autoconfigure/WebFluxAutoConfigurationTests.java
@@ -910,6 +910,21 @@ class WebFluxAutoConfigurationTests {
 	}
 
 	@Test
+	void apiVersionUsePathSegmentIsAppliedLastSoOtherResolversStillRun() {
+		this.contextRunner
+			.withPropertyValues("spring.webflux.apiversion.use.path-segment=0",
+					"spring.webflux.apiversion.use.media-type-parameter[application/json]=mtpv")
+			.run((context) -> {
+				DefaultApiVersionStrategy versionStrategy = context.getBean("webFluxApiVersionStrategy",
+						DefaultApiVersionStrategy.class);
+				MockServerWebExchange request = MockServerWebExchange
+					.from(MockServerHttpRequest.get("https://example.com")
+						.header("content-type", "application/json;mtpv=123"));
+				assertThat(versionStrategy.resolveVersion(request)).isEqualTo("123");
+			});
+	}
+
+	@Test
 	void apiVersionBeansAreInjected() {
 		this.contextRunner.withUserConfiguration(ApiVersionConfiguration.class).run((context) -> {
 			DefaultApiVersionStrategy versionStrategy = context.getBean("webFluxApiVersionStrategy",

--- a/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/WebMvcAutoConfiguration.java
+++ b/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/WebMvcAutoConfiguration.java
@@ -421,8 +421,8 @@ public final class WebMvcAutoConfiguration {
 			PropertyMapper map = PropertyMapper.get();
 			map.from(use::getHeader).whenHasText().to(configurer::useRequestHeader);
 			map.from(use::getQueryParameter).whenHasText().to(configurer::useQueryParam);
-			map.from(use::getPathSegment).to(configurer::usePathSegment);
 			use.getMediaTypeParameter().forEach(configurer::useMediaTypeParameter);
+			map.from(use::getPathSegment).to(configurer::usePathSegment);
 		}
 
 		@Bean

--- a/module/spring-boot-webmvc/src/test/java/org/springframework/boot/webmvc/autoconfigure/WebMvcAutoConfigurationTests.java
+++ b/module/spring-boot-webmvc/src/test/java/org/springframework/boot/webmvc/autoconfigure/WebMvcAutoConfigurationTests.java
@@ -1123,6 +1123,19 @@ class WebMvcAutoConfigurationTests {
 	}
 
 	@Test
+	void apiVersionUsePathSegmentIsAppliedLastSoOtherResolversStillRun() {
+		this.contextRunner
+			.withPropertyValues("spring.mvc.apiversion.use.path-segment=0",
+					"spring.mvc.apiversion.use.media-type-parameter[application/json]=mtpv")
+			.run((context) -> {
+				ApiVersionStrategy versionStrategy = context.getBean("mvcApiVersionStrategy", ApiVersionStrategy.class);
+				MockHttpServletRequest request = new MockHttpServletRequest();
+				request.addHeader(HttpHeaders.CONTENT_TYPE, "application/json;mtpv=123");
+				assertThat(versionStrategy.resolveVersion(request)).isEqualTo("123");
+			});
+	}
+
+	@Test
 	void apiVersionBeansAreInjected() {
 		this.contextRunner.withUserConfiguration(ApiVersionConfiguration.class).run((context) -> {
 			DefaultApiVersionStrategy versionStrategy = context.getBean("mvcApiVersionStrategy",


### PR DESCRIPTION
`PathApiVersionResolver` never returns `null` (as documented on the resolver itself), so any resolvers registered after it in `DefaultApiVersionStrategy` are unreachable. Because `configureApiVersioningUse` currently binds `path-segment` before `media-type-parameter`, configuring both causes the media-type (and any later bean-supplied) resolver to be skipped.

This moves the `path-segment` binding to the end of `configureApiVersioningUse` in both `WebMvcAutoConfiguration` and `WebFluxAutoConfiguration` so that the non-yielding path resolver is always consulted last. Tests are added that combine `path-segment` with `media-type-parameter` and assert the media-type resolver still resolves.

Closes gh-49800