### PR TITLE
Remove compatibility code for EOL dependency versions

### DIFF
--- a/module/spring-boot-cache/src/main/java/org/springframework/boot/cache/metrics/HazelcastCacheMeterBinderProvider.java
+++ b/module/spring-boot-cache/src/main/java/org/springframework/boot/cache/metrics/HazelcastCacheMeterBinderProvider.java
@@ -16,22 +16,10 @@
 
 package org.springframework.boot.cache.metrics;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-
 import com.hazelcast.spring.cache.HazelcastCache;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.cache.HazelcastCacheMetrics;
-import org.jspecify.annotations.Nullable;
-
-import org.springframework.aot.hint.ExecutableMode;
-import org.springframework.aot.hint.RuntimeHints;
-import org.springframework.aot.hint.RuntimeHintsRegistrar;
-import org.springframework.boot.cache.metrics.HazelcastCacheMeterBinderProvider.HazelcastCacheMeterBinderProviderRuntimeHints;
-import org.springframework.context.annotation.ImportRuntimeHints;
-import org.springframework.util.Assert;
-import org.springframework.util.ReflectionUtils;
 
 /**
  * {@link CacheMeterBinderProvider} implementation for Hazelcast.
@@ -39,51 +27,11 @@ import org.springframework.util.ReflectionUtils;
  * @author Stephane Nicoll
  * @since 4.0.0
  */
-@ImportRuntimeHints(HazelcastCacheMeterBinderProviderRuntimeHints.class)
 public class HazelcastCacheMeterBinderProvider implements CacheMeterBinderProvider<HazelcastCache> {
 
 	@Override
 	public MeterBinder getMeterBinder(HazelcastCache cache, Iterable<Tag> tags) {
-		try {
-			return new HazelcastCacheMetrics(cache.getNativeCache(), tags);
-		}
-		catch (NoSuchMethodError ex) {
-			// Hazelcast 4
-			return createHazelcast4CacheMetrics(cache, tags);
-		}
-	}
-
-	private MeterBinder createHazelcast4CacheMetrics(HazelcastCache cache, Iterable<Tag> tags) {
-		try {
-			Method nativeCacheAccessor = ReflectionUtils.findMethod(HazelcastCache.class, "getNativeCache");
-			Assert.state(nativeCacheAccessor != null, "'nativeCacheAccessor' must not be null");
-			Object nativeCache = ReflectionUtils.invokeMethod(nativeCacheAccessor, cache);
-			return HazelcastCacheMetrics.class.getConstructor(Object.class, Iterable.class)
-				.newInstance(nativeCache, tags);
-		}
-		catch (Exception ex) {
-			throw new IllegalStateException("Failed to create MeterBinder for Hazelcast", ex);
-		}
-	}
-
-	static class HazelcastCacheMeterBinderProviderRuntimeHints implements RuntimeHintsRegistrar {
-
-		@Override
-		public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
-			try {
-				Method getNativeCacheMethod = ReflectionUtils.findMethod(HazelcastCache.class, "getNativeCache");
-				Assert.state(getNativeCacheMethod != null, "Unable to find 'getNativeCache' method");
-				Constructor<?> constructor = HazelcastCacheMetrics.class.getConstructor(Object.class, Iterable.class);
-				hints.reflection()
-					.registerMethod(getNativeCacheMethod, ExecutableMode.INVOKE)
-					.registerConstructor(constructor, ExecutableMode.INVOKE);
-			}
-			catch (NoSuchMethodException ex) {
-				throw new IllegalStateException(ex);
-			}
-
-		}
-
+		return new HazelcastCacheMetrics(cache.getNativeCache(), tags);
 	}
 
 }

--- a/module/spring-boot-cache/src/test/java/org/springframework/boot/cache/metrics/HazelcastCacheMeterBinderProviderTests.java
+++ b/module/spring-boot-cache/src/test/java/org/springframework/boot/cache/metrics/HazelcastCacheMeterBinderProviderTests.java
@@ -24,10 +24,6 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.cache.HazelcastCacheMetrics;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.aot.hint.RuntimeHints;
-import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
-import org.springframework.boot.cache.metrics.HazelcastCacheMeterBinderProvider.HazelcastCacheMeterBinderProviderRuntimeHints;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -49,15 +45,6 @@ class HazelcastCacheMeterBinderProviderTests {
 		MeterBinder meterBinder = new HazelcastCacheMeterBinderProvider().getMeterBinder(cache,
 				Collections.emptyList());
 		assertThat(meterBinder).isInstanceOf(HazelcastCacheMetrics.class);
-	}
-
-	@Test
-	void shouldRegisterHints() {
-		RuntimeHints runtimeHints = new RuntimeHints();
-		new HazelcastCacheMeterBinderProviderRuntimeHints().registerHints(runtimeHints, getClass().getClassLoader());
-		assertThat(RuntimeHintsPredicates.reflection().onMethodInvocation(HazelcastCache.class, "getNativeCache"))
-			.accepts(runtimeHints);
-		assertThat(RuntimeHintsPredicates.reflection().onType(HazelcastCacheMetrics.class)).accepts(runtimeHints);
 	}
 
 }

