### PR TITLE
Buildpack module does not validate long-to-int casts

### DIFF
--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/LogUpdateEvent.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/LogUpdateEvent.java
@@ -107,6 +107,7 @@ public class LogUpdateEvent extends UpdateEvent {
 	}
 
 	private static byte @Nullable [] read(InputStream inputStream, long size) throws IOException {
+		Assert.state(size <= Integer.MAX_VALUE, () -> "Log update event data is too large (%d bytes)".formatted(size));
 		byte[] data = new byte[(int) size];
 		int offset = 0;
 		do {

--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/io/Content.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/io/Content.java
@@ -75,7 +75,9 @@ public interface Content {
 	 */
 	static Content of(File file) {
 		Assert.notNull(file, "'file' must not be null");
-		return of((int) file.length(), () -> new FileInputStream(file));
+		long length = file.length();
+		Assert.state(length <= Integer.MAX_VALUE, () -> "'file' is too large (%d bytes) to be used as content".formatted(length));
+		return of((int) length, () -> new FileInputStream(file));
 	}
 
 	/**

--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/io/Content.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/io/Content.java
@@ -76,7 +76,8 @@ public interface Content {
 	static Content of(File file) {
 		Assert.notNull(file, "'file' must not be null");
 		long length = file.length();
-		Assert.state(length <= Integer.MAX_VALUE, () -> "'file' is too large (%d bytes) to be used as content".formatted(length));
+		Assert.state(length <= Integer.MAX_VALUE,
+				() -> "'file' is too large (%d bytes) to be used as content".formatted(length));
 		return of((int) length, () -> new FileInputStream(file));
 	}
 

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/LogUpdateEventTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/LogUpdateEventTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.buildpack.platform.docker;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -58,6 +59,19 @@ class LogUpdateEventTests {
 		List<LogUpdateEvent> events = readAll("log-update-event-invalid-stream-type.stream");
 		assertThat(events).hasSize(1);
 		assertThat(events.get(0)).hasToString("Stream type is out of bounds. Must be >= 0 and < 3, but was 3");
+	}
+
+	@Test
+	void readAllWhenPayloadSizeExceedsIntMaxReturnsErrorEvent() throws IOException {
+		// Docker multiplexed stream header: 1 byte stream type (1=STDOUT),
+		// 3 padding bytes, 4 bytes big-endian size (0xFFFFFFFF = 4294967295)
+		byte[] header = new byte[] { 1, 0, 0, 0, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF };
+		List<LogUpdateEvent> events = new ArrayList<>();
+		try (InputStream inputStream = new ByteArrayInputStream(header)) {
+			LogUpdateEvent.readAll(inputStream, events::add);
+		}
+		assertThat(events).hasSize(1);
+		assertThat(events.get(0)).hasToString("Log update event data is too large (4294967295 bytes)");
 	}
 
 	private List<LogUpdateEvent> readAll(String name) throws IOException {

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/ContentTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/ContentTests.java
@@ -84,8 +84,7 @@ class ContentTests {
 	void ofFileWhenFileTooLargeThrowsException() {
 		File file = mock(File.class);
 		given(file.length()).willReturn((long) Integer.MAX_VALUE + 1);
-		assertThatIllegalStateException().isThrownBy(() -> Content.of(file))
-			.withMessageContaining("too large");
+		assertThatIllegalStateException().isThrownBy(() -> Content.of(file)).withMessageContaining("too large");
 	}
 
 	private byte[] writeToAndGetBytes(Content writable) throws IOException {

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/ContentTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/ContentTests.java
@@ -18,6 +18,7 @@ package org.springframework.boot.buildpack.platform.io;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -26,6 +27,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link Content}.
@@ -74,6 +78,14 @@ class ContentTests {
 		byte[] bytes = { 1, 2, 3, 4 };
 		Content writable = Content.of(bytes);
 		assertThat(writeToAndGetBytes(writable)).isEqualTo(bytes);
+	}
+
+	@Test
+	void ofFileWhenFileTooLargeThrowsException() {
+		File file = mock(File.class);
+		given(file.length()).willReturn((long) Integer.MAX_VALUE + 1);
+		assertThatIllegalStateException().isThrownBy(() -> Content.of(file))
+			.withMessageContaining("too large");
 	}
 
 	private byte[] writeToAndGetBytes(Content writable) throws IOException {


### PR DESCRIPTION
Add explicit size checks before casting `long` values to `int` in two locations in the buildpack module where external data (file sizes, Docker stream headers) could exceed `Integer.MAX_VALUE`.

**`Content.of(File)`**: `file.length()` returns `long` but was cast to `int` without validation. Files larger than 2GB would silently produce incorrect (possibly negative) size values, corrupting tar entry headers. Now throws `IllegalStateException` with the actual file size in the message.

**`LogUpdateEvent.read()`**: The `size` parameter is parsed from a Docker multiplexed stream header (4 unsigned bytes, max ~4GB). Values exceeding `Integer.MAX_VALUE` would cause `NegativeArraySizeException` when allocating the byte array. Now throws `IllegalStateException` with the actual byte count. The error is caught by `readAll()` and forwarded as a `STD_ERR` log event, matching the existing error handling pattern.

Both assertions use the lambda-with-formatted-value pattern already established by `StreamType.forId()` in the same file. Tests added for both overflow paths.