### PR TITLE
Use LinkedHashMap and LinkedHashSet in configuration properties

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureCheck.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureCheck.java
@@ -87,6 +87,8 @@ public abstract class ArchitectureCheck extends DefaultTask {
 			.classFor(getAnnotationClasses().get(), ArchitectureCheckAnnotation.CONDITIONAL_ON_MISSING_BEAN))));
 		getRules().addAll(whenMainSources(() -> ArchitectureRules.configurationProperties(ArchitectureCheckAnnotation
 			.classFor(getAnnotationClasses().get(), ArchitectureCheckAnnotation.CONFIGURATION_PROPERTIES))));
+		getRules().addAll(whenMainSources(() -> ArchitectureRules.configurationProperties(ArchitectureCheckAnnotation
+			.classFor(getAnnotationClasses().get(), ArchitectureCheckAnnotation.CONFIGURATION_PROPERTIES_SOURCE))));
 		getRules().addAll(whenMainSources(
 				() -> ArchitectureRules.configurationPropertiesBinding(ArchitectureCheckAnnotation.classFor(
 						getAnnotationClasses().get(), ArchitectureCheckAnnotation.CONFIGURATION_PROPERTIES_BINDING))));

--- a/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureCheckAnnotation.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureCheckAnnotation.java
@@ -43,6 +43,11 @@ public enum ArchitectureCheckAnnotation {
 	CONFIGURATION_PROPERTIES,
 
 	/**
+	 * Configuration properties source.
+	 */
+	CONFIGURATION_PROPERTIES_SOURCE,
+
+	/**
 	 * Deprecated configuration property.
 	 */
 	DEPRECATED_CONFIGURATION_PROPERTY,
@@ -56,6 +61,8 @@ public enum ArchitectureCheckAnnotation {
 			"org.springframework.boot.autoconfigure.condition.ConditionalOnClass", CONDITIONAL_ON_MISSING_BEAN.name(),
 			"org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean",
 			CONFIGURATION_PROPERTIES.name(), "org.springframework.boot.context.properties.ConfigurationProperties",
+			CONFIGURATION_PROPERTIES_SOURCE.name(),
+			"org.springframework.boot.context.properties.ConfigurationPropertiesSource",
 			DEPRECATED_CONFIGURATION_PROPERTY.name(),
 			"org.springframework.boot.context.properties.DeprecatedConfigurationProperty",
 			CONFIGURATION_PROPERTIES_BINDING.name(),

--- a/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureRules.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureRules.java
@@ -37,7 +37,10 @@ import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClass.Predicates;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaConstructorCall;
 import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaFieldAccess;
+import com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType;
 import com.tngtech.archunit.core.domain.JavaMember;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaModifier;
@@ -77,6 +80,7 @@ import org.springframework.util.ResourceUtils;
  * @author Ngoc Nhan
  * @author Moritz Halbritter
  * @author Stefano Cordio
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 final class ArchitectureRules {
 
@@ -126,7 +130,11 @@ final class ArchitectureRules {
 
 	static List<ArchRule> configurationProperties(String annotationClass) {
 		return List.of(classLevelConfigurationPropertiesShouldNotSpecifyOnlyPrefixAttribute(annotationClass),
-				methodLevelConfigurationPropertiesShouldNotSpecifyOnlyPrefixAttribute(annotationClass));
+				methodLevelConfigurationPropertiesShouldNotSpecifyOnlyPrefixAttribute(annotationClass),
+				initializedConfigurationPropertiesShouldUse("java.util.Set", "java.util.LinkedHashSet",
+						annotationClass),
+				initializedConfigurationPropertiesShouldUse("java.util.Map",
+						List.of("java.util.LinkedHashMap", "java.util.EnumMap"), annotationClass));
 	}
 
 	static List<ArchRule> configurationPropertiesBinding(String annotationClass) {
@@ -426,6 +434,60 @@ final class ArchitectureRules {
 				}
 			}))
 			.allowEmptyShould(true);
+	}
+
+	private static ArchRule initializedConfigurationPropertiesShouldUse(String propertyType, String implementationType,
+			String annotationClass) {
+		return initializedConfigurationPropertiesShouldUse(propertyType, List.of(implementationType), annotationClass);
+	}
+
+	private static ArchRule initializedConfigurationPropertiesShouldUse(String propertyType,
+			List<String> implementationTypes, String annotationClass) {
+		return ArchRuleDefinition.classes()
+			.that()
+			.areAnnotatedWith(annotationClass)
+			.or(areNestedInConfigurationPropertiesClasses(annotationClass))
+			.should(useImplementationForInitializedProperties(propertyType, implementationTypes))
+			.because("@ConfigurationProperties classes should preserve the property type's expected implementation")
+			.allowEmptyShould(true);
+	}
+
+	private static ArchCondition<JavaClass> useImplementationForInitializedProperties(String propertyType,
+			List<String> implementationTypes) {
+		String description = implementationTypes.stream().collect(Collectors.joining(" or "));
+		return check("use %s for initialized %s properties".formatted(description, propertyType),
+				(javaClass, events) -> javaClass.getFields()
+					.stream()
+					.filter((field) -> propertyType.equals(field.getRawType().getName()))
+					.forEach((field) -> checkPropertyInitializer(field, implementationTypes, events)));
+	}
+
+	private static void checkPropertyInitializer(JavaField field, List<String> implementationTypes,
+			ConditionEvents events) {
+		String description = implementationTypes.stream().collect(Collectors.joining(" or "));
+		field.getAccessesToSelf()
+			.stream()
+			.filter((access) -> access.getAccessType() == AccessType.SET)
+			.flatMap((access) -> initializerConstructorCalls(access).stream())
+			.filter((call) -> !implementationTypes.contains(call.getTargetOwner().getName()))
+			.forEach((call) -> addViolation(events, field, "%s should be initialized with %s instead of %s"
+				.formatted(field.getDescription(), description, call.getTargetOwner().getName())));
+	}
+
+	private static List<JavaConstructorCall> initializerConstructorCalls(JavaFieldAccess fieldAccess) {
+		return fieldAccess.getOrigin()
+			.getConstructorCallsFromSelf()
+			.stream()
+			.filter((call) -> call.getLineNumber() == fieldAccess.getLineNumber())
+			.toList();
+	}
+
+	private static DescribedPredicate<JavaClass> areNestedInConfigurationPropertiesClasses(String annotationClass) {
+		return DescribedPredicate.describe("are nested in @ConfigurationProperties",
+				(javaClass) -> javaClass.getEnclosingClass()
+					.map((enclosing) -> enclosing.isAnnotatedWith(annotationClass)
+							|| areNestedInConfigurationPropertiesClasses(annotationClass).test(enclosing))
+					.orElse(false));
 	}
 
 	private static ArchRule autoConfigurationClassesShouldBePublicAndFinal() {

--- a/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureRules.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureRules.java
@@ -131,10 +131,10 @@ final class ArchitectureRules {
 	static List<ArchRule> configurationProperties(String annotationClass) {
 		return List.of(classLevelConfigurationPropertiesShouldNotSpecifyOnlyPrefixAttribute(annotationClass),
 				methodLevelConfigurationPropertiesShouldNotSpecifyOnlyPrefixAttribute(annotationClass),
-				initializedConfigurationPropertiesShouldUse("java.util.Set", "java.util.LinkedHashSet",
-						annotationClass),
-				initializedConfigurationPropertiesShouldUse("java.util.Map",
-						List.of("java.util.LinkedHashMap", "java.util.EnumMap"), annotationClass));
+				configurationPropertyOfTypeShouldUseImplementation(annotationClass, "java.util.Set",
+						List.of("java.util.LinkedHashSet")),
+				configurationPropertyOfTypeShouldUseImplementation(annotationClass, "java.util.Map",
+						List.of("java.util.LinkedHashMap", "java.util.EnumMap")));
 	}
 
 	static List<ArchRule> configurationPropertiesBinding(String annotationClass) {
@@ -436,42 +436,36 @@ final class ArchitectureRules {
 			.allowEmptyShould(true);
 	}
 
-	private static ArchRule initializedConfigurationPropertiesShouldUse(String propertyType, String implementationType,
-			String annotationClass) {
-		return initializedConfigurationPropertiesShouldUse(propertyType, List.of(implementationType), annotationClass);
-	}
-
-	private static ArchRule initializedConfigurationPropertiesShouldUse(String propertyType,
-			List<String> implementationTypes, String annotationClass) {
+	private static ArchRule configurationPropertyOfTypeShouldUseImplementation(String annotationClass,
+			String propertyType, List<String> allowedImplementations) {
 		return ArchRuleDefinition.classes()
 			.that()
 			.areAnnotatedWith(annotationClass)
-			.or(areNestedInConfigurationPropertiesClasses(annotationClass))
-			.should(useImplementationForInitializedProperties(propertyType, implementationTypes))
-			.because("@ConfigurationProperties classes should preserve the property type's expected implementation")
+			.or(areNestedInClassAnnotatedWith(annotationClass))
+			.should(useAllowedImplementationForProperties(propertyType, allowedImplementations))
 			.allowEmptyShould(true);
 	}
 
-	private static ArchCondition<JavaClass> useImplementationForInitializedProperties(String propertyType,
-			List<String> implementationTypes) {
-		String description = implementationTypes.stream().collect(Collectors.joining(" or "));
-		return check("use %s for initialized %s properties".formatted(description, propertyType),
+	private static ArchCondition<JavaClass> useAllowedImplementationForProperties(String propertyType,
+			List<String> allowedImplementations) {
+		return check(
+				"use %s for properties of type %s".formatted(String.join(" or ", allowedImplementations), propertyType),
 				(javaClass, events) -> javaClass.getFields()
 					.stream()
 					.filter((field) -> propertyType.equals(field.getRawType().getName()))
-					.forEach((field) -> checkPropertyInitializer(field, implementationTypes, events)));
+					.forEach((field) -> checkPropertyImplementation(field, allowedImplementations, events)));
 	}
 
-	private static void checkPropertyInitializer(JavaField field, List<String> implementationTypes,
+	private static void checkPropertyImplementation(JavaField field, List<String> allowedImplementations,
 			ConditionEvents events) {
-		String description = implementationTypes.stream().collect(Collectors.joining(" or "));
 		field.getAccessesToSelf()
 			.stream()
 			.filter((access) -> access.getAccessType() == AccessType.SET)
 			.flatMap((access) -> initializerConstructorCalls(access).stream())
-			.filter((call) -> !implementationTypes.contains(call.getTargetOwner().getName()))
-			.forEach((call) -> addViolation(events, field, "%s should be initialized with %s instead of %s"
-				.formatted(field.getDescription(), description, call.getTargetOwner().getName())));
+			.filter((call) -> !allowedImplementations.contains(call.getTargetOwner().getName()))
+			.forEach((call) -> addViolation(events, field,
+					"%s should be initialized with %s instead of %s".formatted(field.getDescription(),
+							String.join(" or ", allowedImplementations), call.getTargetOwner().getName())));
 	}
 
 	private static List<JavaConstructorCall> initializerConstructorCalls(JavaFieldAccess fieldAccess) {
@@ -482,11 +476,11 @@ final class ArchitectureRules {
 			.toList();
 	}
 
-	private static DescribedPredicate<JavaClass> areNestedInConfigurationPropertiesClasses(String annotationClass) {
-		return DescribedPredicate.describe("are nested in @ConfigurationProperties",
+	private static DescribedPredicate<JavaClass> areNestedInClassAnnotatedWith(String annotationClass) {
+		return DescribedPredicate.describe("one of its inner class",
 				(javaClass) -> javaClass.getEnclosingClass()
 					.map((enclosing) -> enclosing.isAnnotatedWith(annotationClass)
-							|| areNestedInConfigurationPropertiesClasses(annotationClass).test(enclosing))
+							|| areNestedInClassAnnotatedWith(annotationClass).test(enclosing))
 					.orElse(false));
 	}
 

--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/ArchitectureCheckTests.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/ArchitectureCheckTests.java
@@ -62,6 +62,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Ivan Malutin
  * @author Dmytro Nosan
  * @author Stefano Cordio
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 class ArchitectureCheckTests {
 
@@ -327,6 +328,41 @@ class ArchitectureCheckTests {
 	@Test
 	void whenMethodLevelConfigurationPropertiesContainsOnlyValueShouldSucceedAndWriteEmptyReport() throws IOException {
 		prepareTask(Task.CHECK_ARCHITECTURE_MAIN, "configurationproperties/methodvalueonly", "annotations");
+		build(this.gradleBuild.withDependencies(SPRING_CONTEXT).withConfigurationPropertiesAnnotation(),
+				Task.CHECK_ARCHITECTURE_MAIN);
+	}
+
+	@Test
+	void whenConfigurationPropertiesUsesHashMapShouldFailAndWriteReport() throws IOException {
+		prepareTask(Task.CHECK_ARCHITECTURE_MAIN, "configurationproperties/hashmap", "annotations");
+		buildAndFail(this.gradleBuild.withDependencies(SPRING_CONTEXT).withConfigurationPropertiesAnnotation(),
+				Task.CHECK_ARCHITECTURE_MAIN, "should be initialized with java.util.LinkedHashMap");
+	}
+
+	@Test
+	void whenConfigurationPropertiesUsesHashSetShouldFailAndWriteReport() throws IOException {
+		prepareTask(Task.CHECK_ARCHITECTURE_MAIN, "configurationproperties/hashset", "annotations");
+		buildAndFail(this.gradleBuild.withDependencies(SPRING_CONTEXT).withConfigurationPropertiesAnnotation(),
+				Task.CHECK_ARCHITECTURE_MAIN, "should be initialized with java.util.LinkedHashSet");
+	}
+
+	@Test
+	void whenConfigurationPropertiesUsesLinkedHashMapShouldSucceedAndWriteEmptyReport() throws IOException {
+		prepareTask(Task.CHECK_ARCHITECTURE_MAIN, "configurationproperties/linkedhashmap", "annotations");
+		build(this.gradleBuild.withDependencies(SPRING_CONTEXT).withConfigurationPropertiesAnnotation(),
+				Task.CHECK_ARCHITECTURE_MAIN);
+	}
+
+	@Test
+	void whenConfigurationPropertiesUsesEnumMapShouldSucceedAndWriteEmptyReport() throws IOException {
+		prepareTask(Task.CHECK_ARCHITECTURE_MAIN, "configurationproperties/enummap", "annotations");
+		build(this.gradleBuild.withDependencies(SPRING_CONTEXT).withConfigurationPropertiesAnnotation(),
+				Task.CHECK_ARCHITECTURE_MAIN);
+	}
+
+	@Test
+	void whenConfigurationPropertiesUsesLinkedHashSetShouldSucceedAndWriteEmptyReport() throws IOException {
+		prepareTask(Task.CHECK_ARCHITECTURE_MAIN, "configurationproperties/linkedhashset", "annotations");
 		build(this.gradleBuild.withDependencies(SPRING_CONTEXT).withConfigurationPropertiesAnnotation(),
 				Task.CHECK_ARCHITECTURE_MAIN);
 	}

--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/ArchitectureCheckTests.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/ArchitectureCheckTests.java
@@ -47,6 +47,7 @@ import org.springframework.boot.build.architecture.annotations.TestConditionalOn
 import org.springframework.boot.build.architecture.annotations.TestConditionalOnMissingBean;
 import org.springframework.boot.build.architecture.annotations.TestConfigurationProperties;
 import org.springframework.boot.build.architecture.annotations.TestConfigurationPropertiesBinding;
+import org.springframework.boot.build.architecture.annotations.TestConfigurationPropertiesSource;
 import org.springframework.boot.build.architecture.annotations.TestDeprecatedConfigurationProperty;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.FileSystemUtils;
@@ -340,9 +341,23 @@ class ArchitectureCheckTests {
 	}
 
 	@Test
+	void whenConfigurationPropertiesSourceUsesHashMapShouldFailAndWriteReport() throws IOException {
+		prepareTask(Task.CHECK_ARCHITECTURE_MAIN, "configurationpropertiessource/hashmap", "annotations");
+		buildAndFail(this.gradleBuild.withDependencies(SPRING_CONTEXT).withConfigurationPropertiesSourceAnnotation(),
+				Task.CHECK_ARCHITECTURE_MAIN, "should be initialized with java.util.LinkedHashMap");
+	}
+
+	@Test
 	void whenConfigurationPropertiesUsesHashSetShouldFailAndWriteReport() throws IOException {
 		prepareTask(Task.CHECK_ARCHITECTURE_MAIN, "configurationproperties/hashset", "annotations");
 		buildAndFail(this.gradleBuild.withDependencies(SPRING_CONTEXT).withConfigurationPropertiesAnnotation(),
+				Task.CHECK_ARCHITECTURE_MAIN, "should be initialized with java.util.LinkedHashSet");
+	}
+
+	@Test
+	void whenConfigurationPropertiesSourceUsesHashSetShouldFailAndWriteReport() throws IOException {
+		prepareTask(Task.CHECK_ARCHITECTURE_MAIN, "configurationpropertiessource/hashset", "annotations");
+		buildAndFail(this.gradleBuild.withDependencies(SPRING_CONTEXT).withConfigurationPropertiesSourceAnnotation(),
 				Task.CHECK_ARCHITECTURE_MAIN, "should be initialized with java.util.LinkedHashSet");
 	}
 
@@ -354,6 +369,13 @@ class ArchitectureCheckTests {
 	}
 
 	@Test
+	void whenConfigurationPropertiesSourceUsesLinkedHashMapShouldSucceedAndWriteEmptyReport() throws IOException {
+		prepareTask(Task.CHECK_ARCHITECTURE_MAIN, "configurationpropertiessource/linkedhashmap", "annotations");
+		build(this.gradleBuild.withDependencies(SPRING_CONTEXT).withConfigurationPropertiesSourceAnnotation(),
+				Task.CHECK_ARCHITECTURE_MAIN);
+	}
+
+	@Test
 	void whenConfigurationPropertiesUsesEnumMapShouldSucceedAndWriteEmptyReport() throws IOException {
 		prepareTask(Task.CHECK_ARCHITECTURE_MAIN, "configurationproperties/enummap", "annotations");
 		build(this.gradleBuild.withDependencies(SPRING_CONTEXT).withConfigurationPropertiesAnnotation(),
@@ -361,9 +383,23 @@ class ArchitectureCheckTests {
 	}
 
 	@Test
+	void whenConfigurationPropertiesSourceUsesEnumMapShouldSucceedAndWriteEmptyReport() throws IOException {
+		prepareTask(Task.CHECK_ARCHITECTURE_MAIN, "configurationpropertiessource/enummap", "annotations");
+		build(this.gradleBuild.withDependencies(SPRING_CONTEXT).withConfigurationPropertiesSourceAnnotation(),
+				Task.CHECK_ARCHITECTURE_MAIN);
+	}
+
+	@Test
 	void whenConfigurationPropertiesUsesLinkedHashSetShouldSucceedAndWriteEmptyReport() throws IOException {
 		prepareTask(Task.CHECK_ARCHITECTURE_MAIN, "configurationproperties/linkedhashset", "annotations");
 		build(this.gradleBuild.withDependencies(SPRING_CONTEXT).withConfigurationPropertiesAnnotation(),
+				Task.CHECK_ARCHITECTURE_MAIN);
+	}
+
+	@Test
+	void whenConfigurationPropertiesSourceUsesLinkedHashSetShouldSucceedAndWriteEmptyReport() throws IOException {
+		prepareTask(Task.CHECK_ARCHITECTURE_MAIN, "configurationpropertiessource/linkedhashset", "annotations");
+		build(this.gradleBuild.withDependencies(SPRING_CONTEXT).withConfigurationPropertiesSourceAnnotation(),
 				Task.CHECK_ARCHITECTURE_MAIN);
 	}
 
@@ -601,6 +637,12 @@ class ArchitectureCheckTests {
 		GradleBuild withConfigurationPropertiesAnnotation() {
 			configureTasks(ArchitectureCheckAnnotation.CONFIGURATION_PROPERTIES.name(),
 					TestConfigurationProperties.class.getName());
+			return this;
+		}
+
+		GradleBuild withConfigurationPropertiesSourceAnnotation() {
+			configureTasks(ArchitectureCheckAnnotation.CONFIGURATION_PROPERTIES_SOURCE.name(),
+					TestConfigurationPropertiesSource.class.getName());
 			return this;
 		}
 

--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/annotations/TestConfigurationPropertiesSource.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/annotations/TestConfigurationPropertiesSource.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.build.architecture.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestConfigurationPropertiesSource {
+
+}

--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationproperties/enummap/ConfigurationPropertiesWithEnumMap.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationproperties/enummap/ConfigurationPropertiesWithEnumMap.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.build.architecture.configurationproperties.enummap;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.springframework.boot.build.architecture.annotations.TestConfigurationProperties;
+
+/**
+ * Test {@link TestConfigurationProperties} using {@link EnumMap}.
+ *
+ * @author Venkata Naga Sai Srikanth Gollapudi
+ */
+@TestConfigurationProperties("testing")
+public class ConfigurationPropertiesWithEnumMap {
+
+	private Map<Example, String> properties = new EnumMap<>(Example.class);
+
+	public Map<Example, String> getProperties() {
+		return this.properties;
+	}
+
+	public void setProperties(Map<Example, String> properties) {
+		this.properties = properties;
+	}
+
+	enum Example {
+
+		ONE
+
+	}
+
+}

--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationproperties/hashmap/ConfigurationPropertiesWithHashMap.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationproperties/hashmap/ConfigurationPropertiesWithHashMap.java
@@ -14,20 +14,29 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.docs.features.externalconfig.typesafeconfigurationproperties.relaxedbinding.mapsfromenvironmentvariables;
+package org.springframework.boot.build.architecture.configurationproperties.hashmap;
 
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Map;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.build.architecture.annotations.TestConfigurationProperties;
 
-@ConfigurationProperties("my.props")
-public class MyMapsProperties {
+/**
+ * Test {@link TestConfigurationProperties} using {@link HashMap}.
+ *
+ * @author Venkata Naga Sai Srikanth Gollapudi
+ */
+@TestConfigurationProperties("testing")
+public class ConfigurationPropertiesWithHashMap {
 
-	private final Map<String, String> values = new LinkedHashMap<>();
+	private Map<String, String> properties = new HashMap<>();
 
-	public Map<String, String> getValues() {
-		return this.values;
+	public Map<String, String> getProperties() {
+		return this.properties;
+	}
+
+	public void setProperties(Map<String, String> properties) {
+		this.properties = properties;
 	}
 
 }

--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationproperties/hashset/ConfigurationPropertiesWithHashSet.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationproperties/hashset/ConfigurationPropertiesWithHashSet.java
@@ -14,14 +14,29 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.docs.features.externalconfig.typesafeconfigurationproperties.relaxedbinding.mapsfromenvironmentvariables
+package org.springframework.boot.build.architecture.configurationproperties.hashset;
 
-import org.springframework.boot.context.properties.ConfigurationProperties
+import java.util.HashSet;
+import java.util.Set;
 
-@ConfigurationProperties("my.props")
-class MyMapsProperties {
+import org.springframework.boot.build.architecture.annotations.TestConfigurationProperties;
 
-	val values: Map<String, String> = LinkedHashMap()
+/**
+ * Test {@link TestConfigurationProperties} using {@link HashSet}.
+ *
+ * @author Venkata Naga Sai Srikanth Gollapudi
+ */
+@TestConfigurationProperties("testing")
+public class ConfigurationPropertiesWithHashSet {
+
+	private Set<String> items = new HashSet<>();
+
+	public Set<String> getItems() {
+		return this.items;
+	}
+
+	public void setItems(Set<String> items) {
+		this.items = items;
+	}
 
 }
-

--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationproperties/linkedhashmap/ConfigurationPropertiesWithLinkedHashMap.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationproperties/linkedhashmap/ConfigurationPropertiesWithLinkedHashMap.java
@@ -14,20 +14,29 @@
  * limitations under the License.
  */
 
-package org.springframework.boot.docs.features.externalconfig.typesafeconfigurationproperties.relaxedbinding.mapsfromenvironmentvariables;
+package org.springframework.boot.build.architecture.configurationproperties.linkedhashmap;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.build.architecture.annotations.TestConfigurationProperties;
 
-@ConfigurationProperties("my.props")
-public class MyMapsProperties {
+/**
+ * Test {@link TestConfigurationProperties} using {@link LinkedHashMap}.
+ *
+ * @author Venkata Naga Sai Srikanth Gollapudi
+ */
+@TestConfigurationProperties("testing")
+public class ConfigurationPropertiesWithLinkedHashMap {
 
-	private final Map<String, String> values = new LinkedHashMap<>();
+	private Map<String, String> properties = new LinkedHashMap<>();
 
-	public Map<String, String> getValues() {
-		return this.values;
+	public Map<String, String> getProperties() {
+		return this.properties;
+	}
+
+	public void setProperties(Map<String, String> properties) {
+		this.properties = properties;
 	}
 
 }

--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationproperties/linkedhashset/ConfigurationPropertiesWithLinkedHashSet.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationproperties/linkedhashset/ConfigurationPropertiesWithLinkedHashSet.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.build.architecture.configurationproperties.linkedhashset;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.springframework.boot.build.architecture.annotations.TestConfigurationProperties;
+
+/**
+ * Test {@link TestConfigurationProperties} using {@link LinkedHashSet}.
+ *
+ * @author Venkata Naga Sai Srikanth Gollapudi
+ */
+@TestConfigurationProperties("testing")
+public class ConfigurationPropertiesWithLinkedHashSet {
+
+	private Set<String> items = new LinkedHashSet<>();
+
+	public Set<String> getItems() {
+		return this.items;
+	}
+
+	public void setItems(Set<String> items) {
+		this.items = items;
+	}
+
+}

--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationpropertiessource/enummap/ConfigurationPropertiesWithEnumMap.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationpropertiessource/enummap/ConfigurationPropertiesWithEnumMap.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.build.architecture.configurationpropertiessource.enummap;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.springframework.boot.build.architecture.annotations.TestConfigurationPropertiesSource;
+
+/**
+ * Test {@link TestConfigurationPropertiesSource} using {@link EnumMap}.
+ *
+ * @author Stephane Nicoll
+ */
+@TestConfigurationPropertiesSource
+public class ConfigurationPropertiesWithEnumMap {
+
+	private Map<Example, String> properties = new EnumMap<>(Example.class);
+
+	public Map<Example, String> getProperties() {
+		return this.properties;
+	}
+
+	public void setProperties(Map<Example, String> properties) {
+		this.properties = properties;
+	}
+
+	enum Example {
+
+		ONE
+
+	}
+
+}

--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationpropertiessource/hashmap/ConfigurationPropertiesWithHashMap.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationpropertiessource/hashmap/ConfigurationPropertiesWithHashMap.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.build.architecture.configurationpropertiessource.hashmap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.build.architecture.annotations.TestConfigurationPropertiesSource;
+
+/**
+ * Test {@link TestConfigurationPropertiesSource} using {@link HashMap}.
+ *
+ * @author Stephane Nicoll
+ */
+@TestConfigurationPropertiesSource
+public class ConfigurationPropertiesWithHashMap {
+
+	private Map<String, String> properties = new HashMap<>();
+
+	public Map<String, String> getProperties() {
+		return this.properties;
+	}
+
+	public void setProperties(Map<String, String> properties) {
+		this.properties = properties;
+	}
+
+}

--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationpropertiessource/hashset/ConfigurationPropertiesWithHashSet.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationpropertiessource/hashset/ConfigurationPropertiesWithHashSet.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.build.architecture.configurationpropertiessource.hashset;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.boot.build.architecture.annotations.TestConfigurationPropertiesSource;
+
+/**
+ * Test {@link TestConfigurationPropertiesSource} using {@link HashSet}.
+ *
+ * @author Stephane Nicoll
+ */
+@TestConfigurationPropertiesSource
+public class ConfigurationPropertiesWithHashSet {
+
+	private Set<String> items = new HashSet<>();
+
+	public Set<String> getItems() {
+		return this.items;
+	}
+
+	public void setItems(Set<String> items) {
+		this.items = items;
+	}
+
+}

--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationpropertiessource/linkedhashmap/ConfigurationPropertiesWithLinkedHashMap.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationpropertiessource/linkedhashmap/ConfigurationPropertiesWithLinkedHashMap.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.build.architecture.configurationpropertiessource.linkedhashmap;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.boot.build.architecture.annotations.TestConfigurationPropertiesSource;
+
+/**
+ * Test {@link TestConfigurationPropertiesSource} using {@link LinkedHashMap}.
+ *
+ * @author Stephane Nicoll
+ */
+@TestConfigurationPropertiesSource
+public class ConfigurationPropertiesWithLinkedHashMap {
+
+	private Map<String, String> properties = new LinkedHashMap<>();
+
+	public Map<String, String> getProperties() {
+		return this.properties;
+	}
+
+	public void setProperties(Map<String, String> properties) {
+		this.properties = properties;
+	}
+
+}

--- a/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationpropertiessource/linkedhashset/ConfigurationPropertiesWithLinkedHashSet.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/architecture/configurationpropertiessource/linkedhashset/ConfigurationPropertiesWithLinkedHashSet.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.build.architecture.configurationpropertiessource.linkedhashset;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.springframework.boot.build.architecture.annotations.TestConfigurationPropertiesSource;
+
+/**
+ * Test {@link TestConfigurationPropertiesSource} using {@link LinkedHashSet}.
+ *
+ * @author Stephane Nicoll
+ */
+@TestConfigurationPropertiesSource
+public class ConfigurationPropertiesWithLinkedHashSet {
+
+	private Set<String> items = new LinkedHashSet<>();
+
+	public Set<String> getItems() {
+		return this.items;
+	}
+
+	public void setItems(Set<String> items) {
+		this.items = items;
+	}
+
+}

--- a/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/context/properties/ConfigurationPropertiesReportEndpointProperties.java
+++ b/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/context/properties/ConfigurationPropertiesReportEndpointProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.context.properties;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.springframework.boot.actuate.context.properties.ConfigurationPropertiesReportEndpoint;
@@ -42,7 +42,7 @@ public class ConfigurationPropertiesReportEndpointProperties {
 	 * Roles used to determine whether a user is authorized to be shown unsanitized
 	 * values. When empty, all authenticated users are authorized.
 	 */
-	private final Set<String> roles = new HashSet<>();
+	private final Set<String> roles = new LinkedHashSet<>();
 
 	public Show getShowValues() {
 		return this.showValues;

--- a/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/env/EnvironmentEndpointProperties.java
+++ b/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/env/EnvironmentEndpointProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.env;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.springframework.boot.actuate.endpoint.Show;
@@ -41,7 +41,7 @@ public class EnvironmentEndpointProperties {
 	 * Roles used to determine whether a user is authorized to be shown unsanitized
 	 * values. When empty, all authenticated users are authorized.
 	 */
-	private final Set<String> roles = new HashSet<>();
+	private final Set<String> roles = new LinkedHashSet<>();
 
 	public Show getShowValues() {
 		return this.showValues;

--- a/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/exchanges/HttpExchangesProperties.java
+++ b/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/exchanges/HttpExchangesProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.actuate.autoconfigure.web.exchanges;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.springframework.boot.actuate.web.exchanges.Include;
@@ -53,7 +53,7 @@ public class HttpExchangesProperties {
 		 * (excluding Authorization and Cookie), response headers (excluding Set-Cookie),
 		 * and time taken.
 		 */
-		private Set<Include> include = new HashSet<>(Include.defaultIncludes());
+		private Set<Include> include = new LinkedHashSet<>(Include.defaultIncludes());
 
 		public Set<Include> getInclude() {
 			return this.include;

--- a/module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/sbom/SbomProperties.java
+++ b/module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/sbom/SbomProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.actuate.sbom;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -41,7 +41,7 @@ public class SbomProperties {
 	/**
 	 * Additional SBOMs.
 	 */
-	private Map<String, Sbom> additional = new HashMap<>();
+	private Map<String, Sbom> additional = new LinkedHashMap<>();
 
 	public Sbom getApplication() {
 		return this.application;

--- a/module/spring-boot-artemis/src/main/java/org/springframework/boot/artemis/autoconfigure/ArtemisProperties.java
+++ b/module/spring-boot-artemis/src/main/java/org/springframework/boot/artemis/autoconfigure/ArtemisProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.artemis.autoconfigure;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -216,7 +216,7 @@ public class ArtemisProperties {
 		 * @see TransportConstants#SERVER_ID_PROP_NAME
 		 */
 		public Map<String, Object> generateTransportParameters() {
-			Map<String, Object> parameters = new HashMap<>();
+			Map<String, Object> parameters = new LinkedHashMap<>();
 			parameters.put(TransportConstants.SERVER_ID_PROP_NAME, getServerId());
 			return parameters;
 		}

--- a/module/spring-boot-flyway/src/main/java/org/springframework/boot/flyway/autoconfigure/FlywayProperties.java
+++ b/module/spring-boot-flyway/src/main/java/org/springframework/boot/flyway/autoconfigure/FlywayProperties.java
@@ -23,7 +23,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -137,7 +137,7 @@ public class FlywayProperties {
 	/**
 	 * Placeholders and their replacements to apply to sql migration scripts.
 	 */
-	private Map<String, String> placeholders = new HashMap<>();
+	private Map<String, String> placeholders = new LinkedHashMap<>();
 
 	/**
 	 * Prefix of placeholders in migration scripts.
@@ -310,7 +310,7 @@ public class FlywayProperties {
 	/**
 	 * Properties to pass to the JDBC driver.
 	 */
-	private Map<String, String> jdbcProperties = new HashMap<>();
+	private Map<String, String> jdbcProperties = new LinkedHashMap<>();
 
 	/**
 	 * Path of the Kerberos config file. Requires Flyway Teams.

--- a/module/spring-boot-freemarker/src/main/java/org/springframework/boot/freemarker/autoconfigure/FreeMarkerProperties.java
+++ b/module/spring-boot-freemarker/src/main/java/org/springframework/boot/freemarker/autoconfigure/FreeMarkerProperties.java
@@ -18,7 +18,6 @@ package org.springframework.boot.freemarker.autoconfigure;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -123,7 +122,7 @@ public class FreeMarkerProperties {
 	/**
 	 * Well-known FreeMarker keys which are passed to FreeMarker's Configuration.
 	 */
-	private Map<String, String> settings = new HashMap<>();
+	private Map<String, String> settings = new LinkedHashMap<>();
 
 	/**
 	 * List of template paths.

--- a/module/spring-boot-grpc-server/src/main/java/org/springframework/boot/grpc/server/autoconfigure/health/GrpcServerHealthProperties.java
+++ b/module/spring-boot-grpc-server/src/main/java/org/springframework/boot/grpc/server/autoconfigure/health/GrpcServerHealthProperties.java
@@ -19,7 +19,6 @@ package org.springframework.boot.grpc.server.autoconfigure.health;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -177,7 +176,7 @@ public class GrpcServerHealthProperties {
 		 * Mapping of health statuses to gRPC service status. By default, registered
 		 * health statuses map to sensible defaults (for example, UP maps to SERVING).
 		 */
-		private final Map<String, ServingStatus> mapping = new HashMap<>();
+		private final Map<String, ServingStatus> mapping = new LinkedHashMap<>();
 
 		public List<String> getOrder() {
 			return this.order;

--- a/module/spring-boot-hibernate/src/main/java/org/springframework/boot/hibernate/autoconfigure/HibernateProperties.java
+++ b/module/spring-boot-hibernate/src/main/java/org/springframework/boot/hibernate/autoconfigure/HibernateProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.boot.hibernate.autoconfigure;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -85,7 +85,7 @@ public class HibernateProperties {
 	}
 
 	private Map<String, Object> getAdditionalProperties(Map<String, String> existing, HibernateSettings settings) {
-		Map<String, Object> result = new HashMap<>(existing);
+		Map<String, Object> result = new LinkedHashMap<>(existing);
 		applyScanner(result);
 		getNaming().applyNamingStrategies(result);
 		String ddlAuto = determineDdlAuto(existing, settings::getDdlAuto);

--- a/module/spring-boot-jersey/src/main/java/org/springframework/boot/jersey/autoconfigure/JerseyProperties.java
+++ b/module/spring-boot-jersey/src/main/java/org/springframework/boot/jersey/autoconfigure/JerseyProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.jersey.autoconfigure;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -42,7 +42,7 @@ public class JerseyProperties {
 	/**
 	 * Init parameters to pass to Jersey through the servlet or filter.
 	 */
-	private Map<String, String> init = new HashMap<>();
+	private Map<String, String> init = new LinkedHashMap<>();
 
 	private final Filter filter = new Filter();
 

--- a/module/spring-boot-jpa/src/main/java/org/springframework/boot/jpa/autoconfigure/JpaProperties.java
+++ b/module/spring-boot-jpa/src/main/java/org/springframework/boot/jpa/autoconfigure/JpaProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.boot.jpa.autoconfigure;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -42,7 +42,7 @@ public class JpaProperties {
 	/**
 	 * Additional native properties to set on the JPA provider.
 	 */
-	private Map<String, String> properties = new HashMap<>();
+	private Map<String, String> properties = new LinkedHashMap<>();
 
 	/**
 	 * Mapping resources (equivalent to "mapping-file" entries in persistence.xml).

--- a/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaProperties.java
+++ b/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaProperties.java
@@ -21,7 +21,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -59,6 +59,7 @@ import org.springframework.util.unit.DataSize;
  * @author Andy Wilkinson
  * @author Scott Frederick
  * @author Yanming Zhou
+ * @author Venkata Naga Sai Srikanth Gollapudi
  * @since 4.0.0
  */
 @ConfigurationProperties("spring.kafka")
@@ -79,7 +80,7 @@ public class KafkaProperties {
 	 * Additional properties, common to producers and consumers, used to configure the
 	 * client.
 	 */
-	private final Map<String, String> properties = new HashMap<>();
+	private final Map<String, String> properties = new LinkedHashMap<>();
 
 	private final Consumer consumer = new Consumer();
 
@@ -162,7 +163,7 @@ public class KafkaProperties {
 	}
 
 	private Map<String, Object> buildCommonProperties() {
-		Map<String, Object> properties = new HashMap<>();
+		Map<String, Object> properties = new LinkedHashMap<>();
 		if (this.bootstrapServers != null) {
 			properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, this.bootstrapServers);
 		}
@@ -318,7 +319,7 @@ public class KafkaProperties {
 		/**
 		 * Additional consumer-specific properties used to configure the client.
 		 */
-		private final Map<String, String> properties = new HashMap<>();
+		private final Map<String, String> properties = new LinkedHashMap<>();
 
 		public Ssl getSsl() {
 			return this.ssl;
@@ -540,7 +541,7 @@ public class KafkaProperties {
 		/**
 		 * Additional producer-specific properties used to configure the client.
 		 */
-		private final Map<String, String> properties = new HashMap<>();
+		private final Map<String, String> properties = new LinkedHashMap<>();
 
 		public Ssl getSsl() {
 			return this.ssl;
@@ -667,7 +668,7 @@ public class KafkaProperties {
 		/**
 		 * Additional admin-specific properties used to configure the client.
 		 */
-		private final Map<String, String> properties = new HashMap<>();
+		private final Map<String, String> properties = new LinkedHashMap<>();
 
 		/**
 		 * Close timeout.
@@ -815,7 +816,7 @@ public class KafkaProperties {
 		/**
 		 * Additional Kafka properties used to configure the streams.
 		 */
-		private final Map<String, String> properties = new HashMap<>();
+		private final Map<String, String> properties = new LinkedHashMap<>();
 
 		public Ssl getSsl() {
 			return this.ssl;
@@ -1510,7 +1511,7 @@ public class KafkaProperties {
 		/**
 		 * Additional JAAS options.
 		 */
-		private final Map<String, String> options = new HashMap<>();
+		private final Map<String, String> options = new LinkedHashMap<>();
 
 		public boolean isEnabled() {
 			return this.enabled;
@@ -1741,7 +1742,7 @@ public class KafkaProperties {
 	}
 
 	@SuppressWarnings("serial")
-	private static final class Properties extends HashMap<String, Object> {
+	private static final class Properties extends LinkedHashMap<String, Object> {
 
 		<V> java.util.function.Consumer<V> in(String key) {
 			return (value) -> put(key, value);

--- a/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaProperties.java
+++ b/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaProperties.java
@@ -59,7 +59,6 @@ import org.springframework.util.unit.DataSize;
  * @author Andy Wilkinson
  * @author Scott Frederick
  * @author Yanming Zhou
- * @author Venkata Naga Sai Srikanth Gollapudi
  * @since 4.0.0
  */
 @ConfigurationProperties("spring.kafka")

--- a/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/autoconfigure/LdapProperties.java
+++ b/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/autoconfigure/LdapProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.ldap.autoconfigure;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -74,7 +74,7 @@ public class LdapProperties {
 	/**
 	 * LDAP specification settings.
 	 */
-	private final Map<String, String> baseEnvironment = new HashMap<>();
+	private final Map<String, String> baseEnvironment = new LinkedHashMap<>();
 
 	private final Template template = new Template();
 

--- a/module/spring-boot-mail/src/main/java/org/springframework/boot/mail/autoconfigure/MailProperties.java
+++ b/module/spring-boot-mail/src/main/java/org/springframework/boot/mail/autoconfigure/MailProperties.java
@@ -18,7 +18,7 @@ package org.springframework.boot.mail.autoconfigure;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -71,7 +71,7 @@ public class MailProperties {
 	/**
 	 * Additional JavaMail Session properties.
 	 */
-	private final Map<String, String> properties = new HashMap<>();
+	private final Map<String, String> properties = new LinkedHashMap<>();
 
 	/**
 	 * Session JNDI name. When set, takes precedence over other Session settings.

--- a/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/export/humio/HumioProperties.java
+++ b/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/export/humio/HumioProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.boot.micrometer.metrics.autoconfigure.export.humio;
 
 import java.time.Duration;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -50,7 +50,7 @@ public class HumioProperties extends StepRegistryProperties {
 	 * are a distinct concept from Micrometer's tags. Micrometer's tags are used to divide
 	 * metrics along dimensional boundaries.
 	 */
-	private Map<String, String> tags = new HashMap<>();
+	private Map<String, String> tags = new LinkedHashMap<>();
 
 	/**
 	 * URI to ship metrics to. If you need to publish metrics to an internal proxy

--- a/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/export/prometheus/PrometheusProperties.java
+++ b/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/export/prometheus/PrometheusProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.boot.micrometer.metrics.autoconfigure.export.prometheus;
 
 import java.time.Duration;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -56,7 +56,7 @@ public class PrometheusProperties {
 	/**
 	 * Additional properties to pass to the Prometheus client.
 	 */
-	private final Map<String, String> properties = new HashMap<>();
+	private final Map<String, String> properties = new LinkedHashMap<>();
 
 	/**
 	 * Step size (i.e. reporting frequency) to use.
@@ -148,7 +148,7 @@ public class PrometheusProperties {
 		/**
 		 * Grouping key for the pushed metrics.
 		 */
-		private Map<String, String> groupingKey = new HashMap<>();
+		private Map<String, String> groupingKey = new LinkedHashMap<>();
 
 		/**
 		 * Operation that should be performed on shutdown.

--- a/module/spring-boot-micrometer-tracing-opentelemetry/src/main/java/org/springframework/boot/micrometer/tracing/opentelemetry/autoconfigure/otlp/OtlpTracingProperties.java
+++ b/module/spring-boot-micrometer-tracing-opentelemetry/src/main/java/org/springframework/boot/micrometer/tracing/opentelemetry/autoconfigure/otlp/OtlpTracingProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.boot.micrometer.tracing.opentelemetry.autoconfigure.otlp;
 
 import java.time.Duration;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -64,7 +64,7 @@ public class OtlpTracingProperties {
 	/**
 	 * Custom HTTP headers you want to pass to the collector, for example auth headers.
 	 */
-	private Map<String, String> headers = new HashMap<>();
+	private Map<String, String> headers = new LinkedHashMap<>();
 
 	private final Ssl ssl = new Ssl();
 

--- a/module/spring-boot-opentelemetry/src/main/java/org/springframework/boot/opentelemetry/autoconfigure/OpenTelemetryProperties.java
+++ b/module/spring-boot-opentelemetry/src/main/java/org/springframework/boot/opentelemetry/autoconfigure/OpenTelemetryProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.opentelemetry.autoconfigure;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -40,7 +40,7 @@ public class OpenTelemetryProperties {
 	/**
 	 * Resource attributes.
 	 */
-	private Map<String, String> resourceAttributes = new HashMap<>();
+	private Map<String, String> resourceAttributes = new LinkedHashMap<>();
 
 	public boolean isEnabled() {
 		return this.enabled;

--- a/module/spring-boot-opentelemetry/src/main/java/org/springframework/boot/opentelemetry/autoconfigure/logging/otlp/OtlpLoggingProperties.java
+++ b/module/spring-boot-opentelemetry/src/main/java/org/springframework/boot/opentelemetry/autoconfigure/logging/otlp/OtlpLoggingProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.boot.opentelemetry.autoconfigure.logging.otlp;
 
 import java.time.Duration;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -64,7 +64,7 @@ public class OtlpLoggingProperties {
 	/**
 	 * Custom HTTP headers you want to pass to the collector, for example auth headers.
 	 */
-	private final Map<String, String> headers = new HashMap<>();
+	private final Map<String, String> headers = new LinkedHashMap<>();
 
 	private final Ssl ssl = new Ssl();
 

--- a/module/spring-boot-quartz/src/main/java/org/springframework/boot/quartz/autoconfigure/QuartzEndpointProperties.java
+++ b/module/spring-boot-quartz/src/main/java/org/springframework/boot/quartz/autoconfigure/QuartzEndpointProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.quartz.autoconfigure;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.springframework.boot.actuate.endpoint.Show;
@@ -41,7 +41,7 @@ public class QuartzEndpointProperties {
 	 * Roles used to determine whether a user is authorized to be shown unsanitized job or
 	 * trigger values. When empty, all authenticated users are authorized.
 	 */
-	private final Set<String> roles = new HashSet<>();
+	private final Set<String> roles = new LinkedHashSet<>();
 
 	public Show getShowValues() {
 		return this.showValues;

--- a/module/spring-boot-quartz/src/main/java/org/springframework/boot/quartz/autoconfigure/QuartzProperties.java
+++ b/module/spring-boot-quartz/src/main/java/org/springframework/boot/quartz/autoconfigure/QuartzProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.boot.quartz.autoconfigure;
 
 import java.time.Duration;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -69,7 +69,7 @@ public class QuartzProperties {
 	/**
 	 * Additional Quartz Scheduler properties.
 	 */
-	private final Map<String, String> properties = new HashMap<>();
+	private final Map<String, String> properties = new LinkedHashMap<>();
 
 	public JobStoreType getJobStoreType() {
 		return this.jobStoreType;

--- a/module/spring-boot-security-oauth2-authorization-server/src/main/java/org/springframework/boot/security/oauth2/server/authorization/autoconfigure/servlet/OAuth2AuthorizationServerProperties.java
+++ b/module/spring-boot-security-oauth2-authorization-server/src/main/java/org/springframework/boot/security/oauth2/server/authorization/autoconfigure/servlet/OAuth2AuthorizationServerProperties.java
@@ -17,8 +17,8 @@
 package org.springframework.boot.security.oauth2.server.authorization.autoconfigure.servlet;
 
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -55,7 +55,7 @@ public class OAuth2AuthorizationServerProperties implements InitializingBean {
 	/**
 	 * Registered clients of the Authorization Server.
 	 */
-	private final Map<String, Client> client = new HashMap<>();
+	private final Map<String, Client> client = new LinkedHashMap<>();
 
 	/**
 	 * Authorization Server endpoints.
@@ -380,27 +380,27 @@ public class OAuth2AuthorizationServerProperties implements InitializingBean {
 		/**
 		 * Client authentication method(s) that the client may use.
 		 */
-		private Set<String> clientAuthenticationMethods = new HashSet<>();
+		private Set<String> clientAuthenticationMethods = new LinkedHashSet<>();
 
 		/**
 		 * Authorization grant type(s) that the client may use.
 		 */
-		private Set<String> authorizationGrantTypes = new HashSet<>();
+		private Set<String> authorizationGrantTypes = new LinkedHashSet<>();
 
 		/**
 		 * Redirect URI(s) that the client may use in redirect-based flows.
 		 */
-		private Set<String> redirectUris = new HashSet<>();
+		private Set<String> redirectUris = new LinkedHashSet<>();
 
 		/**
 		 * Redirect URI(s) that the client may use for logout.
 		 */
-		private Set<String> postLogoutRedirectUris = new HashSet<>();
+		private Set<String> postLogoutRedirectUris = new LinkedHashSet<>();
 
 		/**
 		 * Scope(s) that the client may use.
 		 */
-		private Set<String> scopes = new HashSet<>();
+		private Set<String> scopes = new LinkedHashSet<>();
 
 		public @Nullable String getClientId() {
 			return this.clientId;

--- a/module/spring-boot-security-oauth2-client/src/main/java/org/springframework/boot/security/oauth2/client/autoconfigure/OAuth2ClientProperties.java
+++ b/module/spring-boot-security-oauth2-client/src/main/java/org/springframework/boot/security/oauth2/client/autoconfigure/OAuth2ClientProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.security.oauth2.client.autoconfigure;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -42,12 +42,12 @@ public class OAuth2ClientProperties implements InitializingBean {
 	/**
 	 * OAuth provider details.
 	 */
-	private final Map<String, Provider> provider = new HashMap<>();
+	private final Map<String, Provider> provider = new LinkedHashMap<>();
 
 	/**
 	 * OAuth client registrations.
 	 */
-	private final Map<String, Registration> registration = new HashMap<>();
+	private final Map<String, Registration> registration = new LinkedHashMap<>();
 
 	public Map<String, Provider> getProvider() {
 		return this.provider;

--- a/module/spring-boot-session/src/main/java/org/springframework/boot/session/autoconfigure/SessionProperties.java
+++ b/module/spring-boot-session/src/main/java/org/springframework/boot/session/autoconfigure/SessionProperties.java
@@ -19,7 +19,7 @@ package org.springframework.boot.session.autoconfigure;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -90,7 +90,7 @@ public class SessionProperties {
 		/**
 		 * Session repository filter dispatcher types.
 		 */
-		private Set<DispatcherType> filterDispatcherTypes = new HashSet<>(
+		private Set<DispatcherType> filterDispatcherTypes = new LinkedHashSet<>(
 				Arrays.asList(DispatcherType.ASYNC, DispatcherType.ERROR, DispatcherType.REQUEST));
 
 		public int getFilterOrder() {

--- a/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/autoconfigure/ServerProperties.java
+++ b/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/autoconfigure/ServerProperties.java
@@ -20,7 +20,7 @@ import java.net.InetAddress;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -212,7 +212,7 @@ public class ServerProperties {
 		/**
 		 * Servlet context init parameters.
 		 */
-		private final Map<String, String> contextParameters = new HashMap<>();
+		private final Map<String, String> contextParameters = new LinkedHashMap<>();
 
 		/**
 		 * Context path of the application.

--- a/module/spring-boot-webservices/src/main/java/org/springframework/boot/webservices/autoconfigure/WebServicesProperties.java
+++ b/module/spring-boot-webservices/src/main/java/org/springframework/boot/webservices/autoconfigure/WebServicesProperties.java
@@ -16,7 +16,7 @@
 
 package org.springframework.boot.webservices.autoconfigure;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -59,7 +59,7 @@ public class WebServicesProperties {
 		/**
 		 * Servlet init parameters to pass to Spring Web Services.
 		 */
-		private Map<String, String> init = new HashMap<>();
+		private Map<String, String> init = new LinkedHashMap<>();
 
 		/**
 		 * Load on startup priority of the Spring Web Services servlet.


### PR DESCRIPTION
This PR updates @ConfigurationProperties classes to use LinkedHashMap and LinkedHashSet consistently instead of HashMap and HashSet.

This aligns with the preferred convention discussed in #43919 and provides consistent ordering behavior across collection and map configuration properties.

While working on this, I also noticed a number of cases involving final nested/collection/map properties that would require broader changes to align with the preferred option 2 style (initialized field with getter/setter). To keep this PR focused and easier to review, those changes have been left for potential follow-up work.

<img width="2603" height="570" alt="Screenshot 2026-05-07 145717" src="https://github.com/user-attachments/assets/fa22b0bd-d0cd-415a-aabc-2c81c8c85391" />

<img width="2474" height="488" alt="image" src="https://github.com/user-attachments/assets/ae12460d-1474-4243-aab2-a0e0f9228d1d" />



Closes #43919