### PR TITLE
Document that @Conditional on @AutoConfiguration is not inherited by nested @Configuration classes

### DIFF
--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfiguration.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfiguration.java
@@ -42,6 +42,15 @@ import org.springframework.core.annotation.AliasFor;
  * {@link Conditional @Conditional} (most often using
  * {@link ConditionalOnClass @ConditionalOnClass} and
  * {@link ConditionalOnMissingBean @ConditionalOnMissingBean} annotations).
+ * <p>
+ * {@link Conditional @Conditional} annotations declared on this auto-configuration class
+ * are not automatically inherited by nested {@link Configuration @Configuration} classes.
+ * The outer's conditions transitively gate nested classes only via the configuration
+ * parser's recursion, which is bypassed when a nested class is discovered independently
+ * through component scanning or registered directly with the application context. When
+ * the same gating is intended for every nested {@link Configuration @Configuration},
+ * redeclare the relevant conditions on each, or extract them into a composed
+ * meta-annotation applied to both the outer and the inner classes.
  *
  * @author Moritz Halbritter
  * @see EnableAutoConfiguration

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/developing-auto-configuration.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/developing-auto-configuration.adoc
@@ -91,6 +91,13 @@ These annotations include:
 * xref:features/developing-auto-configuration.adoc#features.developing-auto-configuration.condition-annotations.web-application-conditions[]
 * xref:features/developing-auto-configuration.adoc#features.developing-auto-configuration.condition-annotations.spel-conditions[]
 
+[NOTE]
+====
+A javadoc:org.springframework.context.annotation.Conditional[format=annotation] declared on an javadoc:org.springframework.boot.autoconfigure.AutoConfiguration[format=annotation] class is not automatically inherited by nested javadoc:org.springframework.context.annotation.Configuration[format=annotation] classes.
+The outer's conditions transitively gate nested classes only via the configuration parser's recursion, which is bypassed when a nested class is discovered independently through javadoc:org.springframework.context.annotation.ComponentScan[format=annotation] or registered directly with the application context.
+When the same gating is intended for every nested javadoc:org.springframework.context.annotation.Configuration[format=annotation], redeclare the relevant conditions on each, or extract them into a composed meta-annotation applied to both.
+====
+
 
 
 [[features.developing-auto-configuration.condition-annotations.class-conditions]]


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Document that `@Conditional` declared on an `@AutoConfiguration` class is not automatically inherited by nested `@Configuration` classes, and that the redeclare-on-the-inner pattern (used throughout Spring Boot's own auto-configurations) is the idiomatic workaround.

## Background

When the outer auto-configuration is reached through `ImportCandidates` (the normal path), Spring Framework's `ConfigurationClassParser` evaluates the outer's `@Conditional` at `PARSE_CONFIGURATION` and, on a skip, never descends into nested static `@Configuration` classes. As a result, the outer's conditions transitively gate the inner ones along that path.

That transitive gating does not apply when a nested `@Configuration` is reached independently, most commonly through `@ComponentScan`, but also through direct registration with the application context. In those cases the nested class is parsed using only its own conditions, and the outer's `@Conditional` has no effect.

This is the assumed model throughout Spring Boot's own auto-configurations, which all redeclare conditions on each nested `@Configuration` (see `QuartzAutoConfiguration`, `DevToolsDataSourceAutoConfiguration`, and many others). The expectation is not, however, documented anywhere. Developers writing their own auto-configurations encounter the gap, write code matching the inheritance mental model, and ship configurations that silently misbehave when the application's component scan happens to reach the auto-configuration package.

A previous behavior-change proposal in #37111 was closed as `status: invalid`. This PR makes no behavior change, and it documents the current behavior so that the rule is discoverable rather than tribal knowledge.

## Changes

Two documentation additions, no source changes:

- `AutoConfiguration` Javadoc: new paragraph after the existing "Generally, auto-configuration classes…" paragraph stating that the outer's `@Conditional` is not inherited by nested `@Configuration` classes, explaining when transitive gating does and does not apply, and recommending either redeclaration or a composed meta-annotation.
- Reference docs (`developing-auto-configuration.adoc`, "Condition Annotations" section): `[NOTE]` admonition with the same guidance, placed right after the list of condition-subsection cross-references.

## Validation

- `./gradlew :core:spring-boot-autoconfigure:javadoc :core:spring-boot-autoconfigure:checkstyleMain` - green.
- `./gradlew :documentation:spring-boot-docs:antora` - green.