### PR TITLE
fix(perf): optimize writable json bytes

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/json/WritableJson.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/json/WritableJson.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.json;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -76,9 +75,8 @@ public interface WritableJson {
 	 */
 	default byte[] toByteArray(Charset charset) {
 		Assert.notNull(charset, "'charset' must not be null");
-		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-			toWriter(new OutputStreamWriter(out, charset));
-			return out.toByteArray();
+		try {
+			return WritableJsonBytes.toByteArray(this, charset);
 		}
 		catch (IOException ex) {
 			throw new UncheckedIOException(ex);

--- a/core/spring-boot/src/main/java/org/springframework/boot/json/WritableJsonBytes.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/json/WritableJsonBytes.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.json;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Internal support for writing {@link WritableJson} to bytes.
+ * <p>
+ * An {@link Encoder} is cached per thread and reused when the same {@link Charset} is
+ * requested. This allows the growable byte buffer and {@link OutputStreamWriter} to be
+ * reused while still returning a fresh {@code byte[]} to callers.
+ *
+ * @author Marcus Schiesser
+ */
+final class WritableJsonBytes {
+
+	// Avoid retaining unusually large buffers in long-lived logging threads.
+	private static final int MAX_RETAINED_BUFFER_CAPACITY = 256 * 1024;
+
+	private static final ThreadLocal<Encoder> encoder = new ThreadLocal<>();
+
+	private WritableJsonBytes() {
+	}
+
+	static byte[] toByteArray(WritableJson writableJson, Charset charset) throws IOException {
+		if (requiresFreshWriter(charset)) {
+			return toByteArrayWithFreshWriter(writableJson, charset);
+		}
+		Encoder encoder = getEncoder(charset);
+		try {
+			byte[] bytes = encoder.write(writableJson);
+			if (encoder.isOversized()) {
+				WritableJsonBytes.encoder.remove();
+			}
+			return bytes;
+		}
+		catch (IOException ex) {
+			WritableJsonBytes.encoder.remove();
+			throw ex;
+		}
+	}
+
+	private static boolean requiresFreshWriter(Charset charset) {
+		// Some charsets emit a BOM once per writer. Reusing the writer would change the
+		// bytes returned by subsequent calls compared to the original implementation.
+		String name = charset.name();
+		return StandardCharsets.UTF_16.equals(charset) || "UTF-32".equalsIgnoreCase(name)
+				|| name.toUpperCase(Locale.ENGLISH).contains("BOM");
+	}
+
+	private static byte[] toByteArrayWithFreshWriter(WritableJson writableJson, Charset charset) throws IOException {
+		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+			writableJson.toWriter(new OutputStreamWriter(out, charset));
+			return out.toByteArray();
+		}
+	}
+
+	private static Encoder getEncoder(Charset charset) {
+		Encoder encoder = WritableJsonBytes.encoder.get();
+		if (encoder == null || !encoder.charset().equals(charset)) {
+			encoder = new Encoder(charset);
+			WritableJsonBytes.encoder.set(encoder);
+		}
+		return encoder;
+	}
+
+	static void clear() {
+		encoder.remove();
+	}
+
+	static @Nullable Charset getCachedCharset() {
+		Encoder encoder = WritableJsonBytes.encoder.get();
+		return (encoder != null) ? encoder.charset() : null;
+	}
+
+	private static final class Encoder extends ByteArrayOutputStream {
+
+		private final Charset charset;
+
+		private final Writer writer;
+
+		private Encoder(Charset charset) {
+			this.charset = charset;
+			this.writer = new OutputStreamWriter(this, charset);
+		}
+
+		private Charset charset() {
+			return this.charset;
+		}
+
+		private byte[] write(WritableJson writableJson) throws IOException {
+			reset();
+			writableJson.toWriter(this.writer);
+			return toByteArray();
+		}
+
+		private boolean isOversized() {
+			return this.buf.length > MAX_RETAINED_BUFFER_CAPACITY;
+		}
+
+	}
+
+}

--- a/core/spring-boot/src/main/java/org/springframework/boot/json/WritableJsonBytes.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/json/WritableJsonBytes.java
@@ -61,6 +61,10 @@ final class WritableJsonBytes {
 			WritableJsonBytes.encoder.remove();
 			throw ex;
 		}
+		catch (RuntimeException | Error ex) {
+			WritableJsonBytes.encoder.remove();
+			throw ex;
+		}
 	}
 
 	private static boolean requiresFreshWriter(Charset charset) {

--- a/core/spring-boot/src/test/java/org/springframework/boot/json/WritableJsonPerformanceTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/json/WritableJsonPerformanceTests.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.json;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.UncheckedIOException;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+
+import com.sun.management.ThreadMXBean;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Performance smoke tests for {@link WritableJson}.
+ *
+ * @author Marcus Schiesser
+ */
+class WritableJsonPerformanceTests {
+
+	private static final int WARMUP_ITERATIONS = 5_000;
+
+	private static final int MEASURED_ITERATIONS = 50_000;
+
+	private static final Charset CHARSET = StandardCharsets.UTF_8;
+
+	private static volatile int consumed;
+
+	@AfterEach
+	void clearWritableJsonBytes() {
+		WritableJsonBytes.clear();
+	}
+
+	@Test
+	void toByteArrayComparesLegacyAndOptimizedImplementations() {
+		for (Payload payload : Payload.all()) {
+			WritableJson writable = payload::writeTo;
+			assertThat(writable.toByteArray(CHARSET)).isEqualTo(toByteArrayWithLegacyImplementation(writable, CHARSET));
+			Result legacy = measure(() -> toByteArrayWithLegacyImplementation(writable, CHARSET));
+			WritableJsonBytes.clear();
+			Result optimized = measure(() -> writable.toByteArray(CHARSET));
+			System.out.printf("%s: legacy=%s/%s allocated, optimized=%s/%s allocated%n", payload.name(),
+					legacy.duration(), legacy.allocated(), optimized.duration(), optimized.allocated());
+		}
+	}
+
+	private static byte[] toByteArrayWithLegacyImplementation(WritableJson writableJson, Charset charset) {
+		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+			writableJson.toWriter(new OutputStreamWriter(out, charset));
+			return out.toByteArray();
+		}
+		catch (IOException ex) {
+			throw new UncheckedIOException(ex);
+		}
+	}
+
+	private static Result measure(Operation operation) {
+		for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+			consume(operation.run());
+		}
+		ThreadAllocation allocation = ThreadAllocation.get();
+		long allocatedBefore = allocation.bytes();
+		long start = System.nanoTime();
+		for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+			consume(operation.run());
+		}
+		Duration duration = Duration.ofNanos(System.nanoTime() - start);
+		long allocated = allocation.bytesSince(allocatedBefore);
+		return new Result(duration, allocated);
+	}
+
+	private static void consume(byte[] bytes) {
+		consumed = bytes.length;
+	}
+
+	private record Payload(String name, String json) {
+
+		private static List<Payload> all() {
+			return List.of(new Payload("small", "{\"message\":\"test\"}"),
+					new Payload("structured-log",
+							"""
+									{"@timestamp":"2026-04-24T10:15:30.123Z","@version":"1","message":"Application started","logger_name":"com.example.Application","thread_name":"main","level":"INFO","level_value":20000}
+									"""),
+					new Payload("exception",
+							"""
+									{"@timestamp":"2026-04-24T10:15:30.123Z","message":"Request failed","stack_trace":"java.lang.IllegalStateException: Test failure\\n\\tat com.example.Service.call(Service.java:42)\\n\\tat com.example.Controller.handle(Controller.java:21)"}
+									"""));
+		}
+
+		private void writeTo(Appendable out) throws IOException {
+			out.append(this.json);
+		}
+
+	}
+
+	private record Result(Duration duration, long allocatedBytes) {
+
+		private String allocated() {
+			return (this.allocatedBytes >= 0) ? this.allocatedBytes + "B" : "unavailable";
+		}
+
+	}
+
+	@FunctionalInterface
+	private interface Operation {
+
+		byte[] run();
+
+	}
+
+	private static final class ThreadAllocation {
+
+		private static final ThreadAllocation NONE = new ThreadAllocation(null);
+
+		private final @Nullable ThreadMXBean threadBean;
+
+		private ThreadAllocation(@Nullable ThreadMXBean threadBean) {
+			this.threadBean = threadBean;
+		}
+
+		private static ThreadAllocation get() {
+			java.lang.management.ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+			if (threadBean instanceof ThreadMXBean allocatingThreadBean
+					&& allocatingThreadBean.isThreadAllocatedMemorySupported()) {
+				if (!allocatingThreadBean.isThreadAllocatedMemoryEnabled()) {
+					allocatingThreadBean.setThreadAllocatedMemoryEnabled(true);
+				}
+				return new ThreadAllocation(allocatingThreadBean);
+			}
+			return NONE;
+		}
+
+		private long bytes() {
+			return (this.threadBean != null) ? this.threadBean.getCurrentThreadAllocatedBytes() : -1;
+		}
+
+		private long bytesSince(long before) {
+			long bytes = bytes();
+			return (before >= 0 && bytes >= 0) ? bytes - before : -1;
+		}
+
+	}
+
+}

