### PR TITLE
Polish code to use instanceof pattern matching in conditions

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionEvaluationReport.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/ConditionEvaluationReport.java
@@ -165,8 +165,8 @@ public final class ConditionEvaluationReport {
 	 * @return the {@link ConditionEvaluationReport} or {@code null}
 	 */
 	public static ConditionEvaluationReport find(BeanFactory beanFactory) {
-		if (beanFactory instanceof ConfigurableListableBeanFactory) {
-			return ConditionEvaluationReport.get((ConfigurableListableBeanFactory) beanFactory);
+		if (beanFactory instanceof ConfigurableListableBeanFactory configurableListableBeanFactory) {
+			return ConditionEvaluationReport.get(configurableListableBeanFactory);
 		}
 		return null;
 	}

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnBeanCondition.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/OnBeanCondition.java
@@ -659,8 +659,8 @@ class OnBeanCondition extends FilteringSpringBootCondition implements Configurat
 		}
 
 		private Set<BeanType> deducedBeanType(ConditionContext context, AnnotatedTypeMetadata metadata) {
-			if (metadata instanceof MethodMetadata && metadata.isAnnotated(Bean.class.getName())) {
-				return deducedBeanTypeForBeanMethod(context, (MethodMetadata) metadata);
+			if (metadata instanceof MethodMetadata methodMetadata && metadata.isAnnotated(Bean.class.getName())) {
+				return deducedBeanTypeForBeanMethod(context, methodMetadata);
 			}
 			return Collections.emptySet();
 		}


### PR DESCRIPTION
This updates two condition-related code paths to use `instanceof`
pattern matching where the checked value was immediately cast afterward.

Specifically:
- `ConditionEvaluationReport.find(...)`
- `OnBeanCondition.deducedBeanType(...)`

This keeps the code consistent with the surrounding style and removes
redundant explicit casts without changing behavior.

## Verification

- `./gradlew :core:spring-boot-autoconfigure:test --rerun-tasks`