### PR TITLE
Fix typo in Spring Security OAuth2 client registration documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/web/spring-security.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/web/spring-security.adoc
@@ -214,7 +214,7 @@ For production environments, consider using a javadoc:org.springframework.securi
 ==== OAuth2 Client Registration for Common Providers
 
 For common OAuth2 and OpenID providers (Google, Github, Facebook, and Okta), we provide a set of provider defaults.
-The IDs of these common provides are `google`, `github`, `facebook`, and `okta`, respectively.
+The IDs of these common providers are `google`, `github`, `facebook`, and `okta`, respectively.
 
 If you do not need to customize these providers, set the registration's `provider` property to the ID of one of the common providers.
 Alternatively, you can xref:web/spring-security.adoc#web.security.oauth2.client[use a registration ID that matches the ID of the provider].


### PR DESCRIPTION
Spring Security documentation has "common provides" instead of "common providers".