### PR TITLE
Remove redundant null check in HikariJdbcConnectionDetailsBeanPostProcessor

### DIFF
--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/HikariJdbcConnectionDetailsBeanPostProcessor.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/HikariJdbcConnectionDetailsBeanPostProcessor.java
@@ -39,10 +39,7 @@ class HikariJdbcConnectionDetailsBeanPostProcessor extends JdbcConnectionDetails
 		dataSource.setJdbcUrl(connectionDetails.getJdbcUrl());
 		dataSource.setUsername(connectionDetails.getUsername());
 		dataSource.setPassword(connectionDetails.getPassword());
-		String driverClassName = connectionDetails.getDriverClassName();
-		if (driverClassName != null) {
-			dataSource.setDriverClassName(driverClassName);
-		}
+		dataSource.setDriverClassName(connectionDetails.getDriverClassName());
 		return dataSource;
 	}
 

--- a/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/autoconfigure/HikariJdbcConnectionDetailsBeanPostProcessorTests.java
+++ b/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/autoconfigure/HikariJdbcConnectionDetailsBeanPostProcessorTests.java
@@ -50,15 +50,4 @@ class HikariJdbcConnectionDetailsBeanPostProcessorTests {
 		assertThat(dataSource.getDriverClassName()).isEqualTo(DatabaseDriver.POSTGRESQL.getDriverClassName());
 	}
 
-	@Test
-	@SuppressWarnings("unchecked")
-	void toleratesConnectionDetailsWithNullDriverClassName() {
-		HikariDataSource dataSource = new HikariDataSource();
-		dataSource.setDriverClassName(DatabaseDriver.H2.getDriverClassName());
-		JdbcConnectionDetails connectionDetails = mock(JdbcConnectionDetails.class);
-		new HikariJdbcConnectionDetailsBeanPostProcessor(mock(ObjectProvider.class)).processDataSource(dataSource,
-				connectionDetails);
-		assertThat(dataSource.getDriverClassName()).isEqualTo(DatabaseDriver.H2.getDriverClassName());
-	}
-
 }


### PR DESCRIPTION
This PR removes an unnecessary null check for `driverClassName` in the `HikariJdbcConnectionDetailsBeanPostProcessor`, as `JdbcConnectionDetails#getDriverClassName` is guaranteed to return a non-null value.