### PR TITLE
Add self-reference to ApplicationContextAssertProvider

### DIFF
--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssert.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssert.java
@@ -42,7 +42,7 @@ import org.springframework.util.Assert;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * AssertJ {@link org.assertj.core.api.Assert assertions} that can be applied to an
+ * AssertJ {@linkplain org.assertj.core.api.Assert assertions} that can be applied to an
  * {@link ApplicationContext}.
  *
  * @param <C> the application context type

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssertProvider.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssertProvider.java
@@ -44,16 +44,18 @@ import org.springframework.util.ObjectUtils;
  * Any {@link ApplicationContext} method called on a context that has failed to start will
  * throw an {@link IllegalStateException}.
  *
- * @param <C> the application context type
+ * @param <SELF> the self class reference
+ * @param <C> the source application context type
  * @author Phillip Webb
+ * @author Stefano Cordio
  * @since 2.0.0
  * @see AssertableApplicationContext
  * @see AssertableWebApplicationContext
  * @see AssertableReactiveWebApplicationContext
  * @see ApplicationContextAssert
  */
-public interface ApplicationContextAssertProvider<C extends ApplicationContext>
-		extends ApplicationContext, AssertProvider<ApplicationContextAssert<C>>, Closeable {
+public interface ApplicationContextAssertProvider<SELF extends ApplicationContextAssertProvider<SELF, C>, C extends ApplicationContext>
+		extends ApplicationContext, AssertProvider<ApplicationContextAssert<SELF>>, Closeable {
 
 	/**
 	 * Return an assert for AssertJ.
@@ -63,7 +65,7 @@ public interface ApplicationContextAssertProvider<C extends ApplicationContext>
 	 */
 	@Deprecated(since = "2.0.0", forRemoval = false)
 	@Override
-	ApplicationContextAssert<C> assertThat();
+	ApplicationContextAssert<SELF> assertThat();
 
 	/**
 	 * Return the original source {@link ApplicationContext}.
@@ -104,7 +106,7 @@ public interface ApplicationContextAssertProvider<C extends ApplicationContext>
 	 * {@link ApplicationContext} or throw an exception if the context fails to start.
 	 * @return a {@link ApplicationContextAssertProvider} instance
 	 */
-	static <T extends ApplicationContextAssertProvider<C>, C extends ApplicationContext> T get(Class<T> type,
+	static <T extends ApplicationContextAssertProvider<? super T, C>, C extends ApplicationContext> T get(Class<T> type,
 			Class<? extends C> contextType, Supplier<? extends C> contextSupplier) {
 		return get(type, contextType, contextSupplier, new Class<?>[0]);
 	}
@@ -125,7 +127,7 @@ public interface ApplicationContextAssertProvider<C extends ApplicationContext>
 	 * @since 3.4.0
 	 */
 	@SuppressWarnings("unchecked")
-	static <T extends ApplicationContextAssertProvider<C>, C extends ApplicationContext> T get(Class<T> type,
+	static <T extends ApplicationContextAssertProvider<? super T, C>, C extends ApplicationContext> T get(Class<T> type,
 			Class<? extends C> contextType, Supplier<? extends C> contextSupplier,
 			Class<?>... additionalContextInterfaces) {
 		Assert.notNull(type, "'type' must not be null");

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/AssertableApplicationContext.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/AssertableApplicationContext.java
@@ -35,7 +35,8 @@ import org.springframework.context.ConfigurableApplicationContext;
  * @see ApplicationContext
  */
 public interface AssertableApplicationContext
-		extends ApplicationContextAssertProvider<ConfigurableApplicationContext>, ConfigurableApplicationContext {
+		extends ApplicationContextAssertProvider<AssertableApplicationContext, ConfigurableApplicationContext>,
+		ConfigurableApplicationContext {
 
 	/**
 	 * Factory method to create a new {@link AssertableApplicationContext} instance.

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/AssertableReactiveWebApplicationContext.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/AssertableReactiveWebApplicationContext.java
@@ -33,8 +33,8 @@ import org.springframework.boot.web.context.reactive.ReactiveWebApplicationConte
  * @see ReactiveWebApplicationContext
  * @see ReactiveWebApplicationContext
  */
-public interface AssertableReactiveWebApplicationContext
-		extends ApplicationContextAssertProvider<ConfigurableReactiveWebApplicationContext>,
+public interface AssertableReactiveWebApplicationContext extends
+		ApplicationContextAssertProvider<AssertableReactiveWebApplicationContext, ConfigurableReactiveWebApplicationContext>,
 		ConfigurableReactiveWebApplicationContext {
 
 	/**

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/AssertableWebApplicationContext.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/AssertableWebApplicationContext.java
@@ -35,7 +35,8 @@ import org.springframework.web.context.WebApplicationContext;
  * @see WebApplicationContext
  */
 public interface AssertableWebApplicationContext
-		extends ApplicationContextAssertProvider<ConfigurableWebApplicationContext>, ConfigurableWebApplicationContext {
+		extends ApplicationContextAssertProvider<AssertableWebApplicationContext, ConfigurableWebApplicationContext>,
+		ConfigurableWebApplicationContext {
 
 	/**
 	 * Factory method to create a new {@link AssertableWebApplicationContext} instance.

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/runner/AbstractApplicationContextRunner.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/runner/AbstractApplicationContextRunner.java
@@ -110,7 +110,7 @@ import org.springframework.util.CollectionUtils;
  * @see ReactiveWebApplicationContextRunner
  * @see ApplicationContextAssert
  */
-public abstract class AbstractApplicationContextRunner<SELF extends AbstractApplicationContextRunner<SELF, C, A>, C extends ConfigurableApplicationContext, A extends ApplicationContextAssertProvider<C>> {
+public abstract class AbstractApplicationContextRunner<SELF extends AbstractApplicationContextRunner<SELF, C, A>, C extends ConfigurableApplicationContext, A extends ApplicationContextAssertProvider<A, C>> {
 
 	private final RunnerConfiguration<C> runnerConfiguration;
 

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/assertj/ApplicationContextAssertProviderTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/assertj/ApplicationContextAssertProviderTests.java
@@ -20,7 +20,6 @@ import java.util.function.Supplier;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -40,7 +39,6 @@ import static org.mockito.Mockito.mock;
  */
 class ApplicationContextAssertProviderTests {
 
-	@Mock
 	private final ConfigurableApplicationContext mockContext = mock();
 
 	private RuntimeException startupFailure;
@@ -102,7 +100,8 @@ class ApplicationContextAssertProviderTests {
 
 	@Test
 	void getWhenContextStartsShouldReturnProxyThatCallsRealMethods() {
-		ApplicationContextAssertProvider<ApplicationContext> context = get(this.mockContextSupplier);
+		ApplicationContextAssertProvider<TestAssertProviderApplicationContext, ApplicationContext> context = get(
+				this.mockContextSupplier);
 		assertThat((Object) context).isNotNull();
 		context.getBean("foo");
 		then(this.mockContext).should().getBean("foo");
@@ -110,7 +109,8 @@ class ApplicationContextAssertProviderTests {
 
 	@Test
 	void getWhenContextFailsShouldReturnProxyThatThrowsExceptions() {
-		ApplicationContextAssertProvider<ApplicationContext> context = get(this.startupFailureSupplier);
+		ApplicationContextAssertProvider<TestAssertProviderApplicationContext, ApplicationContext> context = get(
+				this.startupFailureSupplier);
 		assertThat((Object) context).isNotNull();
 		assertThatIllegalStateException().isThrownBy(() -> context.getBean("foo"))
 			.withCause(this.startupFailure)
@@ -119,13 +119,15 @@ class ApplicationContextAssertProviderTests {
 
 	@Test
 	void getSourceContextWhenContextStartsShouldReturnSourceContext() {
-		ApplicationContextAssertProvider<ApplicationContext> context = get(this.mockContextSupplier);
+		ApplicationContextAssertProvider<TestAssertProviderApplicationContext, ApplicationContext> context = get(
+				this.mockContextSupplier);
 		assertThat(context.getSourceApplicationContext()).isSameAs(this.mockContext);
 	}
 
 	@Test
 	void getSourceContextWhenContextFailsShouldThrowException() {
-		ApplicationContextAssertProvider<ApplicationContext> context = get(this.startupFailureSupplier);
+		ApplicationContextAssertProvider<TestAssertProviderApplicationContext, ApplicationContext> context = get(
+				this.startupFailureSupplier);
 		assertThatIllegalStateException().isThrownBy(context::getSourceApplicationContext)
 			.withCause(this.startupFailure)
 			.withMessageContaining("failed to start");
@@ -133,13 +135,15 @@ class ApplicationContextAssertProviderTests {
 
 	@Test
 	void getSourceContextOfTypeWhenContextStartsShouldReturnSourceContext() {
-		ApplicationContextAssertProvider<ApplicationContext> context = get(this.mockContextSupplier);
+		ApplicationContextAssertProvider<TestAssertProviderApplicationContext, ApplicationContext> context = get(
+				this.mockContextSupplier);
 		assertThat(context.getSourceApplicationContext(ApplicationContext.class)).isSameAs(this.mockContext);
 	}
 
 	@Test
 	void getSourceContextOfTypeWhenContextFailsToStartShouldThrowException() {
-		ApplicationContextAssertProvider<ApplicationContext> context = get(this.startupFailureSupplier);
+		ApplicationContextAssertProvider<TestAssertProviderApplicationContext, ApplicationContext> context = get(
+				this.startupFailureSupplier);
 		assertThatIllegalStateException()
 			.isThrownBy(() -> context.getSourceApplicationContext(ApplicationContext.class))
 			.withCause(this.startupFailure)
@@ -148,59 +152,68 @@ class ApplicationContextAssertProviderTests {
 
 	@Test
 	void getStartupFailureWhenContextStartsShouldReturnNull() {
-		ApplicationContextAssertProvider<ApplicationContext> context = get(this.mockContextSupplier);
+		ApplicationContextAssertProvider<TestAssertProviderApplicationContext, ApplicationContext> context = get(
+				this.mockContextSupplier);
 		assertThat(context.getStartupFailure()).isNull();
 	}
 
 	@Test
 	void getStartupFailureWhenContextFailsToStartShouldReturnException() {
-		ApplicationContextAssertProvider<ApplicationContext> context = get(this.startupFailureSupplier);
+		ApplicationContextAssertProvider<TestAssertProviderApplicationContext, ApplicationContext> context = get(
+				this.startupFailureSupplier);
 		assertThat(context.getStartupFailure()).isEqualTo(this.startupFailure);
 	}
 
 	@Test
 	void assertThatWhenContextStartsShouldReturnAssertions() {
-		ApplicationContextAssertProvider<ApplicationContext> context = get(this.mockContextSupplier);
-		ApplicationContextAssert<ApplicationContext> contextAssert = assertThat(context);
+		ApplicationContextAssertProvider<TestAssertProviderApplicationContext, ApplicationContext> context = get(
+				this.mockContextSupplier);
+		ApplicationContextAssert<TestAssertProviderApplicationContext> contextAssert = assertThat(context);
 		assertThat(contextAssert.getApplicationContext()).isSameAs(context);
 		assertThat(contextAssert.getStartupFailure()).isNull();
 	}
 
 	@Test
 	void assertThatWhenContextFailsShouldReturnAssertions() {
-		ApplicationContextAssertProvider<ApplicationContext> context = get(this.startupFailureSupplier);
-		ApplicationContextAssert<ApplicationContext> contextAssert = assertThat(context);
+		ApplicationContextAssertProvider<TestAssertProviderApplicationContext, ApplicationContext> context = get(
+				this.startupFailureSupplier);
+		ApplicationContextAssert<TestAssertProviderApplicationContext> contextAssert = assertThat(context);
 		assertThat(contextAssert.getApplicationContext()).isSameAs(context);
 		assertThat(contextAssert.getStartupFailure()).isSameAs(this.startupFailure);
 	}
 
 	@Test
 	void toStringWhenContextStartsShouldReturnSimpleString() {
-		ApplicationContextAssertProvider<ApplicationContext> context = get(this.mockContextSupplier);
+		ApplicationContextAssertProvider<TestAssertProviderApplicationContext, ApplicationContext> context = get(
+				this.mockContextSupplier);
 		assertThat(context.toString()).startsWith("Started application [ConfigurableApplicationContext.MockitoMock")
 			.endsWith("id = [null], applicationName = [null], beanDefinitionCount = 0]");
 	}
 
 	@Test
 	void toStringWhenContextFailsToStartShouldReturnSimpleString() {
-		ApplicationContextAssertProvider<ApplicationContext> context = get(this.startupFailureSupplier);
+		ApplicationContextAssertProvider<TestAssertProviderApplicationContext, ApplicationContext> context = get(
+				this.startupFailureSupplier);
 		assertThat(context).hasToString("Unstarted application context "
 				+ "org.springframework.context.ApplicationContext[startupFailure=java.lang.RuntimeException]");
 	}
 
 	@Test
 	void closeShouldCloseContext() {
-		ApplicationContextAssertProvider<ApplicationContext> context = get(this.mockContextSupplier);
+		ApplicationContextAssertProvider<TestAssertProviderApplicationContext, ApplicationContext> context = get(
+				this.mockContextSupplier);
 		context.close();
 		then(this.mockContext).should().close();
 	}
 
-	private ApplicationContextAssertProvider<ApplicationContext> get(Supplier<ApplicationContext> contextSupplier) {
+	private ApplicationContextAssertProvider<TestAssertProviderApplicationContext, ApplicationContext> get(
+			Supplier<ApplicationContext> contextSupplier) {
 		return ApplicationContextAssertProvider.get(TestAssertProviderApplicationContext.class,
 				ApplicationContext.class, contextSupplier);
 	}
 
-	interface TestAssertProviderApplicationContext extends ApplicationContextAssertProvider<ApplicationContext> {
+	interface TestAssertProviderApplicationContext
+			extends ApplicationContextAssertProvider<TestAssertProviderApplicationContext, ApplicationContext> {
 
 	}
 

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/runner/AbstractApplicationContextRunnerTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/runner/AbstractApplicationContextRunnerTests.java
@@ -62,8 +62,15 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * @param <A> the assertable context type
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Stefano Cordio
  */
-abstract class AbstractApplicationContextRunnerTests<T extends AbstractApplicationContextRunner<T, C, A>, C extends ConfigurableApplicationContext, A extends ApplicationContextAssertProvider<C>> {
+abstract class AbstractApplicationContextRunnerTests<T extends AbstractApplicationContextRunner<T, C, A>, C extends ConfigurableApplicationContext, A extends ApplicationContextAssertProvider<A, C>> {
+
+	@Test
+	void runContextShouldWorkWithSatisfiesAssertion() {
+		get().run((context) -> assertThat(context).satisfies((ctx) -> assertThat(ctx).hasNotFailed(),
+				(ctx) -> assertThat(ctx).doesNotHaveBean("foo")));
+	}
 
 	@Test
 	void runWithInitializerShouldInitialize() {
@@ -123,7 +130,7 @@ abstract class AbstractApplicationContextRunnerTests<T extends AbstractApplicati
 	}
 
 	@Test
-	void runWithMultiplePropertyValuesShouldAllAllValues() {
+	void runWithMultiplePropertyValuesShouldHaveAllValues() {
 		get().withPropertyValues("test.foo=1").withPropertyValues("test.bar=2").run((context) -> {
 			Environment environment = context.getEnvironment();
 			assertThat(environment.getProperty("test.foo")).isEqualTo("1");

--- a/module/spring-boot-actuator-autoconfigure/src/testFixtures/java/org/springframework/boot/actuate/autoconfigure/integrationtest/AbstractHealthEndpointAdditionalPathIntegrationTests.java
+++ b/module/spring-boot-actuator-autoconfigure/src/testFixtures/java/org/springframework/boot/actuate/autoconfigure/integrationtest/AbstractHealthEndpointAdditionalPathIntegrationTests.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
  * @param <A> the assertions
  * @author Madhura Bhave
  */
-public abstract class AbstractHealthEndpointAdditionalPathIntegrationTests<T extends AbstractApplicationContextRunner<T, C, A>, C extends ConfigurableApplicationContext, A extends ApplicationContextAssertProvider<C>> {
+public abstract class AbstractHealthEndpointAdditionalPathIntegrationTests<T extends AbstractApplicationContextRunner<T, C, A>, C extends ConfigurableApplicationContext, A extends ApplicationContextAssertProvider<A, C>> {
 
 	private final T runner;
 

--- a/module/spring-boot-grpc-server/src/test/java/org/springframework/boot/grpc/server/autoconfigure/GrpcServerAutoConfigurationTests.java
+++ b/module/spring-boot-grpc-server/src/test/java/org/springframework/boot/grpc/server/autoconfigure/GrpcServerAutoConfigurationTests.java
@@ -86,7 +86,7 @@ class GrpcServerAutoConfigurationTests {
 
 	private final ServerServiceDefinition serviceDefinition = ServerServiceDefinition.builder("my-service").build();
 
-	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withConfiguration(autoConfigurations)
 		.with(this::noOpLifecycleBeans)
 		.with(this::serviceBean);
@@ -350,7 +350,7 @@ class GrpcServerAutoConfigurationTests {
 					"nettyGrpcServerLifecycle"));
 	}
 
-	private ContextConsumer<? super ApplicationContextAssertProvider<?>> assertThatServerIsConfigured(
+	private ContextConsumer<? super ApplicationContextAssertProvider<?, ?>> assertThatServerIsConfigured(
 			Class<?> expectedServerFactoryType, String expectedAddress, String expectedLifecycleBeanName) {
 		return (context) -> {
 			assertThat(context).getBean(GrpcServerFactory.class)
@@ -365,12 +365,12 @@ class GrpcServerAutoConfigurationTests {
 		};
 	}
 
-	private <R extends AbstractApplicationContextRunner<R, C, A>, C extends ConfigurableApplicationContext, A extends ApplicationContextAssertProvider<C>> R serviceBean(
+	private <R extends AbstractApplicationContextRunner<R, C, A>, C extends ConfigurableApplicationContext, A extends ApplicationContextAssertProvider<A, C>> R serviceBean(
 			R contextRunner) {
 		return contextRunner.withBean(BindableService.class, () -> this.service);
 	}
 
-	private <R extends AbstractApplicationContextRunner<R, C, A>, C extends ConfigurableApplicationContext, A extends ApplicationContextAssertProvider<C>> R noOpLifecycleBeans(
+	private <R extends AbstractApplicationContextRunner<R, C, A>, C extends ConfigurableApplicationContext, A extends ApplicationContextAssertProvider<A, C>> R noOpLifecycleBeans(
 			R contextRunner) {
 		return contextRunner.withBean("shadedNettyGrpcServerLifecycle", GrpcServerLifecycle.class, Mockito::mock)
 			.withBean("nettyGrpcServerLifecycle", GrpcServerLifecycle.class, Mockito::mock)

--- a/module/spring-boot-grpc-server/src/test/java/org/springframework/boot/grpc/server/autoconfigure/health/GrpcServerHealthAutoConfigurationTests.java
+++ b/module/spring-boot-grpc-server/src/test/java/org/springframework/boot/grpc/server/autoconfigure/health/GrpcServerHealthAutoConfigurationTests.java
@@ -348,7 +348,7 @@ class GrpcServerHealthAutoConfigurationTests {
 		assertThat(context).doesNotHaveBean(GrpcServerHealthAutoConfiguration.class);
 	}
 
-	private <R extends AbstractApplicationContextRunner<R, C, A>, C extends ConfigurableApplicationContext, A extends ApplicationContextAssertProvider<C>> R serviceBean(
+	private <R extends AbstractApplicationContextRunner<R, C, A>, C extends ConfigurableApplicationContext, A extends ApplicationContextAssertProvider<A, C>> R serviceBean(
 			R contextRunner) {
 		return contextRunner.withBean(BindableService.class, () -> this.service);
 	}

--- a/module/spring-boot-grpc-server/src/test/java/org/springframework/boot/grpc/server/autoconfigure/security/GrpcServerOAuth2ResourceServerAutoConfigurationTests.java
+++ b/module/spring-boot-grpc-server/src/test/java/org/springframework/boot/grpc/server/autoconfigure/security/GrpcServerOAuth2ResourceServerAutoConfigurationTests.java
@@ -62,7 +62,7 @@ class GrpcServerOAuth2ResourceServerAutoConfigurationTests {
 	private static final AutoConfigurations autoConfigurations = AutoConfigurations
 		.of(OAuth2ResourceServerAutoConfiguration.class, GrpcServerOAuth2ResourceServerAutoConfiguration.class);
 
-	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withConfiguration(autoConfigurations)
 		.withUserConfiguration(GrpcSecurityConfiguration.class)
 		.with(this::serviceBean)
@@ -115,7 +115,7 @@ class GrpcServerOAuth2ResourceServerAutoConfigurationTests {
 			.run((context) -> assertThat(context).doesNotHaveBean(AuthenticationProcessInterceptor.class));
 	}
 
-	private <R extends AbstractApplicationContextRunner<R, C, A>, C extends ConfigurableApplicationContext, A extends ApplicationContextAssertProvider<C>> R serviceBean(
+	private <R extends AbstractApplicationContextRunner<R, C, A>, C extends ConfigurableApplicationContext, A extends ApplicationContextAssertProvider<A, C>> R serviceBean(
 			R contextRunner) {
 		BindableService service = mock();
 		ServerServiceDefinition serviceDefinition = ServerServiceDefinition.builder("my-service").build();


### PR DESCRIPTION
Prior to this change, the following wouldn't compile:

```java
new ApplicationContextRunner().run(context ->
  assertThat(context)            // returns ApplicationContextAssert<ConfigurableApplicationContext>
    .satisfies(
      ctx -> assertThat(ctx)     // returns ObjectAssert<ConfigurableApplicationContext>
        .hasNotFailed(),         // does not compile
      ctx -> assertThat(ctx)     // returns ObjectAssert<ConfigurableApplicationContext>
        .doesNotHaveBean("foo")) // does not compile
    );
```

This was due to `ApplicationContextAssertProvider` carrying `ConfigurableApplicationContext` as the type under assertion, which didn't play well with AssertJ methods like [`satisfies`](https://www.javadoc.io/doc/org.assertj/assertj-core/3.27.7/org/assertj/core/api/AbstractAssert.html#satisfies(org.assertj.core.api.ThrowingConsumer...)) that allow nesting further assertions via given consumers.

Now `ApplicationContextAssertProvider` instances carry a self-reference, and assertions like `satisfies` can be chained correctly:

```java
new ApplicationContextRunner().run(context ->
  assertThat(context)            // returns ApplicationContextAssert<AssertableApplicationContext>
    .satisfies(
      ctx -> assertThat(ctx)     // returns ApplicationContextAssert<AssertableApplicationContext>
        .hasNotFailed(),         // compiles!
      ctx -> assertThat(ctx)     // returns ApplicationContextAssert<AssertableApplicationContext>
        .doesNotHaveBean("foo")) // compiles!
    );
```

This is effectively a breaking change due to the additional type parameters of `ApplicationContextAssertProvider`. However, I imagine the change will be transparent to users who use the `ApplicationContextRunner` via its fluent API.

Relates to:
* https://github.com/spring-projects/spring-boot/issues/40134#issuecomment-4269664058