### PR TITLE
Add annotation-processor to Gradle JarTypeFileSpec exclusions

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/JarTypeFileSpec.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/JarTypeFileSpec.java
@@ -26,13 +26,15 @@ import org.gradle.api.specs.Spec;
 /**
  * A {@link Spec} for {@link FileCollection#filter(Spec) filtering} {@code FileCollection}
  * to remove jar files based on their {@code Spring-Boot-Jar-Type} as defined in the
- * manifest. Jars of type {@code dependencies-starter} are excluded.
+ * manifest. Jars of type {@code annotation-processor}, {@code dependencies-starter}, or
+ * {@code development-tool} are excluded.
  *
  * @author Andy Wilkinson
  */
 class JarTypeFileSpec implements Spec<File> {
 
-	private static final Set<String> EXCLUDED_JAR_TYPES = Set.of("dependencies-starter", "development-tool");
+	private static final Set<String> EXCLUDED_JAR_TYPES = Set.of("annotation-processor", "dependencies-starter",
+			"development-tool");
 
 	@Override
 	public boolean isSatisfiedBy(File file) {


### PR DESCRIPTION
## Summary

Add `annotation-processor` to the Gradle plugin's `JarTypeFileSpec` excluded JAR types to match the Maven plugin's `JarTypeFilter`.

## Problem

The Maven plugin excludes JARs with `Spring-Boot-Jar-Type` values of `annotation-processor`, `dependencies-starter`, and `development-tool`. The Gradle plugin only excludes `dependencies-starter` and `development-tool`, missing `annotation-processor`.

This means Maven and Gradle builds can produce different fat JARs — annotation processor JARs would be excluded from Maven-built fat JARs but included in Gradle-built ones.

## Fix

Add `annotation-processor` to `JarTypeFileSpec.EXCLUDED_JAR_TYPES` and update the Javadoc to reflect the complete exclusion list.