### PR TITLE
Add support for TLS named groups in SslBundles

### DIFF
--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/PropertiesSslBundle.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/PropertiesSslBundle.java
@@ -71,7 +71,9 @@ public final class PropertiesSslBundle implements SslBundle {
 	}
 
 	private static SslOptions asSslOptions(SslBundleProperties.@Nullable Options options) {
-		return (options != null) ? SslOptions.of(options.getCiphers(), options.getEnabledProtocols()) : SslOptions.NONE;
+		return (options != null)
+				? SslOptions.of(options.getCiphers(), options.getEnabledProtocols(), options.getNamedGroups())
+				: SslOptions.NONE;
 	}
 
 	@Override

--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/SslBundleProperties.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/ssl/SslBundleProperties.java
@@ -88,6 +88,11 @@ public abstract class SslBundleProperties {
 		 */
 		private @Nullable Set<String> enabledProtocols;
 
+		/**
+		 * Enabled key exchange named groups.
+		 */
+		private @Nullable Set<String> namedGroups;
+
 		public @Nullable Set<String> getCiphers() {
 			return this.ciphers;
 		}
@@ -102,6 +107,14 @@ public abstract class SslBundleProperties {
 
 		public void setEnabledProtocols(@Nullable Set<String> enabledProtocols) {
 			this.enabledProtocols = enabledProtocols;
+		}
+
+		public @Nullable Set<String> getNamedGroups() {
+			return this.namedGroups;
+		}
+
+		public void setNamedGroups(@Nullable Set<String> namedGroups) {
+			this.namedGroups = namedGroups;
 		}
 
 	}

--- a/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ssl/PropertiesSslBundleTests.java
+++ b/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/ssl/PropertiesSslBundleTests.java
@@ -52,6 +52,7 @@ class PropertiesSslBundleTests {
 		properties.getKey().setPassword("secret");
 		properties.getOptions().setCiphers(Set.of("cipher1", "cipher2", "cipher3"));
 		properties.getOptions().setEnabledProtocols(Set.of("protocol1", "protocol2"));
+		properties.getOptions().setNamedGroups(Set.of("group1", "group2"));
 		properties.getKeystore().setCertificate("classpath:org/springframework/boot/autoconfigure/ssl/rsa-cert.pem");
 		properties.getKeystore().setPrivateKey("classpath:org/springframework/boot/autoconfigure/ssl/rsa-key.pem");
 		properties.getKeystore().setPrivateKeyPassword(null);
@@ -67,6 +68,7 @@ class PropertiesSslBundleTests {
 		assertThat(sslBundle.getKey().getPassword()).isEqualTo("secret");
 		assertThat(sslBundle.getOptions().getCiphers()).containsExactlyInAnyOrder("cipher1", "cipher2", "cipher3");
 		assertThat(sslBundle.getOptions().getEnabledProtocols()).containsExactlyInAnyOrder("protocol1", "protocol2");
+		assertThat(sslBundle.getOptions().getNamedGroups()).containsExactlyInAnyOrder("group1", "group2");
 		assertThat(sslBundle.getStores()).isNotNull();
 		KeyStore keyStore = sslBundle.getStores().getKeyStore();
 		assertThat(keyStore).isNotNull();
@@ -90,6 +92,7 @@ class PropertiesSslBundleTests {
 		properties.getKey().setPassword("secret");
 		properties.getOptions().setCiphers(Set.of("cipher1", "cipher2", "cipher3"));
 		properties.getOptions().setEnabledProtocols(Set.of("protocol1", "protocol2"));
+		properties.getOptions().setNamedGroups(Set.of("group1", "group2"));
 		properties.getKeystore().setPassword("secret");
 		properties.getKeystore().setProvider("SUN");
 		properties.getKeystore().setType("JKS");
@@ -103,6 +106,7 @@ class PropertiesSslBundleTests {
 		assertThat(sslBundle.getKey().getPassword()).isEqualTo("secret");
 		assertThat(sslBundle.getOptions().getCiphers()).containsExactlyInAnyOrder("cipher1", "cipher2", "cipher3");
 		assertThat(sslBundle.getOptions().getEnabledProtocols()).containsExactlyInAnyOrder("protocol1", "protocol2");
+		assertThat(sslBundle.getOptions().getNamedGroups()).containsExactlyInAnyOrder("group1", "group2");
 		assertThat(sslBundle.getStores()).isNotNull();
 		assertThat(sslBundle.getStores()).extracting("keyStoreDetails")
 			.extracting("location", "password", "provider", "type")

--- a/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/DockerComposeConnectionDetailsFactory.java
+++ b/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/DockerComposeConnectionDetailsFactory.java
@@ -167,7 +167,8 @@ public abstract class DockerComposeConnectionDetailsFactory<D extends Connection
 					service.labels().get("org.springframework.boot.sslbundle.jks.key.password"));
 			SslOptions options = createSslOptions(
 					service.labels().get("org.springframework.boot.sslbundle.jks.options.ciphers"),
-					service.labels().get("org.springframework.boot.sslbundle.jks.options.enabled-protocols"));
+					service.labels().get("org.springframework.boot.sslbundle.jks.options.enabled-protocols"),
+					service.labels().get("org.springframework.boot.sslbundle.jks.options.named-groups"));
 			String protocol = service.labels().get("org.springframework.boot.sslbundle.jks.protocol");
 			Path workingDirectory = getWorkingDirectory(service);
 			return SslBundle.of(
@@ -203,7 +204,8 @@ public abstract class DockerComposeConnectionDetailsFactory<D extends Connection
 			return composeFile.getFiles().get(0).toPath().getParent();
 		}
 
-		private SslOptions createSslOptions(@Nullable String ciphers, @Nullable String enabledProtocols) {
+		private SslOptions createSslOptions(@Nullable String ciphers, @Nullable String enabledProtocols,
+				@Nullable String namedGroups) {
 			Set<String> ciphersSet = null;
 			if (StringUtils.hasLength(ciphers)) {
 				ciphersSet = StringUtils.commaDelimitedListToSet(ciphers);
@@ -212,7 +214,11 @@ public abstract class DockerComposeConnectionDetailsFactory<D extends Connection
 			if (StringUtils.hasLength(enabledProtocols)) {
 				enabledProtocolsSet = StringUtils.commaDelimitedListToSet(enabledProtocols);
 			}
-			return SslOptions.of(ciphersSet, enabledProtocolsSet);
+			Set<String> namedGroupsSet = null;
+			if (StringUtils.hasLength(namedGroups)) {
+				namedGroupsSet = StringUtils.commaDelimitedListToSet(namedGroups);
+			}
+			return SslOptions.of(ciphersSet, enabledProtocolsSet, namedGroupsSet);
 		}
 
 		private @Nullable SslBundle getPemSslBundle(RunningService service) {
@@ -225,7 +231,8 @@ public abstract class DockerComposeConnectionDetailsFactory<D extends Connection
 					service.labels().get("org.springframework.boot.sslbundle.pem.key.password"));
 			SslOptions options = createSslOptions(
 					service.labels().get("org.springframework.boot.sslbundle.pem.options.ciphers"),
-					service.labels().get("org.springframework.boot.sslbundle.pem.options.enabled-protocols"));
+					service.labels().get("org.springframework.boot.sslbundle.pem.options.enabled-protocols"),
+					service.labels().get("org.springframework.boot.sslbundle.pem.options.named-groups"));
 			String protocol = service.labels().get("org.springframework.boot.sslbundle.pem.protocol");
 			Path workingDirectory = getWorkingDirectory(service);
 			ResourceLoader resourceLoader = getResourceLoader(workingDirectory);

--- a/core/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/Ssl.java
+++ b/core/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/Ssl.java
@@ -62,6 +62,14 @@ public @interface Ssl {
 	String[] enabledProtocols() default {};
 
 	/**
+	 * The key exchange named groups that are enabled for the SSL connection.
+	 * @return the enabled key exchange named groups
+	 * @see SslOptions#getNamedGroups()
+	 * @since 4.1.0
+	 */
+	String[] namedGroups() default {};
+
+	/**
 	 * The password that should be used to access the key.
 	 * @return the key password
 	 * @see SslBundleKey#getPassword()

--- a/core/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/SslBundleSource.java
+++ b/core/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/SslBundleSource.java
@@ -66,7 +66,8 @@ record SslBundleSource(@Nullable Ssl ssl, @Nullable PemKeyStore pemKeyStore, @Nu
 			return null;
 		}
 		Ssl ssl = (this.ssl != null) ? this.ssl : MergedAnnotation.of(Ssl.class).synthesize();
-		SslOptions options = SslOptions.of(nullIfEmpty(ssl.ciphers()), nullIfEmpty(ssl.enabledProtocols()));
+		SslOptions options = SslOptions.of(nullIfEmpty(ssl.ciphers()), nullIfEmpty(ssl.enabledProtocols()),
+				nullIfEmpty(ssl.namedGroups()));
 		SslBundleKey key = SslBundleKey.of(nullIfEmpty(ssl.keyPassword()), nullIfEmpty(ssl.keyAlias()));
 		String protocol = ssl.protocol();
 		return SslBundle.of(stores, key, options, protocol);

--- a/core/spring-boot/src/main/java/org/springframework/boot/ssl/SslOptions.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/ssl/SslOptions.java
@@ -40,14 +40,14 @@ public interface SslOptions {
 	/**
 	 * {@link SslOptions} that returns {@code null} results.
 	 */
-	SslOptions NONE = of(null, (Set<String>) null);
+	SslOptions NONE = of(null, (Set<String>) null, null);
 
 	/**
 	 * Return if any SSL options have been specified.
 	 * @return {@code true} if SSL options have been specified
 	 */
 	default boolean isSpecified() {
-		return (getCiphers() != null) || (getEnabledProtocols() != null);
+		return (getCiphers() != null) || (getEnabledProtocols() != null) || (getNamedGroups() != null);
 	}
 
 	/**
@@ -67,12 +67,36 @@ public interface SslOptions {
 	String @Nullable [] getEnabledProtocols();
 
 	/**
+	 * Return the key exchange named groups that should be enabled or {@code null}. The
+	 * named group names should be those used in standard TLS key exchange algorithm
+	 * registries, for example {@code x25519} or {@code secp256r1}.
+	 * @return the named groups to enable or {@code null}
+	 * @since 4.1.0
+	 */
+	default String @Nullable [] getNamedGroups() {
+		return null;
+	}
+
+	/**
 	 * Factory method to create a new {@link SslOptions} instance.
 	 * @param ciphers the ciphers
 	 * @param enabledProtocols the enabled protocols
 	 * @return a new {@link SslOptions} instance
 	 */
 	static SslOptions of(String @Nullable [] ciphers, String @Nullable [] enabledProtocols) {
+		return of(ciphers, enabledProtocols, null);
+	}
+
+	/**
+	 * Factory method to create a new {@link SslOptions} instance.
+	 * @param ciphers the ciphers
+	 * @param enabledProtocols the enabled protocols
+	 * @param namedGroups the key exchange named groups
+	 * @return a new {@link SslOptions} instance
+	 * @since 4.1.0
+	 */
+	static SslOptions of(String @Nullable [] ciphers, String @Nullable [] enabledProtocols,
+			String @Nullable [] namedGroups) {
 		return new SslOptions() {
 
 			@Override
@@ -86,10 +110,16 @@ public interface SslOptions {
 			}
 
 			@Override
+			public String @Nullable [] getNamedGroups() {
+				return namedGroups;
+			}
+
+			@Override
 			public String toString() {
 				ToStringCreator creator = new ToStringCreator(this);
 				creator.append("ciphers", ciphers);
 				creator.append("enabledProtocols", enabledProtocols);
+				creator.append("namedGroups", namedGroups);
 				return creator.toString();
 			}
 
@@ -103,7 +133,20 @@ public interface SslOptions {
 	 * @return a new {@link SslOptions} instance
 	 */
 	static SslOptions of(@Nullable Set<String> ciphers, @Nullable Set<String> enabledProtocols) {
-		return of(toArray(ciphers), toArray(enabledProtocols));
+		return of(toArray(ciphers), toArray(enabledProtocols), null);
+	}
+
+	/**
+	 * Factory method to create a new {@link SslOptions} instance.
+	 * @param ciphers the ciphers
+	 * @param enabledProtocols the enabled protocols
+	 * @param namedGroups the key exchange named groups
+	 * @return a new {@link SslOptions} instance
+	 * @since 4.1.0
+	 */
+	static SslOptions of(@Nullable Set<String> ciphers, @Nullable Set<String> enabledProtocols,
+			@Nullable Set<String> namedGroups) {
+		return of(toArray(ciphers), toArray(enabledProtocols), toArray(namedGroups));
 	}
 
 	/**

--- a/core/spring-boot/src/test/java/org/springframework/boot/ssl/SslOptionsTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/ssl/SslOptionsTests.java
@@ -34,6 +34,7 @@ class SslOptionsTests {
 		SslOptions options = SslOptions.NONE;
 		assertThat(options.getCiphers()).isNull();
 		assertThat(options.getEnabledProtocols()).isNull();
+		assertThat(options.getNamedGroups()).isNull();
 	}
 
 	@Test
@@ -43,6 +44,18 @@ class SslOptionsTests {
 		SslOptions options = SslOptions.of(ciphers, enabledProtocols);
 		assertThat(options.getCiphers()).containsExactly(ciphers);
 		assertThat(options.getEnabledProtocols()).containsExactly(enabledProtocols);
+		assertThat(options.getNamedGroups()).isNull();
+	}
+
+	@Test
+	void ofWithArrayAndNamedGroupsCreatesSslOptions() {
+		String[] ciphers = { "a", "b", "c" };
+		String[] enabledProtocols = { "d", "e", "f" };
+		String[] namedGroups = { "x25519", "secp256r1" };
+		SslOptions options = SslOptions.of(ciphers, enabledProtocols, namedGroups);
+		assertThat(options.getCiphers()).containsExactly(ciphers);
+		assertThat(options.getEnabledProtocols()).containsExactly(enabledProtocols);
+		assertThat(options.getNamedGroups()).containsExactly(namedGroups);
 	}
 
 	@Test
@@ -52,6 +65,7 @@ class SslOptionsTests {
 		SslOptions options = SslOptions.of(ciphers, enabledProtocols);
 		assertThat(options.getCiphers()).isNull();
 		assertThat(options.getEnabledProtocols()).isNull();
+		assertThat(options.getNamedGroups()).isNull();
 	}
 
 	@Test
@@ -61,6 +75,18 @@ class SslOptionsTests {
 		SslOptions options = SslOptions.of(ciphers, enabledProtocols);
 		assertThat(options.getCiphers()).contains("a", "b", "c");
 		assertThat(options.getEnabledProtocols()).contains("d", "e", "f");
+		assertThat(options.getNamedGroups()).isNull();
+	}
+
+	@Test
+	void ofWithSetAndNamedGroupsCreatesSslOptions() {
+		Set<String> ciphers = Set.of("a", "b", "c");
+		Set<String> enabledProtocols = Set.of("d", "e", "f");
+		Set<String> namedGroups = Set.of("x25519", "secp256r1");
+		SslOptions options = SslOptions.of(ciphers, enabledProtocols, namedGroups);
+		assertThat(options.getCiphers()).contains("a", "b", "c");
+		assertThat(options.getEnabledProtocols()).contains("d", "e", "f");
+		assertThat(options.getNamedGroups()).contains("x25519", "secp256r1");
 	}
 
 	@Test
@@ -70,6 +96,7 @@ class SslOptionsTests {
 		SslOptions options = SslOptions.of(ciphers, enabledProtocols);
 		assertThat(options.getCiphers()).isNull();
 		assertThat(options.getEnabledProtocols()).isNull();
+		assertThat(options.getNamedGroups()).isNull();
 	}
 
 	@Test
@@ -81,6 +108,12 @@ class SslOptionsTests {
 	@Test
 	void isSpecifiedWhenHasEnabledProtocols() {
 		SslOptions options = SslOptions.of(null, Set.of("d", "e", "f"));
+		assertThat(options.isSpecified()).isTrue();
+	}
+
+	@Test
+	void isSpecifiedWhenHasNamedGroups() {
+		SslOptions options = SslOptions.of(null, null, Set.of("x25519"));
 		assertThat(options.isSpecified()).isTrue();
 	}
 

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/dev-services.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/dev-services.adoc
@@ -164,6 +164,7 @@ For JKS based keystores and truststores, you can use the following container lab
 * `org.springframework.boot.sslbundle.jks.key.password`
 * `org.springframework.boot.sslbundle.jks.options.ciphers`
 * `org.springframework.boot.sslbundle.jks.options.enabled-protocols`
+* `org.springframework.boot.sslbundle.jks.options.named-groups`
 * `org.springframework.boot.sslbundle.jks.protocol`
 
 * `org.springframework.boot.sslbundle.jks.keystore.type`
@@ -184,6 +185,7 @@ For PEM based keystores and truststores, you can use the following container lab
 * `org.springframework.boot.sslbundle.pem.key.password`
 * `org.springframework.boot.sslbundle.pem.options.ciphers`
 * `org.springframework.boot.sslbundle.pem.options.enabled-protocols`
+* `org.springframework.boot.sslbundle.pem.options.named-groups`
 * `org.springframework.boot.sslbundle.pem.protocol`
 
 * `org.springframework.boot.sslbundle.pem.keystore.type`

--- a/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/SslConnectorCustomizer.java
+++ b/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/SslConnectorCustomizer.java
@@ -119,6 +119,7 @@ public class SslConnectorCustomizer {
 		configureCiphers(options, sslHostConfig);
 		configureSslStores(sslHostConfig, certificate, stores);
 		configureEnabledProtocols(sslHostConfig, options);
+		configureNamedGroups(sslHostConfig, options);
 	}
 
 	private void configureCiphers(SslOptions options, SSLHostConfig sslHostConfig) {
@@ -138,6 +139,13 @@ public class SslConnectorCustomizer {
 		if (options.getEnabledProtocols() != null) {
 			String enabledProtocols = StringUtils.arrayToDelimitedString(options.getEnabledProtocols(), "+");
 			sslHostConfig.setProtocols(enabledProtocols);
+		}
+	}
+
+	private void configureNamedGroups(SSLHostConfig sslHostConfig, SslOptions options) {
+		if (options.getNamedGroups() != null) {
+			String namedGroups = StringUtils.arrayToDelimitedString(options.getNamedGroups(), ":");
+			sslHostConfig.setGroups(namedGroups);
 		}
 	}
 

--- a/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/Ssl.java
+++ b/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/Ssl.java
@@ -62,6 +62,11 @@ public class Ssl {
 	private String @Nullable [] enabledProtocols;
 
 	/**
+	 * Enabled key exchange named groups.
+	 */
+	private String @Nullable [] namedGroups;
+
+	/**
 	 * Alias that identifies the key in the key store.
 	 */
 	private @Nullable String keyAlias;
@@ -206,6 +211,19 @@ public class Ssl {
 
 	public void setEnabledProtocols(String @Nullable [] enabledProtocols) {
 		this.enabledProtocols = enabledProtocols;
+	}
+
+	/**
+	 * Return the enabled key exchange named groups.
+	 * @return the enabled key exchange named groups
+	 * @since 4.1.0
+	 */
+	public String @Nullable [] getNamedGroups() {
+		return this.namedGroups;
+	}
+
+	public void setNamedGroups(String @Nullable [] namedGroups) {
+		this.namedGroups = namedGroups;
 	}
 
 	/**

--- a/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/WebServerSslBundle.java
+++ b/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/WebServerSslBundle.java
@@ -58,7 +58,7 @@ public final class WebServerSslBundle implements SslBundle {
 		this.stores = stores;
 		this.key = SslBundleKey.of(keyPassword, ssl.getKeyAlias());
 		this.protocol = ssl.getProtocol();
-		this.options = SslOptions.of(ssl.getCiphers(), ssl.getEnabledProtocols());
+		this.options = SslOptions.of(ssl.getCiphers(), ssl.getEnabledProtocols(), ssl.getNamedGroups());
 		this.managers = SslManagerBundle.from(this.stores, this.key);
 	}
 


### PR DESCRIPTION
Add a `named-groups` option to SslBundles so applications can configure TLS key exchange groups (used for both classical and post-quantum hybrid groups) alongside the existing ciphers and enabled protocols.

Changes:
- `SslOptions` gains `getNamedGroups()` (default `null`) and matching `of(...)` factory overloads. `isSpecified()` now considers named groups.
- `SslBundleProperties.Options`, `server.ssl.Ssl`, the testcontainers `@Ssl` annotation, and Docker Compose's `org.springframework.boot.sslbundle.{jks|pem}.options.named-groups` label all gain the new field/attribute.
- Tomcat's `SslConnectorCustomizer` propagates the named groups via `SSLHostConfig.setGroups`, which has been available since Tomcat 11.0.13.

See gh-46968