### PR TITLE
Prevent WebSocket messaging from re-registering applicationTaskExecutor

### DIFF
--- a/module/spring-boot-websocket/src/main/java/org/springframework/boot/websocket/autoconfigure/servlet/WebSocketMessagingAutoConfiguration.java
+++ b/module/spring-boot-websocket/src/main/java/org/springframework/boot/websocket/autoconfigure/servlet/WebSocketMessagingAutoConfiguration.java
@@ -18,6 +18,9 @@ package org.springframework.boot.websocket.autoconfigure.servlet;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jspecify.annotations.Nullable;
@@ -174,20 +177,61 @@ public final class WebSocketMessagingAutoConfiguration {
 		@Override
 		public void configureClientInboundChannel(ChannelRegistration registration) {
 			if (this.executor != null) {
-				registration.executor(this.executor);
+				registration.executor(new DelegatingAsyncTaskExecutor(this.executor));
 			}
 		}
 
 		@Override
 		public void configureClientOutboundChannel(ChannelRegistration registration) {
 			if (this.executor != null) {
-				registration.executor(this.executor);
+				registration.executor(new DelegatingAsyncTaskExecutor(this.executor));
 			}
 		}
 
 		@Override
 		public int getOrder() {
 			return 0;
+		}
+
+	}
+
+	static class DelegatingAsyncTaskExecutor implements AsyncTaskExecutor {
+
+		private final AsyncTaskExecutor delegate;
+
+		DelegatingAsyncTaskExecutor(AsyncTaskExecutor delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public void execute(Runnable task) {
+			this.delegate.execute(task);
+		}
+
+		@Override
+		@SuppressWarnings("deprecation")
+		public void execute(Runnable task, long startTimeout) {
+			this.delegate.execute(task, startTimeout);
+		}
+
+		@Override
+		public Future<?> submit(Runnable task) {
+			return this.delegate.submit(task);
+		}
+
+		@Override
+		public <T> Future<T> submit(Callable<T> task) {
+			return this.delegate.submit(task);
+		}
+
+		@Override
+		public CompletableFuture<Void> submitCompletable(Runnable task) {
+			return this.delegate.submitCompletable(task);
+		}
+
+		@Override
+		public <T> CompletableFuture<T> submitCompletable(Callable<T> task) {
+			return this.delegate.submitCompletable(task);
 		}
 
 	}

--- a/module/spring-boot-websocket/src/test/java/org/springframework/boot/websocket/autoconfigure/servlet/WebSocketMessagingAutoConfigurationTests.java
+++ b/module/spring-boot-websocket/src/test/java/org/springframework/boot/websocket/autoconfigure/servlet/WebSocketMessagingAutoConfigurationTests.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,6 +38,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 
 import org.springframework.boot.LazyInitializationBeanFactoryPostProcessor;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
@@ -151,44 +154,63 @@ class WebSocketMessagingAutoConfigurationTests {
 
 	@Test
 	void asyncTaskExecutorBeanIsSelectedForInboundChannel() {
-		AsyncTaskExecutor expectedExecutor = new SimpleAsyncTaskExecutor();
+		RecordingAsyncTaskExecutor expectedExecutor = new RecordingAsyncTaskExecutor();
 		this.context.register(WebSocketMessagingConfiguration.class);
 		this.context.registerBean(AsyncTaskExecutor.class, () -> expectedExecutor);
 		this.context.refresh();
-		assertThat(this.context.getBean("clientInboundChannelExecutor", Executor.class)).isSameAs(expectedExecutor);
+		assertThat(this.context.getBean("clientInboundChannelExecutor", Executor.class))
+			.satisfies((executor) -> assertThatExecutorDelegatesTo(executor, expectedExecutor));
 	}
 
 	@Test
 	void asyncTaskExecutorBeanIsSelectedForOutboundChannel() {
-		AsyncTaskExecutor expectedExecutor = new SimpleAsyncTaskExecutor();
+		RecordingAsyncTaskExecutor expectedExecutor = new RecordingAsyncTaskExecutor();
 		this.context.register(WebSocketMessagingConfiguration.class);
 		this.context.registerBean(AsyncTaskExecutor.class, () -> expectedExecutor);
 		this.context.refresh();
-		assertThat(this.context.getBean("clientOutboundChannelExecutor", Executor.class)).isSameAs(expectedExecutor);
+		assertThat(this.context.getBean("clientOutboundChannelExecutor", Executor.class))
+			.satisfies((executor) -> assertThatExecutorDelegatesTo(executor, expectedExecutor));
 	}
 
 	@Test
 	void withMultipleAsyncTaskExecutorBeansApplicationTaskExecutorIsSelectedForInboundChannel() {
-		AsyncTaskExecutor applicationTaskExecutor = new SimpleAsyncTaskExecutor();
-		AsyncTaskExecutor additionalTaskExecutor = new SimpleAsyncTaskExecutor();
+		RecordingAsyncTaskExecutor applicationTaskExecutor = new RecordingAsyncTaskExecutor();
+		RecordingAsyncTaskExecutor additionalTaskExecutor = new RecordingAsyncTaskExecutor();
 		this.context.registerBean("applicationTaskExecutor", AsyncTaskExecutor.class, () -> applicationTaskExecutor);
 		this.context.registerBean(AsyncTaskExecutor.class, () -> additionalTaskExecutor);
 		this.context.register(WebSocketMessagingConfiguration.class);
 		this.context.refresh();
 		assertThat(this.context.getBean("clientInboundChannelExecutor", Executor.class))
-			.isSameAs(applicationTaskExecutor);
+			.satisfies((executor) -> assertThatExecutorDelegatesTo(executor, applicationTaskExecutor));
+		assertThat(additionalTaskExecutor.executionCount.get()).isZero();
 	}
 
 	@Test
 	void withMultipleAsyncTaskExecutorBeansApplicationTaskExecutorIsSelectedForOutboundChannel() {
-		AsyncTaskExecutor applicationTaskExecutor = new SimpleAsyncTaskExecutor();
-		AsyncTaskExecutor additionalTaskExecutor = new SimpleAsyncTaskExecutor();
+		RecordingAsyncTaskExecutor applicationTaskExecutor = new RecordingAsyncTaskExecutor();
+		RecordingAsyncTaskExecutor additionalTaskExecutor = new RecordingAsyncTaskExecutor();
 		this.context.registerBean("applicationTaskExecutor", AsyncTaskExecutor.class, () -> applicationTaskExecutor);
 		this.context.registerBean(AsyncTaskExecutor.class, () -> additionalTaskExecutor);
 		this.context.register(WebSocketMessagingConfiguration.class);
 		this.context.refresh();
 		assertThat(this.context.getBean("clientOutboundChannelExecutor", Executor.class))
-			.isSameAs(applicationTaskExecutor);
+			.satisfies((executor) -> assertThatExecutorDelegatesTo(executor, applicationTaskExecutor));
+		assertThat(additionalTaskExecutor.executionCount.get()).isZero();
+	}
+
+	@Test
+	void applicationTaskExecutorIsNotRegisteredAsClientChannelExecutors() {
+		AsyncTaskExecutor applicationTaskExecutor = new SimpleAsyncTaskExecutor();
+		this.context.registerBean(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME,
+				AsyncTaskExecutor.class, () -> applicationTaskExecutor);
+		this.context.register(WebSocketMessagingConfiguration.class);
+		this.context.refresh();
+		AsyncTaskExecutor actualApplicationTaskExecutor = this.context
+			.getBean(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME, AsyncTaskExecutor.class);
+		assertThat(this.context.getBean("clientInboundChannelExecutor", Executor.class))
+			.isNotSameAs(actualApplicationTaskExecutor);
+		assertThat(this.context.getBean("clientOutboundChannelExecutor", Executor.class))
+			.isNotSameAs(actualApplicationTaskExecutor);
 	}
 
 	@Test
@@ -268,6 +290,14 @@ class WebSocketMessagingAutoConfigurationTests {
 	private List<MessageConverter> getConverters(DelegatingWebSocketMessageBrokerConfiguration configuration) {
 		CompositeMessageConverter compositeDefaultConverter = configuration.brokerMessageConverter();
 		return compositeDefaultConverter.getConverters();
+	}
+
+	private void assertThatExecutorDelegatesTo(Executor executor, RecordingAsyncTaskExecutor expectedExecutor) {
+		AtomicBoolean taskExecuted = new AtomicBoolean();
+		assertThat(executor).isNotSameAs(expectedExecutor);
+		executor.execute(() -> taskExecuted.set(true));
+		assertThat(taskExecuted).isTrue();
+		assertThat(expectedExecutor.executionCount.get()).isOne();
 	}
 
 	private @Nullable Object performStompSubscription(String topic) throws Throwable {
@@ -378,6 +408,18 @@ class WebSocketMessagingAutoConfigurationTests {
 	@Component
 	@Order(Ordered.LOWEST_PRECEDENCE)
 	static class CustomLowWebSocketMessageBrokerConfigurer implements WebSocketMessageBrokerConfigurer {
+
+	}
+
+	static class RecordingAsyncTaskExecutor implements AsyncTaskExecutor {
+
+		private final AtomicInteger executionCount = new AtomicInteger();
+
+		@Override
+		public void execute(Runnable task) {
+			this.executionCount.incrementAndGet();
+			task.run();
+		}
 
 	}
 


### PR DESCRIPTION
See spring-projects/spring-framework#36845.

This is a proposed fix for the executor instance reuse described in the issue.

`WebSocketMessagingAutoConfiguration` currently passes the selected `AsyncTaskExecutor` directly to the WebSocket client inbound and outbound channel registrations. Spring Framework later exposes those channel executors as `clientInboundChannelExecutor` and `clientOutboundChannelExecutor` beans. When the selected executor is the already-managed `applicationTaskExecutor`, the same executor instance is exposed again under additional bean names.

This change wraps the selected `AsyncTaskExecutor` in a lightweight delegating executor before registering it with the WebSocket channels. This keeps WebSocket execution delegated to the selected application executor while avoiding re-registering the same managed executor instance as the channel executor beans.

Tests were updated to assert delegation rather than object identity, and a regression test was added to verify that `applicationTaskExecutor` is not reused as `clientInboundChannelExecutor` or `clientOutboundChannelExecutor`.

Validation:

- `JAVA_HOME=$(/usr/libexec/java_home -v 25) ./gradlew :module:spring-boot-websocket:test --tests '*WebSocketMessagingAutoConfigurationTests'`
- `JAVA_HOME=$(/usr/libexec/java_home -v 25) ./gradlew :module:spring-boot-websocket:checkFormatMain :module:spring-boot-websocket:checkFormatTest`
