### PR TITLE
Remove incorrect default value from configuration metadata

### DIFF
--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessor.java
@@ -61,6 +61,7 @@ import org.springframework.boot.configurationprocessor.metadata.ItemMetadata;
  * @author Jonas Keßler
  * @author Scott Frederick
  * @author Moritz Halbritter
+ * @author Yanming Zhou
  * @since 1.2.0
  */
 @SupportedAnnotationTypes({ ConfigurationMetadataAnnotationProcessor.CONFIGURATION_PROPERTIES_ANNOTATION,
@@ -287,10 +288,21 @@ public class ConfigurationMetadataAnnotationProcessor extends AbstractProcessor 
 
 	private void processTypeElement(String prefix, TypeElement element, ExecutableElement source,
 			Deque<TypeElement> seen) {
+		processTypeElement(prefix, element, source, seen, new ArrayDeque<>());
+	}
+
+	private void processTypeElement(String prefix, TypeElement element, ExecutableElement source,
+			Deque<TypeElement> seen, Deque<Boolean> initializedToNullDeque) {
 		if (!seen.contains(element)) {
 			seen.push(element);
 			new PropertyDescriptorResolver(this.metadataEnv).resolve(element, source).forEach((descriptor) -> {
-				this.metadataCollector.add(descriptor.resolveItemMetadata(prefix, this.metadataEnv));
+				ItemMetadata metadata = descriptor.resolveItemMetadata(prefix, this.metadataEnv);
+				if (metadata != null && initializedToNullDeque.contains(Boolean.TRUE)) {
+					// clear resolved default value because the group is initialized to
+					// null
+					metadata.setDefaultValue(null);
+				}
+				this.metadataCollector.add(metadata);
 				ItemHint itemHint = descriptor.resolveItemHint(prefix, this.metadataEnv);
 				if (itemHint != null) {
 					this.metadataCollector.add(itemHint);
@@ -299,7 +311,9 @@ public class ConfigurationMetadataAnnotationProcessor extends AbstractProcessor 
 					TypeElement nestedTypeElement = (TypeElement) this.metadataEnv.getTypeUtils()
 						.asElement(descriptor.getType());
 					String nestedPrefix = ConfigurationMetadata.nestedPrefix(prefix, descriptor.getName());
-					processTypeElement(nestedPrefix, nestedTypeElement, source, seen);
+					initializedToNullDeque.push(descriptor.isInitializedToNull(this.metadataEnv));
+					processTypeElement(nestedPrefix, nestedTypeElement, source, seen, initializedToNullDeque);
+					initializedToNullDeque.pop();
 				}
 			});
 			seen.pop();

--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConfigurationPropertiesSourceResolver.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ConfigurationPropertiesSourceResolver.java
@@ -39,6 +39,7 @@ import org.springframework.boot.configurationprocessor.support.ConventionUtils;
  * Resolve source configuration metadata for arbitrary types.
  *
  * @author Stephane Nicoll
+ * @author Yanming Zhou
  */
 class ConfigurationPropertiesSourceResolver {
 
@@ -173,6 +174,11 @@ class ConfigurationPropertiesSourceResolver {
 		protected Object resolveDefaultValue(MetadataGenerationEnvironment environment) {
 			Object defaultValue = this.delegate.resolveDefaultValue(environment);
 			return (defaultValue != null) ? defaultValue : this.sourceItemMetadata.getDefaultValue();
+		}
+
+		@Override
+		protected boolean isInitializedToNull(MetadataGenerationEnvironment environment) {
+			return this.delegate.isInitializedToNull(environment);
 		}
 
 		@Override

--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/JavaBeanPropertyDescriptor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/JavaBeanPropertyDescriptor.java
@@ -29,6 +29,7 @@ import org.springframework.boot.configurationprocessor.metadata.ItemDeprecation;
  *
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Yanming Zhou
  */
 class JavaBeanPropertyDescriptor extends PropertyDescriptor {
 
@@ -69,6 +70,11 @@ class JavaBeanPropertyDescriptor extends PropertyDescriptor {
 	@Override
 	protected Object resolveDefaultValue(MetadataGenerationEnvironment environment) {
 		return environment.getFieldDefaultValue(getDeclaringElement(), this.field);
+	}
+
+	@Override
+	protected boolean isInitializedToNull(MetadataGenerationEnvironment environment) {
+		return environment.isInitializedToNull(getDeclaringElement(), this.field);
 	}
 
 	@Override

--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/LombokPropertyDescriptor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/LombokPropertyDescriptor.java
@@ -33,6 +33,7 @@ import org.springframework.boot.configurationprocessor.metadata.ItemDeprecation;
  *
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Yanming Zhou
  */
 class LombokPropertyDescriptor extends PropertyDescriptor {
 
@@ -82,6 +83,11 @@ class LombokPropertyDescriptor extends PropertyDescriptor {
 	@Override
 	protected Object resolveDefaultValue(MetadataGenerationEnvironment environment) {
 		return environment.getFieldDefaultValue(getDeclaringElement(), this.field);
+	}
+
+	@Override
+	protected boolean isInitializedToNull(MetadataGenerationEnvironment environment) {
+		return environment.isInitializedToNull(getDeclaringElement(), this.field);
 	}
 
 	@Override

--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataGenerationEnvironment.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/MetadataGenerationEnvironment.java
@@ -52,6 +52,7 @@ import org.springframework.boot.configurationprocessor.metadata.ItemDeprecation;
  * @author Stephane Nicoll
  * @author Scott Frederick
  * @author Moritz Halbritter
+ * @author Yanming Zhou
  */
 class MetadataGenerationEnvironment {
 
@@ -151,6 +152,21 @@ class MetadataGenerationEnvironment {
 	Object getFieldDefaultValue(TypeElement type, VariableElement field) {
 		return (field != null) ? this.defaultValues.computeIfAbsent(type, this::resolveFieldValues)
 			.get(field.getSimpleName().toString()) : null;
+	}
+
+	/**
+	 * Return true if the given {@code field} is initialized to {@code null}.
+	 * @param type the type to consider
+	 * @param field the field or {@code null} if it is not available
+	 * @return true if the given {@code field} is initialized to {@code null}
+	 */
+	boolean isInitializedToNull(TypeElement type, VariableElement field) {
+		if (field != null) {
+			Map<String, Object> map = this.defaultValues.computeIfAbsent(type, this::resolveFieldValues);
+			String key = field.getSimpleName().toString();
+			return map.containsKey(key) && map.get(key) == null;
+		}
+		return false;
 	}
 
 	/**

--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ParameterPropertyDescriptor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/ParameterPropertyDescriptor.java
@@ -35,6 +35,7 @@ import javax.tools.Diagnostic.Kind;
  *
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Yanming Zhou
  */
 abstract class ParameterPropertyDescriptor extends PropertyDescriptor {
 
@@ -61,6 +62,11 @@ abstract class ParameterPropertyDescriptor extends PropertyDescriptor {
 		Object defaultValue = getDefaultValueFromAnnotation(environment, getParameter());
 		return (defaultValue != null) ? defaultValue
 				: getParameter().asType().accept(DefaultPrimitiveTypeVisitor.INSTANCE, null);
+	}
+
+	@Override
+	protected boolean isInitializedToNull(MetadataGenerationEnvironment environment) {
+		return false;
 	}
 
 	private Object getDefaultValueFromAnnotation(MetadataGenerationEnvironment environment, Element element) {

--- a/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptor.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptor.java
@@ -34,6 +34,7 @@ import org.springframework.boot.configurationprocessor.metadata.ItemMetadata;
  *
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Yanming Zhou
  */
 abstract class PropertyDescriptor {
 
@@ -225,6 +226,17 @@ abstract class PropertyDescriptor {
 	 * @return the default value or {@code null}
 	 */
 	protected abstract Object resolveDefaultValue(MetadataGenerationEnvironment environment);
+
+	/**
+	 * Return true if the backing field is initialized to {@code null}.
+	 * <p>
+	 * Note: {@link #resolveDefaultValue(MetadataGenerationEnvironment)} returns
+	 * {@code null} does not mean the backing field is initialized to {@code null}, it may
+	 * be initialized to a domain object.
+	 * @param environment the metadata generation environment
+	 * @return true if the backing field is initialized to {@code null}
+	 */
+	protected abstract boolean isInitializedToNull(MetadataGenerationEnvironment environment);
 
 	/**
 	 * Resolve the {@link ItemDeprecation} for this property.

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/ConfigurationMetadataAnnotationProcessorTests.java
@@ -97,6 +97,7 @@ import org.springframework.boot.configurationsample.specific.InvalidDefaultValue
 import org.springframework.boot.configurationsample.specific.InvalidDefaultValueFloatingPointProperties;
 import org.springframework.boot.configurationsample.specific.InvalidDefaultValueNumberProperties;
 import org.springframework.boot.configurationsample.specific.InvalidDoubleRegistrationProperties;
+import org.springframework.boot.configurationsample.specific.NestedProperties;
 import org.springframework.boot.configurationsample.specific.SimplePojo;
 import org.springframework.boot.configurationsample.specific.StaticAccessor;
 import org.springframework.core.test.tools.CompilationException;
@@ -119,6 +120,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Pavel Anisimov
  * @author Scott Frederick
  * @author Moritz Halbritter
+ * @author Yanming Zhou
  */
 class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGenerationTests {
 
@@ -448,6 +450,17 @@ class ConfigurationMetadataAnnotationProcessorTests extends AbstractMetadataGene
 		assertThat(metadata).has(Metadata.withProperty("nestedChildProps.parent-class-property", Integer.class)
 			.fromSource(ClassWithNestedProperties.NestedChildClass.class)
 			.withDefaultValue(10));
+	}
+
+	@Test
+	void nestedProperties() {
+		ConfigurationMetadata metadata = compile(NestedProperties.class);
+		assertThat(metadata).has(Metadata.withProperty("config.foo1.enabled").withDefaultValue(true));
+		assertThat(metadata).has(Metadata.withProperty("config.foo2.enabled").withNoDefaultValue());
+		assertThat(metadata).has(Metadata.withProperty("config.foo1.bar1.enabled").withDefaultValue(true));
+		assertThat(metadata).has(Metadata.withProperty("config.foo1.bar2.enabled").withNoDefaultValue());
+		assertThat(metadata).has(Metadata.withProperty("config.foo2.bar1.enabled").withNoDefaultValue());
+		assertThat(metadata).has(Metadata.withProperty("config.foo2.bar2.enabled").withNoDefaultValue());
 	}
 
 	@Test

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/Metadata.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/metadata/Metadata.java
@@ -33,6 +33,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Phillip Webb
  * @author Stephane Nicoll
+ * @author Yanming Zhou
  */
 public final class Metadata {
 
@@ -125,6 +126,9 @@ public final class Metadata {
 			if (this.defaultValue != null) {
 				description.append(" with defaultValue:").append(this.defaultValue);
 			}
+			else {
+				description.append(" with no defaultValue");
+			}
 			if (this.description != null) {
 				description.append(" with description:").append(this.description);
 			}
@@ -193,6 +197,11 @@ public final class Metadata {
 		public MetadataItemCondition withDefaultValue(Object defaultValue) {
 			return new MetadataItemCondition(this.itemType, this.name, this.type, this.sourceType, this.sourceMethod,
 					this.description, defaultValue, this.deprecation);
+		}
+
+		public MetadataItemCondition withNoDefaultValue() {
+			return new MetadataItemCondition(this.itemType, this.name, this.type, this.sourceType, this.sourceMethod,
+					this.description, null, this.deprecation);
 		}
 
 		public MetadataItemCondition withDeprecation() {

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/NestedProperties.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationsample/specific/NestedProperties.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.configurationsample.specific;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.boot.configurationsample.TestConfigurationProperties;
+import org.springframework.boot.configurationsample.TestNestedConfigurationProperty;
+
+/**
+ * Demonstrate the auto-detection of config classes which contains nested properties.
+ *
+ * @author Yanming Zhou
+ */
+@TestConfigurationProperties("config")
+public class NestedProperties {
+
+	@TestNestedConfigurationProperty
+	private final Foo foo1 = new Foo();
+
+	@TestNestedConfigurationProperty
+	private @Nullable Foo foo2;
+
+	public Foo getFoo1() {
+		return this.foo1;
+	}
+
+	public @Nullable Foo getFoo2() {
+		return this.foo2;
+	}
+
+	public void setFoo2(@Nullable Foo foo2) {
+		this.foo2 = foo2;
+	}
+
+	public static class Foo {
+
+		private boolean enabled = true;
+
+		@TestNestedConfigurationProperty
+		private final Bar bar1 = new Bar();
+
+		@TestNestedConfigurationProperty
+		private @Nullable Bar bar2;
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public Bar getBar1() {
+			return this.bar1;
+		}
+
+		public @Nullable Bar getBar2() {
+			return this.bar2;
+		}
+
+		public void setBar2(@Nullable Bar bar2) {
+			this.bar2 = bar2;
+		}
+
+	}
+
+	public static class Bar {
+
+		private boolean enabled = true;
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+	}
+
+}


### PR DESCRIPTION
Properties shouldn't have default value if one of its ancestor groups is initialized to null, take `org.springframework.boot.web.server.autoconfigure.ServerProperties` for example:

```java
@ConfigurationProperties("server")
public class ServerProperties {

	@NestedConfigurationProperty
	private @Nullable Ssl ssl;

}

@ConfigurationPropertiesSource
public class Ssl {

	private boolean enabled = true;

}
```
Obviously, SSL is not enabled by default, but the property `server.ssl.enabled` has default value `true`.