### PR TITLE
Fix ordering of Kotlinx Serialization CodecCustomizer

### DIFF
--- a/module/spring-boot-http-codec/src/main/java/org/springframework/boot/http/codec/autoconfigure/CodecsAutoConfiguration.java
+++ b/module/spring-boot-http-codec/src/main/java/org/springframework/boot/http/codec/autoconfigure/CodecsAutoConfiguration.java
@@ -103,6 +103,7 @@ public final class CodecsAutoConfiguration {
 	static class KotlinxSerializationJsonCodecConfiguration {
 
 		@Bean
+		@Order(0)
 		@ConditionalOnBean(Json.class)
 		CodecCustomizer kotlinxJsonCodecCustomizer(Json json, ResourceLoader resourceLoader) {
 			ClassLoader classLoader = resourceLoader.getClassLoader();

--- a/module/spring-boot-http-codec/src/test/java/org/springframework/boot/http/codec/autoconfigure/CodecsAutoConfigurationTests.java
+++ b/module/spring-boot-http-codec/src/test/java/org/springframework/boot/http/codec/autoconfigure/CodecsAutoConfigurationTests.java
@@ -160,6 +160,16 @@ class CodecsAutoConfigurationTests {
 			});
 	}
 
+	@Test
+	void userProvidedCustomizerCanOverrideKotlinxJsonCodecCustomizer() {
+		this.contextRunner.withUserConfiguration(KotlinxJsonConfiguration.class, CodecCustomizerConfiguration.class)
+			.run((context) -> {
+				List<CodecCustomizer> codecCustomizers = context.getBean(CodecCustomizers.class).codecCustomizers;
+				assertThat(codecCustomizers).hasSize(3);
+				assertThat(codecCustomizers.get(2)).isInstanceOf(TestCodecCustomizer.class);
+			});
+	}
+
 	@SuppressWarnings("unchecked")
 	private <T> T findEncoder(AssertableApplicationContext context, Class<T> encoderClass) {
 		ServerCodecConfigurer configurer = ServerCodecConfigurer.create();


### PR DESCRIPTION
Kotlinx Serialization `CodecCustomizer` introduced in https://github.com/spring-projects/spring-boot/commit/d161aafcdfb335bbf2acb434fa96f83598482250 lacks an explicit order, meaning it defaults to `LOWEST_PRECEDENCE`. This prevents user-provided customizers from overriding Spring Boot defaults, as the default customizer runs last and overwrites previous configurations.

A similar issue for message converters was fixed in https://github.com/spring-projects/spring-boot/commit/3948e7c4da078e04503c26ffb61f8fa6635777f6. The Jackson `CodecCustomizer` is already explicitly ordered:
https://github.com/spring-projects/spring-boot/blob/21a3eec136dee09dc0838fd52a9915d195cd0fe2/module/spring-boot-http-codec/src/main/java/org/springframework/boot/http/codec/autoconfigure/CodecsAutoConfiguration.java#L68-L77

This PR adds `@Order(0)` to the `kotlinxJsonCodecCustomizer` bean to address this issue.

See #48070 and #48609

@bclozel fyi