### PR TITLE
Add nested override coverage for SpringBootTest imports

### DIFF
--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootTestImportTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootTestImportTests.java
@@ -24,6 +24,8 @@ import org.springframework.boot.test.context.SpringBootTestImportTests.ImportedB
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
+import org.springframework.test.context.NestedTestConfiguration;
+import org.springframework.test.context.NestedTestConfiguration.EnclosingConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,6 +66,38 @@ class SpringBootTestImportTests {
 		@Test
 		void containingClassTestPropertySourceIsHonored() {
 			assertThat(this.environment.getProperty("a")).isEqualTo("alpha");
+		}
+
+	}
+
+	@Nested
+	@SpringBootTest(classes = Config.class)
+	@Import(ImportedByNestedTests.class)
+	@NestedTestConfiguration(EnclosingConfiguration.OVERRIDE)
+	class OverrideNestedTests {
+
+		@Autowired(required = false)
+		private ImportedByContainingTests importedByContainingTests;
+
+		@Autowired(required = false)
+		private ImportedByNestedTests importedByNestedTests;
+
+		@Autowired
+		private Environment environment;
+
+		@Test
+		void sameClassImportIsHonored() {
+			assertThat(this.importedByNestedTests).isNotNull();
+		}
+
+		@Test
+		void containingClassImportIsNotInherited() {
+			assertThat(this.importedByContainingTests).isNull();
+		}
+
+		@Test
+		void containingClassTestPropertySourceIsNotInherited() {
+			assertThat(this.environment.getProperty("a")).isNull();
 		}
 
 	}


### PR DESCRIPTION
This adds `@NestedTestConfiguration(OVERRIDE)` coverage to `SpringBootTestImportTests`.

The existing nested tests verify the default inherited behavior where the enclosing class's `@Import` and `@TestPropertySource` are honored by a nested `@SpringBootTest`. The new nested test class verifies the contrasting override behavior: the nested class keeps its own `@Import`, but no longer inherits the enclosing class's import or test property source.

See gh-23929.

Validation:
- `./gradlew :core:spring-boot-test:test --tests org.springframework.boot.test.context.SpringBootTestImportTests --rerun-tasks --no-daemon`
- `./gradlew :core:spring-boot-test:checkFormatTest :core:spring-boot-test:checkstyleTest --no-daemon`
- `git diff --check`

Additional check:
- Temporarily removing `@NestedTestConfiguration(EnclosingConfiguration.OVERRIDE)` made the new override assertions fail, confirming the test covers the intended behavior.