### PR TITLE
Include security error body in WebFlux Cloud Foundry endpoint responses

### DIFF
--- a/module/spring-boot-cloudfoundry/src/main/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryWebFluxEndpointHandlerMapping.java
+++ b/module/spring-boot-cloudfoundry/src/main/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryWebFluxEndpointHandlerMapping.java
@@ -109,7 +109,7 @@ class CloudFoundryWebFluxEndpointHandlerMapping extends AbstractWebFluxEndpointH
 			return CloudFoundryWebFluxEndpointHandlerMapping.this.securityInterceptor.preHandle(exchange, "")
 				.map((securityResponse) -> {
 					if (!securityResponse.getStatus().equals(HttpStatus.OK)) {
-						return new ResponseEntity<>(securityResponse.getStatus());
+						return new ResponseEntity<>(securityResponse.getMessage(), securityResponse.getStatus());
 					}
 					AccessLevel accessLevel = exchange.getAttribute(AccessLevel.REQUEST_ATTRIBUTE);
 					String requestUri = UriComponentsBuilder.fromUri(request.getURI()).replaceQuery(null).toUriString();
@@ -164,7 +164,7 @@ class CloudFoundryWebFluxEndpointHandlerMapping extends AbstractWebFluxEndpointH
 		private Mono<ResponseEntity<Object>> flatMapResponse(ServerWebExchange exchange,
 				@Nullable Map<String, String> body, SecurityResponse securityResponse) {
 			if (!securityResponse.getStatus().equals(HttpStatus.OK)) {
-				return Mono.just(new ResponseEntity<>(securityResponse.getStatus()));
+				return Mono.just(new ResponseEntity<>(securityResponse.getMessage(), securityResponse.getStatus()));
 			}
 			return this.delegate.handle(exchange, body);
 		}

--- a/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryWebFluxEndpointIntegrationTests.java
+++ b/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryWebFluxEndpointIntegrationTests.java
@@ -100,7 +100,9 @@ class CloudFoundryWebFluxEndpointIntegrationTests {
 			.header("Authorization", "bearer " + mockAccessToken())
 			.exchange()
 			.expectStatus()
-			.isEqualTo(HttpStatus.FORBIDDEN)));
+			.isEqualTo(HttpStatus.FORBIDDEN)
+			.expectBody(String.class)
+			.isEqualTo("{\"security_error\":\"Access denied\"}")));
 	}
 
 	@Test
@@ -179,7 +181,9 @@ class CloudFoundryWebFluxEndpointIntegrationTests {
 			.header("Authorization", "bearer " + mockAccessToken())
 			.exchange()
 			.expectStatus()
-			.isUnauthorized()));
+			.isUnauthorized()
+			.expectBody(String.class)
+			.isEqualTo("{\"security_error\":\"invalid-token\"}")));
 	}
 
 	@Test


### PR DESCRIPTION
## Problem

When a Cloud Foundry security check fails in a WebFlux application,
`SecureReactiveWebOperation` and `CloudFoundryLinksHandler` return only
the HTTP status code with no response body. The servlet counterpart
includes a `{"security_error":"<reason>"}` body, so the reactive path
silently discards the diagnostic information that `SecurityInterceptor`
already computes.

## Change

Updated `CloudFoundryWebFluxEndpointHandlerMapping` to include
`securityResponse.getMessage()` as the response body in both
`CloudFoundryLinksHandler.links()` and
`SecureReactiveWebOperation.flatMapResponse()`, consistent with the
servlet implementation.

## Tests

Updated `operationWithSecurityInterceptorForbidden` and
`linksToOtherEndpointsForbidden` in
`CloudFoundryWebFluxEndpointIntegrationTests` to assert that the
security error body is present in the response.

Closes #50255