### PR TITLE
 DataSourceBuilder cannot derive a DataSource from a lazy connection proxy

### DIFF
--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/DataSourceBuilder.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/DataSourceBuilder.java
@@ -41,7 +41,6 @@ import org.vibur.dbcp.ViburDBCPDataSource;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.core.ResolvableType;
-import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 import org.springframework.lang.Contract;
 import org.springframework.util.Assert;
@@ -238,27 +237,7 @@ public final class DataSourceBuilder<T extends DataSource> {
 	 * @return a new {@link DataSource} builder
 	 */
 	public static DataSourceBuilder<?> derivedFrom(DataSource dataSource) {
-		return new DataSourceBuilder<>(unwrap(dataSource));
-	}
-
-	private static DataSource unwrap(DataSource dataSource) {
-		if ((dataSource instanceof LazyConnectionDataSourceProxy dataSourceProxy)
-				&& (dataSourceProxy.getTargetDataSource() != null)) {
-			dataSource = dataSourceProxy.getTargetDataSource();
-		}
-		try {
-			while (dataSource.isWrapperFor(DataSource.class)) {
-				DataSource unwrapped = dataSource.unwrap(DataSource.class);
-				if (unwrapped == dataSource) {
-					return unwrapped;
-				}
-				dataSource = unwrapped;
-			}
-		}
-		catch (SQLException ex) {
-			// Try to continue with the existing, potentially still wrapped, DataSource
-		}
-		return dataSource;
+		return new DataSourceBuilder<>(DataSourceUnwrapper.unwrapRoot(dataSource));
 	}
 
 	/**

--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/DataSourceBuilder.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/DataSourceBuilder.java
@@ -41,6 +41,7 @@ import org.vibur.dbcp.ViburDBCPDataSource;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.core.ResolvableType;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 import org.springframework.lang.Contract;
 import org.springframework.util.Assert;
@@ -241,6 +242,10 @@ public final class DataSourceBuilder<T extends DataSource> {
 	}
 
 	private static DataSource unwrap(DataSource dataSource) {
+		if ((dataSource instanceof LazyConnectionDataSourceProxy dataSourceProxy)
+				&& (dataSourceProxy.getTargetDataSource() != null)) {
+			dataSource = dataSourceProxy.getTargetDataSource();
+		}
 		try {
 			while (dataSource.isWrapperFor(DataSource.class)) {
 				DataSource unwrapped = dataSource.unwrap(DataSource.class);

--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/DataSourceUnwrapper.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/DataSourceUnwrapper.java
@@ -93,6 +93,37 @@ public final class DataSourceUnwrapper {
 		return unwrap(dataSource, target, target);
 	}
 
+	/**
+	 * Return the root {@link DataSource} by recursively unwrapping all
+	 * {@link org.springframework.jdbc.datasource.DelegatingDataSource delegating}, proxy,
+	 * and {@link java.sql.Wrapper} layers until no further unwrapping is possible.
+	 * @param dataSource the datasource to unwrap
+	 * @return the root {@link DataSource}
+	 * @since 4.1.0
+	 */
+	public static DataSource unwrapRoot(DataSource dataSource) {
+		if (DELEGATING_DATA_SOURCE_PRESENT) {
+			DataSource targetDataSource = DelegatingDataSourceUnwrapper.getTargetDataSource(dataSource);
+			if (targetDataSource != null) {
+				return unwrapRoot(targetDataSource);
+			}
+		}
+		if (AopUtils.isAopProxy(dataSource)) {
+			Object proxyTarget = AopProxyUtils.getSingletonTarget(dataSource);
+			if (proxyTarget instanceof DataSource proxyDataSource) {
+				return unwrapRoot(proxyDataSource);
+			}
+		}
+		DataSource unwrapped = safeUnwrap(dataSource);
+		if (unwrapped != null) {
+			if (unwrapped == dataSource) {
+				return unwrapped;
+			}
+			return unwrapRoot(unwrapped);
+		}
+		return dataSource;
+	}
+
 	private static <S> @Nullable S safeUnwrap(Wrapper wrapper, Class<S> target) {
 		try {
 			if (target.isInterface() && wrapper.isWrapperFor(target)) {
@@ -101,6 +132,18 @@ public final class DataSourceUnwrapper {
 		}
 		catch (Exception ex) {
 			// Continue
+		}
+		return null;
+	}
+
+	private static @Nullable DataSource safeUnwrap(DataSource dataSource) {
+		try {
+			if (dataSource.isWrapperFor(DataSource.class)) {
+				return dataSource.unwrap(DataSource.class);
+			}
+		}
+		catch (Exception ex) {
+			// continue
 		}
 		return null;
 	}

--- a/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/DataSourceBuilderTests.java
+++ b/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/DataSourceBuilderTests.java
@@ -46,6 +46,7 @@ import org.postgresql.ds.PGSimpleDataSource;
 import org.vibur.dbcp.ViburDBCPDataSource;
 
 import org.springframework.jdbc.datasource.AbstractDataSource;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
@@ -61,6 +62,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
  * @author Stephane Nicoll
  * @author Fabio Grassi
  * @author Phillip Webb
+ * @author Vedran Pavic
  */
 class DataSourceBuilderTests {
 
@@ -421,6 +423,19 @@ class DataSourceBuilderTests {
 		dataSource.setPassword("secret");
 		dataSource.setJdbcUrl("jdbc:h2:test");
 		DataSourceBuilder<?> builder = DataSourceBuilder.derivedFrom(wrap(wrap(dataSource)));
+		HikariDataSource built = (HikariDataSource) builder.username("test2").password("secret2").build();
+		assertThat(built.getUsername()).isEqualTo("test2");
+		assertThat(built.getPassword()).isEqualTo("secret2");
+		assertThat(built.getJdbcUrl()).isEqualTo("jdbc:h2:test");
+	}
+
+	@Test
+	void buildWhenDerivedFromLazyConnectionDataSourceProxy() {
+		HikariDataSource dataSource = new HikariDataSource();
+		dataSource.setUsername("test");
+		dataSource.setPassword("secret");
+		dataSource.setJdbcUrl("jdbc:h2:test");
+		DataSourceBuilder<?> builder = DataSourceBuilder.derivedFrom(new LazyConnectionDataSourceProxy(dataSource));
 		HikariDataSource built = (HikariDataSource) builder.username("test2").password("secret2").build();
 		assertThat(built.getUsername()).isEqualTo("test2");
 		assertThat(built.getPassword()).isEqualTo("secret2");

--- a/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/DataSourceUnwrapperTests.java
+++ b/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/DataSourceUnwrapperTests.java
@@ -107,6 +107,40 @@ class DataSourceUnwrapperTests {
 	}
 
 	@Test
+	void unwrapRootWithPlainDataSource() {
+		DataSource dataSource = new HikariDataSource();
+		assertThat(DataSourceUnwrapper.unwrapRoot(dataSource)).isSameAs(dataSource);
+	}
+
+	@Test
+	void unwrapRootWithDelegate() {
+		DataSource dataSource = new HikariDataSource();
+		DataSource actual = wrapInDelegate(wrapInDelegate(dataSource));
+		assertThat(DataSourceUnwrapper.unwrapRoot(actual)).isSameAs(dataSource);
+	}
+
+	@Test
+	void unwrapRootWithProxy() {
+		DataSource dataSource = new HikariDataSource();
+		DataSource actual = wrapInProxy(wrapInProxy(dataSource));
+		assertThat(DataSourceUnwrapper.unwrapRoot(actual)).isSameAs(dataSource);
+	}
+
+	@Test
+	void unwrapRootWithLazyConnectionDataSource() {
+		DataSource dataSource = new HikariDataSource();
+		DataSource actual = new LazyConnectionDataSourceProxy(dataSource);
+		assertThat(DataSourceUnwrapper.unwrapRoot(actual)).isSameAs(dataSource);
+	}
+
+	@Test
+	void unwrapRootWithSeveralLevelOfWrapping() {
+		DataSource dataSource = new HikariDataSource();
+		DataSource actual = wrapInProxy(wrapInDelegate(wrapInDelegate(wrapInProxy(wrapInDelegate(dataSource)))));
+		assertThat(DataSourceUnwrapper.unwrapRoot(actual)).isSameAs(dataSource);
+	}
+
+	@Test
 	void unwrappingIsNotAttemptedWhenTargetIsNotAnInterface() {
 		DataSource dataSource = mock(DataSource.class);
 		assertThat(DataSourceUnwrapper.unwrap(dataSource, HikariDataSource.class)).isNull();

--- a/module/spring-boot-liquibase/src/test/java/org/springframework/boot/liquibase/autoconfigure/LiquibaseAutoConfigurationTests.java
+++ b/module/spring-boot-liquibase/src/test/java/org/springframework/boot/liquibase/autoconfigure/LiquibaseAutoConfigurationTests.java
@@ -51,6 +51,7 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
 import org.springframework.boot.jdbc.autoconfigure.EmbeddedDataSourceConfiguration;
 import org.springframework.boot.jdbc.autoconfigure.JdbcConnectionDetails;
 import org.springframework.boot.jdbc.autoconfigure.JdbcTemplateAutoConfiguration;
@@ -90,6 +91,7 @@ import static org.assertj.core.api.Assertions.contentOf;
  * @author Moritz Halbritter
  * @author Phillip Webb
  * @author Ahmed Ashour
+ * @author Vedran Pavic
  */
 @ExtendWith(OutputCaptureExtension.class)
 class LiquibaseAutoConfigurationTests {
@@ -369,6 +371,20 @@ class LiquibaseAutoConfigurationTests {
 			.run(assertLiquibase((liquibase) -> {
 				SimpleDriverDataSource dataSource = (SimpleDriverDataSource) liquibase.getDataSource();
 				assertThat(dataSource.getUrl()).contains("jdbc:h2:mem:" + databaseName);
+				assertThat(dataSource.getUsername()).isEqualTo("sa");
+			}));
+	}
+
+	@Test
+	@WithDbChangelogMasterYamlResource
+	void lazyConnectionDataSource() {
+		String jdbcUrl = "jdbc:h2:mem:liquibase-" + UUID.randomUUID();
+		this.contextRunner.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
+			.withPropertyValues("spring.datasource.url:" + jdbcUrl, "spring.datasource.username:not-sa",
+					"spring.datasource.connection-fetch:lazy", "spring.liquibase.user:sa")
+			.run(assertLiquibase((liquibase) -> {
+				SimpleDriverDataSource dataSource = (SimpleDriverDataSource) liquibase.getDataSource();
+				assertThat(dataSource.getUrl()).isEqualTo(jdbcUrl);
 				assertThat(dataSource.getUsername()).isEqualTo("sa");
 			}));
 	}


### PR DESCRIPTION
While attempting to use newly introduced `spring.datasource.connection-fetch=lazy` in a project that uses separate JDBC credentials for running Liquibase migrations I came across the issue with the following root cause:

```
 Caused by: org.springframework.boot.jdbc.UnsupportedDataSourcePropertyException: Unable to find suitable method for url
 	at org.springframework.boot.jdbc.UnsupportedDataSourcePropertyException.throwIf(UnsupportedDataSourcePropertyException.java:36)
 	at org.springframework.boot.jdbc.DataSourceBuilder$ReflectionDataSourceProperties.getMethod(DataSourceBuilder.java:605)
 	at org.springframework.boot.jdbc.DataSourceBuilder$ReflectionDataSourceProperties.get(DataSourceBuilder.java:595)
 	at org.springframework.boot.jdbc.DataSourceBuilder.build(DataSourceBuilder.java:186)
 	at org.springframework.boot.liquibase.autoconfigure.LiquibaseAutoConfiguration$LiquibaseConfiguration.getMigrationDataSource(LiquibaseAutoConfiguration.java:173)
 	at org.springframework.boot.liquibase.autoconfigure.LiquibaseAutoConfiguration$LiquibaseConfiguration.createSpringLiquibase(LiquibaseAutoConfiguration.java:148)
 	at org.springframework.boot.liquibase.autoconfigure.LiquibaseAutoConfiguration$LiquibaseConfiguration.liquibase(LiquibaseAutoConfiguration.java:105)
 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
 	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
 	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.lambda$instantiate$0(SimpleInstantiationStrategy.java:155)
 	... 124 more
```

The exact scenario that led to this can be reproduced using `LiquibaseAutoConfigurationTests#lazyConnectionDataSource` test from the first commit in this PR.

At quick glance it seems the same issue can happen with Flyway and Spring Boot's database initialization and looks like a limitation of `DataSourceBuilder` and its support for deriving a builder from existing data sources which second commit in this PR attempts to address.