### PR TITLE
MappingsEndpoint reports the context's own ID as parentId when a parent exists

### DIFF
--- a/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/web/mappings/MappingsEndpointTests.java
+++ b/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/web/mappings/MappingsEndpointTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.web.mappings;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.web.mappings.MappingsEndpoint.ApplicationMappingsDescriptor;
+import org.springframework.boot.actuate.web.mappings.MappingsEndpoint.ContextMappingsDescriptor;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MappingsEndpoint}.
+ *
+ * @author Lee JiWon
+ */
+class MappingsEndpointTests {
+
+	@Test
+	void mappingsParentIdMatchesParentContextId() {
+		ApplicationContextRunner parentRunner = new ApplicationContextRunner();
+		parentRunner.run((parent) -> new ApplicationContextRunner().withUserConfiguration(EndpointConfiguration.class)
+			.withParent(parent)
+			.run((child) -> {
+				ApplicationMappingsDescriptor result = child.getBean(MappingsEndpoint.class).mappings();
+				ContextMappingsDescriptor parentDescriptor = result.getContexts().get(parent.getId());
+				ContextMappingsDescriptor childDescriptor = result.getContexts().get(child.getId());
+				assertThat(parentDescriptor).isNotNull();
+				assertThat(parentDescriptor.getParentId()).isNull();
+				assertThat(childDescriptor).isNotNull();
+				assertThat(childDescriptor.getParentId()).isEqualTo(parent.getId());
+			}));
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class EndpointConfiguration {
+
+		@Bean
+		MappingsEndpoint mappingsEndpoint(ConfigurableApplicationContext context) {
+			return new MappingsEndpoint(Collections.emptyList(), context);
+		}
+
+	}
+
+}

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/mappings/MappingsEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/mappings/MappingsEndpoint.java
@@ -29,6 +29,7 @@ import org.springframework.context.ApplicationContext;
  * {@link Endpoint @Endpoint} to expose HTTP request mappings.
  *
  * @author Andy Wilkinson
+ * @author Lee JiWon
  * @since 2.0.0
  */
 @Endpoint(id = "mappings")
@@ -58,8 +59,8 @@ public class MappingsEndpoint {
 		Map<String, Object> mappings = new HashMap<>();
 		this.descriptionProviders.forEach(
 				(provider) -> mappings.put(provider.getMappingName(), provider.describeMappings(applicationContext)));
-		return new ContextMappingsDescriptor(mappings,
-				(applicationContext.getParent() != null) ? applicationContext.getParent().getId() : null);
+		ApplicationContext parent = applicationContext.getParent();
+		return new ContextMappingsDescriptor(mappings, (parent != null) ? parent.getId() : null);
 	}
 
 	/**

--- a/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/mappings/MappingsEndpoint.java
+++ b/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/web/mappings/MappingsEndpoint.java
@@ -59,7 +59,7 @@ public class MappingsEndpoint {
 		this.descriptionProviders.forEach(
 				(provider) -> mappings.put(provider.getMappingName(), provider.describeMappings(applicationContext)));
 		return new ContextMappingsDescriptor(mappings,
-				(applicationContext.getParent() != null) ? applicationContext.getId() : null);
+				(applicationContext.getParent() != null) ? applicationContext.getParent().getId() : null);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #50368. `MappingsEndpoint` reported the context's own id as
`parentId` when a parent context existed, instead of the parent context's
id.

Sibling endpoints (`BeansEndpoint`, `ConfigurationPropertiesReportEndpoint`,
`ConditionsReportEndpoint`) already use `parent.getId()`.

## Test plan

- `MappingsEndpointTests#mappingsParentIdMatchesParentContextId` — child
  descriptor's `parentId` equals the parent context id; root descriptor's
  `parentId` is `null`