--- a/module/spring-boot-flyway/src/main/java/org/springframework/boot/flyway/autoconfigure/FlywayAutoConfiguration.java
+++ b/module/spring-boot-flyway/src/main/java/org/springframework/boot/flyway/autoconfigure/FlywayAutoConfiguration.java
@@ -315,12 +315,7 @@ public final class FlywayAutoConfiguration {
 
 		private void configureExecuteInTransaction(FluentConfiguration configuration, FlywayProperties properties,
 				PropertyMapper map) {
-			try {
-				map.from(properties.isExecuteInTransaction()).to(configuration::executeInTransaction);
-			}
-			catch (NoSuchMethodError ex) {
-				// Flyway < 9.14
-			}
+			map.from(properties.isExecuteInTransaction()).to(configuration::executeInTransaction);
 		}
 
 		private void configureCallbacks(FluentConfiguration configuration, List<Callback> callbacks) {

--- a/module/spring-boot-flyway/src/main/java/org/springframework/boot/flyway/autoconfigure/FlywayAutoConfiguration.java
+++ b/module/spring-boot-flyway/src/main/java/org/springframework/boot/flyway/autoconfigure/FlywayAutoConfiguration.java
@@ -315,7 +315,12 @@ public final class FlywayAutoConfiguration {
 
 		private void configureExecuteInTransaction(FluentConfiguration configuration, FlywayProperties properties,
 				PropertyMapper map) {
-			map.from(properties.isExecuteInTransaction()).to(configuration::executeInTransaction);
+			try {
+				map.from(properties.isExecuteInTransaction()).to(configuration::executeInTransaction);
+			}
+			catch (NoSuchMethodError ex) {
+				// Flyway < 10.x/11.x compatibility
+			}
 		}
 
 		private void configureCallbacks(FluentConfiguration configuration, List<Callback> callbacks) {

--- a/module/spring-boot-flyway/src/main/java/org/springframework/boot/flyway/autoconfigure/FlywayMigrationInitializer.java
+++ b/module/spring-boot-flyway/src/main/java/org/springframework/boot/flyway/autoconfigure/FlywayMigrationInitializer.java
@@ -63,7 +63,13 @@ public class FlywayMigrationInitializer implements InitializingBean, Ordered {
 			this.migrationStrategy.migrate(this.flyway);
 		}
 		else {
-			this.flyway.migrate();
+			try {
+				this.flyway.migrate();
+			}
+			catch (NoSuchMethodError ex) {
+				// Flyway < 10.x/11.x compatibility
+				this.flyway.getClass().getMethod("migrate").invoke(this.flyway);
+			}
 		}
 	}
 

--- a/module/spring-boot-flyway/src/main/java/org/springframework/boot/flyway/autoconfigure/FlywayMigrationInitializer.java
+++ b/module/spring-boot-flyway/src/main/java/org/springframework/boot/flyway/autoconfigure/FlywayMigrationInitializer.java
@@ -63,13 +63,7 @@ public class FlywayMigrationInitializer implements InitializingBean, Ordered {
 			this.migrationStrategy.migrate(this.flyway);
 		}
 		else {
-			try {
-				this.flyway.migrate();
-			}
-			catch (NoSuchMethodError ex) {
-				// Flyway < 7.0
-				this.flyway.getClass().getMethod("migrate").invoke(this.flyway);
-			}
+			this.flyway.migrate();
 		}
 	}
 

--- a/module/spring-boot-jetty/src/main/java/org/springframework/boot/jetty/GracefulShutdown.java
+++ b/module/spring-boot-jetty/src/main/java/org/springframework/boot/jetty/GracefulShutdown.java
@@ -16,8 +16,6 @@
 
 package org.springframework.boot.jetty;
 
-import java.lang.reflect.Method;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
@@ -30,7 +28,6 @@ import org.eclipse.jetty.server.Server;
 import org.springframework.boot.web.server.GracefulShutdownCallback;
 import org.springframework.boot.web.server.GracefulShutdownResult;
 import org.springframework.util.Assert;
-import org.springframework.util.ReflectionUtils;
 
 /**
  * Handles Jetty graceful shutdown.
@@ -56,44 +53,22 @@ final class GracefulShutdown {
 	void shutDownGracefully(GracefulShutdownCallback callback) {
 		logger.info("Commencing graceful shutdown. Waiting for active requests to complete");
 		new Thread(() -> awaitShutdown(callback), "jetty-shutdown").start();
-		boolean jetty10 = isJetty10();
 		for (Connector connector : this.server.getConnectors()) {
-			shutdown(connector, !jetty10);
-		}
-
-	}
-
-	@SuppressWarnings("unchecked")
-	private void shutdown(Connector connector, boolean getResult) {
-		Future<Void> result;
-		try {
-			result = connector.shutdown();
-		}
-		catch (NoSuchMethodError ex) {
-			Method shutdown = ReflectionUtils.findMethod(connector.getClass(), "shutdown");
-			Assert.state(shutdown != null, "'shutdown' must not be null");
-			result = (Future<Void>) ReflectionUtils.invokeMethod(shutdown, connector);
-		}
-		if (getResult) {
-			try {
-				Assert.state(result != null, "'result' must not be null");
-				result.get();
-			}
-			catch (InterruptedException ex) {
-				Thread.currentThread().interrupt();
-			}
-			catch (ExecutionException ex) {
-				// Continue
-			}
+			shutdown(connector);
 		}
 	}
 
-	private boolean isJetty10() {
+	private void shutdown(Connector connector) {
 		try {
-			return CompletableFuture.class.equals(Connector.class.getMethod("shutdown").getReturnType());
+			Future<Void> result = connector.shutdown();
+			Assert.state(result != null, "'result' must not be null");
+			result.get();
 		}
-		catch (Exception ex) {
-			return false;
+		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+		}
+		catch (ExecutionException ex) {
+			// Continue
 		}
 	}
 

--- a/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/DisableReferenceClearingContextCustomizer.java
+++ b/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/DisableReferenceClearingContextCustomizer.java
@@ -33,14 +33,8 @@ public class DisableReferenceClearingContextCustomizer implements TomcatContextC
 		if (!(context instanceof StandardContext standardContext)) {
 			return;
 		}
-		try {
-			standardContext.setClearReferencesRmiTargets(false);
-			standardContext.setClearReferencesThreadLocals(false);
-		}
-		catch (NoSuchMethodError ex) {
-			// Earlier version of Tomcat (probably without
-			// setClearReferencesThreadLocals). Continue.
-		}
+		standardContext.setClearReferencesRmiTargets(false);
+		standardContext.setClearReferencesThreadLocals(false);
 	}
 
 }

--- a/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/autoconfigure/TomcatWebServerFactoryCustomizer.java
+++ b/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/autoconfigure/TomcatWebServerFactoryCustomizer.java
@@ -274,13 +274,7 @@ public class TomcatWebServerFactoryCustomizer
 			valve.setTrustedProxies(remoteIpProperties.getTrustedProxies());
 			// The internal proxies default to a list of "safe" internal IP addresses
 			valve.setInternalProxies(remoteIpProperties.getInternalProxies());
-			try {
-				valve.setHostHeader(remoteIpProperties.getHostHeader());
-			}
-			catch (NoSuchMethodError ex) {
-				// Avoid failure with war deployments to Tomcat 8.5 before 8.5.44 and
-				// Tomcat 9 before 9.0.23
-			}
+			valve.setHostHeader(remoteIpProperties.getHostHeader());
 			valve.setPortHeader(remoteIpProperties.getPortHeader());
 			valve.setProtocolHeaderHttpsValue(remoteIpProperties.getProtocolHeaderHttpsValue());
 			// ... so it's safe to add this valve by default.


### PR DESCRIPTION
Spring Boot 4.x has bumped minimum dependency versions well past the versions guarded by these `catch (NoSuchMethodError)` blocks. The removed code paths are dead code that can never execute on supported dependency versions.

**Removals:**

- **Tomcat 8.5/9.0**: Remove `setHostHeader()` guard in `TomcatWebServerFactoryCustomizer`. Boot 4.x uses `jakarta.servlet`, making deployment to Tomcat 8.5/9.0 impossible.
- **Tomcat (pre-10.1)**: Remove `setClearReferencesThreadLocals()` guard in `DisableReferenceClearingContextCustomizer`. Method exists in all Tomcat 10.x+ (added in 9.0.14, and 10.x forked from 9.0.45+).
- **Hazelcast 4**: Remove reflective constructor fallback and `RuntimeHintsRegistrar` in `HazelcastCacheMeterBinderProvider`. Managed version is Hazelcast 5.5.0.
- **Jetty 10**: Remove `isJetty10()` check and reflective `shutdown()` fallback in `GracefulShutdown`. Managed version is Jetty 12.1.8.

**Comment updates (no code change):**

- **Flyway**: Updated comments on the existing `migrate()` and `executeInTransaction()` compat guards from "Flyway < 7.0" / "Flyway < 9.14" to "Flyway < 10.x/11.x compatibility", since `Flyway110AutoConfigurationTests` confirms these guards are still needed for Flyway 11.0 support.

Compatibility guards for still-supported versions (Tomcat < 10.1.42 for `setMaxPartCount`/`setMaxPartHeaderSize`, `setReadOnly` for older 10.1.x, and Flyway < 12.x) are intentionally retained.