### PR TITLE
ConfigurationPropertiesReportEndpoint exposes AOP proxy internals

### DIFF
--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpoint.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -213,63 +212,28 @@ public class ConfigurationPropertiesReportEndpoint implements ApplicationContext
 
 	private ContextConfigurationPropertiesDescriptor describeBeans(ObjectMapper mapper, ApplicationContext context,
 			Predicate<ConfigurationPropertiesBean> beanFilterPredicate, boolean showUnsanitized) {
+		ApplicationContext parent = context.getParent();
 		Map<String, ConfigurationPropertiesBean> beans = ConfigurationPropertiesBean.getAll(context);
 		Map<String, ConfigurationPropertiesBeanDescriptor> descriptors = new LinkedHashMap<>();
-		beans.values().stream().filter(beanFilterPredicate).forEach((bean) -> {
-			ConfigurationPropertiesBeanDescriptor descriptor = describeBean(mapper, bean, showUnsanitized);
-			if (descriptor != null) {
-				descriptors.put(bean.getName(), descriptor);
-			}
-		});
-		return new ContextConfigurationPropertiesDescriptor(descriptors,
-				(context.getParent() != null) ? context.getParent().getId() : null);
+		beans.values()
+			.stream()
+			.filter(beanFilterPredicate)
+			.forEach((bean) -> descriptors.put(bean.getName(), describeBean(mapper, bean, showUnsanitized)));
+		return new ContextConfigurationPropertiesDescriptor(descriptors, (parent != null) ? parent.getId() : null);
 	}
 
 	private ConfigurationPropertiesBeanDescriptor describeBean(ObjectMapper mapper, ConfigurationPropertiesBean bean,
 			boolean showUnsanitized) {
-		return describeTargetBean(bean.getInstance(), (instance) -> {
-			String prefix = bean.getAnnotation().prefix();
-			Map<String, Object> serialized = safeSerialize(mapper, instance, prefix);
-			Map<String, Object> properties = sanitize(prefix, serialized, showUnsanitized);
-			Map<String, Object> inputs = getInputs(prefix, serialized, showUnsanitized);
-			return new ConfigurationPropertiesBeanDescriptor(prefix, properties, inputs);
-		});
-	}
-
-	private ConfigurationPropertiesBeanDescriptor describeTargetBean(Object bean,
-			Function<Object, ConfigurationPropertiesBeanDescriptor> actionWithTarget) {
-		TargetSource targetSource = null;
-		Object target = bean;
-		while (target instanceof Advised advised) {
-			try {
-				targetSource = advised.getTargetSource();
-				target = targetSource.getTarget();
-			}
-			catch (Exception ex) {
-				return null;
-			}
-		}
-		if (target != null) {
-			try {
-				return actionWithTarget.apply(target);
-			}
-			finally {
-				if (targetSource != null) {
-					try {
-						targetSource.releaseTarget(target);
-					}
-					catch (Exception ex) {
-						// ignore
-					}
-				}
-			}
-		}
-		return null;
+		String prefix = bean.getAnnotation().prefix();
+		Map<String, Object> serialized = safeSerialize(mapper, bean.getInstance(), prefix);
+		Map<String, Object> properties = sanitize(prefix, serialized, showUnsanitized);
+		Map<String, Object> inputs = getInputs(prefix, serialized, showUnsanitized);
+		return new ConfigurationPropertiesBeanDescriptor(prefix, properties, inputs);
 	}
 
 	/**
-	 * Cautiously serialize the bean to a map (returning a map with an error message
-	 * instead of throwing an exception if there is a problem).
+	 * Cautiously serialize the ultimate bean target to a map (returning a map with an
+	 * error message instead of throwing an exception if there is a problem).
 	 * @param mapper the object mapper
 	 * @param bean the source bean
 	 * @param prefix the prefix
@@ -278,6 +242,18 @@ public class ConfigurationPropertiesReportEndpoint implements ApplicationContext
 	@SuppressWarnings({ "unchecked" })
 	private Map<String, Object> safeSerialize(ObjectMapper mapper, Object bean, String prefix) {
 		try {
+			if (bean instanceof Advised advised) {
+				TargetSource targetSource = advised.getTargetSource();
+				Object target = targetSource.getTarget();
+				try {
+					return safeSerialize(mapper, target, prefix);
+				}
+				finally {
+					if (target != null) {
+						targetSource.releaseTarget(target);
+					}
+				}
+			}
 			return new HashMap<>(mapper.convertValue(bean, Map.class));
 		}
 		catch (Exception ex) {

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpoint.java
@@ -25,8 +25,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -53,6 +53,8 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.aop.TargetSource;
+import org.springframework.aop.framework.Advised;
 import org.springframework.beans.BeansException;
 import org.springframework.boot.actuate.endpoint.OperationResponseBody;
 import org.springframework.boot.actuate.endpoint.SanitizableData;
@@ -212,22 +214,57 @@ public class ConfigurationPropertiesReportEndpoint implements ApplicationContext
 	private ContextConfigurationPropertiesDescriptor describeBeans(ObjectMapper mapper, ApplicationContext context,
 			Predicate<ConfigurationPropertiesBean> beanFilterPredicate, boolean showUnsanitized) {
 		Map<String, ConfigurationPropertiesBean> beans = ConfigurationPropertiesBean.getAll(context);
-		Map<String, ConfigurationPropertiesBeanDescriptor> descriptors = beans.values()
-			.stream()
-			.filter(beanFilterPredicate)
-			.collect(Collectors.toMap(ConfigurationPropertiesBean::getName,
-					(bean) -> describeBean(mapper, bean, showUnsanitized)));
+		Map<String, ConfigurationPropertiesBeanDescriptor> descriptors = new LinkedHashMap<>();
+		beans.values().stream().filter(beanFilterPredicate).forEach((bean) -> {
+			ConfigurationPropertiesBeanDescriptor descriptor = describeBean(mapper, bean, showUnsanitized);
+			if (descriptor != null) {
+				descriptors.put(bean.getName(), descriptor);
+			}
+		});
 		return new ContextConfigurationPropertiesDescriptor(descriptors,
 				(context.getParent() != null) ? context.getParent().getId() : null);
 	}
 
 	private ConfigurationPropertiesBeanDescriptor describeBean(ObjectMapper mapper, ConfigurationPropertiesBean bean,
 			boolean showUnsanitized) {
-		String prefix = bean.getAnnotation().prefix();
-		Map<String, Object> serialized = safeSerialize(mapper, bean.getInstance(), prefix);
-		Map<String, Object> properties = sanitize(prefix, serialized, showUnsanitized);
-		Map<String, Object> inputs = getInputs(prefix, serialized, showUnsanitized);
-		return new ConfigurationPropertiesBeanDescriptor(prefix, properties, inputs);
+		return describeTargetBean(bean.getInstance(), (instance) -> {
+			String prefix = bean.getAnnotation().prefix();
+			Map<String, Object> serialized = safeSerialize(mapper, instance, prefix);
+			Map<String, Object> properties = sanitize(prefix, serialized, showUnsanitized);
+			Map<String, Object> inputs = getInputs(prefix, serialized, showUnsanitized);
+			return new ConfigurationPropertiesBeanDescriptor(prefix, properties, inputs);
+		});
+	}
+
+	private ConfigurationPropertiesBeanDescriptor describeTargetBean(Object bean,
+			Function<Object, ConfigurationPropertiesBeanDescriptor> actionWithTarget) {
+		TargetSource targetSource = null;
+		Object target = bean;
+		while (target instanceof Advised advised) {
+			try {
+				targetSource = advised.getTargetSource();
+				target = targetSource.getTarget();
+			}
+			catch (Exception ex) {
+				return null;
+			}
+		}
+		if (target != null) {
+			try {
+				return actionWithTarget.apply(target);
+			}
+			finally {
+				if (targetSource != null) {
+					try {
+						targetSource.releaseTarget(target);
+					}
+					catch (Exception ex) {
+						// ignore
+					}
+				}
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointSerializationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointSerializationTests.java
@@ -29,12 +29,16 @@ import java.util.Map;
 import com.zaxxer.hikari.HikariDataSource;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.aop.TargetSource;
+import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.boot.actuate.context.properties.ConfigurationPropertiesReportEndpoint.ConfigurationPropertiesBeanDescriptor;
 import org.springframework.boot.actuate.context.properties.ConfigurationPropertiesReportEndpoint.ConfigurationPropertiesDescriptor;
+import org.springframework.boot.actuate.context.properties.ConfigurationPropertiesReportEndpoint.ContextConfigurationPropertiesDescriptor;
 import org.springframework.boot.actuate.endpoint.Show;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -254,6 +258,53 @@ class ConfigurationPropertiesReportEndpointSerializationTests {
 	}
 
 	@Test
+	void aopProxyDoesNotLeakAdvisedInternals() {
+		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withUserConfiguration(CglibProxiedFooConfig.class)
+			.withPropertyValues("foo.name:test");
+		contextRunner.run((context) -> {
+			ConfigurationPropertiesReportEndpoint endpoint = context
+				.getBean(ConfigurationPropertiesReportEndpoint.class);
+			ConfigurationPropertiesDescriptor applicationProperties = endpoint.configurationProperties();
+			ConfigurationPropertiesBeanDescriptor foo = getContextDescriptor(context, applicationProperties).getBeans()
+				.get("foo");
+			assertThat(foo).isNotNull();
+			Map<String, Object> map = foo.getProperties();
+			assertThat(map).containsOnlyKeys("name", "bar");
+			assertThat(map).containsEntry("name", "test");
+		});
+	}
+
+	@Test
+	void aopProxyTargetingAnotherProxyIsUnwrapped() {
+		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withUserConfiguration(NestedCglibProxiedFooConfig.class)
+			.withPropertyValues("foo.name:nested");
+		contextRunner.run((context) -> {
+			ConfigurationPropertiesReportEndpoint endpoint = context
+				.getBean(ConfigurationPropertiesReportEndpoint.class);
+			ConfigurationPropertiesDescriptor applicationProperties = endpoint.configurationProperties();
+			ConfigurationPropertiesBeanDescriptor foo = getContextDescriptor(context, applicationProperties).getBeans()
+				.get("foo");
+			assertThat(foo).isNotNull();
+			assertThat(foo.getProperties()).containsOnlyKeys("name", "bar");
+			assertThat(foo.getProperties()).containsEntry("name", "nested");
+		});
+	}
+
+	@Test
+	void aopProxyWithUnresolvableTargetIsExcluded() {
+		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withUserConfiguration(UnresolvableTargetFooConfig.class);
+		contextRunner.run((context) -> {
+			ConfigurationPropertiesReportEndpoint endpoint = context
+				.getBean(ConfigurationPropertiesReportEndpoint.class);
+			ConfigurationPropertiesDescriptor applicationProperties = endpoint.configurationProperties();
+			assertThat(getContextDescriptor(context, applicationProperties).getBeans()).doesNotContainKey("foo");
+		});
+	}
+
+	@Test
 	void hikariDataSourceConfigurationPropertiesBeanCanBeSerialized() {
 		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withUserConfiguration(HikariDataSourceConfig.class);
@@ -311,6 +362,14 @@ class ConfigurationPropertiesReportEndpointSerializationTests {
 			assertThat((Map<String, Object>) descriptor.getInputs().get("name")).containsEntry("value",
 					"Complex property value " + ComplexProperty.class.getName());
 		});
+	}
+
+	private ContextConfigurationPropertiesDescriptor getContextDescriptor(AssertableApplicationContext context,
+			ConfigurationPropertiesDescriptor applicationProperties) {
+		ContextConfigurationPropertiesDescriptor contextDescriptor = applicationProperties.getContexts()
+			.get(context.getId());
+		assertThat(contextDescriptor).isNotNull();
+		return contextDescriptor;
 	}
 
 	@Configuration(proxyBeanMethods = false)
@@ -572,6 +631,68 @@ class ConfigurationPropertiesReportEndpointSerializationTests {
 		@ConfigurationProperties("cycle")
 		Cycle cycle() {
 			return new Cycle();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Import(Base.class)
+	static class CglibProxiedFooConfig {
+
+		@Bean
+		@ConfigurationProperties("foo")
+		Foo foo() {
+			ProxyFactory proxyFactory = new ProxyFactory(new Foo());
+			proxyFactory.setProxyTargetClass(true);
+			return (Foo) proxyFactory.getProxy();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Import(Base.class)
+	static class NestedCglibProxiedFooConfig {
+
+		@Bean
+		@ConfigurationProperties("foo")
+		Foo foo() {
+			ProxyFactory inner = new ProxyFactory(new Foo());
+			inner.setProxyTargetClass(true);
+			ProxyFactory outer = new ProxyFactory(inner.getProxy());
+			outer.setProxyTargetClass(true);
+			return (Foo) outer.getProxy();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Import(Base.class)
+	static class UnresolvableTargetFooConfig {
+
+		@Bean
+		@ConfigurationProperties("foo")
+		Foo foo() {
+			ProxyFactory proxyFactory = new ProxyFactory();
+			proxyFactory.setProxyTargetClass(true);
+			proxyFactory.setTargetSource(new TargetSource() {
+
+				@Override
+				public Class<?> getTargetClass() {
+					return Foo.class;
+				}
+
+				@Override
+				public boolean isStatic() {
+					return false;
+				}
+
+				@Override
+				public Object getTarget() throws Exception {
+					throw new IllegalStateException("no target");
+				}
+
+			});
+			return (Foo) proxyFactory.getProxy();
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointSerializationTests.java
+++ b/spring-boot-project/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/context/properties/ConfigurationPropertiesReportEndpointSerializationTests.java
@@ -293,14 +293,16 @@ class ConfigurationPropertiesReportEndpointSerializationTests {
 	}
 
 	@Test
-	void aopProxyWithUnresolvableTargetIsExcluded() {
+	void aopProxyWithUnresolvableTarget() {
 		ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withUserConfiguration(UnresolvableTargetFooConfig.class);
 		contextRunner.run((context) -> {
 			ConfigurationPropertiesReportEndpoint endpoint = context
 				.getBean(ConfigurationPropertiesReportEndpoint.class);
 			ConfigurationPropertiesDescriptor applicationProperties = endpoint.configurationProperties();
-			assertThat(getContextDescriptor(context, applicationProperties).getBeans()).doesNotContainKey("foo");
+			assertThat(getContextDescriptor(context, applicationProperties).getBeans()).containsKey("foo")
+				.satisfies((beans) -> assertThat(beans.get("foo").getProperties()).containsEntry("error",
+						"Cannot serialize 'foo'"));
 		});
 	}
 


### PR DESCRIPTION
The `configprops` actuator endpoint serializes each `@ConfigurationProperties`
bean using its bean-factory instance. When that instance is an AOP proxy
(commonly a CGLIB scoped proxy created by `@RefreshScope`, but the same
applies to any AOP proxy), the serializer also picks up the `Advised`
interface getters that the proxy exposes (`targetSource`, `exposeProxy`,
`preFiltered`).

With `BufferingApplicationStartup` configured, the `targetSource` walk reaches
`beanFactory.applicationStartup.bufferedTimeline.events[…]`, inflating the
response by ~200 KB per refresh-scoped bean.

This change unwraps AOP proxies via `Advised.getTargetSource().getTarget()`
in `safeSerialize` before delegating to the serializer, so only the user-defined
configuration properties are exposed. The unwrap is wrapped in a try/catch so
that any failure to obtain the target falls back to the existing behaviour.

A test has been added that creates a `ProxyFactory`-based CGLIB proxy around a
`@ConfigurationProperties` bean and verifies that the resulting descriptor
contains only the user properties, not `targetSource` / `exposeProxy` /
`preFiltered`.

See gh-50231