### PR TITLE
Fix MappingsEndpoint parentId to use parent's ID

### DIFF
--- a/module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/mappings/MappingsEndpoint.java
+++ b/module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/mappings/MappingsEndpoint.java
@@ -61,7 +61,7 @@ public class MappingsEndpoint {
 		this.descriptionProviders.forEach(
 				(provider) -> mappings.put(provider.getMappingName(), provider.describeMappings(applicationContext)));
 		return new ContextMappingsDescriptor(mappings,
-				(applicationContext.getParent() != null) ? applicationContext.getId() : null);
+				(applicationContext.getParent() != null) ? applicationContext.getParent().getId() : null);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #50368

## Summary
- Fix MappingsEndpoint to use parent.getId() instead of applicationContext.getId() for parentId when parent exists
- Other actuator endpoints already use the correct pattern

## Changes
- Changed applicationContext.getId() to applicationContext.getParent().getId()

## Test plan
- Verify MappingsEndpoint returns correct parentId when parent context exists