### PR TITLE
Remove obsolete JUnit 4 notes from test slice annotations

### DIFF
--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonTest.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/json/JsonTest.java
@@ -40,26 +40,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Annotation for a JSON test that focuses <strong>only</strong> on JSON serialization.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to JSON tests.
- * Similarly, component scanning is limited to beans annotated with:
- * <ul>
- * <li>{@code @JacksonComponent}</li>
- * </ul>
- * <p>
- * as well as beans that implement:
- * <ul>
- * <li>{@code JacksonModule}, if Jackson is available</li>
- * </ul>
- * <p>
- * By default, tests annotated with {@code JsonTest} will also initialize
- * {@link JacksonTester}, {@link JsonbTester} and {@link GsonTester} fields. More
- * fine-grained control can be provided through the
- * {@link AutoConfigureJsonTesters @AutoConfigureJsonTesters} annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Phillip Webb
  * @author Artsiom Yudovin
  * @see AutoConfigureJson

--- a/module/spring-boot-data-cassandra-test/src/main/java/org/springframework/boot/data/cassandra/test/autoconfigure/DataCassandraTest.java
+++ b/module/spring-boot-data-cassandra-test/src/main/java/org/springframework/boot/data/cassandra/test/autoconfigure/DataCassandraTest.java
@@ -38,14 +38,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 /**
  * Annotation that can be used for a Cassandra test that focuses <strong>only</strong> on
  * Cassandra components.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to Data Casandra
- * tests. Similarly, component scanning is limited to Cassandra repositories and entities
- * ({@code @Table}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Artsiom Yudovin
  * @author Stephane Nicoll
  * @since 4.0.0

--- a/module/spring-boot-data-couchbase-test/src/main/java/org/springframework/boot/data/couchbase/test/autoconfigure/DataCouchbaseTest.java
+++ b/module/spring-boot-data-couchbase-test/src/main/java/org/springframework/boot/data/couchbase/test/autoconfigure/DataCouchbaseTest.java
@@ -38,14 +38,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 /**
  * Annotation that can be used for a Data Couchbase test that focuses
  * <strong>only</strong> on Data Couchbase components.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to Data
- * Couchbase tests. Similarly, component scanning is limited to Couchbase repositories and
- * entities ({@code @Document}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Eddú Meléndez
  * @since 4.0.0
  */

--- a/module/spring-boot-data-elasticsearch-test/src/main/java/org/springframework/boot/data/elasticsearch/test/autoconfigure/DataElasticsearchTest.java
+++ b/module/spring-boot-data-elasticsearch-test/src/main/java/org/springframework/boot/data/elasticsearch/test/autoconfigure/DataElasticsearchTest.java
@@ -38,14 +38,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 /**
  * Annotation that can be used for a Data Elasticsearch test that focuses
  * <strong>only</strong> on Data Elasticsearch components.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to Data
- * Elasticsearch tests. Similarly, component scanning is limited to Elasticsearch
- * repositories and entities ({@code @Document}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Eddú Meléndez
  * @since 4.0.0
  */

--- a/module/spring-boot-data-jdbc-test/src/main/java/org/springframework/boot/data/jdbc/test/autoconfigure/DataJdbcTest.java
+++ b/module/spring-boot-data-jdbc-test/src/main/java/org/springframework/boot/data/jdbc/test/autoconfigure/DataJdbcTest.java
@@ -41,25 +41,6 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * Annotation that can be used for a Data JDBC test that focuses <strong>only</strong> on
  * Data JDBC components.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to Data JDBC
- * tests. Similarly, component scanning is limited to JDBC repositories and entities
- * ({@code @Table}), as well as beans that implement {@code AbstractJdbcConfiguration}.
- * <p>
- * By default, tests annotated with {@code @DataJdbcTest} are transactional and roll back
- * at the end of each test. They also use an embedded in-memory database (replacing any
- * explicit or usually auto-configured DataSource). The
- * {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase} annotation can be used to
- * override these settings.
- * <p>
- * If you are looking to load your full application configuration, but use an embedded
- * database, you should consider {@link SpringBootTest @SpringBootTest} combined with
- * {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase} rather than this
- * annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Andy Wilkinson
  * @since 4.0.0
  */

