### PR TITLE
Log condition report for child management context

### DIFF
--- a/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ChildManagementContextInitializer.java
+++ b/module/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/web/server/ChildManagementContextInitializer.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.support.RegisteredBean;
 import org.springframework.boot.LazyInitializationBeanFactoryPostProcessor;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.logging.ConditionEvaluationReportLoggingListener;
 import org.springframework.boot.context.event.ApplicationFailedEvent;
 import org.springframework.boot.web.server.context.ConfigurableWebServerApplicationContext;
 import org.springframework.boot.web.server.context.WebServerApplicationContext;
@@ -167,6 +168,7 @@ class ChildManagementContextInitializer implements BeanRegistrationAotProcessor,
 		if (managementContext instanceof DefaultResourceLoader resourceLoader) {
 			resourceLoader.setClassLoader(this.parentContext.getClassLoader());
 		}
+		new ConditionEvaluationReportLoggingListener().initialize(managementContext);
 		CloseManagementContextListener.addIfPossible(this.parentContext, managementContext);
 		return managementContext;
 	}

--- a/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/web/server/ChildManagementContextInitializerTests.java
+++ b/module/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/web/server/ChildManagementContextInitializerTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.web.server;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
+import org.springframework.boot.autoconfigure.logging.ConditionEvaluationReportLoggingListener;
+import org.springframework.boot.web.server.servlet.MockServletWebServerFactory;
+import org.springframework.boot.web.server.servlet.context.AnnotationConfigServletWebServerApplicationContext;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ChildManagementContextInitializer}.
+ */
+class ChildManagementContextInitializerTests {
+
+	@Test
+	void childManagementContextHasConditionEvaluationReportLoggingListener() {
+		try (AnnotationConfigServletWebServerApplicationContext context = new AnnotationConfigServletWebServerApplicationContext()) {
+			context.register(ManagementContextAutoConfiguration.class, WebEndpointAutoConfiguration.class,
+					EndpointAutoConfiguration.class);
+			context.register(WebServerConfiguration.class, TestServletManagementContextConfiguration.class);
+			context.setEnvironment(
+					new MockEnvironment().withProperty("server.port", "0").withProperty("management.server.port", "0"));
+			context.refresh();
+			ChildManagementContextInitializer initializer = context.getBean(ChildManagementContextInitializer.class);
+			ApplicationContext managementContext = initializer.getManagementContext();
+			assertThat(managementContext).isInstanceOf(AbstractApplicationContext.class);
+			assertThat(((AbstractApplicationContext) managementContext).getApplicationListeners())
+				.anySatisfy((listener) -> assertThat(listener.getClass().getEnclosingClass())
+					.isEqualTo(ConditionEvaluationReportLoggingListener.class));
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class TestServletManagementContextConfiguration {
+
+		@Bean
+		ManagementContextFactory managementContextFactory() {
+			return new ManagementContextFactory(WebApplicationType.SERVLET, MockServletWebServerFactory.class);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class WebServerConfiguration {
+
+		@Bean
+		MockServletWebServerFactory servletWebServerFactory() {
+			return new MockServletWebServerFactory();
+		}
+
+	}
+
+}


### PR DESCRIPTION
When `management.server.port` differs from `server.port`, Spring Boot creates a child management context with its own conditions. The `ConditionEvaluationReportLoggingListener` registered via `spring.factories` only attaches to the parent context, so the child's conditions are absent from the report logged at startup.

This change registers a `ConditionEvaluationReportLoggingListener` on the management context as part of `ChildManagementContextInitializer.createManagementContext`, so the child's conditions are logged alongside the parent's.

See gh-6698