### PR TITLE
Added endSessionUri as supported configuration property

### DIFF
--- a/module/spring-boot-security-oauth2-client/src/main/java/org/springframework/boot/security/oauth2/client/autoconfigure/OAuth2ClientProperties.java
+++ b/module/spring-boot-security-oauth2-client/src/main/java/org/springframework/boot/security/oauth2/client/autoconfigure/OAuth2ClientProperties.java
@@ -197,6 +197,11 @@ public class OAuth2ClientProperties implements InitializingBean {
 		private @Nullable String authorizationUri;
 
 		/**
+		 * End-Session URI for the provider.
+		 */
+		private @Nullable String endSessionUri;
+
+		/**
 		 * Token URI for the provider.
 		 */
 		private @Nullable String tokenUri;
@@ -234,6 +239,14 @@ public class OAuth2ClientProperties implements InitializingBean {
 
 		public void setAuthorizationUri(@Nullable String authorizationUri) {
 			this.authorizationUri = authorizationUri;
+		}
+
+		public @Nullable String getEndSessionUri() {
+			return this.endSessionUri;
+		}
+
+		public void setEndSessionUri(@Nullable String endSessionUri) {
+			this.endSessionUri = endSessionUri;
 		}
 
 		public @Nullable String getTokenUri() {

--- a/module/spring-boot-security-oauth2-client/src/main/java/org/springframework/boot/security/oauth2/client/autoconfigure/OAuth2ClientPropertiesMapper.java
+++ b/module/spring-boot-security-oauth2-client/src/main/java/org/springframework/boot/security/oauth2/client/autoconfigure/OAuth2ClientPropertiesMapper.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.security.oauth2.client.autoconfigure;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -133,6 +134,10 @@ public final class OAuth2ClientPropertiesMapper {
 			.to(builder::userInfoAuthenticationMethod);
 		map.from(provider::getJwkSetUri).to(builder::jwkSetUri);
 		map.from(provider::getUserNameAttribute).to(builder::userNameAttributeName);
+
+		Map<String, Object> configurationMetadata = new LinkedHashMap<>();
+		map.from(provider::getEndSessionUri).to(value -> configurationMetadata.put("end_session_endpoint", value));
+		builder.providerConfigurationMetadata(configurationMetadata);
 		return builder;
 	}
 

--- a/module/spring-boot-security-oauth2-client/src/test/java/org/springframework/boot/security/oauth2/client/autoconfigure/OAuth2ClientPropertiesMapperTests.java
+++ b/module/spring-boot-security-oauth2-client/src/test/java/org/springframework/boot/security/oauth2/client/autoconfigure/OAuth2ClientPropertiesMapperTests.java
@@ -93,6 +93,7 @@ class OAuth2ClientPropertiesMapperTests {
 		assertThat(adapted.getRedirectUri()).isEqualTo("https://example.com/redirect");
 		assertThat(adapted.getScopes()).containsExactly("user");
 		assertThat(adapted.getClientName()).isEqualTo("clientName");
+		assertThat(adaptedProvider.getConfigurationMetadata()).containsOnly(Map.entry("end_session_endpoint", "https://example.com/end-session"));
 	}
 
 	@Test
@@ -276,6 +277,7 @@ class OAuth2ClientPropertiesMapperTests {
 	private Provider createProvider() {
 		Provider provider = new Provider();
 		provider.setAuthorizationUri("https://example.com/auth");
+		provider.setEndSessionUri("https://example.com/end-session");
 		provider.setTokenUri("https://example.com/token");
 		provider.setUserInfoUri("https://example.com/info");
 		provider.setUserNameAttribute("sub");


### PR DESCRIPTION
Added property to enable static configuration of the [End Session Endpoint](https://openid.net/specs/openid-connect-session-1_0-17.html#rfc.section.2.1) Also added mapping to Spring Security model.

See #21375
