### PR TITLE
Configuration property metadata includes incorrect class references

### DIFF
--- a/module/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/module/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -201,7 +201,7 @@
     },
     {
       "name": "management.wavefront.api-token-type",
-      "type": "org.springframework.boot.actuate.autoconfigure.wavefront.WavefrontProperties$TokenType",
+      "type": "java.lang.String",
       "deprecation": {
         "level": "error",
         "reason": "Wavefront is end-of-life.",

--- a/module/spring-boot-jdbc/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/module/spring-boot-jdbc/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -50,7 +50,7 @@
     },
     {
       "name": "spring.datasource.initialization-mode",
-      "type": "org.springframework.boot.jdbc.DataSourceInitializationMode",
+      "type": "org.springframework.boot.sql.init.DatabaseInitializationMode",
       "deprecation": {
         "level": "error",
         "replacement": "spring.sql.init.mode",

--- a/module/spring-boot-mail/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/module/spring-boot-mail/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -10,7 +10,7 @@
     {
       "name": "spring.mail.test-connection",
       "description": "Whether to test that the mail server is available on startup.",
-      "sourceType": "org.springframework.boot.autoconfigure.mail.MailProperties",
+      "sourceType": "org.springframework.boot.mail.autoconfigure.MailSenderValidatorAutoConfiguration",
       "type": "java.lang.Boolean",
       "defaultValue": false
     }

--- a/module/spring-boot-micrometer-metrics/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/module/spring-boot-micrometer-metrics/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1393,7 +1393,7 @@
     },
     {
       "name": "management.metrics.export.prometheus.pushgateway.shutdown-operation",
-      "type": "org.springframework.boot.actuate.metrics.export.prometheus.PrometheusPushGatewayManager$ShutdownOperation",
+      "type": "org.springframework.boot.micrometer.metrics.export.prometheus.PrometheusPushGatewayManager$ShutdownOperation",
       "deprecation": {
         "level": "error",
         "replacement": "management.prometheus.metrics.export.pushgateway.shutdown-operation",

--- a/module/spring-boot-opentelemetry/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/module/spring-boot-opentelemetry/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -15,9 +15,9 @@
 		},
 		{
 			"name": "management.otlp.logging.compression",
-			"type": "org.springframework.boot.opentelemetry.actuate.autoconfigure.logging.OpenTelemetryLoggingExportProperties$Compression",
+			"type": "org.springframework.boot.opentelemetry.autoconfigure.logging.otlp.OtlpLoggingProperties$Compression",
 			"description": "Method used to compress the payload.",
-			"sourceType": "org.springframework.boot.opentelemetry.actuate.autoconfigure.logging.OpenTelemetryLoggingExportProperties",
+			"sourceType": "org.springframework.boot.opentelemetry.autoconfigure.logging.otlp.OtlpLoggingProperties",
 			"defaultValue": "none",
 			"deprecation": {
 				"level": "error",
@@ -29,7 +29,7 @@
 			"name": "management.otlp.logging.connect-timeout",
 			"type": "java.time.Duration",
 			"description": "Connect timeout for the OTel collector connection.",
-			"sourceType": "org.springframework.boot.opentelemetry.actuate.autoconfigure.logging.OpenTelemetryLoggingExportProperties",
+			"sourceType": "org.springframework.boot.opentelemetry.autoconfigure.logging.otlp.OtlpLoggingProperties",
 			"defaultValue": "10s",
 			"deprecation": {
 				"level": "error",
@@ -41,7 +41,7 @@
 			"name": "management.otlp.logging.endpoint",
 			"type": "java.lang.String",
 			"description": "URL to the OTel collector's HTTP API.",
-			"sourceType": "org.springframework.boot.opentelemetry.actuate.autoconfigure.logging.OpenTelemetryLoggingExportProperties",
+			"sourceType": "org.springframework.boot.opentelemetry.autoconfigure.logging.otlp.OtlpLoggingProperties",
 			"deprecation": {
 				"level": "error",
 				"replacement": "management.opentelemetry.logging.export.otlp.endpoint",
@@ -60,7 +60,7 @@
 			"name": "management.otlp.logging.headers",
 			"type": "java.util.Map<java.lang.String,java.lang.String>",
 			"description": "Custom HTTP headers you want to pass to the collector, for example auth headers.",
-			"sourceType": "org.springframework.boot.opentelemetry.actuate.autoconfigure.logging.OpenTelemetryLoggingExportProperties",
+			"sourceType": "org.springframework.boot.opentelemetry.autoconfigure.logging.otlp.OtlpLoggingProperties",
 			"deprecation": {
 				"level": "error",
 				"replacement": "management.opentelemetry.logging.export.otlp.headers",
@@ -71,7 +71,7 @@
 			"name": "management.otlp.logging.timeout",
 			"type": "java.time.Duration",
 			"description": "Call timeout for the OTel Collector to process an exported batch of data. This timeout spans the entire call: resolving DNS, connecting, writing the request body, server processing, and reading the response body. If the call requires redirects or retries all must complete within one timeout period.",
-			"sourceType": "org.springframework.boot.opentelemetry.actuate.autoconfigure.logging.OpenTelemetryLoggingExportProperties",
+			"sourceType": "org.springframework.boot.opentelemetry.autoconfigure.logging.otlp.OtlpLoggingProperties",
 			"defaultValue": "10s",
 			"deprecation": {
 				"level": "error",
@@ -81,9 +81,9 @@
 		},
 		{
 			"name": "management.otlp.logging.transport",
-			"type": "org.springframework.boot.opentelemetry.actuate.autoconfigure.logging.Transport",
+			"type": "org.springframework.boot.opentelemetry.autoconfigure.logging.otlp.Transport",
 			"description": "Transport used to send the logs.",
-			"sourceType": "org.springframework.boot.opentelemetry.actuate.autoconfigure.logging.OpenTelemetryLoggingExportProperties",
+			"sourceType": "org.springframework.boot.opentelemetry.autoconfigure.logging.otlp.OtlpLoggingProperties",
 			"defaultValue": "http",
 			"deprecation": {
 				"level": "error",


### PR DESCRIPTION
This updates stale `type` and `sourceType` references in additional configuration metadata after package changes and type removals.

The updated metadata now points to existing classes, avoiding references to removed or relocated types.

Validation:

```
./gradlew :module:spring-boot-opentelemetry:checkAdditionalSpringConfigurationMetadata :module:spring-boot-mail:checkAdditionalSpringConfigurationMetadata :module:spring-boot-jdbc:checkAdditionalSpringConfigurationMetadata :module:spring-boot-actuator-autoconfigure:checkAdditionalSpringConfigurationMetadata :module:spring-boot-micrometer-metrics:checkAdditionalSpringConfigurationMetadata
```