### PR TITLE
Do not generate metadata for non-static nested class that are not initialized

### DIFF
--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/JavaBeanPropertyDescriptor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/JavaBeanPropertyDescriptor.java
@@ -29,6 +29,7 @@ import org.springframework.boot.configurationprocessor.metadata.ItemDeprecation;
  *
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Daeho Kwon
  */
 class JavaBeanPropertyDescriptor extends PropertyDescriptor {
 
@@ -77,11 +78,22 @@ class JavaBeanPropertyDescriptor extends PropertyDescriptor {
 	}
 
 	@Override
+	protected boolean hasSetter() {
+		return this.setter != null;
+	}
+
+	@Override
+	protected boolean isInitialized(MetadataGenerationEnvironment environment) {
+		return environment.hasFieldInitializer(getDeclaringElement(), this.field);
+	}
+
+	@Override
 	public boolean isProperty(MetadataGenerationEnvironment env) {
 		boolean isCollection = env.getTypeUtils().isCollectionOrMap(getType());
 		boolean hasGetter = getGetter() != null;
 		boolean hasSetter = getSetter() != null;
-		return !env.isExcluded(getType()) && hasGetter && (hasSetter || isCollection);
+		return !env.isExcluded(getType()) && hasGetter && (hasSetter || isCollection)
+				&& !(hasSetter && isNonStaticInnerClass(env));
 	}
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/LombokPropertyDescriptor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/LombokPropertyDescriptor.java
@@ -33,6 +33,7 @@ import org.springframework.boot.configurationprocessor.metadata.ItemDeprecation;
  *
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Daeho Kwon
  */
 class LombokPropertyDescriptor extends PropertyDescriptor {
 
@@ -95,12 +96,25 @@ class LombokPropertyDescriptor extends PropertyDescriptor {
 			return false;
 		}
 		boolean isCollection = env.getTypeUtils().isCollectionOrMap(getType());
-		return !env.isExcluded(getType()) && (hasSetter(env) || isCollection);
+		boolean hasSetter = hasSetter(env);
+		return !env.isExcluded(getType()) && (hasSetter || isCollection)
+				&& !(hasSetter && isNonStaticInnerClass(env));
+	}
+
+	@Override
+	protected boolean isInitialized(MetadataGenerationEnvironment environment) {
+		return environment.hasFieldInitializer(getDeclaringElement(), this.field);
 	}
 
 	@Override
 	public boolean isNested(MetadataGenerationEnvironment environment) {
-		return hasLombokPublicAccessor(environment, true) && super.isNested(environment);
+		if (!hasLombokPublicAccessor(environment, true)) {
+			return false;
+		}
+		if (isNonStaticInnerClass(environment) && (hasSetter(environment) || !isInitialized(environment))) {
+			return isMarkedAsNested(environment);
+		}
+		return super.isNested(environment);
 	}
 
 	private boolean hasSetter(MetadataGenerationEnvironment env) {

--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataGenerationEnvironment.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataGenerationEnvironment.java
@@ -52,6 +52,7 @@ import org.springframework.boot.configurationprocessor.metadata.ItemDeprecation;
  * @author Stephane Nicoll
  * @author Scott Frederick
  * @author Moritz Halbritter
+ * @author Daeho Kwon
  */
 class MetadataGenerationEnvironment {
 
@@ -79,6 +80,8 @@ class MetadataGenerationEnvironment {
 	private final ConfigurationPropertiesSourceResolver sourceResolver;
 
 	private final Map<TypeElement, Map<String, Object>> defaultValues = new HashMap<>();
+
+	private final Map<TypeElement, Set<String>> initializedFields = new HashMap<>();
 
 	private final Map<TypeElement, SourceMetadata> sources = new HashMap<>();
 
@@ -382,6 +385,33 @@ class MetadataGenerationEnvironment {
 	private boolean isElementDeprecated(Element element) {
 		return hasAnnotation(element, "java.lang.Deprecated")
 				|| hasAnnotation(element, this.deprecatedConfigurationPropertyAnnotation);
+	}
+
+	boolean hasFieldInitializer(TypeElement type, VariableElement field) {
+		if (field == null) {
+			return false;
+		}
+		return this.initializedFields.computeIfAbsent(type, this::resolveInitializedFields)
+			.contains(field.getSimpleName().toString());
+	}
+
+	private Set<String> resolveInitializedFields(TypeElement element) {
+		Set<String> fields = new HashSet<>();
+		resolveInitializedFieldsFor(fields, element);
+		return fields;
+	}
+
+	private void resolveInitializedFieldsFor(Set<String> fields, TypeElement element) {
+		try {
+			fields.addAll(this.fieldValuesParser.getInitializedFields(element));
+		}
+		catch (Exception ex) {
+			// continue
+		}
+		Element superType = this.typeUtils.asElement(element.getSuperclass());
+		if (superType instanceof TypeElement && superType.asType().getKind() != TypeKind.NONE) {
+			resolveInitializedFieldsFor(fields, (TypeElement) superType);
+		}
 	}
 
 	private Map<String, Object> resolveFieldValues(TypeElement element) {

--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptor.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.NestingKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 
@@ -34,6 +36,7 @@ import org.springframework.boot.configurationprocessor.metadata.ItemMetadata;
  *
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Daeho Kwon
  */
 abstract class PropertyDescriptor {
 
@@ -139,7 +142,36 @@ abstract class PropertyDescriptor {
 			return true;
 		}
 		return !isCyclePresent(typeElement, getDeclaringElement())
-				&& isParentTheSame(environment, typeElement, getDeclaringElement());
+				&& isParentTheSame(environment, typeElement, getDeclaringElement())
+				&& !(isNonStaticInnerClass(environment) && (hasSetter() || !isInitialized(environment)));
+	}
+
+	/**
+	 * Return whether this property's field is initialized at declaration.
+	 * @param environment the metadata generation environment
+	 * @return {@code true} if the field has an initializer
+	 */
+	protected boolean isInitialized(MetadataGenerationEnvironment environment) {
+		return false;
+	}
+
+	/**
+	 * Return whether this property's type is a non-static inner class.
+	 * @param environment the metadata generation environment
+	 * @return {@code true} if the type is a non-static member class
+	 */
+	protected final boolean isNonStaticInnerClass(MetadataGenerationEnvironment environment) {
+		Element typeElement = environment.getTypeUtils().asElement(getType());
+		return typeElement instanceof TypeElement te && te.getNestingKind() == NestingKind.MEMBER
+				&& !te.getModifiers().contains(Modifier.STATIC);
+	}
+
+	/**
+	 * Return whether this property has a setter.
+	 * @return {@code true} if the property has a setter
+	 */
+	protected boolean hasSetter() {
+		return false;
 	}
 
 	/**

--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/fieldvalues/FieldValuesParser.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/fieldvalues/FieldValuesParser.java
@@ -18,6 +18,7 @@ package org.springframework.boot.configurationprocessor.fieldvalues;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import javax.lang.model.element.TypeElement;
 
@@ -27,6 +28,7 @@ import org.springframework.boot.configurationprocessor.fieldvalues.javac.JavaCom
  * Parser which can be used to obtain the field values from an {@link TypeElement}.
  *
  * @author Phillip Webb
+ * @author Daeho Kwon
  * @since 1.1.2
  * @see JavaCompilerFieldValuesParser
  */
@@ -41,9 +43,19 @@ public interface FieldValuesParser {
 	/**
 	 * Return the field values for the given element.
 	 * @param element the element to inspect
-	 * @return a map of field names to values.
+	 * @return a map of field names to values
 	 * @throws Exception if the values cannot be extracted
 	 */
 	Map<String, Object> getFieldValues(TypeElement element) throws Exception;
+
+	/**
+	 * Return the names of fields that have an initializer for the given element.
+	 * @param element the element to inspect
+	 * @return a set of field names that have an initializer
+	 * @throws Exception if the fields cannot be extracted
+	 */
+	default Set<String> getInitializedFields(TypeElement element) throws Exception {
+		return Collections.emptySet();
+	}
 
 }

--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/fieldvalues/javac/JavaCompilerFieldValuesParser.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/fieldvalues/javac/JavaCompilerFieldValuesParser.java
@@ -18,6 +18,7 @@ package org.springframework.boot.configurationprocessor.fieldvalues.javac;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -36,6 +37,7 @@ import org.springframework.boot.configurationprocessor.support.ConventionUtils;
  *
  * @author Phillip Webb
  * @author Stephane Nicoll
+ * @author Daeho Kwon
  * @since 1.2.0
  */
 public class JavaCompilerFieldValuesParser implements FieldValuesParser {
@@ -55,6 +57,17 @@ public class JavaCompilerFieldValuesParser implements FieldValuesParser {
 			return fieldCollector.getFieldValues();
 		}
 		return Collections.emptyMap();
+	}
+
+	@Override
+	public Set<String> getInitializedFields(TypeElement element) throws Exception {
+		Tree tree = this.trees.getTree(element);
+		if (tree != null) {
+			FieldCollector fieldCollector = new FieldCollector();
+			tree.accept(fieldCollector);
+			return fieldCollector.getInitializedFields();
+		}
+		return Collections.emptySet();
 	}
 
 	/**
@@ -152,6 +165,8 @@ public class JavaCompilerFieldValuesParser implements FieldValuesParser {
 
 		private final Map<String, Object> staticFinals = new HashMap<>();
 
+		private final Set<String> initializedFields = new HashSet<>();
+
 		@Override
 		public void visitVariable(VariableTree variable) throws Exception {
 			Set<Modifier> flags = variable.getModifierFlags();
@@ -160,6 +175,9 @@ public class JavaCompilerFieldValuesParser implements FieldValuesParser {
 			}
 			if (!flags.contains(Modifier.FINAL)) {
 				this.fieldValues.put(variable.getName(), getValue(variable));
+			}
+			if (!flags.contains(Modifier.STATIC) && variable.getInitializer() != null) {
+				this.initializedFields.add(variable.getName());
 			}
 		}
 
@@ -242,6 +260,10 @@ public class JavaCompilerFieldValuesParser implements FieldValuesParser {
 
 		Map<String, Object> getFieldValues() {
 			return this.fieldValues;
+		}
+
+		Set<String> getInitializedFields() {
+			return Collections.unmodifiableSet(this.initializedFields);
 		}
 
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -97,6 +97,7 @@ import org.springframework.boot.configurationsample.specific.InvalidDefaultValue
 import org.springframework.boot.configurationsample.specific.InvalidDefaultValueFloatingPointProperties;
 import org.springframework.boot.configurationsample.specific.InvalidDefaultValueNumberProperties;
 import org.springframework.boot.configurationsample.specific.InvalidDoubleRegistrationProperties;
+import org.springframework.boot.configurationsample.specific.NonStaticInnerClassProperties;
 import org.springframework.boot.configurationsample.specific.SimplePojo;
 import org.springframework.boot.configurationsample.specific.StaticAccessor;
 import org.springframework.core.test.tools.CompilationException;
@@ -119,6 +120,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Pavel Anisimov
  * @author Scott Frederick
  * @author Moritz Halbritter
+ * @author Daeho Kwon
  */
 class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGenerationTests {
 
@@ -399,6 +401,26 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 			.ofType(DeprecatedSimplePojo.class)
 			.fromSource(InnerClassProperties.class));
 		assertThat(metadata).has(Metadata.withProperty("config.fifth.value").withDeprecation());
+	}
+
+	@Test
+	void nonStaticInnerClassProperties() {
+		ConfigurationMetadata metadata = compile(NonStaticInnerClassProperties.class);
+		assertThat(metadata).has(Metadata.withGroup("non-static-inner").fromSource(NonStaticInnerClassProperties.class));
+		assertThat(metadata).doesNotHave(Metadata.withGroup("non-static-inner.inner-with-setter"));
+		assertThat(metadata).doesNotHave(Metadata.withProperty("non-static-inner.inner-with-setter.value"));
+		assertThat(metadata).has(Metadata.withGroup("non-static-inner.inner-without-setter")
+			.ofType(NonStaticInnerClassProperties.InnerWithoutSetter.class)
+			.fromSource(NonStaticInnerClassProperties.class));
+		assertThat(metadata).has(Metadata.withProperty("non-static-inner.inner-without-setter.value"));
+		assertThat(metadata).has(Metadata.withGroup("non-static-inner.explicitly-nested")
+			.ofType(NonStaticInnerClassProperties.InnerWithSetter.class)
+			.fromSource(NonStaticInnerClassProperties.class));
+		assertThat(metadata).has(Metadata.withProperty("non-static-inner.explicitly-nested.value"));
+		assertThat(metadata).has(Metadata.withGroup("non-static-inner.initialized-without-setter")
+			.ofType(NonStaticInnerClassProperties.InnerWithoutSetter.class)
+			.fromSource(NonStaticInnerClassProperties.class));
+		assertThat(metadata).doesNotHave(Metadata.withGroup("non-static-inner.uninitialized-without-setter"));
 	}
 
 	@Test

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/LombokMetadataGenerationTests.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/LombokMetadataGenerationTests.java
@@ -27,6 +27,7 @@ import org.springframework.boot.configurationsample.lombok.LombokAccessLevelProp
 import org.springframework.boot.configurationsample.lombok.LombokExplicitProperties;
 import org.springframework.boot.configurationsample.lombok.LombokInnerClassProperties;
 import org.springframework.boot.configurationsample.lombok.LombokInnerClassWithGetterProperties;
+import org.springframework.boot.configurationsample.lombok.LombokNonStaticInnerClassProperties;
 import org.springframework.boot.configurationsample.lombok.LombokSimpleDataProperties;
 import org.springframework.boot.configurationsample.lombok.LombokSimpleProperties;
 import org.springframework.boot.configurationsample.lombok.LombokSimpleValueProperties;
@@ -129,6 +130,18 @@ class LombokMetadataGenerationTests extends AbstractMetadataGenerationTests {
 			.fromSource(LombokInnerClassWithGetterProperties.class));
 		assertThat(metadata).has(Metadata.withProperty("config.first.name"));
 		assertThat(metadata.getItems()).hasSize(3);
+	}
+
+	@Test
+	void lombokNonStaticInnerClassProperties() {
+		ConfigurationMetadata metadata = compile(LombokNonStaticInnerClassProperties.class);
+		assertThat(metadata)
+			.has(Metadata.withGroup("lombok-non-static-inner").fromSource(LombokNonStaticInnerClassProperties.class));
+		assertThat(metadata).doesNotHave(Metadata.withGroup("lombok-non-static-inner.inner-with-setter"));
+		assertThat(metadata)
+			.has(Metadata.withGroup("lombok-non-static-inner.inner-without-setter")
+				.ofType(LombokNonStaticInnerClassProperties.InnerWithoutSetter.class)
+				.fromSource(LombokNonStaticInnerClassProperties.class));
 	}
 
 	private void assertSimpleLombokProperties(ConfigurationMetadata metadata, Class<?> source, String prefix) {

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/fieldvalues/AbstractFieldValuesProcessorTests.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/fieldvalues/AbstractFieldValuesProcessorTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.configurationprocessor.fieldvalues;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Phillip Webb
  * @author Stephane Nicoll
+ * @author Daeho Kwon
  */
 public abstract class AbstractFieldValuesProcessorTests {
 
@@ -116,6 +118,19 @@ public abstract class AbstractFieldValuesProcessorTests {
 		assertThat(values.get("memberSelectInt")).isNull();
 	}
 
+	@Test
+	void getInitializedFields() {
+		InitializedFieldsTestProcessor processor = new InitializedFieldsTestProcessor();
+		TestCompiler compiler = TestCompiler.forSystem()
+			.withProcessors(processor)
+			.withSources(SourceFile.forTestClass(FieldValues.class));
+		compiler.compile((compiled) -> {
+		});
+		Set<String> fields = processor.getFields();
+		assertThat(fields).contains("stringConst", "bool", "integer", "objectInstance");
+		assertThat(fields).doesNotContain("stringNone", "boolNone", "integerNone", "objectNone");
+	}
+
 	@SupportedAnnotationTypes({ "org.springframework.boot.configurationsample.TestConfigurationProperties" })
 	@SupportedSourceVersion(SourceVersion.RELEASE_6)
 	private final class TestProcessor extends AbstractProcessor {
@@ -148,6 +163,42 @@ public abstract class AbstractFieldValuesProcessorTests {
 
 		Map<String, Object> getValues() {
 			return this.values;
+		}
+
+	}
+
+	@SupportedAnnotationTypes({ "org.springframework.boot.configurationsample.TestConfigurationProperties" })
+	@SupportedSourceVersion(SourceVersion.RELEASE_6)
+	private final class InitializedFieldsTestProcessor extends AbstractProcessor {
+
+		private FieldValuesParser processor;
+
+		private final Set<String> fields = new HashSet<>();
+
+		@Override
+		public synchronized void init(ProcessingEnvironment env) {
+			this.processor = createProcessor(env);
+		}
+
+		@Override
+		public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+			for (TypeElement annotation : annotations) {
+				for (Element element : roundEnv.getElementsAnnotatedWith(annotation)) {
+					if (element instanceof TypeElement typeElement) {
+						try {
+							this.fields.addAll(this.processor.getInitializedFields(typeElement));
+						}
+						catch (Exception ex) {
+							throw new IllegalStateException(ex);
+						}
+					}
+				}
+			}
+			return false;
+		}
+
+		Set<String> getFields() {
+			return this.fields;
 		}
 
 	}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokNonStaticInnerClassProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/lombok/LombokNonStaticInnerClassProperties.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.configurationsample.lombok;
+
+import lombok.Data;
+
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+
+/**
+ * Lombok properties with non-static nested classes.
+ *
+ * @author Daeho Kwon
+ */
+@Data
+@TestConfigurationProperties("lombok-non-static-inner")
+@SuppressWarnings("unused")
+public class LombokNonStaticInnerClassProperties {
+
+	// non-final → @Data generates setter → non-static + setter → no metadata
+	private InnerWithSetter innerWithSetter;
+
+	// final → @Data does not generate setter → non-static + no setter → metadata generated
+	private final InnerWithoutSetter innerWithoutSetter = new InnerWithoutSetter();
+
+	@Data
+	public class InnerWithSetter {
+
+		private String value;
+
+	}
+
+	@Data
+	public class InnerWithoutSetter {
+
+		private String value;
+
+	}
+
+}

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/NonStaticInnerClassProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/NonStaticInnerClassProperties.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.configurationsample.specific;
+
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
+
+/**
+ * Properties with non-static nested classes.
+ *
+ * @author Daeho Kwon
+ */
+@TestConfigurationProperties("non-static-inner")
+public class NonStaticInnerClassProperties {
+
+	private InnerWithSetter innerWithSetter;
+
+	private final InnerWithoutSetter innerWithoutSetter = new InnerWithoutSetter();
+
+	private InnerWithoutSetter initializedWithoutSetter = new InnerWithoutSetter();
+
+	private InnerWithoutSetter uninitializedWithoutSetter;
+
+	@TestNestedConfigurationProperty
+	private InnerWithSetter explicitlyNested;
+
+	public InnerWithSetter getInnerWithSetter() {
+		return this.innerWithSetter;
+	}
+
+	public void setInnerWithSetter(InnerWithSetter innerWithSetter) {
+		this.innerWithSetter = innerWithSetter;
+	}
+
+	public InnerWithoutSetter getInnerWithoutSetter() {
+		return this.innerWithoutSetter;
+	}
+
+	public InnerWithoutSetter getInitializedWithoutSetter() {
+		return this.initializedWithoutSetter;
+	}
+
+	public InnerWithoutSetter getUninitializedWithoutSetter() {
+		return this.uninitializedWithoutSetter;
+	}
+
+	public InnerWithSetter getExplicitlyNested() {
+		return this.explicitlyNested;
+	}
+
+	public void setExplicitlyNested(InnerWithSetter explicitlyNested) {
+		this.explicitlyNested = explicitlyNested;
+	}
+
+	public class InnerWithSetter {
+
+		private String value;
+
+		public String getValue() {
+			return this.value;
+		}
+
+		public void setValue(String value) {
+			this.value = value;
+		}
+
+	}
+
+	public class InnerWithoutSetter {
+
+		private String value;
+
+		public String getValue() {
+			return this.value;
+		}
+
+		public void setValue(String value) {
+			this.value = value;
+		}
+
+	}
+
+}


### PR DESCRIPTION
This PR addresses #50133 by updating `PropertyDescriptor`,                                                                                                                                                   
  `JavaBeanPropertyDescriptor`, and `LombokPropertyDescriptor` to skip                                                                                                                                         
  metadata generation for non-static inner classes with a setter or                                                                                                                                            
  without an initializer. `FieldValuesParser` and                                                                                                                                                              
  `JavaCompilerFieldValuesParser` are extended to detect whether a field                                                                                                                                       
  has an initializer at declaration. 

Closes #50133 