### PR TITLE
Align DocumentBuilderFactory configuration

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/BomResolver.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/BomResolver.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -68,7 +69,10 @@ class BomResolver {
 		this.configurations = configurations;
 		this.dependencies = dependencies;
 		try {
-			this.documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			this.documentBuilder = factory.newDocumentBuilder();
 		}
 		catch (ParserConfigurationException ex) {
 			throw new RuntimeException(ex);

--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/BomResolver.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/BomResolver.java
@@ -26,11 +26,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
@@ -51,6 +48,7 @@ import org.springframework.boot.build.bom.ResolvedBom.Id;
 import org.springframework.boot.build.bom.ResolvedBom.JavadocLink;
 import org.springframework.boot.build.bom.ResolvedBom.Links;
 import org.springframework.boot.build.bom.ResolvedBom.ResolvedLibrary;
+import org.springframework.boot.build.xml.XmlDocument;
 
 /**
  * Creates a {@link ResolvedBom resolved bom}.
@@ -68,15 +66,7 @@ class BomResolver {
 	BomResolver(ConfigurationContainer configurations, DependencyHandler dependencies) {
 		this.configurations = configurations;
 		this.dependencies = dependencies;
-		try {
-			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			this.documentBuilder = factory.newDocumentBuilder();
-		}
-		catch (ParserConfigurationException ex) {
-			throw new RuntimeException(ex);
-		}
+		this.documentBuilder = XmlDocument.builder();
 	}
 
 	ResolvedBom resolve(BomExtension bomExtension) {

--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/Library.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/Library.java
@@ -35,6 +35,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
@@ -676,7 +677,10 @@ public class Library {
 
 		private String propertyFrom(File pomFile) {
 			try {
-				DocumentBuilder documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+				DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+				dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+				dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+				DocumentBuilder documentBuilder = dbf.newDocumentBuilder();
 				Document document = documentBuilder.parse(pomFile);
 				XPath xpath = XPathFactory.newInstance().newXPath();
 				return xpath.evaluate("/project/properties/" + this.name + "/text()", document);

--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/Library.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/Library.java
@@ -35,9 +35,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathFactory;
 
@@ -52,6 +49,7 @@ import org.w3c.dom.Document;
 
 import org.springframework.boot.build.bom.ResolvedBom.Id;
 import org.springframework.boot.build.bom.bomr.version.DependencyVersion;
+import org.springframework.boot.build.xml.XmlDocument;
 
 /**
  * A collection of modules, Maven plugins, and Maven boms that are versioned and released
@@ -677,11 +675,7 @@ public class Library {
 
 		private String propertyFrom(File pomFile) {
 			try {
-				DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-				dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-				dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-				DocumentBuilder documentBuilder = dbf.newDocumentBuilder();
-				Document document = documentBuilder.parse(pomFile);
+				Document document = XmlDocument.parse(pomFile);
 				XPath xpath = XPathFactory.newInstance().newXPath();
 				return xpath.evaluate("/project/properties/" + this.name + "/text()", document);
 			}

--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/bomr/MavenMetadataVersionResolver.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/bomr/MavenMetadataVersionResolver.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.build.bom.bomr;
 
-import java.io.StringReader;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,8 +25,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 
@@ -37,9 +34,9 @@ import org.gradle.api.credentials.Credentials;
 import org.gradle.internal.artifacts.repositories.AuthenticationSupportedInternal;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
 
 import org.springframework.boot.build.bom.bomr.version.DependencyVersion;
+import org.springframework.boot.build.xml.XmlDocument;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -94,10 +91,7 @@ final class MavenMetadataVersionResolver implements VersionResolver {
 			}
 			HttpEntity<Void> request = new HttpEntity<>(headers);
 			String metadata = this.rest.exchange(url, HttpMethod.GET, request, String.class).getBody();
-			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			Document metadataDocument = factory.newDocumentBuilder().parse(new InputSource(new StringReader(metadata)));
+			Document metadataDocument = XmlDocument.parseContent(metadata);
 			NodeList versionNodes = (NodeList) XPathFactory.newInstance()
 				.newXPath()
 				.evaluate("/metadata/versioning/versions/version", metadataDocument, XPathConstants.NODESET);

--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/bomr/MavenMetadataVersionResolver.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/bomr/MavenMetadataVersionResolver.java
@@ -26,6 +26,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
@@ -93,9 +94,10 @@ final class MavenMetadataVersionResolver implements VersionResolver {
 			}
 			HttpEntity<Void> request = new HttpEntity<>(headers);
 			String metadata = this.rest.exchange(url, HttpMethod.GET, request, String.class).getBody();
-			Document metadataDocument = DocumentBuilderFactory.newInstance()
-				.newDocumentBuilder()
-				.parse(new InputSource(new StringReader(metadata)));
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			Document metadataDocument = factory.newDocumentBuilder().parse(new InputSource(new StringReader(metadata)));
 			NodeList versionNodes = (NodeList) XPathFactory.newInstance()
 				.newXPath()
 				.evaluate("/metadata/versioning/versions/version", metadataDocument, XPathConstants.NODESET);

--- a/buildSrc/src/main/java/org/springframework/boot/build/mavenplugin/PluginXmlParser.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/mavenplugin/PluginXmlParser.java
@@ -23,8 +23,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
@@ -32,6 +30,8 @@ import javax.xml.xpath.XPathFactory;
 
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
+import org.springframework.boot.build.xml.XmlDocument;
 
 /**
  * A parser for a Maven plugin's {@code plugin.xml} file.
@@ -49,10 +49,7 @@ class PluginXmlParser {
 
 	Plugin parse(File pluginXml) {
 		try {
-			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			Node root = factory.newDocumentBuilder().parse(pluginXml);
+			Node root = XmlDocument.parse(pluginXml);
 			List<Mojo> mojos = parseMojos(root);
 			return new Plugin(textAt("//plugin/groupId", root), textAt("//plugin/artifactId", root),
 					textAt("//plugin/version", root), textAt("//plugin/goalPrefix", root), mojos);

--- a/buildSrc/src/main/java/org/springframework/boot/build/mavenplugin/PluginXmlParser.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/mavenplugin/PluginXmlParser.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
@@ -48,7 +49,10 @@ class PluginXmlParser {
 
 	Plugin parse(File pluginXml) {
 		try {
-			Node root = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(pluginXml);
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			Node root = factory.newDocumentBuilder().parse(pluginXml);
 			List<Mojo> mojos = parseMojos(root);
 			return new Plugin(textAt("//plugin/groupId", root), textAt("//plugin/artifactId", root),
 					textAt("//plugin/version", root), textAt("//plugin/goalPrefix", root), mojos);

--- a/buildSrc/src/main/java/org/springframework/boot/build/xml/XmlDocument.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/xml/XmlDocument.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.build.xml;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * XML {@link Document} builder and parsing.
+ *
+ * @author Phillip Webb
+ * @author Sebastien Tardif
+ */
+public final class XmlDocument {
+
+	private static final DocumentBuilderFactory factory;
+	static {
+		try {
+			factory = DocumentBuilderFactory.newInstance();
+			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+		}
+		catch (ParserConfigurationException ex) {
+			throw new IllegalStateException(ex);
+		}
+	}
+
+	private XmlDocument() {
+	}
+
+	public static Document parseContent(String content) throws SAXException, IOException {
+		return builder().parse(new InputSource(new StringReader(content)));
+	}
+
+	public static Document parse(File file) throws SAXException, IOException {
+		return builder().parse(file);
+	}
+
+	public static DocumentBuilder builder() {
+		try {
+			return factory.newDocumentBuilder();
+		}
+		catch (ParserConfigurationException ex) {
+			throw new IllegalStateException(ex);
+		}
+	}
+
+}

--- a/buildSrc/src/test/java/org/springframework/boot/build/assertj/NodeAssert.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/assertj/NodeAssert.java
@@ -18,7 +18,6 @@ package org.springframework.boot.build.assertj;
 
 import java.io.File;
 
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
@@ -30,14 +29,14 @@ import org.assertj.core.api.StringAssert;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
+import org.springframework.boot.build.xml.XmlDocument;
+
 /**
  * AssertJ {@link AssertProvider} for {@link Node} assertions.
  *
  * @author Andy Wilkinson
  */
 public class NodeAssert extends AbstractAssert<NodeAssert, Node> implements AssertProvider<NodeAssert> {
-
-	private static final DocumentBuilderFactory FACTORY = DocumentBuilderFactory.newInstance();
 
 	private final XPathFactory xpathFactory = XPathFactory.newInstance();
 
@@ -53,7 +52,7 @@ public class NodeAssert extends AbstractAssert<NodeAssert, Node> implements Asse
 
 	private static Document read(File xmlFile) {
 		try {
-			return FACTORY.newDocumentBuilder().parse(xmlFile);
+			return XmlDocument.parse(xmlFile);
 		}
 		catch (Exception ex) {
 			throw new RuntimeException(ex);

--- a/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractPackagerMojo.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractPackagerMojo.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
@@ -207,6 +208,8 @@ public abstract class AbstractPackagerMojo extends AbstractDependencyFilterMojo 
 	private Document getDocumentIfAvailable(File xmlFile) throws Exception {
 		InputSource inputSource = new InputSource(new FileInputStream(xmlFile));
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 		factory.setNamespaceAware(true);
 		DocumentBuilder builder = factory.newDocumentBuilder();
 		return builder.parse(inputSource);


### PR DESCRIPTION
## Summary

Add `FEATURE_SECURE_PROCESSING` and `disallow-doctype-decl` to all `DocumentBuilderFactory` instances in `buildSrc` and the Maven plugin to align with other areas of the codebase.

## Changes

- `MavenMetadataVersionResolver` — parses network-fetched maven-metadata.xml
- `BomResolver` — parses POM files resolved from repositories
- `Library` (propertyFrom method) — parses POM files
- `PluginXmlParser` — parses plugin.xml files
- `AbstractPackagerMojo` — parses custom layers configuration XML