### PR TITLE
RabbitProperties enables SSL even when spring.rabbitmq.ssl.bundle is overridden to an empty string

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/amqp/RabbitProperties.java
@@ -474,7 +474,7 @@ public class RabbitProperties {
 		 * @see #getEnabled() ()
 		 */
 		public boolean determineEnabled() {
-			boolean defaultEnabled = Boolean.TRUE.equals(getEnabled()) || this.bundle != null;
+			boolean defaultEnabled = Boolean.TRUE.equals(getEnabled()) || StringUtils.hasText(this.bundle);
 			if (CollectionUtils.isEmpty(RabbitProperties.this.parsedAddresses)) {
 				return defaultEnabled;
 			}

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/amqp/RabbitPropertiesTests.java
@@ -336,6 +336,12 @@ class RabbitPropertiesTests {
 	}
 
 	@Test
+	void determineSslEnabledIsFalseWhenBundleIsEmpty() {
+		this.properties.getSsl().setBundle("");
+		assertThat(this.properties.getSsl().determineEnabled()).isFalse();
+	}
+
+	@Test
 	void propertiesUseConsistentDefaultValues() {
 		ConnectionFactory connectionFactory = new ConnectionFactory();
 		assertThat(connectionFactory).hasFieldOrPropertyWithValue("maxInboundMessageBodySize",


### PR DESCRIPTION
Fixes #50426

This also fixes the same empty-string handling in `RabbitProperties.Stream.Ssl`.