### PR TITLE
Add ApplicationContextAssert.assertWith for fluent multi-assertion

### DIFF
--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssert.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssert.java
@@ -20,7 +20,10 @@ import java.io.BufferedReader;
 import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractObjectArrayAssert;
@@ -474,6 +477,73 @@ public class ApplicationContextAssert<C extends ApplicationContext>
 	public ApplicationContextAssert<C> hasNotFailed() {
 		if (this.startupFailure != null) {
 			throwAssertionError(contextFailedToStartWhenExpecting(this.startupFailure, "to have not failed"));
+		}
+		return this;
+	}
+
+	/**
+	 * Verifies that the application context satisfies all of the given assertion
+	 * consumers, where each consumer is invoked with this
+	 * {@code ApplicationContextAssert} instance (rather than the underlying
+	 * {@link ApplicationContext}). This enables the fluent context assertions to be
+	 * invoked from each consumer, including from within an
+	 * {@link org.assertj.core.api.SoftAssertions} block where
+	 * {@link org.assertj.core.api.SoftAssertions#assertThat(Object)
+	 * softly.assertThat(context)} would otherwise resolve to a plain
+	 * {@link AbstractObjectAssert}.
+	 * <p>
+	 * Example: <pre class="code">
+	 * assertThat(context).assertWith(
+	 *     (ctx) -&gt; ctx.hasBean("foo"),
+	 *     (ctx) -&gt; ctx.doesNotHaveBean(MyBean.class));
+	 * </pre>
+	 * <p>
+	 * All consumers are invoked even if one of them fails. A single failure is re-thrown
+	 * as-is; multiple failures are aggregated into a single {@code AssertionError} whose
+	 * suppressed exceptions carry the individual failures.
+	 * @param requirements the assertion consumers to run against this assertion
+	 * @return {@code this} assertion object.
+	 * @throws AssertionError if any of the consumers throw an assertion error
+	 * @since 4.0.0
+	 */
+	@SafeVarargs
+	@SuppressWarnings("varargs")
+	public final ApplicationContextAssert<C> assertWith(Consumer<? super ApplicationContextAssert<C>>... requirements) {
+		return assertWithForProxy(requirements);
+	}
+
+	/**
+	 * Variant of {@link #assertWith(Consumer[])} that is {@code protected} so that it can
+	 * be proxied for {@code SoftAssertions} and {@code Assumptions}. The public method is
+	 * marked {@code final} and annotated with {@link SafeVarargs} in order to avoid
+	 * unchecked warnings in user code.
+	 * @param requirements the assertion consumers
+	 * @return {@code this} assertion object.
+	 */
+	protected ApplicationContextAssert<C> assertWithForProxy(
+			Consumer<? super ApplicationContextAssert<C>>[] requirements) {
+		Assert.notNull(requirements, "'requirements' must not be null");
+		for (Consumer<? super ApplicationContextAssert<C>> requirement : requirements) {
+			Assert.notNull(requirement, "No assertion consumer should be null");
+		}
+		List<AssertionError> errors = new ArrayList<>();
+		for (Consumer<? super ApplicationContextAssert<C>> requirement : requirements) {
+			try {
+				requirement.accept(this);
+			}
+			catch (AssertionError ex) {
+				errors.add(ex);
+			}
+		}
+		if (errors.size() == 1) {
+			throw errors.get(0);
+		}
+		if (!errors.isEmpty()) {
+			AssertionError aggregated = new AssertionError("Multiple Failures (" + errors.size() + " failures)");
+			for (AssertionError error : errors) {
+				aggregated.addSuppressed(error);
+			}
+			throw aggregated;
 		}
 		return this;
 	}

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/assertj/ApplicationContextAssertTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/assertj/ApplicationContextAssertTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.boot.test.context.assertj;
 
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -396,6 +399,47 @@ class ApplicationContextAssertTests {
 	@Test
 	void hasNotFailedWhenNotFailedShouldPass() {
 		assertThat(getAssert(this.context)).hasNotFailed();
+	}
+
+	@Test
+	void assertWithAllPassingConsumersShouldPass() {
+		this.context.registerSingleton("foo", Foo.class);
+		assertThat(getAssert(this.context)).assertWith((ctx) -> ctx.hasBean("foo"),
+				(ctx) -> ctx.hasSingleBean(Foo.class), (ctx) -> ctx.doesNotHaveBean(Bar.class));
+	}
+
+	@Test
+	void assertWithSingleFailingConsumerShouldRethrowOriginalError() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(getAssert(this.context)).assertWith((ctx) -> ctx.hasBean("foo")))
+			.withMessageContaining("no such bean");
+	}
+
+	@Test
+	void assertWithMultipleFailingConsumersShouldAggregateErrors() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(getAssert(this.context)).assertWith((ctx) -> ctx.hasBean("foo"),
+					(ctx) -> ctx.hasSingleBean(Foo.class)))
+			.withMessageContaining("Multiple Failures")
+			.satisfies((ex) -> assertThat(ex.getSuppressed()).hasSize(2));
+	}
+
+	@Test
+	@SuppressWarnings("NullAway") // Test null check
+	void assertWithNullRequirementShouldThrowException() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> assertThat(getAssert(this.context))
+				.assertWith((Consumer<? super ApplicationContextAssert<ConfigurableApplicationContext>>) null))
+			.withMessageContaining("No assertion consumer should be null");
+	}
+
+	@Test
+	void assertWithPassesThisAssertionRatherThanActualToConsumer() {
+		this.context.registerSingleton("foo", Foo.class);
+		AtomicReference<ApplicationContextAssert<?>> received = new AtomicReference<>();
+		ApplicationContextAssert<?> assertion = assertThat(getAssert(this.context));
+		assertion.assertWith(received::set);
+		assertThat(received.get()).isSameAs(assertion);
 	}
 
 	private AssertableApplicationContext getAssert(ConfigurableApplicationContext applicationContext) {


### PR DESCRIPTION
Following @philwebb's direction in https://github.com/spring-projects/spring-boot/issues/40134#issuecomment-3045820720, this is a draft for review on the approach before polishing further.

## Problem recap

`AbstractAssert#satisfies(Consumer[])` invokes each consumer with `actual`, which for `ApplicationContextAssert` is the underlying `ApplicationContext`. That means callers cannot chain the fluent context assertions from within a consumer — the relevant case being a `SoftAssertions` block where `softly.assertThat(context)` resolves to a plain `ObjectAssert` (see #40134 for the full background).

## What this change does

Adds a new `assertWith(Consumer<? super ApplicationContextAssert<C>>...)` overload on `ApplicationContextAssert` that passes `this` (the assertion) to each consumer. A protected `assertWithForProxy` companion is included so the public method can stay `final` + `@SafeVarargs` while still being proxyable for `SoftAssertions` / `Assumptions`.

A single failure is re-thrown as-is; multiple failures are aggregated into one `AssertionError` whose suppressed exceptions carry the individual errors. (Re-using `AbstractAssert#multipleAssertionsError` was not possible because it's `private` — see Q1 below.)

Example usage:

```java
assertThat(context).assertWith(
    (ctx) -> ctx.hasBean(\"foo\"),
    (ctx) -> ctx.doesNotHaveBean(MyBean.class));
```

Or within a `SoftAssertions` block where direct `softly.assertThat(context).doesNotHaveBean(...)` is currently blocked because the soft-assertion proxy machinery requires a single-argument constructor (`ApplicationContextAssert` has two — context + startup failure):

```java
SoftAssertions.assertSoftly((softly) ->
    softly.assertThat(context).assertWith(
        (ctx) -> ctx.hasBean(\"foo\"),
        (ctx) -> ctx.doesNotHaveBean(MyBean.class)));
```

## Why a new method name rather than overriding `satisfiesForProxy`

The original suggestion was to override `satisfiesForProxy` and use a `catchOptionalAssertionError` variant that calls `assertions.accept(this)` rather than `assertions.accept(actual)`.

I tried that first, but ran into an erasure clash:

```
error: name clash: satisfies(Consumer<? super ApplicationContextAssert<C>>[]) in
ApplicationContextAssert and satisfies(Consumer<? super C>[]) in AbstractAssert
have the same erasure, yet neither overrides the other
```

A literal override (keeping the parent's `Consumer<? super C>[]` signature) would compile if we cast inside the method body, but the lambda parameter on the caller side would still be typed as `ApplicationContext` rather than `ApplicationContextAssert<C>`, defeating the point — callers would need an explicit `Consumer` cast at every call site.

So this PR introduces a separate `assertWith` method instead, which keeps the call sites clean. Happy to revisit the naming if there's a preferred convention I missed.

## Questions for reviewers

1. **`multipleAssertionsError` is `private` on `AbstractAssert`.** I rolled a small aggregate-via-suppressed-exceptions implementation here. Is there a sanctioned way to reuse AssertJ's own multi-failure formatting that I missed, or is this acceptable as-is?
2. **Naming.** `assertWith` was the cleanest fit I could find that didn't collide with anything on `AbstractAssert`. Open to alternatives (e.g. `satisfiesAssertable`, `applyAssertions`).
3. **Scope.** This only covers `Consumer` — should a `ThrowingConsumer` overload follow the same pattern, mirroring `AbstractAssert#satisfies(ThrowingConsumer[])`?

## Verification

- `./gradlew :core:spring-boot-test:check` passes locally (JDK 25, format + checkstyle + architecture + tests)
- New tests in `ApplicationContextAssertTests` cover: all-passing consumers, single failure rethrow, multi-failure aggregation with suppressed exceptions, null requirement rejection, and that consumers receive `this` (the assertion) rather than `actual`.

Marked as draft pending direction on the above. Closes gh-40134 once approach is confirmed.