### PR TITLE
Gradle gRPC support fails if protobuf-java dependency is used instead of protobuf-java-util

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ProtobufPluginAction.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ProtobufPluginAction.java
@@ -33,7 +33,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.DependencyResolveDetails;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.jspecify.annotations.Nullable;
 
@@ -141,9 +140,8 @@ final class ProtobufPluginAction implements PluginApplicationAction {
 				.getByName("runtimeClasspath")
 				.getIncoming()
 				.getResolutionResult()
-				.getAllDependencies()
+				.getAllComponents()
 				.stream()
-				.map(DependencyResult::getFrom)
 				.map(ResolvedComponentResult::getId)
 				.filter(ModuleComponentIdentifier.class::isInstance)
 				.map(ModuleComponentIdentifier.class::cast)

--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ProtobufPluginAction.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ProtobufPluginAction.java
@@ -41,6 +41,7 @@ import org.jspecify.annotations.Nullable;
  * applied.
  *
  * @author Andy Wilkinson
+ * @author Dongliang Xie
  */
 final class ProtobufPluginAction implements PluginApplicationAction {
 
@@ -49,7 +50,7 @@ final class ProtobufPluginAction implements PluginApplicationAction {
 	private static final Dependency grpcDependency = new Dependency("io.grpc", "protoc-gen-grpc-java");
 
 	private static final List<VersionAlignment> versionAlignment = List.of(
-			protocDependency.alignVersionWith("com.google.protobuf", "protobuf-java-util"),
+			protocDependency.alignVersionWith("com.google.protobuf", "protobuf-java"),
 			grpcDependency.alignVersionWith("io.grpc", "grpc-util"));
 
 	@Override

--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/ProtobufPluginActionIntegrationTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/ProtobufPluginActionIntegrationTests.java
@@ -16,6 +16,10 @@
 
 package org.springframework.boot.gradle.plugin;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
 import org.junit.jupiter.api.TestTemplate;
 
 import org.springframework.boot.gradle.junit.GradleCompatibility;
@@ -27,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for {@link ProtobufPluginAction}.
  *
  * @author Andy Wilkinson
+ * @author Dongliang Xie
  */
 @GradleCompatibility
 class ProtobufPluginActionIntegrationTests {
@@ -57,6 +62,20 @@ class ProtobufPluginActionIntegrationTests {
 	void alignsVersionOfProtocDependency() {
 		assertThat(this.gradleBuild.build("dependencies", "--configuration", "protobufToolsLocator_protoc").getOutput())
 			.contains("com.google.protobuf:protoc:null -> 4.34.0");
+	}
+
+	@TestTemplate
+	void generatesProtoSourcesWhenProtobufJavaProvidesProtocVersion() throws IOException {
+		File proto = new File(this.gradleBuild.getProjectDir(), "src/main/proto/example.proto");
+		proto.getParentFile().mkdirs();
+		Files.writeString(proto.toPath(), """
+				syntax = "proto3";
+				option java_package = "com.example";
+				message Example {
+				  string name = 1;
+				}
+				""");
+		this.gradleBuild.build("generateProto");
 	}
 
 	@TestTemplate

--- a/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/ProtobufPluginActionIntegrationTests.gradle
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/ProtobufPluginActionIntegrationTests.gradle
@@ -29,7 +29,7 @@ repositories {
 }
 
 dependencies {
-	implementation("com.google.protobuf:protobuf-java-util:4.34.0")
+	implementation("com.google.protobuf:protobuf-java:4.34.0")
 	implementation("io.grpc:grpc-util:1.79.0")
 }
 
@@ -60,4 +60,3 @@ tasks.register("generateProtoTasksGrpcPluginOptions") {
 		tasks.withType(com.google.protobuf.gradle.GenerateProtoTask).each { println "${it.name}: ${it.pluginsForCaching.collect { it.options }}" }
 	}
 }
-


### PR DESCRIPTION
Fixes #50401.

This updates the Protobuf Gradle plugin action to align `protoc` with `com.google.protobuf:protobuf-java` rather than `protobuf-java-util`. The gRPC client starter brings in `protobuf-java` but not `protobuf-java-util`, so the previous alignment could leave `protoc` with a null version.

The integration test fixture now uses `protobuf-java`, and a `generateProto` coverage case with a proto source file verifies the client-style setup.

Tests:
- `./gradlew :build-plugin:spring-boot-gradle-plugin:test --tests org.springframework.boot.gradle.plugin.ProtobufPluginActionIntegrationTests --rerun-tasks`
- `./gradlew :build-plugin:spring-boot-gradle-plugin:test --tests org.springframework.boot.gradle.plugin.ProtobufPluginActionIntegrationTests :build-plugin:spring-boot-gradle-plugin:checkFormatMain :build-plugin:spring-boot-gradle-plugin:checkFormatTest :build-plugin:spring-boot-gradle-plugin:checkstyleMain :build-plugin:spring-boot-gradle-plugin:checkstyleTest`