### PR TITLE
Generalize port file writing support

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/context/NetworkServerPortFileWriter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/NetworkServerPortFileWriter.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.context;
+
+import java.io.File;
+import java.util.Locale;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.boot.context.event.PortBound;
+import org.springframework.boot.system.SystemProperties;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.log.LogMessage;
+import org.springframework.util.Assert;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * An {@link ApplicationListener} that saves bound network ports into a file. Useful for
+ * obtaining the local port of a running server that publishes a {@link PortBound} event.
+ *
+ * @author Somil Jain
+ * @since 4.0.0
+ */
+public class NetworkServerPortFileWriter implements ApplicationListener<ApplicationEvent> {
+
+	private static final String DEFAULT_FILE_NAME = "application.port";
+
+	private static final String[] PROPERTY_VARIABLES = { "PORTFILE", "portfile" };
+
+	private static final Log logger = LogFactory.getLog(NetworkServerPortFileWriter.class);
+
+	private final File file;
+
+	/**
+	 * Create a new {@link NetworkServerPortFileWriter} instance using the filename
+	 * {@code application.port}.
+	 */
+	public NetworkServerPortFileWriter() {
+		this(new File(DEFAULT_FILE_NAME));
+	}
+
+	/**
+	 * Create a new {@link NetworkServerPortFileWriter} instance with a specified
+	 * filename.
+	 * @param filename the name of the file containing the port
+	 */
+	public NetworkServerPortFileWriter(String filename) {
+		this(new File(filename));
+	}
+
+	/**
+	 * Create a new {@link NetworkServerPortFileWriter} instance with a specified file.
+	 * @param file the file containing the port
+	 */
+	public NetworkServerPortFileWriter(File file) {
+		Assert.notNull(file, "'file' must not be null");
+		String override = SystemProperties.get(PROPERTY_VARIABLES);
+		if (override != null) {
+			this.file = new File(override);
+		}
+		else {
+			this.file = file;
+		}
+	}
+
+	@Override
+	public void onApplicationEvent(ApplicationEvent event) {
+		if (event instanceof PortBound portBoundEvent) {
+			File portFile = getPortFile(portBoundEvent);
+			try {
+				String port = String.valueOf(portBoundEvent.getPort());
+				createParentDirectory(portFile);
+				FileCopyUtils.copy(port.getBytes(), portFile);
+				portFile.deleteOnExit();
+			}
+			catch (Exception ex) {
+				logger.warn(LogMessage.format("Cannot create port file %s", portFile));
+			}
+		}
+	}
+
+	/**
+	 * Return the port file to write for the given event.
+	 * @param event the port bound event
+	 * @return the port file
+	 */
+	protected File getPortFile(PortBound event) {
+		String namespace = event.getNamespace();
+		if (!StringUtils.hasLength(namespace)) {
+			return this.file;
+		}
+		String filename = this.file.getName();
+		String extension = StringUtils.getFilenameExtension(filename);
+		String filenameWithoutExtension = (extension != null)
+				? filename.substring(0, filename.length() - extension.length() - 1) : filename;
+		String suffix = (!isUpperCase(filename)) ? namespace.toLowerCase(Locale.ENGLISH)
+				: namespace.toUpperCase(Locale.ENGLISH);
+		return new File(this.file.getParentFile(),
+				filenameWithoutExtension + "-" + suffix + ((!StringUtils.hasLength(extension)) ? "" : "." + extension));
+	}
+
+	private boolean isUpperCase(String name) {
+		for (int i = 0; i < name.length(); i++) {
+			if (Character.isLetter(name.charAt(i)) && !Character.isUpperCase(name.charAt(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private void createParentDirectory(File file) {
+		File parent = file.getParentFile();
+		if (parent != null && !parent.mkdirs() && !parent.exists()) {
+			throw new IllegalStateException("Cannot create parent directory " + parent);
+		}
+	}
+
+}

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/event/PortBound.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/event/PortBound.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.context.event;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Interface to be implemented by events that publish a bound network port.
+ *
+ * @author Somil Jain
+ * @since 4.0.0
+ */
+public interface PortBound {
+
+	/**
+	 * Return the port that the server bound to.
+	 * @return the bound port
+	 */
+	int getPort();
+
+	/**
+	 * Return the namespace of the server, if any.
+	 * @return the server namespace or {@code null}
+	 */
+	@Nullable String getNamespace();
+
+}

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/NetworkServerPortFileWriterTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/NetworkServerPortFileWriterTests.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.context;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.springframework.boot.context.event.PortBound;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.util.StringUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.contentOf;
+
+/**
+ * Tests for {@link NetworkServerPortFileWriter}.
+ *
+ * @author Somil Jain
+ */
+class NetworkServerPortFileWriterTests {
+
+	@TempDir
+	@SuppressWarnings("NullAway.Init")
+	File tempDir;
+
+	@BeforeEach
+	@AfterEach
+	void reset() {
+		System.clearProperty("PORTFILE");
+	}
+
+	@Test
+	void createPortFile() {
+		File file = new File(this.tempDir, "port.file");
+		NetworkServerPortFileWriter listener = new NetworkServerPortFileWriter(file);
+		listener.onApplicationEvent(new TestPortBoundEvent(this, 8080, ""));
+		assertThat(contentOf(file)).isEqualTo("8080");
+	}
+
+	@Test
+	void createsParentDirectories() {
+		File file = new File(this.tempDir, "nested/path/port.file");
+		NetworkServerPortFileWriter listener = new NetworkServerPortFileWriter(file);
+		listener.onApplicationEvent(new TestPortBoundEvent(this, 8080, ""));
+		assertThat(contentOf(file)).isEqualTo("8080");
+		assertThat(file.getParentFile()).exists().isDirectory();
+	}
+
+	@Test
+	void systemPropertyOverridesDefaultValue() {
+		System.setProperty("PORTFILE", new File(this.tempDir, "override.file").getAbsolutePath());
+		NetworkServerPortFileWriter listener = new NetworkServerPortFileWriter();
+		listener.onApplicationEvent(new TestPortBoundEvent(this, 8080, ""));
+		String content = contentOf(new File(System.getProperty("PORTFILE")));
+		assertThat(content).isEqualTo("8080");
+	}
+
+	@Test
+	void systemPropertyOverridesConstructorValue() {
+		File constructorFile = new File(this.tempDir, "port.file");
+		System.setProperty("PORTFILE", new File(this.tempDir, "override.file").getAbsolutePath());
+		NetworkServerPortFileWriter listener = new NetworkServerPortFileWriter(constructorFile);
+		listener.onApplicationEvent(new TestPortBoundEvent(this, 8080, ""));
+		String content = contentOf(new File(System.getProperty("PORTFILE")));
+
+		assertThat(content).isEqualTo("8080");
+		assertThat(constructorFile).doesNotExist();
+	}
+
+	@Test
+	void createNamespacePortFile() {
+		File file = new File(this.tempDir, "port.file");
+		NetworkServerPortFileWriter listener = new NetworkServerPortFileWriter(file);
+		listener.onApplicationEvent(new TestPortBoundEvent(this, 8080, ""));
+		listener.onApplicationEvent(new TestPortBoundEvent(this, 9090, "management"));
+		assertThat(contentOf(file)).isEqualTo("8080");
+
+		String managementFile = file.getName();
+		String extension = StringUtils.getFilenameExtension(managementFile);
+		assertThat(extension).isNotNull();
+		managementFile = managementFile.substring(0, managementFile.length() - extension.length() - 1);
+		managementFile = managementFile + "-management." + StringUtils.getFilenameExtension(file.getName());
+
+		String content = contentOf(new File(file.getParentFile(), managementFile));
+		assertThat(content).isEqualTo("9090");
+		assertThat(collectFileNames(file.getParentFile())).contains(managementFile);
+	}
+
+	@Test
+	void createUpperCaseNamespacePortFile() {
+		File file = new File(this.tempDir, "port.file");
+		file = new File(file.getParentFile(), file.getName().toUpperCase(Locale.ENGLISH));
+		NetworkServerPortFileWriter listener = new NetworkServerPortFileWriter(file);
+		listener.onApplicationEvent(new TestPortBoundEvent(this, 9090, "management"));
+
+		String managementFile = file.getName();
+		String extension = StringUtils.getFilenameExtension(managementFile);
+		assertThat(extension).isNotNull();
+		managementFile = managementFile.substring(0, managementFile.length() - extension.length() - 1);
+		managementFile = managementFile + "-MANAGEMENT." + StringUtils.getFilenameExtension(file.getName());
+
+		String content = contentOf(new File(file.getParentFile(), managementFile));
+		assertThat(content).isEqualTo("9090");
+		assertThat(collectFileNames(file.getParentFile())).contains(managementFile);
+	}
+
+	@Test
+	void getPortFileWhenPortFileNameDoesNotHaveExtension() {
+		File file = new File(this.tempDir, "portfile");
+		NetworkServerPortFileWriter listener = new NetworkServerPortFileWriter(file);
+		TestPortBoundEvent event = new TestPortBoundEvent(this, 9090, "management");
+		assertThat(listener.getPortFile(event).getName()).isEqualTo("portfile-management");
+	}
+
+	@Test
+	void unrelatedEventsAreIgnored() {
+		File file = new File(this.tempDir, "port.file");
+		NetworkServerPortFileWriter listener = new NetworkServerPortFileWriter(file);
+
+		ApplicationEvent unrelatedEvent = new ApplicationEvent(this) {
+		};
+
+		listener.onApplicationEvent(unrelatedEvent);
+
+		assertThat(file).doesNotExist();
+	}
+
+	@Test
+	void existingFileIsOverwritten() throws Exception {
+		File file = new File(this.tempDir, "port.file");
+		FileCopyUtils.copy("9999".getBytes(), file);
+
+		NetworkServerPortFileWriter listener = new NetworkServerPortFileWriter(file);
+		listener.onApplicationEvent(new TestPortBoundEvent(this, 8080, ""));
+
+		assertThat(contentOf(file)).isEqualTo("8080");
+	}
+
+	@Test
+	void namespaceCanBeNullUsesDefaultFile() {
+		File file = new File(this.tempDir, "port.file");
+		NetworkServerPortFileWriter listener = new NetworkServerPortFileWriter(file);
+
+		listener.onApplicationEvent(new TestPortBoundEvent(this, 8080, null));
+		assertThat(contentOf(file)).isEqualTo("8080");
+	}
+
+	@Test
+	void emptyNamespaceUsesDefaultFile() {
+		File file = new File(this.tempDir, "port.file");
+		NetworkServerPortFileWriter listener = new NetworkServerPortFileWriter(file);
+
+		listener.onApplicationEvent(new TestPortBoundEvent(this, 8080, ""));
+		assertThat(contentOf(file)).isEqualTo("8080");
+	}
+
+	private Set<String> collectFileNames(File directory) {
+		Set<String> names = new HashSet<>();
+		if (directory.isDirectory()) {
+			for (File file : Objects.requireNonNull(directory.listFiles())) {
+				names.add(file.getName());
+			}
+		}
+		return names;
+	}
+
+	@Test
+	void systemPropertyOverrideWithNamespaceAppendsSuffixCorrectly() {
+		File customFile = new File(this.tempDir, "custom.file");
+		System.setProperty("PORTFILE", customFile.getAbsolutePath());
+
+		NetworkServerPortFileWriter listener = new NetworkServerPortFileWriter();
+		listener.onApplicationEvent(new TestPortBoundEvent(this, 9090, "management"));
+
+		assertThat(customFile).doesNotExist();
+
+		File expectedFile = new File(this.tempDir, "custom-management.file");
+		assertThat(contentOf(expectedFile)).isEqualTo("9090");
+	}
+
+	@Test
+	void createPortFileWithStringFilenameConstructor() {
+		File file = new File(this.tempDir, "string-constructor.file");
+		NetworkServerPortFileWriter listener = new NetworkServerPortFileWriter(file.getAbsolutePath());
+		listener.onApplicationEvent(new TestPortBoundEvent(this, 8080, ""));
+		assertThat(contentOf(file)).isEqualTo("8080");
+	}
+
+	/**
+	 * Private test event to simulate any server broadcasting a bound port.
+	 */
+	private static class TestPortBoundEvent extends ApplicationEvent implements PortBound {
+
+		private final int port;
+
+		private final @Nullable String namespace;
+
+		TestPortBoundEvent(Object source, int port, @Nullable String namespace) {
+			super(source);
+			this.port = port;
+			this.namespace = namespace;
+		}
+
+		@Override
+		public int getPort() {
+			return this.port;
+		}
+
+		@Override
+		public @Nullable String getNamespace() {
+			return this.namespace;
+		}
+
+	}
+
+}

--- a/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/context/WebServerInitializedEvent.java
+++ b/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/context/WebServerInitializedEvent.java
@@ -16,6 +16,9 @@
 
 package org.springframework.boot.web.server.context;
 
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.boot.context.event.PortBound;
 import org.springframework.boot.web.server.WebServer;
 import org.springframework.context.ApplicationEvent;
 
@@ -28,10 +31,28 @@ import org.springframework.context.ApplicationEvent;
  * @since 4.0.0
  */
 @SuppressWarnings("serial")
-public abstract class WebServerInitializedEvent extends ApplicationEvent {
+public abstract class WebServerInitializedEvent extends ApplicationEvent implements PortBound {
 
 	protected WebServerInitializedEvent(WebServer webServer) {
 		super(webServer);
+	}
+
+	/**
+	 * Return the port that the {@link WebServer} bound to.
+	 * @return the bound port
+	 */
+	@Override
+	public int getPort() {
+		return getWebServer().getPort();
+	}
+
+	/**
+	 * Return the namespace of the underlying web server, if available.
+	 * @return the server namespace or {@code null}
+	 */
+	@Override
+	public @Nullable String getNamespace() {
+		return getApplicationContext().getServerNamespace();
 	}
 
 	/**

--- a/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/context/WebServerInitializedEventTests.java
+++ b/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/context/WebServerInitializedEventTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.web.server.context;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.context.event.PortBound;
+import org.springframework.boot.web.server.WebServer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link WebServerInitializedEvent}.
+ *
+ * @author Somil Jain
+ */
+class WebServerInitializedEventTests {
+
+	@Test
+	void implementsPortBoundAndExposesProperties() {
+		WebServer webServer = mock(WebServer.class);
+		given(webServer.getPort()).willReturn(8080);
+
+		WebServerApplicationContext applicationContext = mock(WebServerApplicationContext.class);
+		given(applicationContext.getServerNamespace()).willReturn("management");
+
+		WebServerInitializedEvent event = new TestWebServerInitializedEvent(webServer, applicationContext);
+
+		assertThat(event).isInstanceOf(PortBound.class);
+		assertThat(event.getPort()).isEqualTo(8080);
+		assertThat(event.getNamespace()).isEqualTo("management");
+	}
+
+	private static class TestWebServerInitializedEvent extends WebServerInitializedEvent {
+
+		private final WebServerApplicationContext applicationContext;
+
+		TestWebServerInitializedEvent(WebServer webServer, WebServerApplicationContext applicationContext) {
+			super(webServer);
+			this.applicationContext = applicationContext;
+		}
+
+		@Override
+		public WebServerApplicationContext getApplicationContext() {
+			return this.applicationContext;
+		}
+
+	}
+
+}


### PR DESCRIPTION
Fixes #48035 

Introduce a new `PortBound` abstraction and a `NetworkServerPortFileWriter` that can write port files for applications that are not backed by a `WebServer`. `WebServerInitializedEvent` now implements `PortBound`, allowing existing web server behavior to continue working while enabling other server technologies to publish bound ports through the same mechanism.

Also adds tests covering generic port-bound events, namespace handling, and backward compatibility with existing `WebServer` port file behavior.