### PR TITLE
Use application name as implicit client name for redis

### DIFF
--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/DataRedisConnectionConfiguration.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/DataRedisConnectionConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.boot.data.redis.autoconfigure.DataRedisConnectionDeta
 import org.springframework.boot.data.redis.autoconfigure.DataRedisConnectionDetails.Standalone;
 import org.springframework.boot.data.redis.autoconfigure.DataRedisProperties.Pool;
 import org.springframework.boot.ssl.SslBundle;
+import org.springframework.core.env.Environment;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisNode;
 import org.springframework.data.redis.connection.RedisPassword;
@@ -36,6 +37,7 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.RedisStaticMasterReplicaConfiguration;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Base Redis connection configuration.
@@ -55,6 +57,8 @@ abstract class DataRedisConnectionConfiguration {
 	private static final boolean COMMONS_POOL2_AVAILABLE = ClassUtils.isPresent("org.apache.commons.pool2.ObjectPool",
 			DataRedisConnectionConfiguration.class.getClassLoader());
 
+	private final Environment environment;
+
 	private final DataRedisProperties properties;
 
 	private final @Nullable RedisStandaloneConfiguration standaloneConfiguration;
@@ -69,12 +73,13 @@ abstract class DataRedisConnectionConfiguration {
 
 	protected final Mode mode;
 
-	protected DataRedisConnectionConfiguration(DataRedisProperties properties,
+	protected DataRedisConnectionConfiguration(Environment environment, DataRedisProperties properties,
 			DataRedisConnectionDetails connectionDetails,
 			ObjectProvider<RedisStandaloneConfiguration> standaloneConfigurationProvider,
 			ObjectProvider<RedisSentinelConfiguration> sentinelConfigurationProvider,
 			ObjectProvider<RedisClusterConfiguration> clusterConfigurationProvider,
 			ObjectProvider<RedisStaticMasterReplicaConfiguration> masterReplicaConfiguration) {
+		this.environment = environment;
 		this.properties = properties;
 		this.standaloneConfiguration = standaloneConfigurationProvider.getIfAvailable();
 		this.sentinelConfiguration = sentinelConfigurationProvider.getIfAvailable();
@@ -178,6 +183,17 @@ abstract class DataRedisConnectionConfiguration {
 
 	protected final DataRedisProperties getProperties() {
 		return this.properties;
+	}
+
+	protected @Nullable String determineClientName() {
+		String clientName = getProperties().getClientName();
+		if (!StringUtils.hasText(clientName)) {
+			String applicationName = this.environment.getProperty("spring.application.name");
+			if (StringUtils.hasText(applicationName)) {
+				clientName = applicationName;
+			}
+		}
+		return clientName;
 	}
 
 	protected @Nullable SslBundle getSslBundle() {

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/JedisConnectionConfiguration.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/JedisConnectionConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.boot.ssl.SslOptions;
 import org.springframework.boot.thread.Threading;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -56,6 +57,7 @@ import org.springframework.util.StringUtils;
  * @author Andy Wilkinson
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author Yanming Zhou
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass({ GenericObjectPool.class, JedisConnection.class, Jedis.class })
@@ -63,13 +65,13 @@ import org.springframework.util.StringUtils;
 @ConditionalOnProperty(name = "spring.data.redis.client-type", havingValue = "jedis", matchIfMissing = true)
 class JedisConnectionConfiguration extends DataRedisConnectionConfiguration {
 
-	JedisConnectionConfiguration(DataRedisProperties properties,
+	JedisConnectionConfiguration(Environment environment, DataRedisProperties properties,
 			ObjectProvider<RedisStandaloneConfiguration> standaloneConfigurationProvider,
 			ObjectProvider<RedisSentinelConfiguration> sentinelConfiguration,
 			ObjectProvider<RedisClusterConfiguration> clusterConfiguration,
 			ObjectProvider<RedisStaticMasterReplicaConfiguration> masterReplicaConfiguration,
 			DataRedisConnectionDetails connectionDetails) {
-		super(properties, connectionDetails, standaloneConfigurationProvider, sentinelConfiguration,
+		super(environment, properties, connectionDetails, standaloneConfigurationProvider, sentinelConfiguration,
 				clusterConfiguration, masterReplicaConfiguration);
 	}
 
@@ -130,7 +132,7 @@ class JedisConnectionConfiguration extends DataRedisConnectionConfiguration {
 		PropertyMapper map = PropertyMapper.get();
 		map.from(getProperties().getTimeout()).to(builder::readTimeout);
 		map.from(getProperties().getConnectTimeout()).to(builder::connectTimeout);
-		map.from(getProperties().getClientName()).whenHasText().to(builder::clientName);
+		map.from(determineClientName()).whenHasText().to(builder::clientName);
 		return builder;
 	}
 

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/LettuceConnectionConfiguration.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/LettuceConnectionConfiguration.java
@@ -44,6 +44,7 @@ import org.springframework.boot.ssl.SslOptions;
 import org.springframework.boot.thread.Threading;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -65,20 +66,21 @@ import org.springframework.util.StringUtils;
  * @author Moritz Halbritter
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author Yanming Zhou
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(RedisClient.class)
 @ConditionalOnProperty(name = "spring.data.redis.client-type", havingValue = "lettuce", matchIfMissing = true)
 class LettuceConnectionConfiguration extends DataRedisConnectionConfiguration {
 
-	LettuceConnectionConfiguration(DataRedisProperties properties,
+	LettuceConnectionConfiguration(Environment environment, DataRedisProperties properties,
 			ObjectProvider<RedisStandaloneConfiguration> standaloneConfigurationProvider,
 			ObjectProvider<RedisSentinelConfiguration> sentinelConfigurationProvider,
 			ObjectProvider<RedisClusterConfiguration> clusterConfigurationProvider,
 			ObjectProvider<RedisStaticMasterReplicaConfiguration> masterReplicaConfiguration,
 			DataRedisConnectionDetails connectionDetails) {
-		super(properties, connectionDetails, standaloneConfigurationProvider, sentinelConfigurationProvider,
-				clusterConfigurationProvider, masterReplicaConfiguration);
+		super(environment, properties, connectionDetails, standaloneConfigurationProvider,
+				sentinelConfigurationProvider, clusterConfigurationProvider, masterReplicaConfiguration);
 	}
 
 	@Bean(destroyMethod = "shutdown")
@@ -183,8 +185,9 @@ class LettuceConnectionConfiguration extends DataRedisConnectionConfiguration {
 				builder.readFrom(getReadFrom(readFrom));
 			}
 		}
-		if (StringUtils.hasText(getProperties().getClientName())) {
-			builder.clientName(getProperties().getClientName());
+		String clientName = determineClientName();
+		if (StringUtils.hasText(clientName)) {
+			builder.clientName(clientName);
 		}
 	}
 

--- a/module/spring-boot-data-redis/src/test/java/org/springframework/boot/data/redis/autoconfigure/DataRedisAutoConfigurationJedisTests.java
+++ b/module/spring-boot-data-redis/src/test/java/org/springframework/boot/data/redis/autoconfigure/DataRedisAutoConfigurationJedisTests.java
@@ -50,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Andy Wilkinson
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author Yanming Zhou
  */
 @ClassPathExclusions("lettuce-core-*.jar")
 class DataRedisAutoConfigurationJedisTests {
@@ -207,13 +208,19 @@ class DataRedisAutoConfigurationJedisTests {
 	}
 
 	@Test
-	void testRedisConfigurationWithClientName() {
-		this.contextRunner.withPropertyValues("spring.data.redis.host:foo", "spring.data.redis.client-name:spring-boot")
-			.run((context) -> {
-				JedisConnectionFactory cf = context.getBean(JedisConnectionFactory.class);
-				assertThat(cf.getHostName()).isEqualTo("foo");
-				assertThat(cf.getClientName()).isEqualTo("spring-boot");
-			});
+	void testRedisConfigurationWithImplicitClientName() {
+		this.contextRunner.withPropertyValues("spring.application.name:spring-boot").run((context) -> {
+			JedisConnectionFactory cf = context.getBean(JedisConnectionFactory.class);
+			assertThat(cf.getClientName()).isEqualTo("spring-boot");
+		});
+	}
+
+	@Test
+	void testRedisConfigurationWithExplicitClientName() {
+		this.contextRunner.withPropertyValues("spring.data.redis.client-name:spring-boot").run((context) -> {
+			JedisConnectionFactory cf = context.getBean(JedisConnectionFactory.class);
+			assertThat(cf.getClientName()).isEqualTo("spring-boot");
+		});
 	}
 
 	@Test

--- a/module/spring-boot-data-redis/src/test/java/org/springframework/boot/data/redis/autoconfigure/DataRedisAutoConfigurationTests.java
+++ b/module/spring-boot-data-redis/src/test/java/org/springframework/boot/data/redis/autoconfigure/DataRedisAutoConfigurationTests.java
@@ -94,6 +94,7 @@ import static org.mockito.Mockito.mock;
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Yanming Zhou
  */
 class DataRedisAutoConfigurationTests {
 
@@ -341,13 +342,19 @@ class DataRedisAutoConfigurationTests {
 	}
 
 	@Test
-	void testRedisConfigurationWithClientName() {
-		this.contextRunner.withPropertyValues("spring.data.redis.host:foo", "spring.data.redis.client-name:spring-boot")
-			.run((context) -> {
-				LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
-				assertThat(cf.getHostName()).isEqualTo("foo");
-				assertThat(cf.getClientName()).isEqualTo("spring-boot");
-			});
+	void testRedisConfigurationWithImplicitClientName() {
+		this.contextRunner.withPropertyValues("spring.application.name:spring-boot").run((context) -> {
+			LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+			assertThat(cf.getClientName()).isEqualTo("spring-boot");
+		});
+	}
+
+	@Test
+	void testRedisConfigurationWithExplicitClientName() {
+		this.contextRunner.withPropertyValues("spring.data.redis.client-name:spring-boot").run((context) -> {
+			LettuceConnectionFactory cf = context.getBean(LettuceConnectionFactory.class);
+			assertThat(cf.getClientName()).isEqualTo("spring-boot");
+		});
 	}
 
 	@Test


### PR DESCRIPTION
Similar to application name as implicit service name for OpenTelemetry.