### PR TITLE
Register reflection hint for Class<?> configuration property values

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBeanFactoryInitializationAotProcessor.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/context/properties/ConfigurationPropertiesBeanFactoryInitializationAotProcessor.java
@@ -16,10 +16,18 @@
 
 package org.springframework.boot.context.properties;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.springframework.aot.generate.GenerationContext;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.ReflectionHints;
 import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
 import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor;
 import org.springframework.beans.factory.aot.BeanFactoryInitializationCode;
@@ -28,6 +36,7 @@ import org.springframework.boot.context.properties.bind.BindMethod;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.BindableRuntimeHintsRegistrar;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * {@link BeanFactoryInitializationAotProcessor} that contributes runtime hints for
@@ -45,17 +54,26 @@ class ConfigurationPropertiesBeanFactoryInitializationAotProcessor implements Be
 			ConfigurableListableBeanFactory beanFactory) {
 		String[] beanNames = beanFactory.getBeanNamesForAnnotation(ConfigurationProperties.class);
 		List<Bindable<?>> bindables = new ArrayList<>();
+		Map<Class<?>, Object> instances = new HashMap<>();
 		for (String beanName : beanNames) {
 			Class<?> beanType = beanFactory.getType(beanName, false);
 			if (beanType != null) {
 				BindMethod bindMethod = beanFactory.containsBeanDefinition(beanName)
 						? (BindMethod) beanFactory.getBeanDefinition(beanName).getAttribute(BindMethod.class.getName())
 						: null;
-				bindables.add(Bindable.of(ClassUtils.getUserClass(beanType))
+				Class<?> userClass = ClassUtils.getUserClass(beanType);
+				bindables.add(Bindable.of(userClass)
 					.withBindMethod((bindMethod != null) ? bindMethod : BindMethod.JAVA_BEAN));
+				try {
+					instances.putIfAbsent(userClass, beanFactory.getBean(beanName));
+				}
+				catch (Exception ex) {
+					// Ignore and continue without an instance
+				}
 			}
 		}
-		return (!bindables.isEmpty()) ? new ConfigurationPropertiesReflectionHintsContribution(bindables) : null;
+		return (!bindables.isEmpty()) ? new ConfigurationPropertiesReflectionHintsContribution(bindables, instances)
+				: null;
 	}
 
 	static final class ConfigurationPropertiesReflectionHintsContribution
@@ -63,15 +81,63 @@ class ConfigurationPropertiesBeanFactoryInitializationAotProcessor implements Be
 
 		private final List<Bindable<?>> bindables;
 
-		private ConfigurationPropertiesReflectionHintsContribution(List<Bindable<?>> bindables) {
+		private final Map<Class<?>, Object> instances;
+
+		private ConfigurationPropertiesReflectionHintsContribution(List<Bindable<?>> bindables,
+				Map<Class<?>, Object> instances) {
 			this.bindables = bindables;
+			this.instances = instances;
 		}
 
 		@Override
 		public void applyTo(GenerationContext generationContext,
 				BeanFactoryInitializationCode beanFactoryInitializationCode) {
+			ReflectionHints reflection = generationContext.getRuntimeHints().reflection();
 			BindableRuntimeHintsRegistrar.forBindables(this.bindables)
 				.registerHints(generationContext.getRuntimeHints());
+			Set<Class<?>> seen = new HashSet<>();
+			for (Map.Entry<Class<?>, Object> entry : this.instances.entrySet()) {
+				registerClassPropertyHints(reflection, entry.getKey(), entry.getValue(), seen);
+			}
+		}
+
+		private static void registerClassPropertyHints(ReflectionHints reflection, Class<?> type, Object instance,
+				Set<Class<?>> seen) {
+			if (instance == null || isJavaType(type) || !seen.add(type)) {
+				return;
+			}
+			ReflectionUtils.doWithFields(type, (field) -> processField(reflection, field, instance, seen));
+		}
+
+		private static void processField(ReflectionHints reflection, Field field, Object instance, Set<Class<?>> seen) {
+			if (Modifier.isStatic(field.getModifiers())) {
+				return;
+			}
+			Class<?> fieldType = field.getType();
+			if (fieldType.isPrimitive() || (isJavaType(fieldType) && fieldType != Class.class)) {
+				return;
+			}
+			Object value;
+			try {
+				ReflectionUtils.makeAccessible(field);
+				value = field.get(instance);
+			}
+			catch (Throwable ex) {
+				return;
+			}
+			if (fieldType == Class.class) {
+				if (value instanceof Class<?> classValue) {
+					reflection.registerType(classValue, MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS);
+				}
+				return;
+			}
+			if (value != null) {
+				registerClassPropertyHints(reflection, fieldType, value, seen);
+			}
+		}
+
+		private static boolean isJavaType(Class<?> type) {
+			return type.getPackageName().startsWith("java.");
 		}
 
 		Iterable<Bindable<?>> getBindables() {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesBeanFactoryInitializationAotProcessorTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesBeanFactoryInitializationAotProcessorTests.java
@@ -23,8 +23,10 @@ import org.assertj.core.api.AssertProvider;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.TypeHint;
 import org.springframework.aot.hint.TypeReference;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
 import org.springframework.aot.test.generate.TestGenerationContext;
 import org.springframework.beans.factory.aot.AotServices;
 import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor;
@@ -108,6 +110,36 @@ class ConfigurationPropertiesBeanFactoryInitializationAotProcessorTests {
 			.hasType(PossibleConstructorBindingProperties.class);
 		assertThat(typeHints(contribution).map(TypeHint::getType))
 			.containsExactly(TypeReference.of(PossibleConstructorBindingProperties.class));
+	}
+
+	@Test
+	void javaBeanWithClassPropertyRegistersConstructorHintForDefaultValue() {
+		ConfigurationPropertiesReflectionHintsContribution contribution = process(
+				EnableClassPropertyProperties.class);
+		TestGenerationContext generationContext = new TestGenerationContext();
+		contribution.applyTo(generationContext, null);
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(ClassPropertySample.class)
+			.withMemberCategory(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS)).accepts(generationContext.getRuntimeHints());
+	}
+
+	@Test
+	void javaBeanWithNestedClassPropertyRegistersConstructorHintForDefaultValue() {
+		ConfigurationPropertiesReflectionHintsContribution contribution = process(
+				EnableNestedClassPropertyProperties.class);
+		TestGenerationContext generationContext = new TestGenerationContext();
+		contribution.applyTo(generationContext, null);
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(ClassPropertySample.class)
+			.withMemberCategory(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS)).accepts(generationContext.getRuntimeHints());
+	}
+
+	@Test
+	void javaBeanWithNullClassPropertyDoesNotRegisterAdditionalHint() {
+		ConfigurationPropertiesReflectionHintsContribution contribution = process(
+				EnableNullClassPropertyProperties.class);
+		assertThat(typeHints(contribution).map(TypeHint::getType))
+			.containsExactly(TypeReference.of(NullClassPropertyProperties.class));
 	}
 
 	private Stream<TypeHint> typeHints(ConfigurationPropertiesReflectionHintsContribution contribution) {
@@ -208,6 +240,80 @@ class ConfigurationPropertiesBeanFactoryInitializationAotProcessorTests {
 		void setValue(String value) {
 			this.value = value;
 		}
+
+	}
+
+	@EnableConfigurationProperties(ClassPropertyProperties.class)
+	static class EnableClassPropertyProperties {
+
+	}
+
+	@ConfigurationProperties("class-property")
+	static class ClassPropertyProperties {
+
+		private Class<?> target = ClassPropertySample.class;
+
+		Class<?> getTarget() {
+			return this.target;
+		}
+
+		void setTarget(Class<?> target) {
+			this.target = target;
+		}
+
+	}
+
+	@EnableConfigurationProperties(NestedClassPropertyProperties.class)
+	static class EnableNestedClassPropertyProperties {
+
+	}
+
+	@ConfigurationProperties("nested-class-property")
+	static class NestedClassPropertyProperties {
+
+		private final Nested nested = new Nested();
+
+		Nested getNested() {
+			return this.nested;
+		}
+
+		static class Nested {
+
+			private Class<?> target = ClassPropertySample.class;
+
+			Class<?> getTarget() {
+				return this.target;
+			}
+
+			void setTarget(Class<?> target) {
+				this.target = target;
+			}
+
+		}
+
+	}
+
+	@EnableConfigurationProperties(NullClassPropertyProperties.class)
+	static class EnableNullClassPropertyProperties {
+
+	}
+
+	@ConfigurationProperties("null-class-property")
+	static class NullClassPropertyProperties {
+
+		private Class<?> target;
+
+		Class<?> getTarget() {
+			return this.target;
+		}
+
+		void setTarget(Class<?> target) {
+			this.target = target;
+		}
+
+	}
+
+	static class ClassPropertySample {
 
 	}
 


### PR DESCRIPTION
## Problem
Native builds of applications that have `@ConfigurationProperties` beans with `Class<?>` properties fail to start, e.g. `spring-boot-starter-kafka` reports:

```
Failed to bind properties under 'spring.kafka.consumer.key-deserializer' to java.lang.Class<?>
```

Because no reflection metadata is registered for the class referenced by the property value, `ClassUtils.forName(...)` cannot resolve it at runtime.

## Root Cause
`ConfigurationPropertiesBeanFactoryInitializationAotProcessor` only registers reflection hints for the declared `@ConfigurationProperties` types. The classes referenced through `Class<?>` typed properties (such as `KafkaProperties.Consumer#keyDeserializer = StringDeserializer.class`) are not visible to the binder in a native image because they have not been marked as reachable.

## Fix
After the existing `BindableRuntimeHintsRegistrar` pass, the processor now walks each `@ConfigurationProperties` bean instance, descends into any non-Java nested configuration objects, and for every non-null field of type `Class<?>` registers an `INVOKE_PUBLIC_CONSTRUCTORS` reflection hint for the referenced class. This makes the class reachable both for binding and for typical reflective instantiation by user libraries (e.g. Kafka calling `getDeclaredConstructor().newInstance()`).

The traversal:

- ignores static fields and primitive/Java types (other than `Class`);
- skips fields it cannot read and continues with the next field;
- guards against infinite recursion by tracking already-visited types;
- swallows exceptions from `getBean(...)` so a misbehaving bean does not abort the whole AOT contribution.

## Tests Added

| Test | Verifies |
| --- | --- |
| `javaBeanWithClassPropertyRegistersConstructorHintForDefaultValue` | A direct `Class<?>` field default is registered with `INVOKE_PUBLIC_CONSTRUCTORS`. |
| `javaBeanWithNestedClassPropertyRegistersConstructorHintForDefaultValue` | A `Class<?>` field on a nested configuration object is also registered. |
| `javaBeanWithNullClassPropertyDoesNotRegisterAdditionalHint` | A `null` `Class<?>` value adds no extra type hint. |

Closes gh-50221