--- a/module/spring-boot-data-jpa-test/src/main/java/org/springframework/boot/data/jpa/test/autoconfigure/DataJpaTest.java
+++ b/module/spring-boot-data-jpa-test/src/main/java/org/springframework/boot/data/jpa/test/autoconfigure/DataJpaTest.java
@@ -44,29 +44,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Annotation for a JPA test that focuses <strong>only</strong> on JPA components.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to Data JPA
- * tests. Similarly, component scanning is limited to JPA repositories and entities
- * ({@code @Entity}).
- * <p>
- * By default, tests annotated with {@code @DataJpaTest} are transactional and roll back
- * at the end of each test. They also use an embedded in-memory database (replacing any
- * explicit or usually auto-configured DataSource). The
- * {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase} annotation can be used to
- * override these settings.
- * <p>
- * SQL queries are logged by default by setting the {@code spring.jpa.show-sql} property
- * to {@code true}. This can be disabled using the {@link DataJpaTest#showSql() showSql}
- * attribute.
- * <p>
- * If you are looking to load your full application configuration, but use an embedded
- * database, you should consider {@link SpringBootTest @SpringBootTest} combined with
- * {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase} rather than this
- * annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Phillip Webb
  * @author Artsiom Yudovin
  * @author Scott Frederick

--- a/module/spring-boot-data-ldap-test/src/main/java/org/springframework/boot/data/ldap/test/autoconfigure/DataLdapTest.java
+++ b/module/spring-boot-data-ldap-test/src/main/java/org/springframework/boot/data/ldap/test/autoconfigure/DataLdapTest.java
@@ -38,17 +38,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 /**
  * Annotation that can be used for an LDAP test that focuses <strong>only</strong> on LDAP
  * components.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to Data LDAP
- * tests. Similarly, component scanning is limited to LDAP repositories and entities
- * ({@code @Entry}).
- * <p>
- * By default, tests annotated with {@code @DataLdapTest} will use an embedded in-memory
- * LDAP process (if available).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Eddú Meléndez
  * @author Artsiom Yudovin
  * @since 4.0.0

--- a/module/spring-boot-data-mongodb-test/src/main/java/org/springframework/boot/data/mongodb/test/autoconfigure/DataMongoTest.java
+++ b/module/spring-boot-data-mongodb-test/src/main/java/org/springframework/boot/data/mongodb/test/autoconfigure/DataMongoTest.java
@@ -38,14 +38,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 /**
  * Annotation that can be used for a MongoDB test that focuses <strong>only</strong> on
  * MongoDB components.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to Data Mongo
- * tests. Similarly, component scanning is limited to Mongo repositories and entities
- * ({@code @Document}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Michael Simons
  * @author Stephane Nicoll
  * @author Artsiom Yudovin

--- a/module/spring-boot-data-neo4j-test/src/main/java/org/springframework/boot/data/neo4j/test/autoconfigure/DataNeo4jTest.java
+++ b/module/spring-boot-data-neo4j-test/src/main/java/org/springframework/boot/data/neo4j/test/autoconfigure/DataNeo4jTest.java
@@ -39,19 +39,6 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * Annotation that can be used for a Neo4j test that focuses <strong>only</strong> on
  * Neo4j components.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to Data Neo4j
- * tests. Similarly, component scanning is limited to Neo4j repositories and entities
- * ({@code @Node} and {@code @RelationshipProperties}).
- * <p>
- * By default, tests annotated with {@code @DataNeo4jTest} are transactional with the
- * usual test-related semantics (i.e. rollback by default). This feature is not supported
- * with reactive access so this should be disabled by annotating the test class with
- * {@code @Transactional(propagation = Propagation.NOT_SUPPORTED)}.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Eddú Meléndez
  * @author Stephane Nicoll
  * @author Artsiom Yudovin

--- a/module/spring-boot-data-r2dbc-test/src/main/java/org/springframework/boot/data/r2dbc/test/autoconfigure/DataR2dbcTest.java
+++ b/module/spring-boot-data-r2dbc-test/src/main/java/org/springframework/boot/data/r2dbc/test/autoconfigure/DataR2dbcTest.java
@@ -38,14 +38,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 /**
  * Annotation that can be used for a R2DBC test that focuses <strong>only</strong> on Data
  * R2DBC components.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to Data R2DBC
- * tests. Similarly, component scanning is limited to R2DBC repositories and entities
- * ({@code @Table}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Mark Paluch
  * @author Stephane Nicoll
  * @since 4.0.0

--- a/module/spring-boot-data-redis-test/src/main/java/org/springframework/boot/data/redis/test/autoconfigure/DataRedisTest.java
+++ b/module/spring-boot-data-redis-test/src/main/java/org/springframework/boot/data/redis/test/autoconfigure/DataRedisTest.java
@@ -38,14 +38,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 /**
  * Annotation for a Data Redis test that focuses <strong>only</strong> on Redis
  * components.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to Data Redis
- * tests. Similarly, component scanning is limited to Redis repositories and entities
- * ({@code @RedisHash}).
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Jayaram Pradhan
  * @author Artsiom Yudovin
  * @since 4.0.0

--- a/module/spring-boot-jdbc-test/src/main/java/org/springframework/boot/jdbc/test/autoconfigure/JdbcTest.java
+++ b/module/spring-boot-jdbc-test/src/main/java/org/springframework/boot/jdbc/test/autoconfigure/JdbcTest.java
@@ -39,25 +39,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Annotation for a JDBC test that focuses <strong>only</strong> on JDBC-based components.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to JDBC tests.
- * Similarly, component scanning is configured to skip regular components and
- * configuration properties.
- * <p>
- * By default, tests annotated with {@code @JdbcTest} are transactional and roll back at
- * the end of each test. They also use an embedded in-memory database (replacing any
- * explicit or usually auto-configured DataSource). The
- * {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase} annotation can be used to
- * override these settings.
- * <p>
- * If you are looking to load your full application configuration, but use an embedded
- * database, you should consider {@link SpringBootTest @SpringBootTest} combined with
- * {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase} rather than this
- * annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Stephane Nicoll
  * @author Artsiom Yudovin
  * @since 4.0.0

--- a/module/spring-boot-jooq-test/src/main/java/org/springframework/boot/jooq/test/autoconfigure/JooqTest.java
+++ b/module/spring-boot-jooq-test/src/main/java/org/springframework/boot/jooq/test/autoconfigure/JooqTest.java
@@ -39,19 +39,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Annotation for a jOOQ test that focuses <strong>only</strong> on jOOQ-based components.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to jOOQ tests.
- * Similarly, component scanning is configured to skip regular components and
- * configuration properties.
- * <p>
- * By default, tests annotated with {@code @JooqTest} use the configured database. If you
- * want to replace any explicit or usually auto-configured DataSource by an embedded
- * in-memory database, the {@link AutoConfigureTestDatabase @AutoConfigureTestDatabase}
- * annotation can be used to override these settings.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Michael Simons
  * @author Stephane Nicoll
  * @author Artsiom Yudovin

--- a/module/spring-boot-restclient-test/src/main/java/org/springframework/boot/restclient/test/autoconfigure/RestClientTest.java
+++ b/module/spring-boot-restclient-test/src/main/java/org/springframework/boot/restclient/test/autoconfigure/RestClientTest.java
@@ -41,28 +41,6 @@ import org.springframework.web.client.RestClient.Builder;
 /**
  * Annotation for a Spring rest client test that focuses <strong>only</strong> on beans
  * that use {@link RestTemplateBuilder} or {@link Builder RestClient.Builder}.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to rest client
- * tests. Similarly, component scanning is limited to beans annotated with:
- * <ul>
- * <li>{@code @JacksonComponent}</li>
- * <li>{@code @JsonComponent}(deprecated)</li>
- * </ul>
- * <p>
- * as well as beans that implement:
- * <ul>
- * <li>{@code JacksonModule}, if Jackson is available</li>
- * <li>{@code Module}, if Jackson 2 is available (deprecated)</li>
- * </ul>
- * <p>
- * By default, tests annotated with {@code RestClientTest} will also auto-configure a
- * {@link MockRestServiceServer}. For more fine-grained control the
- * {@link AutoConfigureMockRestServiceServer @AutoConfigureMockRestServiceServer}
- * annotation can be used.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Stephane Nicoll
  * @author Phillip Webb
  * @author Artsiom Yudovin

--- a/module/spring-boot-webclient-test/src/main/java/org/springframework/boot/webclient/test/autoconfigure/WebClientTest.java
+++ b/module/spring-boot-webclient-test/src/main/java/org/springframework/boot/webclient/test/autoconfigure/WebClientTest.java
@@ -39,21 +39,6 @@ import org.springframework.web.client.RestClient.Builder;
 /**
  * Annotation for a Spring WebClient test that focuses <strong>only</strong> on beans that
  * use {@link Builder WebClient.Builder}.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to rest client
- * tests. Similarly, component scanning is limited to beans annotated with:
- * <ul>
- * <li>{@code @JacksonComponent}</li>
- * </ul>
- * <p>
- * as well as beans that implement:
- * <ul>
- * <li>{@code JacksonModule}, if Jackson is available</li>
- * </ul>
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Andy Wilkinson
  * @since 4.0.0
  */

--- a/module/spring-boot-webflux-test/src/main/java/org/springframework/boot/webflux/test/autoconfigure/WebFluxTest.java
+++ b/module/spring-boot-webflux-test/src/main/java/org/springframework/boot/webflux/test/autoconfigure/WebFluxTest.java
@@ -43,45 +43,6 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 /**
  * Annotation that can be used for a Spring WebFlux test that focuses
  * <strong>only</strong> on Spring WebFlux components.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to WebFlux
- * tests. Similarly, component scanning is limited to beans annotated with:
- * <ul>
- * <li>{@code @Controller}</li>
- * <li>{@code @ControllerAdvice}</li>
- * <li>{@code @JacksonComponent}</li>
- * <li>{@code @JsonComponent} (Jackson 2, deprecated)</li>
- * </ul>
- * <p>
- * as well as beans that implement:
- * <ul>
- * <li>{@code Converter}</li>
- * <li>{@code GenericConverter}</li>
- * <li>{@code IDialect}, if Thymeleaf is available</li>
- * <li>{@code JacksonModule}, if Jackson is available</li>
- * <li>{@code Module}, if Jackson 2 is available (deprecated)</li>
- * <li>{@code WebExceptionHandler}</li>
- * <li>{@code WebFluxConfigurer}</li>
- * <li>{@code WebFilter}</li>
- * </ul>
- * <p>
- * By default, tests annotated with {@code @WebFluxTest} will also auto-configure a
- * {@link WebTestClient}. For more fine-grained control of WebTestClient the
- * {@link AutoConfigureWebTestClient @AutoConfigureWebTestClient} annotation can be used.
- * <p>
- * Typically {@code @WebFluxTest} is used in combination with
- * {@link org.springframework.test.context.bean.override.mockito.MockitoBean @MockitoBean}
- * or {@link Import @Import} to create any collaborators required by your
- * {@code @Controller} beans.
- * <p>
- * If you are looking to load your full application configuration and use WebTestClient,
- * you should consider {@link SpringBootTest @SpringBootTest} combined with
- * {@link AutoConfigureWebTestClient @AutoConfigureWebTestClient} rather than this
- * annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Stephane Nicoll
  * @author Artsiom Yudovin
  * @since 4.0.0

--- a/module/spring-boot-webmvc-test/src/main/java/org/springframework/boot/webmvc/test/autoconfigure/WebMvcTest.java
+++ b/module/spring-boot-webmvc-test/src/main/java/org/springframework/boot/webmvc/test/autoconfigure/WebMvcTest.java
@@ -41,53 +41,6 @@ import org.springframework.test.web.servlet.MockMvc;
 /**
  * Annotation that can be used for a Spring MVC test that focuses <strong>only</strong> on
  * Spring MVC components.
- * <p>
- * Using this annotation only enables auto-configuration that is relevant to MVC tests.
- * Similarly, component scanning is limited to beans annotated with:
- * <ul>
- * <li>{@code @Controller}</li>
- * <li>{@code @ControllerAdvice}</li>
- * <li>{@code @JacksonComponent}</li>
- * <li>{@code @JsonComponent} (Jackson 2, deprecated)</li>
- * </ul>
- * <p>
- * as well as beans that implement:
- * <ul>
- * <li>{@code Converter}</li>
- * <li>{@code DelegatingFilterProxyRegistrationBean}</li>
- * <li>{@code ErrorAttributes}</li>
- * <li>{@code Filter}</li>
- * <li>{@code FilterRegistrationBean}</li>
- * <li>{@code GenericConverter}</li>
- * <li>{@code HandlerInterceptor}</li>
- * <li>{@code HandlerMethodArgumentResolver}</li>
- * <li>{@code HttpMessageConverter}</li>
- * <li>{@code IDialect}, if Thymeleaf is available</li>
- * <li>{@code JacksonModule}, if Jackson is available</li>
- * <li>{@code Module} (deprecated), if Jackson 2 is available</li>
- * <li>{@code SecurityFilterChain}</li>
- * <li>{@code WebMvcConfigurer}</li>
- * <li>{@code WebMvcRegistrations}</li>
- * <li>{@code WebSecurityConfigurer}</li>
- * </ul>
- * <p>
- * By default, tests annotated with {@code @WebMvcTest} will also auto-configure Spring
- * Security and {@link MockMvc} (include support for HtmlUnit WebClient and Selenium
- * WebDriver). For more fine-grained control of MockMVC the
- * {@link AutoConfigureMockMvc @AutoConfigureMockMvc} annotation can be used.
- * <p>
- * Typically {@code @WebMvcTest} is used in combination with
- * {@link org.springframework.test.context.bean.override.mockito.MockitoBean @MockitoBean}
- * or {@link Import @Import} to create any collaborators required by your
- * {@code @Controller} beans.
- * <p>
- * If you are looking to load your full application configuration and use MockMVC, you
- * should consider {@link SpringBootTest @SpringBootTest} combined with
- * {@link AutoConfigureMockMvc @AutoConfigureMockMvc} rather than this annotation.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Phillip Webb
  * @author Artsiom Yudovin
  * @see AutoConfigureWebMvc

--- a/module/spring-boot-webservices-test/src/main/java/org/springframework/boot/webservices/test/autoconfigure/client/WebServiceClientTest.java
+++ b/module/spring-boot-webservices-test/src/main/java/org/springframework/boot/webservices/test/autoconfigure/client/WebServiceClientTest.java
@@ -43,14 +43,6 @@ import org.springframework.ws.test.client.MockWebServiceServer;
  * when a test focuses <strong>only</strong> on beans that use
  * {@link WebServiceTemplateBuilder}. By default, tests annotated with
  * {@code WebServiceClientTest} will also auto-configure a {@link MockWebServiceServer}.
- * <p>
- * If you are testing a bean that doesn't use {@link WebServiceTemplateBuilder} but
- * instead injects a {@link WebServiceTemplate} directly, you can add
- * {@code @AutoConfigureWebServiceClient(registerWebServiceTemplate=true)}.
- * <p>
- * When using JUnit 4, this annotation should be used in combination with
- * {@code @RunWith(SpringRunner.class)}.
- *
  * @author Dmytro Nosan
  * @since 2.3.0
  */


### PR DESCRIPTION
Issue #47228 tracks cleaning up JUnit 4 references while the ecosystem moves to JUnit Jupiter. The test slice annotations in `src/main` still carried the old paragraph about combining the annotation with `@RunWith(SpringRunner.class)` even though these types are already aimed at JUnit Jupiter via `SpringExtension` and `@ExtendWith`.

This deletes that redundant block from every slice annotation under `module/spring-boot-*-test/.../test/autoconfigure` plus `JsonTest` in `spring-boot-test-autoconfigure`. Wrapped `{@code ... @RunWith(SpringRunner.class)}` javadoc that splits across two lines is handled the same as the single-line form.

I did not change `SpringBootTest`, Antora pages, or `src/test` sources; those still mention JUnit 4 in other wording and can be follow-ups if you want one large sweep.

Refs #47228
