### PR TITLE
Add Spring Boot version to MongoDB driver handshake and append metadata for user-provided clients

### DIFF
--- a/module/spring-boot-data-mongodb/src/main/java/org/springframework/boot/data/mongodb/autoconfigure/DataMongoReactiveAutoConfiguration.java
+++ b/module/spring-boot-data-mongodb/src/main/java/org/springframework/boot/data/mongodb/autoconfigure/DataMongoReactiveAutoConfiguration.java
@@ -16,9 +16,11 @@
 
 package org.springframework.boot.data.mongodb.autoconfigure;
 
+import java.lang.reflect.Method;
 import java.util.Optional;
 
 import com.mongodb.ClientSessionOptions;
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.reactivestreams.client.ClientSession;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoDatabase;
@@ -27,6 +29,7 @@ import org.bson.codecs.configuration.CodecRegistry;
 import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Mono;
 
+import org.springframework.boot.SpringBootVersion;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -76,16 +79,32 @@ import org.springframework.util.StringUtils;
 @Import(DataMongoConfiguration.class)
 public final class DataMongoReactiveAutoConfiguration {
 
+	private static final MongoDriverInformation DRIVER_INFO = MongoDriverInformation.builder()
+		.driverName("spring-boot")
+		.driverVersion(SpringBootVersion.getVersion())
+		.build();
+
 	@Bean
 	@ConditionalOnMissingBean(ReactiveMongoDatabaseFactory.class)
 	SimpleReactiveMongoDatabaseFactory reactiveMongoDatabaseFactory(MongoProperties properties, MongoClient mongo,
 			MongoConnectionDetails connectionDetails) {
+		appendMetadata(mongo);
 		String database = properties.getDatabase();
 		if (database == null) {
 			database = connectionDetails.getConnectionString().getDatabase();
 		}
 		Assert.hasText(database, "Database name must not be empty");
 		return new SimpleReactiveMongoDatabaseFactory(mongo, database);
+	}
+
+	private static void appendMetadata(MongoClient mongoClient) {
+		try {
+			Method method = mongoClient.getClass().getMethod("appendMetadata", MongoDriverInformation.class);
+			method.invoke(mongoClient, DRIVER_INFO);
+		}
+		catch (Exception ex) {
+			// appendMetadata not available in this driver version — skip silently
+		}
 	}
 
 	@Bean

--- a/module/spring-boot-data-mongodb/src/main/java/org/springframework/boot/data/mongodb/autoconfigure/MongoDatabaseFactoryConfiguration.java
+++ b/module/spring-boot-data-mongodb/src/main/java/org/springframework/boot/data/mongodb/autoconfigure/MongoDatabaseFactoryConfiguration.java
@@ -16,8 +16,12 @@
 
 package org.springframework.boot.data.mongodb.autoconfigure;
 
+import java.lang.reflect.Method;
+
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.client.MongoClient;
 
+import org.springframework.boot.SpringBootVersion;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.mongodb.autoconfigure.MongoConnectionDetails;
@@ -43,15 +47,31 @@ import org.springframework.util.Assert;
 @ConditionalOnSingleCandidate(MongoClient.class)
 class MongoDatabaseFactoryConfiguration {
 
+	private static final MongoDriverInformation DRIVER_INFO = MongoDriverInformation.builder()
+		.driverName("spring-boot")
+		.driverVersion(SpringBootVersion.getVersion())
+		.build();
+
 	@Bean
 	MongoDatabaseFactorySupport<?> mongoDatabaseFactory(MongoClient mongoClient, MongoProperties properties,
 			MongoConnectionDetails connectionDetails) {
+		appendMetadata(mongoClient);
 		String database = properties.getDatabase();
 		if (database == null) {
 			database = connectionDetails.getConnectionString().getDatabase();
 		}
 		Assert.hasText(database, "Database name must not be empty");
 		return new SimpleMongoClientDatabaseFactory(mongoClient, database);
+	}
+
+	private static void appendMetadata(MongoClient mongoClient) {
+		try {
+			Method method = mongoClient.getClass().getMethod("appendMetadata", MongoDriverInformation.class);
+			method.invoke(mongoClient, DRIVER_INFO);
+		}
+		catch (Exception ex) {
+			// appendMetadata not available in this driver version — skip silently
+		}
 	}
 
 }

--- a/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoClientFactorySupport.java
+++ b/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoClientFactorySupport.java
@@ -25,6 +25,8 @@ import com.mongodb.MongoClientSettings.Builder;
 import com.mongodb.MongoDriverInformation;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.boot.SpringBootVersion;
+
 /**
  * Base class for setup that is common to MongoDB client factories.
  *
@@ -60,6 +62,7 @@ public abstract class MongoClientFactorySupport<T> {
 	private MongoDriverInformation driverInformation() {
 		return MongoDriverInformation.builder(MongoDriverInformation.builder().build())
 			.driverName("spring-boot")
+			.driverVersion(SpringBootVersion.getVersion())
 			.build();
 	}
 


### PR DESCRIPTION
Enhance Spring Boot's MongoDB client metadata reporting:

- **Add `driverVersion`** to the existing `MongoDriverInformation` in `MongoClientFactorySupport`, so the handshake includes the Spring Boot version (not just the name) when Spring Boot constructs the `MongoClient`.

- **Append metadata to user-provided clients**: When a `MongoClient` bean is created externally by the user, Spring Boot now calls `appendMetadata` via reflection at the point it first uses the client — in `MongoDatabaseFactoryConfiguration` (blocking) and `DataMongoReactiveAutoConfiguration` (reactive). This ensures MongoDB server-side telemetry registers Spring Boot usage regardless of who constructs the client.

Reflection is used for `appendMetadata` because it was added in Java driver 5.6.0 and the actual driver version is governed by the Spring Data BOM — older versions skip the call silently.