### PR TITLE
Configure KafkaAdmin for observation

### DIFF
--- a/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/ConcurrentKafkaListenerContainerFactoryConfigurer.java
+++ b/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/ConcurrentKafkaListenerContainerFactoryConfigurer.java
@@ -25,11 +25,14 @@ import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.boot.kafka.autoconfigure.KafkaProperties.Listener;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.ContainerCustomizer;
 import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.AfterRollbackProcessor;
 import org.springframework.kafka.listener.BatchInterceptor;
 import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.listener.ConsumerAwareRebalanceListener;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.MessageListenerContainer;
@@ -84,6 +87,10 @@ public class ConcurrentKafkaListenerContainerFactoryConfigurer {
 	private @Nullable SimpleAsyncTaskExecutor listenerTaskExecutor;
 
 	private @Nullable KafkaListenerObservationConvention observationConvention;
+
+	private @Nullable KafkaAdmin kafkaAdmin;
+
+	private @Nullable ContainerCustomizer<Object, Object, ConcurrentMessageListenerContainer<Object, Object>> containerCustomizer;
 
 	/**
 	 * Set the {@link KafkaProperties} to use.
@@ -197,6 +204,15 @@ public class ConcurrentKafkaListenerContainerFactoryConfigurer {
 		this.observationConvention = observationConvention;
 	}
 
+	void setKafkaAdmin(@Nullable KafkaAdmin kafkaAdmin) {
+		this.kafkaAdmin = kafkaAdmin;
+	}
+
+	void setContainerCustomizer(
+			@Nullable ContainerCustomizer<Object, Object, ConcurrentMessageListenerContainer<Object, Object>> containerCustomizer) {
+		this.containerCustomizer = containerCustomizer;
+	}
+
 	/**
 	 * Configure the specified Kafka listener container factory. The factory can be
 	 * further tuned and default settings can be overridden.
@@ -230,6 +246,20 @@ public class ConcurrentKafkaListenerContainerFactoryConfigurer {
 		map.from(this.batchInterceptor).to(factory::setBatchInterceptor);
 		map.from(this.threadNameSupplier).to(factory::setThreadNameSupplier);
 		map.from(properties::getChangeConsumerThreadName).to(factory::setChangeConsumerThreadName);
+		map.from(getContainerCustomizer()).to(factory::setContainerCustomizer);
+	}
+
+	private @Nullable ContainerCustomizer<Object, Object, ConcurrentMessageListenerContainer<Object, Object>> getContainerCustomizer() {
+		KafkaAdmin kafkaAdmin = this.kafkaAdmin;
+		if (kafkaAdmin == null) {
+			return this.containerCustomizer;
+		}
+		return (container) -> {
+			container.setKafkaAdmin(kafkaAdmin);
+			if (this.containerCustomizer != null) {
+				this.containerCustomizer.configure(container);
+			}
+		};
 	}
 
 	private void configureContainer(ContainerProperties container) {

--- a/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaAnnotationDrivenConfiguration.java
+++ b/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaAnnotationDrivenConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.kafka.config.ContainerCustomizer;
 import org.springframework.kafka.config.KafkaListenerConfigUtils;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.AfterRollbackProcessor;
 import org.springframework.kafka.listener.BatchInterceptor;
@@ -89,11 +90,14 @@ class KafkaAnnotationDrivenConfiguration {
 
 	private final @Nullable KafkaListenerObservationConvention observationConvention;
 
+	private final KafkaConnectionDetails connectionDetails;
+
 	KafkaAnnotationDrivenConfiguration(KafkaProperties properties,
 			ObjectProvider<RecordMessageConverter> recordMessageConverter,
 			ObjectProvider<RecordFilterStrategy<Object, Object>> recordFilterStrategy,
 			ObjectProvider<BatchMessageConverter> batchMessageConverter,
 			ObjectProvider<KafkaTemplate<Object, Object>> kafkaTemplate,
+			ObjectProvider<KafkaConnectionDetails> connectionDetails,
 			ObjectProvider<KafkaAwareTransactionManager<Object, Object>> kafkaTransactionManager,
 			ObjectProvider<ConsumerAwareRebalanceListener> rebalanceListener,
 			ObjectProvider<CommonErrorHandler> commonErrorHandler,
@@ -108,6 +112,7 @@ class KafkaAnnotationDrivenConfiguration {
 		this.batchMessageConverter = batchMessageConverter
 			.getIfUnique(() -> new BatchMessagingMessageConverter(this.recordMessageConverter));
 		this.kafkaTemplate = kafkaTemplate.getIfUnique();
+		this.connectionDetails = connectionDetails.getObject();
 		this.transactionManager = kafkaTransactionManager.getIfUnique();
 		this.rebalanceListener = rebalanceListener.getIfUnique();
 		this.commonErrorHandler = commonErrorHandler.getIfUnique();
@@ -151,6 +156,12 @@ class KafkaAnnotationDrivenConfiguration {
 		configurer.setBatchInterceptor(this.batchInterceptor);
 		configurer.setThreadNameSupplier(this.threadNameSupplier);
 		configurer.setObservationConvention(this.observationConvention);
+		KafkaProperties.Admin admin = this.properties.getListener().getAdmin();
+		if (admin != null) {
+			KafkaAdmin kafkaAdmin = KafkaAutoConfiguration.createKafkaAdmin(this.properties.buildAdminProperties(admin),
+					admin, this.connectionDetails);
+			configurer.setKafkaAdmin(kafkaAdmin);
+		}
 		return configurer;
 	}
 
@@ -161,9 +172,9 @@ class KafkaAnnotationDrivenConfiguration {
 			ObjectProvider<ConsumerFactory<Object, Object>> kafkaConsumerFactory,
 			ObjectProvider<ContainerCustomizer<Object, Object, ConcurrentMessageListenerContainer<Object, Object>>> kafkaContainerCustomizer) {
 		ConcurrentKafkaListenerContainerFactory<Object, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+		kafkaContainerCustomizer.ifAvailable(configurer::setContainerCustomizer);
 		configurer.configure(factory, kafkaConsumerFactory
 			.getIfAvailable(() -> new DefaultKafkaConsumerFactory<>(this.properties.buildConsumerProperties())));
-		kafkaContainerCustomizer.ifAvailable(factory::setContainerCustomizer);
 		return factory;
 	}
 

--- a/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaAutoConfiguration.java
+++ b/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaAutoConfiguration.java
@@ -106,13 +106,19 @@ public final class KafkaAutoConfiguration {
 	KafkaTemplate<?, ?> kafkaTemplate(ProducerFactory<Object, Object> kafkaProducerFactory,
 			ProducerListener<Object, Object> kafkaProducerListener,
 			ObjectProvider<RecordMessageConverter> messageConverter,
-			ObjectProvider<KafkaTemplateObservationConvention> observationConvention) {
+			ObjectProvider<KafkaTemplateObservationConvention> observationConvention,
+			KafkaConnectionDetails connectionDetails) {
 		PropertyMapper map = PropertyMapper.get();
 		KafkaTemplate<Object, Object> kafkaTemplate = new KafkaTemplate<>(kafkaProducerFactory);
 		messageConverter.ifUnique(kafkaTemplate::setMessageConverter);
 		observationConvention.ifUnique(kafkaTemplate::setObservationConvention);
 		map.from(kafkaProducerListener).to(kafkaTemplate::setProducerListener);
 		Template templateProperties = this.properties.getTemplate();
+		KafkaProperties.Admin admin = templateProperties.getAdmin();
+		if (admin != null) {
+			kafkaTemplate
+				.setKafkaAdmin(createKafkaAdmin(this.properties.buildAdminProperties(admin), admin, connectionDetails));
+		}
 		map.from(templateProperties.getDefaultTopic()).to(kafkaTemplate::setDefaultTopic);
 		map.from(templateProperties.getTransactionIdPrefix()).to(kafkaTemplate::setTransactionIdPrefix);
 		map.from(templateProperties.getCloseTimeout()).to(kafkaTemplate::setCloseTimeout);
@@ -180,9 +186,14 @@ public final class KafkaAutoConfiguration {
 	@ConditionalOnMissingBean
 	KafkaAdmin kafkaAdmin(KafkaConnectionDetails connectionDetails) {
 		Map<String, Object> properties = this.properties.buildAdminProperties();
+		KafkaProperties.Admin admin = this.properties.getAdmin();
+		return createKafkaAdmin(properties, admin, connectionDetails);
+	}
+
+	static KafkaAdmin createKafkaAdmin(Map<String, Object> properties, KafkaProperties.Admin admin,
+			KafkaConnectionDetails connectionDetails) {
 		applyKafkaConnectionDetailsForAdmin(properties, connectionDetails);
 		KafkaAdmin kafkaAdmin = new KafkaAdmin(properties);
-		KafkaProperties.Admin admin = this.properties.getAdmin();
 		if (admin.getCloseTimeout() != null) {
 			kafkaAdmin.setCloseTimeout((int) admin.getCloseTimeout().getSeconds());
 		}
@@ -225,7 +236,7 @@ public final class KafkaAutoConfiguration {
 		applySslBundle(properties, producer.getSslBundle());
 	}
 
-	private void applyKafkaConnectionDetailsForAdmin(Map<String, Object> properties,
+	static void applyKafkaConnectionDetailsForAdmin(Map<String, Object> properties,
 			KafkaConnectionDetails connectionDetails) {
 		Configuration admin = connectionDetails.getAdmin();
 		properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, admin.getBootstrapServers());

--- a/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaProperties.java
+++ b/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaProperties.java
@@ -214,8 +214,12 @@ public class KafkaProperties {
 	 * instance
 	 */
 	public Map<String, Object> buildAdminProperties() {
+		return buildAdminProperties(this.admin);
+	}
+
+	Map<String, Object> buildAdminProperties(Admin admin) {
 		Map<String, Object> properties = buildCommonProperties();
-		properties.putAll(this.admin.buildProperties());
+		properties.putAll(admin.buildProperties());
 		return properties;
 	}
 
@@ -908,6 +912,11 @@ public class KafkaProperties {
 	public static class Template {
 
 		/**
+		 * Admin properties used to look up the Kafka cluster id for observation.
+		 */
+		private @Nullable Admin admin;
+
+		/**
 		 * Default topic to which messages are sent.
 		 */
 		private @Nullable String defaultTopic;
@@ -932,6 +941,14 @@ public class KafkaProperties {
 		 * Whether to enable observation.
 		 */
 		private boolean observationEnabled;
+
+		public @Nullable Admin getAdmin() {
+			return this.admin;
+		}
+
+		public void setAdmin(@Nullable Admin admin) {
+			this.admin = admin;
+		}
 
 		public @Nullable String getDefaultTopic() {
 			return this.defaultTopic;
@@ -976,6 +993,11 @@ public class KafkaProperties {
 	}
 
 	public static class Listener {
+
+		/**
+		 * Admin properties used to look up the Kafka cluster id for observation.
+		 */
+		private @Nullable Admin admin;
 
 		public enum Type {
 
@@ -1099,6 +1121,14 @@ public class KafkaProperties {
 		 * Time between retries after authentication exceptions.
 		 */
 		private @Nullable Duration authExceptionRetryInterval;
+
+		public @Nullable Admin getAdmin() {
+			return this.admin;
+		}
+
+		public void setAdmin(@Nullable Admin admin) {
+			this.admin = admin;
+		}
 
 		public Type getType() {
 			return this.type;

--- a/module/spring-boot-kafka/src/test/java/org/springframework/boot/kafka/autoconfigure/ConcurrentKafkaListenerContainerFactoryConfigurerTests.java
+++ b/module/spring-boot-kafka/src/test/java/org/springframework/boot/kafka/autoconfigure/ConcurrentKafkaListenerContainerFactoryConfigurerTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.kafka.autoconfigure;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +25,10 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.ContainerCustomizer;
 import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.kafka.support.micrometer.KafkaListenerObservation.DefaultKafkaListenerObservationConvention;
 
@@ -96,6 +100,29 @@ class ConcurrentKafkaListenerContainerFactoryConfigurerTests {
 		this.configurer.setObservationConvention(convention);
 		this.configurer.configure(this.factory, this.consumerFactory);
 		assertThat(this.factory.getContainerProperties().getObservationConvention()).isSameAs(convention);
+	}
+
+	@Test
+	void shouldApplyKafkaAdmin() {
+		KafkaAdmin kafkaAdmin = new KafkaAdmin(Collections.emptyMap());
+		this.configurer.setKafkaAdmin(kafkaAdmin);
+		this.configurer.configure(this.factory, this.consumerFactory);
+		ConcurrentMessageListenerContainer<Object, Object> container = this.factory.createContainer("test");
+		assertThat(container.getKafkaAdmin()).isSameAs(kafkaAdmin);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void shouldApplyKafkaAdminAndContainerCustomizer() {
+		KafkaAdmin kafkaAdmin = new KafkaAdmin(Collections.emptyMap());
+		ContainerCustomizer<Object, Object, ConcurrentMessageListenerContainer<Object, Object>> customizer = mock(
+				ContainerCustomizer.class);
+		this.configurer.setKafkaAdmin(kafkaAdmin);
+		this.configurer.setContainerCustomizer(customizer);
+		this.configurer.configure(this.factory, this.consumerFactory);
+		ConcurrentMessageListenerContainer<Object, Object> container = this.factory.createContainer("test");
+		assertThat(container.getKafkaAdmin()).isSameAs(kafkaAdmin);
+		then(customizer).should().configure(container);
 	}
 
 }

--- a/module/spring-boot-kafka/src/test/java/org/springframework/boot/kafka/autoconfigure/KafkaAutoConfigurationTests.java
+++ b/module/spring-boot-kafka/src/test/java/org/springframework/boot/kafka/autoconfigure/KafkaAutoConfigurationTests.java
@@ -773,6 +773,23 @@ class KafkaAutoConfigurationTests {
 			});
 	}
 
+	@Test
+	void templateAdminProperties() {
+		this.contextRunner
+			.withPropertyValues("spring.kafka.template.admin.client-id=templateAdmin",
+					"spring.kafka.template.admin.operation-timeout=60s",
+					"spring.kafka.template.admin.properties.fiz.buz=fix.fox")
+			.run((context) -> {
+				KafkaTemplate<?, ?> kafkaTemplate = context.getBean(KafkaTemplate.class);
+				KafkaAdmin admin = kafkaTemplate.getKafkaAdmin();
+				assertThat(admin).isNotNull();
+				assertThat(admin.getConfigurationProperties())
+					.containsEntry(AdminClientConfig.CLIENT_ID_CONFIG, "templateAdmin")
+					.containsEntry("fiz.buz", "fix.fox");
+				assertThat(admin).hasFieldOrPropertyWithValue("operationTimeout", 60);
+			});
+	}
+
 	@SuppressWarnings("unchecked")
 	@Test
 	void listenerProperties() {
@@ -825,6 +842,25 @@ class KafkaAutoConfigurationTests {
 				assertThat(context.getBeansOfType(KafkaTransactionManager.class)).hasSize(1);
 				assertThat(((Map<String, String>) ReflectionTestUtils.getField(jaas, "options")))
 					.containsExactly(entry("useKeyTab", "true"));
+			});
+	}
+
+	@Test
+	void listenerAdminProperties() {
+		this.contextRunner
+			.withPropertyValues("spring.kafka.listener.admin.client-id=listenerAdmin",
+					"spring.kafka.listener.admin.operation-timeout=60s",
+					"spring.kafka.listener.admin.properties.fiz.buz=fix.fox")
+			.run((context) -> {
+				ConcurrentKafkaListenerContainerFactory<?, ?> factory = context
+					.getBean(ConcurrentKafkaListenerContainerFactory.class);
+				ConcurrentMessageListenerContainer<?, ?> container = factory.createContainer("someTopic");
+				KafkaAdmin admin = container.getKafkaAdmin();
+				assertThat(admin).isNotNull();
+				assertThat(admin.getConfigurationProperties())
+					.containsEntry(AdminClientConfig.CLIENT_ID_CONFIG, "listenerAdmin")
+					.containsEntry("fiz.buz", "fix.fox");
+				assertThat(admin).hasFieldOrPropertyWithValue("operationTimeout", 60);
 			});
 	}
 
@@ -1019,6 +1055,19 @@ class KafkaAutoConfigurationTests {
 					.getBean(ConcurrentKafkaListenerContainerFactory.class);
 				ConcurrentMessageListenerContainer<?, ?> container = factory.createContainer("someTopic");
 				assertThat(container.getContainerProperties().isObservationEnabled()).isEqualTo(true);
+			});
+	}
+
+	@Test
+	void testConcurrentKafkaListenerContainerFactoryWithCustomContainerCustomizerAndListenerAdminProperties() {
+		this.contextRunner.withUserConfiguration(ObservationEnabledContainerCustomizerConfiguration.class)
+			.withPropertyValues("spring.kafka.listener.admin.client-id=listenerAdmin")
+			.run((context) -> {
+				ConcurrentKafkaListenerContainerFactory<?, ?> factory = context
+					.getBean(ConcurrentKafkaListenerContainerFactory.class);
+				ConcurrentMessageListenerContainer<?, ?> container = factory.createContainer("someTopic");
+				assertThat(container.getContainerProperties().isObservationEnabled()).isEqualTo(true);
+				assertThat(container.getKafkaAdmin()).isNotNull();
 			});
 	}
 


### PR DESCRIPTION
Closes gh-38830

This PR adds dedicated admin property groups for Kafka template and listener observation support. It allows the auto-configured `KafkaTemplate` and listener containers to use internal `KafkaAdmin` instances configured from `spring.kafka.template.admin.*` and `spring.kafka.listener.admin.*` when looking up the Kafka cluster id.

The listener container customization composes with a user-provided `ContainerCustomizer` so existing customization remains applied.

Tests:
- `JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64 ./gradlew :module:spring-boot-kafka:test --tests org.springframework.boot.kafka.autoconfigure.KafkaAutoConfigurationTests --tests org.springframework.boot.kafka.autoconfigure.ConcurrentKafkaListenerContainerFactoryConfigurerTests`
- `JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64 ./gradlew :module:spring-boot-kafka:checkFormat :module:spring-boot-kafka:checkstyleMain :module:spring-boot-kafka:checkstyleTest`
- `git diff --check`