### PR TITLE
Fix Zip64 long truncation in VirtualZipDataBlock

### DIFF
--- a/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/zip/VirtualZipDataBlock.java
+++ b/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/zip/VirtualZipDataBlock.java
@@ -60,12 +60,13 @@ class VirtualZipDataBlock extends VirtualDataBlock implements CloseableDataBlock
 			boolean hasDescriptorRecord = ZipDataDescriptorRecord.isPresentBasedOnFlag(centralRecord);
 			ZipDataDescriptorRecord dataDescriptorRecord = (!hasDescriptorRecord) ? null
 					: ZipDataDescriptorRecord.load(data, localRecordPos + localRecord.size() + content.size());
-			sizeOfCentralDirectory += addToCentral(centralParts, centralRecord, centralRecordPos, name, (int) offset);
+			sizeOfCentralDirectory += addToCentral(centralParts, centralRecord, centralRecordPos, name,
+					Math.toIntExact(offset));
 			offset += addToLocal(parts, centralRecord, localRecord, dataDescriptorRecord, name, content);
 		}
 		parts.addAll(centralParts);
 		ZipEndOfCentralDirectoryRecord eocd = new ZipEndOfCentralDirectoryRecord((short) centralRecords.length,
-				(int) sizeOfCentralDirectory, (int) offset);
+				Math.toIntExact(sizeOfCentralDirectory), Math.toIntExact(offset));
 		parts.add(new ByteArrayDataBlock(eocd.asByteArray()));
 		setParts(parts);
 	}


### PR DESCRIPTION
Fixes #50364

## Summary
- Use Math.toIntExact() instead of silent (int) casts for offset and sizeOfCentralDirectory values
- This prevents silent truncation when these values exceed Integer.MAX_VALUE for Zip64-format jars

## Changes
- Replaced (int) offset with Math.toIntExact(offset)
- Replaced (int) sizeOfCentralDirectory with Math.toIntExact(sizeOfCentralDirectory)

## Test plan
- Verify Zip64 files with large offsets are handled correctly