### PR TITLE
Close FileOutputStream delegate in InspectingOutputStream

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/io/InspectedContent.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/io/InspectedContent.java
@@ -147,6 +147,11 @@ public class InspectedContent implements Content {
 		}
 
 		@Override
+		public void close() throws IOException {
+			this.delegate.close();
+		}
+
+		@Override
 		public void write(int b) throws IOException {
 			this.singleByteBuffer[0] = (byte) (b & 0xFF);
 			write(this.singleByteBuffer);


### PR DESCRIPTION
`InspectingOutputStream` extends `OutputStream` but does not override `close()`. When content exceeds `MEMORY_LIMIT` (approximately 4 KB), `convertToTempFile()` replaces the `ByteArrayOutputStream` delegate with a `FileOutputStream`. The try-with-resources in `InspectedContent.of()` calls `close()`, which inherits the no-op `OutputStream.close()`, leaving the `FileOutputStream` open and leaking a file descriptor.

This commit overrides `close()` to delegate to the underlying stream.