### PR TITLE
Apply HTML escaping to timestamp attribute in Whitelabel error page

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/AbstractErrorWebExceptionHandler.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/reactive/error/AbstractErrorWebExceptionHandler.java
@@ -17,7 +17,6 @@
 package org.springframework.boot.autoconfigure.web.reactive.error;
 
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -237,17 +236,17 @@ public abstract class AbstractErrorWebExceptionHandler implements ErrorWebExcept
 	protected Mono<ServerResponse> renderDefaultErrorView(ServerResponse.BodyBuilder responseBody,
 			Map<String, Object> error) {
 		StringBuilder builder = new StringBuilder();
-		Date timestamp = (Date) error.get("timestamp");
+		Object timestamp = error.get("timestamp");
 		Object message = error.get("message");
 		Object trace = error.get("trace");
 		Object requestId = error.get("requestId");
 		builder.append("<html><body><h1>Whitelabel Error Page</h1>")
 			.append("<p>This application has no configured error view, so you are seeing this as a fallback.</p>")
 			.append("<div id='created'>")
-			.append(timestamp)
+			.append(htmlEscape(timestamp))
 			.append("</div>")
 			.append("<div>[")
-			.append(requestId)
+			.append(htmlEscape(requestId))
 			.append("] There was an unexpected error (type=")
 			.append(htmlEscape(error.get("error")))
 			.append(", status=")

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfiguration.java
@@ -213,7 +213,7 @@ public class ErrorMvcAutoConfiguration {
 			builder.append("<html><body><h1>Whitelabel Error Page</h1>")
 				.append("<p>This application has no explicit mapping for /error, so you are seeing this as a fallback.</p>")
 				.append("<div id='created'>")
-				.append(timestamp)
+				.append(htmlEscape(timestamp))
 				.append("</div>")
 				.append("<div>There was an unexpected error (type=")
 				.append(htmlEscape(model.get("error")))

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandlerIntegrationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandlerIntegrationTests.java
@@ -461,6 +461,27 @@ class DefaultErrorWebExceptionHandlerIntegrationTests {
 	}
 
 	@Test
+	void escapeHtmlInTimestampAndRequestIdAttributes() {
+		this.contextRunner.withPropertyValues("spring.mustache.prefix=classpath:/unknown/")
+			.withUserConfiguration(CustomErrorAttributesWithHtmlInTimestampAndRequestId.class)
+			.run((context) -> {
+				WebTestClient client = getWebClient(context);
+				String body = client.get()
+					.uri("/")
+					.accept(MediaType.TEXT_HTML)
+					.exchange()
+					.expectStatus()
+					.isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+					.expectHeader()
+					.contentType(TEXT_HTML_UTF8)
+					.expectBody(String.class)
+					.returnResult()
+					.getResponseBody();
+				assertThat(body).doesNotContain("<script>").contains("&lt;script&gt;");
+			});
+	}
+
+	@Test
 	void testExceptionWithNullMessage() {
 		this.contextRunner.withPropertyValues("spring.mustache.prefix=classpath:/unknown/").run((context) -> {
 			WebTestClient client = getWebClient(context);
@@ -773,6 +794,28 @@ class DefaultErrorWebExceptionHandlerIntegrationTests {
 				public Map<String, Object> getErrorAttributes(ServerRequest request, ErrorAttributeOptions options) {
 					Map<String, Object> attributes = new LinkedHashMap<>(super.getErrorAttributes(request, options));
 					attributes.remove("status");
+					return attributes;
+				}
+
+			};
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomErrorAttributesWithHtmlInTimestampAndRequestId {
+
+		@Bean
+		ErrorAttributes errorAttributes() {
+			return new DefaultErrorAttributes() {
+
+				@Override
+				public Map<String, Object> getErrorAttributes(ServerRequest request,
+						ErrorAttributeOptions options) {
+					Map<String, Object> attributes = new LinkedHashMap<>(
+							super.getErrorAttributes(request, options));
+					attributes.put("timestamp", "<script>alert('xss')</script>");
+					attributes.put("requestId", "<script>alert('xss')</script>");
 					return attributes;
 				}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandlerIntegrationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/reactive/error/DefaultErrorWebExceptionHandlerIntegrationTests.java
@@ -461,9 +461,9 @@ class DefaultErrorWebExceptionHandlerIntegrationTests {
 	}
 
 	@Test
-	void escapeHtmlInTimestampAndRequestIdAttributes() {
+	void escapeHtmlInErrorAttributes() {
 		this.contextRunner.withPropertyValues("spring.mustache.prefix=classpath:/unknown/")
-			.withUserConfiguration(CustomErrorAttributesWithHtmlInTimestampAndRequestId.class)
+			.withUserConfiguration(CustomErrorAttributesWithEscaping.class)
 			.run((context) -> {
 				WebTestClient client = getWebClient(context);
 				String body = client.get()
@@ -477,7 +477,9 @@ class DefaultErrorWebExceptionHandlerIntegrationTests {
 					.expectBody(String.class)
 					.returnResult()
 					.getResponseBody();
-				assertThat(body).doesNotContain("<script>").contains("&lt;script&gt;");
+				assertThat(body).doesNotContain("<script>")
+					.contains("&lt;script&gt;")
+					.contains("xss-error", "xss-message", "xss-requestId", "xss-timestamp", "xss-trace");
 			});
 	}
 
@@ -803,19 +805,20 @@ class DefaultErrorWebExceptionHandlerIntegrationTests {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	static class CustomErrorAttributesWithHtmlInTimestampAndRequestId {
+	static class CustomErrorAttributesWithEscaping {
 
 		@Bean
 		ErrorAttributes errorAttributes() {
 			return new DefaultErrorAttributes() {
 
 				@Override
-				public Map<String, Object> getErrorAttributes(ServerRequest request,
-						ErrorAttributeOptions options) {
-					Map<String, Object> attributes = new LinkedHashMap<>(
-							super.getErrorAttributes(request, options));
-					attributes.put("timestamp", "<script>alert('xss')</script>");
-					attributes.put("requestId", "<script>alert('xss')</script>");
+				public Map<String, Object> getErrorAttributes(ServerRequest request, ErrorAttributeOptions options) {
+					Map<String, Object> attributes = new LinkedHashMap<>(super.getErrorAttributes(request, options));
+					attributes.put("error", "<script>alert('xss-error')</script>");
+					attributes.put("message", "<script>alert('xss-message')</script>");
+					attributes.put("requestId", "<script>alert('xss-requestId')</script>");
+					attributes.put("timestamp", "<script>alert('xss-timestamp')</script>");
+					attributes.put("trace", "<script>alert('xss-trace')</script>");
 					return attributes;
 				}
 

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfigurationTests.java
@@ -86,19 +86,25 @@ class ErrorMvcAutoConfigurationTests {
 	}
 
 	@Test
-	void renderEscapesHtmlInTimestampAttribute() {
+	void renderEscapesHtmlInErrorAttributes() {
 		this.contextRunner.run((context) -> {
 			View errorView = context.getBean("error", View.class);
 			ErrorAttributes errorAttributes = context.getBean(ErrorAttributes.class);
 			DispatcherServletWebRequest webRequest = createWebRequest(new IllegalStateException("Exception message"),
 					false);
 			Map<String, Object> attributes = errorAttributes.getErrorAttributes(webRequest, withAllOptions());
-			attributes.put("timestamp", "<script>alert('xss')</script>");
+			attributes.put("error", "<script>alert('xss-error')</script>");
+			attributes.put("message", "<script>alert('xss-message')</script>");
+			attributes.put("timestamp", "<script>alert('xss-timestamp')</script>");
+			attributes.put("trace", "<script>alert('xss-trace')</script>");
 			HttpServletResponse response = webRequest.getResponse();
 			assertThat(response).isNotNull();
 			errorView.render(attributes, webRequest.getRequest(), response);
 			String responseString = ((MockHttpServletResponse) response).getContentAsString();
-			assertThat(responseString).contains("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;")
+			assertThat(responseString).contains("&lt;script&gt;alert(&#39;xss-error&#39;)&lt;/script&gt;")
+				.contains("&lt;script&gt;alert(&#39;xss-message&#39;)&lt;/script&gt;")
+				.contains("&lt;script&gt;alert(&#39;xss-timestamp&#39;)&lt;/script&gt;")
+				.contains("&lt;script&gt;alert(&#39;xss-trace&#39;)&lt;/script&gt;")
 				.doesNotContain("<script>");
 		});
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfigurationTests.java
@@ -19,6 +19,7 @@ package org.springframework.boot.autoconfigure.web.servlet.error;
 import java.time.Clock;
 import java.util.Map;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -81,6 +82,24 @@ class ErrorMvcAutoConfigurationTests {
 			assertThat(webRequest.getResponse().getContentType()).isEqualTo("text/html;charset=UTF-8");
 			String responseString = ((MockHttpServletResponse) webRequest.getResponse()).getContentAsString();
 			assertThat(responseString).contains("This application has no explicit mapping for /error");
+		});
+	}
+
+	@Test
+	void renderEscapesHtmlInTimestampAttribute() {
+		this.contextRunner.run((context) -> {
+			View errorView = context.getBean("error", View.class);
+			ErrorAttributes errorAttributes = context.getBean(ErrorAttributes.class);
+			DispatcherServletWebRequest webRequest = createWebRequest(new IllegalStateException("Exception message"),
+					false);
+			Map<String, Object> attributes = errorAttributes.getErrorAttributes(webRequest, withAllOptions());
+			attributes.put("timestamp", "<script>alert('xss')</script>");
+			HttpServletResponse response = webRequest.getResponse();
+			assertThat(response).isNotNull();
+			errorView.render(attributes, webRequest.getRequest(), response);
+			String responseString = ((MockHttpServletResponse) response).getContentAsString();
+			assertThat(responseString).contains("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;")
+				.doesNotContain("<script>");
 		});
 	}
 


### PR DESCRIPTION
Apply `htmlEscape()` to the `timestamp` attribute.

Closes gh-50203