### PR TITLE
Fix: consider getter annotation for @NestedConfigurationProperty in L…

### DIFF
--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/LombokPropertyDescriptor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/LombokPropertyDescriptor.java
@@ -70,9 +70,10 @@ class LombokPropertyDescriptor extends PropertyDescriptor {
 	}
 
 	@Override
-	protected boolean isMarkedAsNested(MetadataGenerationEnvironment environment) {
-		return environment.getNestedConfigurationPropertyAnnotation(getField()) != null;
-	}
+    protected boolean isMarkedAsNested(MetadataGenerationEnvironment environment) {
+        return environment.getNestedConfigurationPropertyAnnotation(getField()) != null
+            || environment.getNestedConfigurationPropertyAnnotation(getGetter()) != null;
+    }
 
 	@Override
 	protected String resolveDescription(MetadataGenerationEnvironment environment) {


### PR DESCRIPTION
Fixes an issue where @NestedConfigurationProperty annotations on getter methods
were not considered in LombokPropertyDescriptor.

Previously, only field-level annotations were checked when determining if a property
is nested. This change updates the logic to also consider annotations present on
getter methods.

This ensures consistent behavior when using Lombok or placing annotations on getters.
