### PR TITLE
Document SSL reloading with Let's Encrypt

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/ssl.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/ssl.adoc
@@ -185,7 +185,9 @@ You can configure the quiet period (to make sure that there are no more changes)
 [[features.ssl.reloading.lets-encrypt]]
 === Reloading SSL Bundles With Let's Encrypt
 
-If you use certificates issued by https://letsencrypt.org/[Let's Encrypt] and renewed by an external tool, such as https://certbot.eff.org/[Certbot], you can configure a PEM bundle to use the files from the `live` directory and enable reloading:
+If you use certificates issued by https://letsencrypt.org/[Let's Encrypt] and renewed by an external tool, such as https://certbot.eff.org/[Certbot], you can configure a PEM bundle to use the generated files and enable reloading.
+Certbot typically stores these in `/etc/letsencrypt/live/` under a directory named after your domain.
+The following example shows how to configure a PEM bundle for `example.com`:
 
 [configprops,yaml]
 ----
@@ -193,14 +195,14 @@ If you use certificates issued by https://letsencrypt.org/[Let's Encrypt] and re
       ssl:
         bundle:
           pem:
-            web-server:
+            webserver:
               reload-on-update: true
               keystore:
                 certificate: "file:/etc/letsencrypt/live/example.com/fullchain.pem"
                 private-key: "file:/etc/letsencrypt/live/example.com/privkey.pem"
     server:
       ssl:
-        bundle: "web-server"
+        bundle: "webserver"
 ----
 
 Spring Boot does not request or renew Let's Encrypt certificates.

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/ssl.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/features/ssl.adoc
@@ -181,3 +181,31 @@ A file watcher is then watching the files and if they change, the SSL bundle wil
 This in turn triggers a reload in the consuming component, e.g. Tomcat rotates the certificates in the SSL enabled connectors.
 
 You can configure the quiet period (to make sure that there are no more changes) of the file watcher with the configprop:spring.ssl.bundle.watch.file.quiet-period[] property.
+
+[[features.ssl.reloading.lets-encrypt]]
+=== Reloading SSL Bundles With Let's Encrypt
+
+If you use certificates issued by https://letsencrypt.org/[Let's Encrypt] and renewed by an external tool, such as https://certbot.eff.org/[Certbot], you can configure a PEM bundle to use the files from the `live` directory and enable reloading:
+
+[configprops,yaml]
+----
+    spring:
+      ssl:
+        bundle:
+          pem:
+            web-server:
+              reload-on-update: true
+              keystore:
+                certificate: "file:/etc/letsencrypt/live/example.com/fullchain.pem"
+                private-key: "file:/etc/letsencrypt/live/example.com/privkey.pem"
+    server:
+      ssl:
+        bundle: "web-server"
+----
+
+Spring Boot does not request or renew Let's Encrypt certificates.
+When Certbot or another ACME client updates the configured files, the SSL bundle is reloaded.
+Compatible consumers, such as Tomcat and Netty web servers, can then use the updated certificate without restarting the application.
+
+The files in `/etc/letsencrypt/live` are typically symbolic links to files in `/etc/letsencrypt/archive`.
+The file watcher follows symbolic links so that updates to the target files can trigger a reload.


### PR DESCRIPTION
## Summary
- Document how to configure SSL bundle reloading with Let's Encrypt certificates renewed by Certbot or another ACME client.
- Clarify that Spring Boot reloads externally updated files, but does not request or renew Let's Encrypt certificates.
- Note that the file watcher follows the symlinks commonly used by Certbot's `live` directory.

Closes #38275

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk PATH=/usr/lib/jvm/java-21-openjdk/bin:$PATH ./gradlew :spring-boot-project:spring-boot-docs:antora`