### PR TITLE
NullPointerException in reactor-netty SniProvider when SSL bundle uses client-auth or server truststore without server-name-bundles

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/SslServerCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/SslServerCustomizer.java
@@ -75,11 +75,15 @@ public class SslServerCustomizer implements NettyServerCustomizer {
 	}
 
 	private void applySecurity(SslContextSpec spec) {
-		spec.sslContext(this.sslProvider.getSslContext()).setSniAsyncMappings((serverName, promise) -> {
-			SslProvider provider = (serverName != null) ? this.serverNameSslProviders.get(serverName)
-					: this.sslProvider;
-			return promise.setSuccess(provider);
-		});
+		spec.sslContext(this.sslProvider.getSslContext())
+			.setSniAsyncMappings((serverName, promise) -> promise.setSuccess(getSslProvider(serverName)));
+	}
+
+	SslProvider getSslProvider(String serverName) {
+		if (serverName == null) {
+			return this.sslProvider;
+		}
+		return this.serverNameSslProviders.getOrDefault(serverName, this.sslProvider);
 	}
 
 	void updateSslBundle(String serverName, SslBundle sslBundle) {

--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/SslServerCustomizer.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/embedded/netty/SslServerCustomizer.java
@@ -80,10 +80,8 @@ public class SslServerCustomizer implements NettyServerCustomizer {
 	}
 
 	SslProvider getSslProvider(String serverName) {
-		if (serverName == null) {
-			return this.sslProvider;
-		}
-		return this.serverNameSslProviders.getOrDefault(serverName, this.sslProvider);
+		return (serverName != null) ? this.serverNameSslProviders.getOrDefault(serverName, this.sslProvider)
+				: this.sslProvider;
 	}
 
 	void updateSslBundle(String serverName, SslBundle sslBundle) {

--- a/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/netty/SslServerCustomizerTests.java
+++ b/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/web/embedded/netty/SslServerCustomizerTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.embedded.netty;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import reactor.netty.tcp.SslProvider;
+
+import org.springframework.boot.ssl.SslBundle;
+import org.springframework.boot.ssl.pem.PemSslStoreBundle;
+import org.springframework.boot.ssl.pem.PemSslStoreDetails;
+import org.springframework.boot.testsupport.classpath.resources.WithPackageResources;
+import org.springframework.boot.web.server.Ssl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SslServerCustomizer}.
+ *
+ * @author Daeho Kwon
+ */
+class SslServerCustomizerTests {
+
+	@Test
+	@WithPackageResources({ "1.key", "1.crt", "2.key", "2.crt" })
+	void getSslProviderReturnsMappedProviderForKnownServerName() {
+		SslBundle defaultBundle = createBundle("1.key", "1.crt");
+		SslBundle mappedBundle = createBundle("2.key", "2.crt");
+		SslServerCustomizer customizer = new SslServerCustomizer(null, Ssl.ClientAuth.NONE, defaultBundle,
+				Map.of("mapped.example", mappedBundle));
+		SslProvider mapped = customizer.getSslProvider("mapped.example");
+		assertThat(mapped).isNotNull().isNotSameAs(customizer.getSslProvider(null));
+	}
+
+	@Test
+	@WithPackageResources({ "1.key", "1.crt", "2.key", "2.crt" })
+	void getSslProviderFallsBackToDefaultWhenServerNameIsUnmapped() {
+		SslBundle defaultBundle = createBundle("1.key", "1.crt");
+		SslBundle mappedBundle = createBundle("2.key", "2.crt");
+		SslServerCustomizer customizer = new SslServerCustomizer(null, Ssl.ClientAuth.NONE, defaultBundle,
+				Map.of("mapped.example", mappedBundle));
+		assertThat(customizer.getSslProvider("unmapped.example")).isSameAs(customizer.getSslProvider(null));
+	}
+
+	@Test
+	@WithPackageResources({ "1.key", "1.crt" })
+	void getSslProviderReturnsDefaultWhenServerNameIsNull() {
+		SslBundle defaultBundle = createBundle("1.key", "1.crt");
+		SslServerCustomizer customizer = new SslServerCustomizer(null, Ssl.ClientAuth.NONE, defaultBundle,
+				Collections.emptyMap());
+		assertThat(customizer.getSslProvider(null)).isNotNull();
+	}
+
+	private static SslBundle createBundle(String key, String certificate) {
+		return SslBundle.of(new PemSslStoreBundle(
+				new PemSslStoreDetails(null, "classpath:" + certificate, "classpath:" + key), null));
+	}
+
+}


### PR DESCRIPTION
Falls back to the default `SslProvider` when the SNI hostname is not                                                                                                 
present in `server-name-bundles`. The lookup logic is extracted into
a package-private `getSslProvider(String)` method to make it directly                                                                                                
testable.                                                                                                                                                            
   
A unit test is used instead of an end-to-end test because the
synchronous SNI lookup exception is silently swallowed inside Netty's
SslClientHelloHandler and the handshake falls back to the default
SslContext, so the NPE does not surface at the response level
(see netty/netty#16794).

Closes gh-50246