### PR TITLE
Close URLClassLoader in ArchitectureCheck

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureCheck.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/architecture/ArchitectureCheck.java
@@ -132,17 +132,18 @@ public abstract class ArchitectureCheck extends DefaultTask {
 
 	private void withCompileClasspath(Callable<?> callable) throws Exception {
 		ClassLoader previous = Thread.currentThread().getContextClassLoader();
-		try {
-			List<URL> urls = new ArrayList<>();
-			for (File file : getCompileClasspath().getFiles()) {
-				urls.add(file.toURI().toURL());
-			}
-			ClassLoader classLoader = new URLClassLoader(urls.toArray(new URL[0]), getClass().getClassLoader());
-			Thread.currentThread().setContextClassLoader(classLoader);
-			callable.call();
+		List<URL> urls = new ArrayList<>();
+		for (File file : getCompileClasspath().getFiles()) {
+			urls.add(file.toURI().toURL());
 		}
-		finally {
-			Thread.currentThread().setContextClassLoader(previous);
+		try (URLClassLoader classLoader = new URLClassLoader(urls.toArray(new URL[0]), getClass().getClassLoader())) {
+			Thread.currentThread().setContextClassLoader(classLoader);
+			try {
+				callable.call();
+			}
+			finally {
+				Thread.currentThread().setContextClassLoader(previous);
+			}
 		}
 	}
 


### PR DESCRIPTION
URLClassLoader implements Closeable but was never closed in
`withCompileClasspath()`, leaking JAR file handles in long-running
Gradle daemon processes.

The fix declares the classloader before the try block and closes it
in the finally block after restoring the original context classloader.