### PR TITLE
Add WAR TLD loader integration test

### DIFF
--- a/integration-test/spring-boot-loader-integration-tests/build.gradle
+++ b/integration-test/spring-boot-loader-integration-tests/build.gradle
@@ -82,6 +82,17 @@ tasks.register("buildSignedJarRsaApp", GradleBuild) {
 	tasks  = ["build"]
 }
 
+tasks.register("syncWarAppSource", org.springframework.boot.build.SyncAppSource) {
+	sourceDirectory = file("spring-boot-loader-tests-war")
+	destinationDirectory = file(layout.buildDirectory.dir("spring-boot-loader-tests-war"))
+}
+
+tasks.register("buildWarApp", GradleBuild) {
+	dependsOn syncWarAppSource, syncMavenRepository
+	dir = layout.buildDirectory.dir("spring-boot-loader-tests-war")
+	startParameter.buildCacheEnabled = false
+	tasks = ["build"]
+}
 
 tasks.register("downloadJdk", Download) {
 	def destFolder = new File(project.gradle.gradleUserHomeDir, "caches/springboot/downloads/jdk/oracle")
@@ -105,5 +116,5 @@ tasks.named("processDockerTestResources").configure {
 }
 
 tasks.named("dockerTest").configure {
-	dependsOn buildApp, buildSignedJarApp, buildSignedJarRsaApp
+	dependsOn buildApp, buildWarApp, buildSignedJarApp, buildSignedJarRsaApp
 }

--- a/integration-test/spring-boot-loader-integration-tests/spring-boot-loader-tests-war/build.gradle
+++ b/integration-test/spring-boot-loader-integration-tests/spring-boot-loader-tests-war/build.gradle
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+	id "war"
+	id "org.springframework.boot"
+}
+
+java {
+	sourceCompatibility = '17'
+	targetCompatibility = '17'
+}
+
+repositories {
+	maven { url = layout.projectDirectory.dir("../docker-test-maven-repository") }
+	mavenCentral()
+	spring.mavenRepositories()
+}
+
+dependencies {
+	implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
+	implementation("org.springframework.boot:spring-boot-starter-webmvc")
+
+	providedRuntime(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
+	providedRuntime("org.springframework.boot:spring-boot-starter-tomcat-runtime")
+	providedRuntime("org.glassfish.web:jakarta.servlet.jsp.jstl")
+	providedRuntime("org.apache.tomcat.embed:tomcat-embed-jasper")
+}

--- a/integration-test/spring-boot-loader-integration-tests/spring-boot-loader-tests-war/settings.gradle
+++ b/integration-test/spring-boot-loader-integration-tests/spring-boot-loader-tests-war/settings.gradle
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pluginManagement {
+	evaluate(new File("${gradle.parent.rootProject.rootDir}/buildSrc/SpringRepositorySupport.groovy")).apply(this)
+	repositories {
+		maven { url = layout.settingsDirectory.dir("../docker-test-maven-repository") }
+		mavenCentral()
+		spring.mavenRepositories()
+	}
+	resolutionStrategy {
+		eachPlugin {
+			if (requested.id.id == "org.springframework.boot") {
+				useModule "org.springframework.boot:spring-boot-gradle-plugin:${requested.version}"
+			}
+		}
+	}
+}

--- a/integration-test/spring-boot-loader-integration-tests/spring-boot-loader-tests-war/src/main/java/org/springframework/boot/loaderwarapp/LoaderWarTestApplication.java
+++ b/integration-test/spring-boot-loader-integration-tests/spring-boot-loader-tests-war/src/main/java/org/springframework/boot/loaderwarapp/LoaderWarTestApplication.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.loaderwarapp;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+
+@SpringBootApplication
+public class LoaderWarTestApplication extends SpringBootServletInitializer {
+
+	@Override
+	protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+		return application.sources(LoaderWarTestApplication.class);
+	}
+
+	public static void main(String[] args) {
+		SpringApplication.run(LoaderWarTestApplication.class, args).close();
+	}
+
+}

--- a/integration-test/spring-boot-loader-integration-tests/spring-boot-loader-tests-war/src/main/webapp/WEB-INF/jsp/welcome.jsp
+++ b/integration-test/spring-boot-loader-integration-tests/spring-boot-loader-tests-war/src/main/webapp/WEB-INF/jsp/welcome.jsp
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<%@ taglib prefix="spring" uri="http://www.springframework.org/tags"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+
+<html lang="en">
+<body>
+	<c:url value="/" var="url"/>
+	<spring:url value="/" htmlEscape="true" var="springUrl" />
+	Spring URL: ${springUrl}
+	JSTL URL: ${url}
+</body>
+</html>

