### PR TITLE
Document Java 25 requirement for AOT cache

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/class-data-sharing.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/class-data-sharing.adoc
@@ -4,7 +4,8 @@
 Class Data Sharing (CDS) is a https://docs.oracle.com/en/java/javase/17/vm/class-data-sharing.html[JVM feature] that can help reduce the startup time and memory footprint of Java applications.
 
 In Java 24, CDS is succeeded by the AOT Cache via https://openjdk.org/jeps/483[JEP 483].
-Spring Boot supports both CDS and AOT cache, and it is recommended that you use the latter if it is available in the JVM version you are using (Java 24+).
+Spring Boot supports both CDS and AOT cache.
+As Java 24 is no longer supported, Java 25 is the minimum supported version where AOT cache can be used.
 
 [[packaging.class-data-sharing.cds]]
 == CDS

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/class-data-sharing.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/class-data-sharing.adoc
@@ -3,9 +3,11 @@
 
 Class Data Sharing (CDS) is a https://docs.oracle.com/en/java/javase/17/vm/class-data-sharing.html[JVM feature] that can help reduce the startup time and memory footprint of Java applications.
 
-In Java 24, CDS is succeeded by the AOT Cache via https://openjdk.org/jeps/483[JEP 483].
-Spring Boot supports both CDS and AOT cache.
-As Java 24 is no longer supported, Java 25 is the minimum supported version where AOT cache can be used.
+If you are using Java 25 or above, CDS has been succeeded by the AOT Cache via https://openjdk.org/jeps/483[JEP 483].
+
+NOTE: Spring Boot supports both CDS and AOT cache, however, we recommend using the AOT cache whenever possible.
+
+
 
 [[packaging.class-data-sharing.cds]]
 == CDS
@@ -29,6 +31,8 @@ $ java -XX:SharedArchiveFile=application.jsa -jar my-app.jar
 ----
 
 NOTE: For more details about CDS, refer to the xref:how-to:class-data-sharing.adoc[CDS how-to guide] and the {url-spring-framework-docs}/integration/cds.html[Spring Framework reference documentation].
+
+
 
 [[packaging.class-data-sharing.aot-cache]]
 == AOT Cache

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/container-images/dockerfiles.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/container-images/dockerfiles.adoc
@@ -83,8 +83,7 @@ If you want to additionally enable the xref:reference:packaging/class-data-shari
 ----
 include::reference:partial$dockerfile[]
 # Execute the AOT cache training run
-RUN java -XX:AOTMode=record -XX:AOTConfiguration=app.aotconf -Dspring.context.exit=onRefresh -jar application.jar
-RUN java -XX:AOTMode=create -XX:AOTConfiguration=app.aotconf -XX:AOTCache=app.aot -jar application.jar && rm app.aotconf
+RUN java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh -jar application.jar
 # Start the application jar with AOT cache enabled - this is not the uber jar used by the builder
 # This jar only contains application code and references to the extracted jar files
 # This layout is efficient to start up and AOT cache friendly

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/container-images/dockerfiles.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/container-images/dockerfiles.adoc
@@ -57,6 +57,27 @@ Additionally, the layout created by the `jarmode` is CDS and AOT cache friendly 
 
 
 
+[[packaging.container-images.dockerfiles.aot-cache]]
+== AOT cache
+
+If you are using Java 25 or above, and want to additionally enable the xref:reference:packaging/class-data-sharing.adoc#packaging.class-data-sharing.aot-cache[AOT cache], you can use this `Dockerfile`:
+[source,dockerfile]
+----
+include::reference:partial$dockerfile[]
+
+# Execute the AOT cache training run
+RUN java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh -jar application.jar
+
+# Start the application jar with AOT cache enabled - this is not the uber jar used by the builder
+# This jar only contains application code and references to the extracted jar files
+# This layout is efficient to start up and AOT cache friendly
+ENTRYPOINT ["java", "-XX:AOTCache=app.aot", "-jar", "application.jar"]
+----
+
+This is mostly the same as the above `Dockerfile`.
+As the last steps, it creates the AOT cache file by doing a training run and passes the AOT cache parameter to `java -jar`.
+
+
 [[packaging.container-images.dockerfiles.cds]]
 == CDS
 
@@ -64,8 +85,10 @@ If you want to additionally enable xref:reference:packaging/class-data-sharing.a
 [source,dockerfile]
 ----
 include::reference:partial$dockerfile[]
+
 # Execute the CDS training run
 RUN java -XX:ArchiveClassesAtExit=application.jsa -Dspring.context.exit=onRefresh -jar application.jar
+
 # Start the application jar with CDS enabled - this is not the uber jar used by the builder
 # This jar only contains application code and references to the extracted jar files
 # This layout is efficient to start up and CDS friendly
@@ -75,20 +98,4 @@ ENTRYPOINT ["java", "-XX:SharedArchiveFile=application.jsa", "-jar", "applicatio
 This is mostly the same as the above `Dockerfile`.
 As the last steps, it creates the CDS archive by doing a training run and passes the CDS parameter to `java -jar`.
 
-[[packaging.container-images.dockerfiles.aot-cache]]
-== AOT cache
-
-If you want to additionally enable the xref:reference:packaging/class-data-sharing.adoc#packaging.class-data-sharing.aot-cache[AOT cache], you can use this `Dockerfile`:
-[source,dockerfile]
-----
-include::reference:partial$dockerfile[]
-# Execute the AOT cache training run
-RUN java -XX:AOTCacheOutput=app.aot -Dspring.context.exit=onRefresh -jar application.jar
-# Start the application jar with AOT cache enabled - this is not the uber jar used by the builder
-# This jar only contains application code and references to the extracted jar files
-# This layout is efficient to start up and AOT cache friendly
-ENTRYPOINT ["java", "-XX:AOTCache=app.aot", "-jar", "application.jar"]
-----
-
-This is mostly the same as the above `Dockerfile`.
-As the last steps, it creates the AOT cache file by doing a training run and passes the AOT cache parameter to `java -jar`.
+NOTE: If you are using Java 25 or above, we recommend using an AOT cache instead of CDS.

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/partials/dockerfile
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/reference/partials/dockerfile
@@ -1,17 +1,21 @@
 # Perform the extraction in a separate builder container
 FROM bellsoft/liberica-openjre-debian:24-cds AS builder
 WORKDIR /builder
+
 # This points to the built jar file in the target folder
 # Adjust this to 'build/libs/*.jar' if you're using Gradle
 ARG JAR_FILE=target/*.jar
+
 # Copy the jar file to the working directory and rename it to application.jar
 COPY ${JAR_FILE} application.jar
+
 # Extract the jar file using an efficient layout
 RUN java -Djarmode=tools -jar application.jar extract --layers --destination extracted
 
 # This is the runtime container
 FROM bellsoft/liberica-openjre-debian:24-cds
 WORKDIR /application
+
 # Copy the extracted jar contents from the builder container into the working directory in the runtime container
 # Every copy step creates a new docker layer
 # This allows docker to only pull the changes it really needs


### PR DESCRIPTION
Closes gh-50471

This update documents Java 25 as the minimum supported version for using AOT cache and updates the Dockerfile example to use the promoted AOT cache output flag.

Verification:
- `./gradlew --no-daemon --no-scan :spring-boot-project:spring-boot-docs:check`
