### PR TITLE
Nullable annotations from AbstractErrorController.getErrorAttributes are not aligned with implementation

### DIFF
--- a/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/error/BasicErrorController.java
+++ b/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/error/BasicErrorController.java
@@ -95,7 +95,7 @@ public class BasicErrorController extends AbstractErrorController {
 	}
 
 	@RequestMapping
-	public ResponseEntity<Map<String, Object>> error(HttpServletRequest request) {
+	public ResponseEntity<Map<String, @Nullable Object>> error(HttpServletRequest request) {
 		HttpStatus status = getStatus(request);
 		if (status == HttpStatus.NO_CONTENT) {
 			return new ResponseEntity<>(status);


### PR DESCRIPTION
This fixes a warning emitted by a more recent version of NullAway.  It looks like a clean fix, as the type of `body` is `Map<String, @Nullable Object>`.