### PR TITLE
Add configuration property for leaveGroupOnClose in Kafka Streams

### DIFF
--- a/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaProperties.java
+++ b/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaProperties.java
@@ -813,6 +813,11 @@ public class KafkaProperties {
 		private @Nullable String stateDir;
 
 		/**
+		 * Whether the consumer should leave the group when stopping Kafka Streams.
+		 */
+		private boolean leaveGroupOnClose;
+
+		/**
 		 * Additional Kafka properties used to configure the streams.
 		 */
 		private final Map<String, String> properties = new LinkedHashMap<>();
@@ -883,6 +888,14 @@ public class KafkaProperties {
 
 		public void setStateDir(@Nullable String stateDir) {
 			this.stateDir = stateDir;
+		}
+
+		public boolean isLeaveGroupOnClose() {
+			return this.leaveGroupOnClose;
+		}
+
+		public void setLeaveGroupOnClose(boolean leaveGroupOnClose) {
+			this.leaveGroupOnClose = leaveGroupOnClose;
 		}
 
 		public Map<String, String> getProperties() {

--- a/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaStreamsAnnotationDrivenConfiguration.java
+++ b/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaStreamsAnnotationDrivenConfiguration.java
@@ -101,6 +101,7 @@ class KafkaStreamsAnnotationDrivenConfiguration {
 			KafkaProperties.Cleanup cleanup = this.properties.getStreams().getCleanup();
 			CleanupConfig cleanupConfig = new CleanupConfig(cleanup.isOnStartup(), cleanup.isOnShutdown());
 			factoryBean.setCleanupConfig(cleanupConfig);
+			factoryBean.setLeaveGroupOnClose(this.properties.getStreams().isLeaveGroupOnClose());
 		}
 
 		@Override

--- a/module/spring-boot-kafka/src/test/java/org/springframework/boot/kafka/autoconfigure/KafkaAutoConfigurationTests.java
+++ b/module/spring-boot-kafka/src/test/java/org/springframework/boot/kafka/autoconfigure/KafkaAutoConfigurationTests.java
@@ -475,6 +475,7 @@ class KafkaAutoConfigurationTests {
 				assertThat(factoryBean.isAutoStartup()).isFalse();
 				assertThat(factoryBean).extracting("cleanupConfig.onStart").isEqualTo(true);
 				assertThat(factoryBean).extracting("cleanupConfig.onStop").isEqualTo(true);
+				assertThat(factoryBean).extracting("leaveGroupOnClose").isEqualTo(false);
 				factoryBean.addListener(listener);
 			})
 			.withPropertyValues("spring.kafka.client-id=cid",
@@ -693,6 +694,19 @@ class KafkaAutoConfigurationTests {
 						assertThat(cleanupConfig.cleanupOnStart()).isTrue();
 						assertThat(cleanupConfig.cleanupOnStop()).isFalse();
 					});
+			});
+	}
+
+	@Test
+	void streamsWithLeaveGroupOnClose() {
+		this.contextRunner
+			.withUserConfiguration(EnableKafkaStreamsConfiguration.class, TestKafkaStreamsConfiguration.class)
+			.withPropertyValues("spring.application.name=my-test-app",
+					"spring.kafka.bootstrap-servers=localhost:9092,localhost:9093",
+					"spring.kafka.streams.auto-startup=false", "spring.kafka.streams.leave-group-on-close=true")
+			.run((context) -> {
+				StreamsBuilderFactoryBean streamsBuilderFactoryBean = context.getBean(StreamsBuilderFactoryBean.class);
+				assertThat(streamsBuilderFactoryBean).extracting("leaveGroupOnClose").isEqualTo(true);
 			});
 	}
 


### PR DESCRIPTION
Setting the option to leave the group on close in Kafka Streams is often a deployment time concern rather than at build time, eg. for rolling deployments in Kubernetes.

Earlier there was a "internal.leave.group.on.close" property in Kafka Streams, but this has been removed and been replaced by API option in `KafkaStreams.close` that the `StreamsBuilderFactoryBean` uses, but could only by set with `StreamsBuilderFactoryBean.setLeaveGroupOnClose(true)` in code.

This change makes it possible again to set the option to leave the group on close at configuration/deployment time using the application properties:

```
spring:
  kafka:
     streams:
       leave-group-on-close: true
```

The default is `false`, which is the same as `StreamsBuilderFactoryBean.leaveGroupOnClose` default, so there should be no change in behaviour unless the property is explicitly set.

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