--- a/core/spring-boot/src/test/java/org/springframework/boot/json/WritableJsonTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/json/WritableJsonTests.java
@@ -21,8 +21,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -44,6 +47,16 @@ class WritableJsonTests {
 	@SuppressWarnings("NullAway.Init")
 	File temp;
 
+	@BeforeEach
+	void clearWritableJsonBytes() {
+		WritableJsonBytes.clear();
+	}
+
+	@AfterEach
+	void clearWritableJsonBytesAfterEachTest() {
+		WritableJsonBytes.clear();
+	}
+
 	@Test
 	void toJsonStringReturnsString() {
 		WritableJson writable = (out) -> out.append("{}");
@@ -64,6 +77,73 @@ class WritableJsonTests {
 	void toByteArrayReturnsByteArray() {
 		WritableJson writable = (out) -> out.append("{}");
 		assertThat(writable.toByteArray()).isEqualTo("{}".getBytes());
+	}
+
+	@Test
+	void toByteArrayWhenCalledRepeatedlyReturnsByteArray() {
+		WritableJson writable = (out) -> out.append("{\"message\":\"test\"}");
+		byte[] bytes = writable.toByteArray();
+		assertThat(writable.toByteArray()).isEqualTo(bytes);
+		assertThat(WritableJsonBytes.getCachedCharset()).isEqualTo(StandardCharsets.UTF_8);
+	}
+
+	@Test
+	void toByteArrayWithCharsetReturnsByteArray() {
+		WritableJson writable = (out) -> out.append("{\"message\":\"é\"}");
+		assertThat(writable.toByteArray(StandardCharsets.ISO_8859_1))
+			.isEqualTo("{\"message\":\"é\"}".getBytes(StandardCharsets.ISO_8859_1));
+		assertThat(WritableJsonBytes.getCachedCharset()).isEqualTo(StandardCharsets.ISO_8859_1);
+	}
+
+	@Test
+	void toByteArrayWhenCharsetChangesReplacesCachedEncoder() {
+		WritableJson writable = (out) -> out.append("{\"message\":\"test\"}");
+		writable.toByteArray(StandardCharsets.UTF_8);
+		assertThat(WritableJsonBytes.getCachedCharset()).isEqualTo(StandardCharsets.UTF_8);
+		writable.toByteArray(StandardCharsets.ISO_8859_1);
+		assertThat(WritableJsonBytes.getCachedCharset()).isEqualTo(StandardCharsets.ISO_8859_1);
+	}
+
+	@Test
+	void toByteArrayWithBomCharsetUsesFreshWriterForEachCall() {
+		assertUsesFreshWriterForEachCall(StandardCharsets.UTF_16);
+		assertUsesFreshWriterForEachCall(Charset.forName("UTF-32"));
+	}
+
+	private void assertUsesFreshWriterForEachCall(Charset charset) {
+		WritableJson writable = (out) -> out.append("{\"message\":\"test\"}");
+		byte[] expected = "{\"message\":\"test\"}".getBytes(charset);
+		assertThat(writable.toByteArray(charset)).isEqualTo(expected);
+		assertThat(writable.toByteArray(charset)).isEqualTo(expected);
+		assertThat(WritableJsonBytes.getCachedCharset()).isNull();
+	}
+
+	@Test
+	void toByteArrayWithNonAsciiAndSurrogatePairReturnsByteArray() {
+		String json = "{\"message\":\"Héllo 😀\"}";
+		WritableJson writable = (out) -> out.append(json);
+		assertThat(writable.toByteArray()).isEqualTo(json.getBytes(StandardCharsets.UTF_8));
+	}
+
+	@Test
+	void toByteArrayWhenIOExceptionIsThrownThrowsUncheckedIOExceptionAndClearsCachedEncoder() {
+		WritableJson writable = (out) -> out.append("{}");
+		writable.toByteArray();
+		WritableJson failing = (out) -> {
+			throw new IOException("bad");
+		};
+		assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(failing::toByteArray)
+			.havingCause()
+			.withMessage("bad");
+		assertThat(WritableJsonBytes.getCachedCharset()).isNull();
+	}
+
+	@Test
+	void toByteArrayWhenBufferIsOversizedDiscardsCachedEncoder() {
+		String json = "{\"message\":\"%s\"}".formatted("a".repeat(300 * 1024));
+		WritableJson writable = (out) -> out.append(json);
+		assertThat(writable.toByteArray()).isEqualTo(json.getBytes(StandardCharsets.UTF_8));
+		assertThat(WritableJsonBytes.getCachedCharset()).isNull();
 	}
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/json/WritableJsonTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/json/WritableJsonTests.java
@@ -34,6 +34,7 @@ import org.springframework.core.io.FileSystemResource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
  * Tests for {@link WritableJson}.
@@ -136,6 +137,18 @@ class WritableJsonTests {
 			.havingCause()
 			.withMessage("bad");
 		assertThat(WritableJsonBytes.getCachedCharset()).isNull();
+	}
+
+	@Test
+	void toByteArrayWhenRuntimeExceptionIsThrownClearsCachedEncoder() {
+		WritableJson failing = (out) -> {
+			out.append("bad");
+			throw new IllegalStateException("bad");
+		};
+		assertThatIllegalStateException().isThrownBy(failing::toByteArray).withMessage("bad");
+		assertThat(WritableJsonBytes.getCachedCharset()).isNull();
+		WritableJson writable = (out) -> out.append("{}");
+		assertThat(writable.toByteArray()).isEqualTo("{}".getBytes(StandardCharsets.UTF_8));
 	}
 
 	@Test


### PR DESCRIPTION
fixes https://github.com/spring-projects/spring-boot/issues/49428 

Optimize `WritableJson.toByteArray(Charset)` by reusing a per-thread encoder for the most recently used charset. The implementation still returns a fresh `byte[]` for each call, clears the cached encoder on failures, avoids retaining unusually large buffers, and preserves fresh-writer behavior for BOM-emitting charsets.