### PR TITLE
Propagate error on restart abort instead of silently returning

### DIFF
--- a/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/Restarter.java
+++ b/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/Restarter.java
@@ -266,7 +266,13 @@ public class Restarter {
 				return;
 			}
 			if (failureHandler.handle(error) == Outcome.ABORT) {
-				return;
+				if (error instanceof Exception ex) {
+					throw ex;
+				}
+				if (error instanceof Error err) {
+					throw err;
+				}
+				throw new Exception(error);
 			}
 		}
 		while (true);

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/RestarterTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/RestarterTests.java
@@ -192,6 +192,21 @@ class RestarterTests {
 	}
 
 	@Test
+	void startThrowsExceptionWhenFailureHandlerAbortsWithException() {
+		Restarter.clearInstance();
+		TestableRestarter restarter = new TestableRestarter() {
+			@Override
+			protected @Nullable Throwable relaunch(ClassLoader classLoader) {
+				return new RuntimeException("app failed to start");
+			}
+		};
+		Restarter.setInstance(restarter);
+		assertThatIllegalStateException().isThrownBy(() -> restarter.restart(FailureHandler.NONE))
+			.withCauseInstanceOf(RuntimeException.class)
+			.withMessageContaining("app failed to start");
+	}
+
+	@Test
 	void getInitialUrls() throws Exception {
 		Restarter.clearInstance();
 		RestartInitializer initializer = mock(RestartInitializer.class);


### PR DESCRIPTION
## Summary

- When `FailureHandler` returns `ABORT`, `Restarter.start()` was silently returning instead of propagating the error, causing misconfigured CLI apps with DevTools to exit with code 0.
- Now the error is re-thrown: `Exception` and `Error` are thrown directly, other `Throwable` types are wrapped.
- Added test to verify the exception propagates correctly on abort.

Fixes #28541

## Test plan

- [x] New test `startThrowsExceptionWhenFailureHandlerAbortsWithException` verifies exception propagation
- [ ] Verify a misconfigured CLI app with DevTools now exits with non-zero code