### PR TITLE
Docker Compose support does not restore thread interrupt flag when catching InterruptedException

### DIFF
--- a/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/ProcessRunner.java
+++ b/spring-boot-project/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/ProcessRunner.java
@@ -122,7 +122,8 @@ class ProcessRunner {
 			return process.waitFor();
 		}
 		catch (InterruptedException ex) {
-			throw new IllegalStateException("Interrupted waiting for %s".formatted(process));
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException("Interrupted waiting for %s".formatted(process), ex);
 		}
 	}
 
@@ -174,6 +175,7 @@ class ProcessRunner {
 				return this.output.toString();
 			}
 			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
 				return null;
 			}
 		}


### PR DESCRIPTION
ProcessRunner.waitForProcess and ReaderThread.toString catch
InterruptedException without restoring the thread interrupt flag.
This prevents callers higher up the stack from detecting the
interruption. Every other InterruptedException handler in the
codebase restores the flag; these two were the only omissions.

Add Thread.currentThread().interrupt() before re-throwing or
returning in both catch blocks. Also chain the original exception
as the cause in waitForProcess for debuggability.

Closes #50450

Signed-off-by: Sebastien Tardif <sebtardif@ncf.ca>