### PR TITLE
Meter registries are not removed from the global registry when the context is closed

### DIFF
--- a/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/MetricsAutoConfiguration.java
+++ b/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/MetricsAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.boot.micrometer.metrics.autoconfigure;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
@@ -112,6 +113,7 @@ public final class MetricsAutoConfiguration {
 		public void onApplicationEvent(ContextClosedEvent event) {
 			if (this.context.equals(event.getApplicationContext())) {
 				for (MeterRegistry meterRegistry : this.meterRegistries) {
+					Metrics.globalRegistry.remove(meterRegistry);
 					if (!meterRegistry.isClosed()) {
 						meterRegistry.close();
 					}

--- a/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/MetricsAutoConfiguration.java
+++ b/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/MetricsAutoConfiguration.java
@@ -77,8 +77,8 @@ public final class MetricsAutoConfiguration {
 	}
 
 	@Bean
-	MeterRegistryCloser meterRegistryCloser(ApplicationContext context) {
-		return new MeterRegistryCloser(context);
+	MeterRegistryCloser meterRegistryCloser(ApplicationContext context, MetricsProperties properties) {
+		return new MeterRegistryCloser(context, properties.isUseGlobalRegistry());
 	}
 
 	@Bean
@@ -104,17 +104,19 @@ public final class MetricsAutoConfiguration {
 
 		private final Iterable<MeterRegistry> meterRegistries;
 
-		MeterRegistryCloser(ApplicationContext context) {
+		private final boolean useGlobalRegistry;
+
+		MeterRegistryCloser(ApplicationContext context, boolean useGlobalRegistry) {
 			this.meterRegistries = context.getBeansOfType(MeterRegistry.class).values();
 			this.context = context;
+			this.useGlobalRegistry = useGlobalRegistry;
 		}
 
 		@Override
 		public void onApplicationEvent(ContextClosedEvent event) {
 			if (this.context.equals(event.getApplicationContext())) {
-				boolean useGlobalRegistry = this.context.getBean(MetricsProperties.class).isUseGlobalRegistry();
 				for (MeterRegistry meterRegistry : this.meterRegistries) {
-					if (useGlobalRegistry) {
+					if (this.useGlobalRegistry) {
 						Metrics.globalRegistry.remove(meterRegistry);
 					}
 					if (!meterRegistry.isClosed()) {

--- a/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/MetricsAutoConfiguration.java
+++ b/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/MetricsAutoConfiguration.java
@@ -112,8 +112,11 @@ public final class MetricsAutoConfiguration {
 		@Override
 		public void onApplicationEvent(ContextClosedEvent event) {
 			if (this.context.equals(event.getApplicationContext())) {
+				boolean useGlobalRegistry = this.context.getBean(MetricsProperties.class).isUseGlobalRegistry();
 				for (MeterRegistry meterRegistry : this.meterRegistries) {
-					Metrics.globalRegistry.remove(meterRegistry);
+					if (useGlobalRegistry) {
+						Metrics.globalRegistry.remove(meterRegistry);
+					}
 					if (!meterRegistry.isClosed()) {
 						meterRegistry.close();
 					}

--- a/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/autoconfigure/MetricsAutoConfigurationTests.java
+++ b/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/autoconfigure/MetricsAutoConfigurationTests.java
@@ -108,6 +108,23 @@ class MetricsAutoConfigurationTests {
 	}
 
 	@Test
+	void meterRegistryCloserShouldNotRemoveRegistryFromGlobalRegistryWhenUseGlobalRegistryIsFalse() {
+		this.contextRunner.withUserConfiguration(MeterRegistryConfiguration.class)
+			.withPropertyValues("management.metrics.use-global-registry=false")
+			.run((context) -> {
+				MeterRegistry meterRegistry = context.getBean(MeterRegistry.class);
+				Metrics.globalRegistry.add(meterRegistry);
+				try {
+					context.close();
+					assertThat(Metrics.globalRegistry.getRegistries()).contains(meterRegistry);
+				}
+				finally {
+					Metrics.globalRegistry.remove(meterRegistry);
+				}
+			});
+	}
+
+	@Test
 	void meterRegistryCloserShouldOnlyCloseRegistriesBelongingToContextBeingClosed() {
 		MeterRegistry parentMeterRegistry = new SimpleMeterRegistry();
 		MeterRegistry childMeterRegistry = new SimpleMeterRegistry();

--- a/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/autoconfigure/MetricsAutoConfigurationTests.java
+++ b/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/autoconfigure/MetricsAutoConfigurationTests.java
@@ -19,6 +19,7 @@ package org.springframework.boot.micrometer.metrics.autoconfigure;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.MeterFilterReply;
@@ -93,6 +94,16 @@ class MetricsAutoConfigurationTests {
 			assertThat(meterRegistry.isClosed()).isFalse();
 			context.close();
 			assertThat(meterRegistry.isClosed()).isTrue();
+		});
+	}
+
+	@Test
+	void meterRegistryCloserShouldRemoveRegistryFromGlobalRegistryOnShutdown() {
+		this.contextRunner.withUserConfiguration(MeterRegistryConfiguration.class).run((context) -> {
+			MeterRegistry meterRegistry = context.getBean(MeterRegistry.class);
+			assertThat(Metrics.globalRegistry.getRegistries()).contains(meterRegistry);
+			context.close();
+			assertThat(Metrics.globalRegistry.getRegistries()).doesNotContain(meterRegistry);
 		});
 	}
 


### PR DESCRIPTION
Remove closed MeterRegistry instances from Metrics.globalRegistry when
the context is closed to prevent memory leaks.

Closes #50232
