### PR TITLE
Use try-with-resources for ObjectInputStream in HttpRestartServer

### DIFF
--- a/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/server/HttpRestartServer.java
+++ b/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/server/HttpRestartServer.java
@@ -77,11 +77,11 @@ public class HttpRestartServer {
 	public void handle(ServerHttpRequest request, ServerHttpResponse response) throws IOException {
 		try {
 			Assert.state(request.getHeaders().getContentLength() > 0, "No content");
-			ObjectInputStream objectInputStream = new ObjectInputStream(request.getBody());
-			objectInputStream.setObjectInputFilter(this.inputFilter);
-			ClassLoaderFiles files = (ClassLoaderFiles) objectInputStream.readObject();
-			objectInputStream.close();
-			this.server.updateAndRestart(files);
+			try (ObjectInputStream objectInputStream = new ObjectInputStream(request.getBody())) {
+				objectInputStream.setObjectInputFilter(this.inputFilter);
+				ClassLoaderFiles files = (ClassLoaderFiles) objectInputStream.readObject();
+				this.server.updateAndRestart(files);
+			}
 			response.setStatusCode(HttpStatus.OK);
 		}
 		catch (Exception ex) {


### PR DESCRIPTION
## Summary

Use try-with-resources to ensure `ObjectInputStream` is always closed in `HttpRestartServer.handle()`.

## Problem

The `ObjectInputStream` is created and closed with explicit `close()` call, but if `readObject()` throws an exception, the `close()` call is skipped — the outer catch block handles the exception without closing the stream, causing a resource leak.

## Fix

Wrap the `ObjectInputStream` in a try-with-resources block to guarantee cleanup regardless of whether `readObject()` or `updateAndRestart()` throws.