### PR TITLE
Fix GraphQL argument binder conversion service auto-configuration

### DIFF
--- a/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/GraphQlAutoConfiguration.java
+++ b/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/GraphQlAutoConfiguration.java
@@ -49,6 +49,7 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.core.log.LogMessage;
 import org.springframework.data.domain.ScrollPosition;
 import org.springframework.graphql.ExecutionGraphQlService;
+import org.springframework.graphql.data.GraphQlArgumentBinder;
 import org.springframework.graphql.data.method.HandlerMethodArgumentResolver;
 import org.springframework.graphql.data.method.annotation.support.AnnotatedControllerConfigurer;
 import org.springframework.graphql.data.pagination.ConnectionFieldTypeVisitor;
@@ -156,8 +157,8 @@ public final class GraphQlAutoConfiguration {
 			@Qualifier(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME) ObjectProvider<Executor> executorProvider,
 			ObjectProvider<HandlerMethodArgumentResolver> argumentResolvers) {
 		AnnotatedControllerConfigurer controllerConfigurer = new AnnotatedControllerConfigurer();
-		controllerConfigurer
-			.configureBinder((options) -> options.conversionService(ApplicationConversionService.getSharedInstance()));
+		controllerConfigurer.setBinderOptions(GraphQlArgumentBinder.Options.create()
+			.conversionService(ApplicationConversionService.getSharedInstance()));
 		executorProvider.ifAvailable(controllerConfigurer::setExecutor);
 		argumentResolvers.orderedStream().forEach(controllerConfigurer::addCustomArgumentResolver);
 		return controllerConfigurer;

--- a/module/spring-boot-graphql/src/test/java/org/springframework/boot/graphql/autoconfigure/GraphQlAutoConfigurationTests.java
+++ b/module/spring-boot-graphql/src/test/java/org/springframework/boot/graphql/autoconfigure/GraphQlAutoConfigurationTests.java
@@ -35,6 +35,7 @@ import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
+import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.boot.graphql.autoconfigure.GraphQlAutoConfiguration.GraphQlResourcesRuntimeHints;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.system.CapturedOutput;
@@ -45,6 +46,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.graphql.ExecutionGraphQlService;
+import org.springframework.graphql.data.GraphQlArgumentBinder;
 import org.springframework.graphql.data.method.HandlerMethodArgumentResolver;
 import org.springframework.graphql.data.method.annotation.support.AnnotatedControllerConfigurer;
 import org.springframework.graphql.data.pagination.EncodingCursorStrategy;
@@ -280,6 +282,18 @@ class GraphQlAutoConfigurationTests {
 			AnnotatedControllerConfigurer annotatedControllerConfigurer = context
 				.getBean(AnnotatedControllerConfigurer.class);
 			assertThat(annotatedControllerConfigurer).extracting("executor").isNull();
+		});
+	}
+
+	@Test
+	void annotatedControllerConfigurerShouldUseApplicationConversionService() {
+		this.contextRunner.run((context) -> {
+			AnnotatedControllerConfigurer annotatedControllerConfigurer = context
+				.getBean(AnnotatedControllerConfigurer.class);
+			assertThat(annotatedControllerConfigurer).extracting("binderOptions")
+				.isInstanceOfSatisfying(GraphQlArgumentBinder.Options.class,
+						(options) -> assertThat(options.conversionService())
+							.isSameAs(ApplicationConversionService.getSharedInstance()));
 		});
 	}
 


### PR DESCRIPTION
Fixes gh-50421.

`GraphQlArgumentBinder.Options` is immutable in Spring GraphQL 2.0. The previous `configureBinder` callback called `options.conversionService(...)`, but the returned `Options` instance was discarded, so the auto-configured `ApplicationConversionService` was not applied.

This update sets the complete binder options instance via `setBinderOptions(...)` and adds a regression test that verifies the auto-configured `AnnotatedControllerConfigurer` uses `ApplicationConversionService.getSharedInstance()`.

Local validation:
- `./gradlew --no-daemon :module:spring-boot-graphql:compileTestJava`
- `./gradlew --no-daemon :module:spring-boot-graphql:test --tests '*GraphQlAutoConfigurationTests'`
- `./gradlew --no-daemon :module:spring-boot-graphql:checkFormatMain :module:spring-boot-graphql:checkFormatTest`
