### PR TITLE
Expose Path getters on ApplicationHome and ApplicationTemp

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/system/ApplicationHome.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/system/ApplicationHome.java
@@ -23,6 +23,7 @@ import java.net.JarURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Path;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.Enumeration;
@@ -164,11 +165,31 @@ public class ApplicationHome {
 	}
 
 	/**
+	 * Returns the path of the underlying source used to find the home directory. This is
+	 * usually the jar file or a directory. Can return {@code null} if the source cannot
+	 * be determined.
+	 * @return the underlying source path or {@code null}
+	 * @since 4.2.0
+	 */
+	public @Nullable Path getSourcePath() {
+		return (this.source != null) ? this.source.toPath() : null;
+	}
+
+	/**
 	 * Returns the application home directory.
 	 * @return the home directory (never {@code null})
 	 */
 	public File getDir() {
 		return this.dir;
+	}
+
+	/**
+	 * Returns the path of the application home directory.
+	 * @return the home path (never {@code null})
+	 * @since 4.2.0
+	 */
+	public Path getPath() {
+		return this.dir.toPath();
 	}
 
 	@Override

--- a/core/spring-boot/src/main/java/org/springframework/boot/system/ApplicationTemp.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/system/ApplicationTemp.java
@@ -117,7 +117,12 @@ public class ApplicationTemp {
 		return createDirectory(getPath().resolve(subDir)).toFile();
 	}
 
-	private Path getPath() {
+	/**
+	 * Return the path to be used for application specific temp files.
+	 * @return the application temp path
+	 * @since 4.2.0
+	 */
+	public Path getPath() {
 		if (this.path == null) {
 			this.pathLock.lock();
 			try {

--- a/core/spring-boot/src/test/java/org/springframework/boot/system/ApplicationHomeTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/system/ApplicationHomeTests.java
@@ -57,6 +57,29 @@ class ApplicationHomeTests {
 		assertThat(applicationHome.getDir()).isEqualTo(app);
 	}
 
+	@Test
+	void getPathReturnsSamePathAsGetDir() throws Exception {
+		File app = new File(this.tempDir, "app");
+		ApplicationHome applicationHome = createApplicationHome(app);
+		assertThat(applicationHome.getPath()).isEqualTo(applicationHome.getDir().toPath());
+	}
+
+	@Test
+	void getSourcePathReturnsSamePathAsGetSource() throws Exception {
+		File app = new File(this.tempDir, "app");
+		ApplicationHome applicationHome = createApplicationHome(app);
+		File source = applicationHome.getSource();
+		assertThat(source).isNotNull();
+		assertThat(applicationHome.getSourcePath()).isEqualTo(source.toPath());
+	}
+
+	@Test
+	void getSourcePathReturnsNullWhenSourceIsNull() {
+		ApplicationHome applicationHome = new ApplicationHome();
+		assertThat(applicationHome.getSource()).isNull();
+		assertThat(applicationHome.getSourcePath()).isNull();
+	}
+
 	private ApplicationHome createApplicationHome(File location) throws Exception {
 		File examplePackage = new File(location, "com/example");
 		examplePackage.mkdirs();

--- a/core/spring-boot/src/test/java/org/springframework/boot/system/ApplicationTempTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/system/ApplicationTempTests.java
@@ -80,6 +80,12 @@ class ApplicationTempTests {
 	}
 
 	@Test
+	void getPathReturnsSamePathAsGetDir() {
+		ApplicationTemp temp = new ApplicationTemp();
+		assertThat(temp.getPath()).isEqualTo(temp.getDir().toPath());
+	}
+
+	@Test
 	void posixPermissions() throws IOException {
 		ApplicationTemp temp = new ApplicationTemp();
 		Path path = temp.getDir().toPath();


### PR DESCRIPTION
`ApplicationTemp` already uses `java.nio.file.Path` internally but only exposes `java.io.File` via `getDir()` / `getDir(String)`. Callers that want to use the NIO `Files` API have to round-trip through `getDir().toPath()`.

This change makes `getPath()` public and adds `getPath(String subDir)` to mirror the existing `getDir` methods.

Closes gh-50192