### PR TITLE
Fix typos in documentation

### DIFF
--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/appendix/pages/deprecated-application-properties/index.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/appendix/pages/deprecated-application-properties/index.adoc
@@ -3,7 +3,7 @@
 = Deprecated Application Properties
 
 The following deprecated properties can be specified inside your `application.properties` file, inside your `application.yaml` file, or as command line switches.
-Support for these properties will be removed in a future release and should you should migrate away from them.
+Support for these properties will be removed in a future release and you should migrate away from them.
 
 [TIP]
 ====

--- a/spring-boot-project/spring-boot-docs/src/docs/antora/modules/tutorial/pages/first-application/index.adoc
+++ b/spring-boot-project/spring-boot-docs/src/docs/antora/modules/tutorial/pages/first-application/index.adoc
@@ -132,7 +132,7 @@ endif::[]
 
 ifeval::["{build-type}" == "commercial"]
 You will also have to configure your build to access the Spring Commercial repository.
-This is usual done through a local artifact repository that mirrors the content of the Spring Commercial repository.
+This is usually done through a local artifact repository that mirrors the content of the Spring Commercial repository.
 Alternatively, while it is not recommended, the Spring Commercial repository can also be accessed directly.
 In either case, see https://docs.vmware.com/en/Tanzu-Spring-Runtime/Commercial/Tanzu-Spring-Runtime/spring-enterprise-subscription.html[the Tanzu Spring Runtime documentation] for further details.
 

--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/getting-started.adoc
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/getting-started.adoc
@@ -6,7 +6,7 @@ To get started with the plugin it needs to be applied to your project.
 ifeval::["{build-type}" == "commercial"]
 The plugin is published to the Spring Commercial repository.
 You will have to configure your build to access this repository.
-This is usual done through a local artifact repository that mirrors the content of the Spring Commercial repository.
+This is usually done through a local artifact repository that mirrors the content of the Spring Commercial repository.
 Alternatively, while it is not recommended, the Spring Commercial repository can also be accessed directly.
 In either case, see https://docs.vmware.com/en/Tanzu-Spring-Runtime/Commercial/Tanzu-Spring-Runtime/spring-enterprise-subscription.html[the Tanzu Spring Runtime documentation] for further details.
 


### PR DESCRIPTION
This PR fixes two small typos in the documentation:

- removes a duplicated phrase in the deprecated application properties appendix
- changes "usual" to "usually" in the Gradle plugin getting started page

Validation:
- `git diff --check`