--- a/integration-test/spring-boot-loader-integration-tests/src/dockerTest/java/org/springframework/boot/loader/LoaderIntegrationTests.java
+++ b/integration-test/spring-boot-loader-integration-tests/src/dockerTest/java/org/springframework/boot/loader/LoaderIntegrationTests.java
@@ -65,6 +65,21 @@ class LoaderIntegrationTests {
 
 	@ParameterizedTest
 	@MethodSource("javaRuntimes")
+	void runWarWithTldScanning(JavaRuntime javaRuntime) {
+		try (GenericContainer<?> container = createContainer(javaRuntime, "spring-boot-loader-tests-war", null,
+				"war")) {
+			container.start();
+			System.out.println(this.output.toUtf8String());
+			assertThat(this.output.toUtf8String()).contains("Started LoaderWarTestApplication")
+				.doesNotContain("no entry name specified")
+				.doesNotContain("Failed to scan")
+				.doesNotContain("ZipException")
+				.doesNotContain("WARNING:");
+		}
+	}
+
+	@ParameterizedTest
+	@MethodSource("javaRuntimes")
 	void runSignedJar(JavaRuntime javaRuntime) {
 		try (GenericContainer<?> container = createContainer(javaRuntime, "spring-boot-loader-tests-signed-jar",
 				null)) {
@@ -97,31 +112,37 @@ class LoaderIntegrationTests {
 	}
 
 	private GenericContainer<?> createContainer(JavaRuntime javaRuntime, String name, String classifier) {
-		return javaRuntime.getContainer()
-			.withLogConsumer(this.output)
-			.withCopyFileToContainer(findApplication(name, classifier), "/app.jar")
-			.withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(Duration.ofMinutes(5)))
-			.withCommand(command());
+		return createContainer(javaRuntime, name, classifier, "jar");
 	}
 
-	private String[] command() {
+	private GenericContainer<?> createContainer(JavaRuntime javaRuntime, String name, String classifier,
+			String extension) {
+		String application = "app." + extension;
+		return javaRuntime.getContainer()
+			.withLogConsumer(this.output)
+			.withCopyFileToContainer(findApplication(name, classifier, extension), "/" + application)
+			.withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(Duration.ofMinutes(5)))
+			.withCommand(command(application));
+	}
+
+	private String[] command(String application) {
 		List<String> command = new ArrayList<>();
 		command.add("java");
 		command.add("-jar");
-		command.add("app.jar");
+		command.add(application);
 		return command.toArray(new String[0]);
 	}
 
-	private MountableFile findApplication(String name, String classifier) {
-		return MountableFile.forHostPath(findJarFile(name, classifier).toPath());
+	private MountableFile findApplication(String name, String classifier, String extension) {
+		return MountableFile.forHostPath(findArchiveFile(name, classifier, extension).toPath());
 	}
 
-	private File findJarFile(String name, String classifier) {
+	private File findArchiveFile(String name, String classifier, String extension) {
 		classifier = (classifier != null) ? "-" + classifier : "";
-		String path = String.format("build/%1$s/build/libs/%1$s%2$s.jar", name, classifier);
-		File jar = new File(path);
-		Assert.state(jar.isFile(), () -> "Could not find " + path + ". Have you built it?");
-		return jar;
+		String path = String.format("build/%1$s/build/libs/%1$s%2$s.%3$s", name, classifier, extension);
+		File archive = new File(path);
+		Assert.state(archive.isFile(), () -> "Could not find " + path + ". Have you built it?");
+		return archive;
 	}
 
 	static Stream<JavaRuntime> javaRuntimes() {


### PR DESCRIPTION
This adds a Tomcat WAR loader integration test for executable WARs that exercise TLD scanning.

The new test fixture builds a WAR application with JSP taglibs and runs it via `java -jar app.war` in the loader integration test suite. The test verifies that the application starts successfully and that known TLD scanning failure signatures are absent.

This should help catch regressions like the one described in gh-38047.

Fixes gh-38068

## Verification

- `./gradlew :integration-test:spring-boot-loader-integration-tests:dockerTest --rerun-tasks`