### PR TITLE
Add missing null check in ApplicationContextAssertProvider

### DIFF
--- a/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssertProvider.java
+++ b/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssertProvider.java
@@ -55,8 +55,8 @@ public interface ApplicationContextAssertProvider<C extends ApplicationContext>
 		extends ApplicationContext, AssertProvider<ApplicationContextAssert<C>>, Closeable {
 
 	/**
-	 * Return an assert for AspectJ.
-	 * @return an AspectJ assert
+	 * Return an assert for AssertJ.
+	 * @return an AssertJ assert
 	 * @deprecated to prevent accidental use. Prefer standard AssertJ
 	 * {@code assertThat(context)...} calls instead.
 	 */
@@ -131,6 +131,7 @@ public interface ApplicationContextAssertProvider<C extends ApplicationContext>
 		Assert.isTrue(type.isInterface(), "'type' must be an interface");
 		Assert.notNull(contextType, "'contextType' must not be null");
 		Assert.isTrue(contextType.isInterface(), "'contextType' must be an interface");
+		Assert.notNull(contextSupplier, "'contextSupplier' must not be null");
 		Class<?>[] interfaces = merge(new Class<?>[] { type, contextType }, additionalContextInterfaces);
 		return (T) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(), interfaces,
 				new AssertProviderApplicationContextInvocationHandler(contextType, contextSupplier));

--- a/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/assertj/ApplicationContextAssertProviderTests.java
+++ b/spring-boot-project/spring-boot-test/src/test/java/org/springframework/boot/test/context/assertj/ApplicationContextAssertProviderTests.java
@@ -20,9 +20,6 @@ import java.util.function.Supplier;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -32,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link ApplicationContextAssertProvider} and
@@ -39,11 +37,9 @@ import static org.mockito.BDDMockito.then;
  *
  * @author Phillip Webb
  */
-@ExtendWith(MockitoExtension.class)
 class ApplicationContextAssertProviderTests {
 
-	@Mock
-	private ConfigurableApplicationContext mockContext;
+	private final ConfigurableApplicationContext mockContext = mock();
 
 	private RuntimeException startupFailure;
 
@@ -69,13 +65,6 @@ class ApplicationContextAssertProviderTests {
 
 	@Test
 	void getWhenTypeIsClassShouldThrowException() {
-		assertThatIllegalArgumentException().isThrownBy(
-				() -> ApplicationContextAssertProvider.get(null, ApplicationContext.class, this.mockContextSupplier))
-			.withMessageContaining("'type' must not be null");
-	}
-
-	@Test
-	void getWhenContextTypeIsNullShouldThrowException() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> ApplicationContextAssertProvider.get(TestAssertProviderApplicationContextClass.class,
 					ApplicationContext.class, this.mockContextSupplier))
@@ -83,7 +72,7 @@ class ApplicationContextAssertProviderTests {
 	}
 
 	@Test
-	void getWhenContextTypeIsClassShouldThrowException() {
+	void getWhenContextTypeIsNullShouldThrowException() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> ApplicationContextAssertProvider.get(TestAssertProviderApplicationContext.class, null,
 					this.mockContextSupplier))
@@ -91,11 +80,19 @@ class ApplicationContextAssertProviderTests {
 	}
 
 	@Test
-	void getWhenSupplierIsNullShouldThrowException() {
+	void getWhenContextTypeIsClassShouldThrowException() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> ApplicationContextAssertProvider.get(TestAssertProviderApplicationContext.class,
 					StaticApplicationContext.class, this.mockContextSupplier))
 			.withMessageContaining("'contextType' must be an interface");
+	}
+
+	@Test
+	void getWhenSupplierIsNullShouldThrowException() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> ApplicationContextAssertProvider.get(TestAssertProviderApplicationContext.class,
+					ApplicationContext.class, null))
+			.withMessageContaining("'contextSupplier' must not be null");
 	}
 
 	@Test


### PR DESCRIPTION
While working on a solution for what I mentioned at https://github.com/spring-projects/spring-boot/issues/40134#issuecomment-4269664058, I noticed inconsistencies in the `ApplicationContextAssertProviderTests` method names, which led me to spot what I believe is a missing null check for `contextSupplier` in `ApplicationContextAssertProvider`.