### PR TITLE
SSL should not be enabled when a SSL bundle is overridden to an empty string

### DIFF
--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/cassandra/CassandraProperties.java
@@ -23,6 +23,7 @@ import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.io.Resource;
+import org.springframework.util.StringUtils;
 
 /**
  * Configuration properties for Cassandra.
@@ -236,7 +237,7 @@ public class CassandraProperties {
 		private String bundle;
 
 		public boolean isEnabled() {
-			return (this.enabled != null) ? this.enabled : this.bundle != null;
+			return (this.enabled != null) ? this.enabled : StringUtils.hasText(this.bundle);
 		}
 
 		public void setEnabled(boolean enabled) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
 
 /**
  * Configuration properties for Redis.
@@ -425,7 +426,7 @@ public class RedisProperties {
 		private String bundle;
 
 		public boolean isEnabled() {
-			return (this.enabled != null) ? this.enabled : this.bundle != null;
+			return (this.enabled != null) ? this.enabled : StringUtils.hasText(this.bundle);
 		}
 
 		public void setEnabled(boolean enabled) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mail/MailSenderPropertiesConfiguration.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mail/MailSenderPropertiesConfiguration.java
@@ -69,7 +69,7 @@ class MailSenderPropertiesConfiguration {
 		if (ssl.isEnabled()) {
 			javaMailProperties.setProperty("mail." + protocol + ".ssl.enable", "true");
 		}
-		if (ssl.getBundle() != null) {
+		if (StringUtils.hasLength(ssl.getBundle())) {
 			SslBundle sslBundle = sslBundles.getBundle(ssl.getBundle());
 			javaMailProperties.put("mail." + protocol + ".ssl.socketFactory",
 					sslBundle.createSslContext().getSocketFactory());

--- a/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java
@@ -22,6 +22,7 @@ import com.mongodb.ConnectionString;
 import org.bson.UuidRepresentation;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
 
 /**
  * Configuration properties for Mongo.
@@ -289,7 +290,7 @@ public class MongoProperties {
 		private String bundle;
 
 		public boolean isEnabled() {
-			return (this.enabled != null) ? this.enabled : this.bundle != null;
+			return (this.enabled != null) ? this.enabled : StringUtils.hasText(this.bundle);
 		}
 
 		public void setEnabled(boolean enabled) {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cassandra/CassandraPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/cassandra/CassandraPropertiesTests.java
@@ -58,4 +58,11 @@ class CassandraPropertiesTests {
 		assertThat(driverDefaults.get(TypedDriverOption.HEARTBEAT_TIMEOUT)).isEqualTo(Duration.ofSeconds(5));
 	}
 
+	@Test
+	void sslIsNotEnabledWhenBundleIsEmpty() {
+		CassandraProperties properties = new CassandraProperties();
+		properties.getSsl().setBundle("");
+		assertThat(properties.getSsl().isEnabled()).isFalse();
+	}
+
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/data/redis/RedisPropertiesTests.java
@@ -39,4 +39,11 @@ class RedisPropertiesTests {
 			.isEqualTo(defaultClusterTopologyRefreshOptions.useDynamicRefreshSources());
 	}
 
+	@Test
+	void sslIsNotEnabledWhenBundleIsEmpty() {
+		RedisProperties properties = new RedisProperties();
+		properties.getSsl().setBundle("");
+		assertThat(properties.getSsl().isEnabled()).isFalse();
+	}
+
 }

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mail/MailSenderAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mail/MailSenderAutoConfigurationTests.java
@@ -246,6 +246,21 @@ class MailSenderAutoConfigurationTests {
 	}
 
 	@Test
+	@WithPackageResources("test.jks")
+	void sslIsNotEnabledWhenBundleIsEmpty() {
+		this.contextRunner
+			.withPropertyValues("spring.mail.host:localhost", "spring.mail.ssl.bundle: ",
+					"spring.ssl.bundle.jks.test-bundle.keystore.location:classpath:test.jks",
+					"spring.ssl.bundle.jks.test-bundle.keystore.password:secret",
+					"spring.ssl.bundle.jks.test-bundle.key.password:password")
+			.run((context) -> {
+				assertThat(context).hasSingleBean(JavaMailSenderImpl.class);
+				JavaMailSenderImpl mailSender = context.getBean(JavaMailSenderImpl.class);
+				assertThat(mailSender.getJavaMailProperties().get("mail.smtp.ssl.socketFactory")).isNull();
+			});
+	}
+
+	@Test
 	void smtpSslEnabled() {
 		this.contextRunner.withPropertyValues("spring.mail.host:localhost", "spring.mail.ssl.enabled:true")
 			.run((context) -> {

--- a/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoPropertiesTests.java
+++ b/spring-boot-project/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/mongo/MongoPropertiesTests.java
@@ -37,6 +37,13 @@ class MongoPropertiesTests {
 		assertThat(springBootDefault).isEqualTo(springDataDefault);
 	}
 
+	@Test
+	void sslIsNotEnabledWhenBundleIsEmpty() {
+		MongoProperties properties = new MongoProperties();
+		properties.getSsl().setBundle("");
+		assertThat(properties.getSsl().isEnabled()).isFalse();
+	}
+
 	private UuidRepresentation springDataDefaultUuidRepresentation() {
 		return new MongoConfigurationSupport() {
 


### PR DESCRIPTION
Follow-up to #50429, which treated an empty RabbitMQ SSL bundle as unset.

`Ssl.isEnabled()` in Cassandra, Redis, and MongoDB still derived
enablement from `this.bundle != null`, so an empty `bundle` value enabled
SSL instead of being treated as unset. They now use `StringUtils.hasText`,
matching RabbitMQ and the existing Couchbase behavior.

Testing:
- `CassandraPropertiesTests.sslIsNotEnabledWhenBundleIsEmpty`
- `RedisPropertiesTests.sslIsNotEnabledWhenBundleIsEmpty`
- `MongoPropertiesTests.sslIsNotEnabledWhenBundleIsEmpty`