### PR TITLE
NullPointerException in reactor-netty SniProvider and unmapped SSL bundle with RSocket

### DIFF
--- a/module/spring-boot-rsocket/src/main/java/org/springframework/boot/rsocket/netty/NettyRSocketServerFactory.java
+++ b/module/spring-boot-rsocket/src/main/java/org/springframework/boot/rsocket/netty/NettyRSocketServerFactory.java
@@ -269,13 +269,13 @@ public class NettyRSocketServerFactory implements RSocketServerFactory, Configur
 
 	}
 
-	private static final class HttpServerSslCustomizer extends SslCustomizer {
+	static final class HttpServerSslCustomizer extends SslCustomizer {
 
 		private final SslProvider sslProvider;
 
 		private final Map<String, SslProvider> serverNameSslProviders;
 
-		private HttpServerSslCustomizer(Ssl.@Nullable ClientAuth clientAuth, SslBundle sslBundle,
+		HttpServerSslCustomizer(Ssl.@Nullable ClientAuth clientAuth, SslBundle sslBundle,
 				Map<String, SslBundle> serverNameSslBundles) {
 			super(Ssl.ClientAuth.map(clientAuth, ClientAuth.NONE, ClientAuth.OPTIONAL, ClientAuth.REQUIRE));
 			this.sslProvider = createSslProvider(sslBundle);
@@ -287,11 +287,13 @@ public class NettyRSocketServerFactory implements RSocketServerFactory, Configur
 		}
 
 		private void applySecurity(SslContextSpec spec) {
-			spec.sslContext(this.sslProvider.getSslContext()).setSniAsyncMappings((serverName, promise) -> {
-				SslProvider provider = (serverName != null) ? this.serverNameSslProviders.get(serverName)
-						: this.sslProvider;
-				return promise.setSuccess(provider);
-			});
+			spec.sslContext(this.sslProvider.getSslContext())
+				.setSniAsyncMappings((serverName, promise) -> promise.setSuccess(getSslProvider(serverName)));
+		}
+
+		SslProvider getSslProvider(@Nullable String serverName) {
+			return (serverName != null) ? this.serverNameSslProviders.getOrDefault(serverName, this.sslProvider)
+					: this.sslProvider;
 		}
 
 		private Map<String, SslProvider> createServerNameSslProviders(Map<String, SslBundle> serverNameSslBundles) {

--- a/module/spring-boot-rsocket/src/test/java/org/springframework/boot/rsocket/netty/NettyRSocketServerFactoryTests.java
+++ b/module/spring-boot-rsocket/src/test/java/org/springframework/boot/rsocket/netty/NettyRSocketServerFactoryTests.java
@@ -20,6 +20,8 @@ import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 import io.netty.buffer.PooledByteBufAllocator;
@@ -267,6 +269,26 @@ class NettyRSocketServerFactoryTests {
 		testBasicSslWithPemCertificateFromBundle(testCert, testKey, testCert, Transport.WEBSOCKET);
 	}
 
+	@Test
+	@WithPackageResources({ "test-cert.pem", "test-key.pem" })
+	void websocketTransportSslProviderFallsBackToDefaultWhenServerNameIsUnmapped() {
+		SslBundle defaultBundle = createBundle("test-cert.pem", "test-key.pem");
+		SslBundle mappedBundle = createBundle("test-cert.pem", "test-key.pem");
+		NettyRSocketServerFactory.HttpServerSslCustomizer customizer = new NettyRSocketServerFactory.HttpServerSslCustomizer(
+				Ssl.ClientAuth.NONE, defaultBundle, Map.of("mapped.example", mappedBundle));
+		assertThat(customizer.getSslProvider("unmapped.example")).isSameAs(customizer.getSslProvider(null));
+	}
+
+	@Test
+	@WithPackageResources({ "test-cert.pem", "test-key.pem" })
+	@SuppressWarnings("NullAway") // Test null check
+	void websocketTransportSslProviderReturnsDefaultWhenServerNameIsNull() {
+		SslBundle defaultBundle = createBundle("test-cert.pem", "test-key.pem");
+		NettyRSocketServerFactory.HttpServerSslCustomizer customizer = new NettyRSocketServerFactory.HttpServerSslCustomizer(
+				Ssl.ClientAuth.NONE, defaultBundle, Collections.emptyMap());
+		assertThat(customizer.getSslProvider(null)).isNotNull();
+	}
+
 	private void checkEchoRequest() {
 		String payload = "test payload";
 		assertThat(this.requester).isNotNull();
@@ -336,6 +358,12 @@ class NettyRSocketServerFactoryTests {
 		this.requester = (transport == Transport.TCP) ? createSecureRSocketTcpClient()
 				: createSecureRSocketWebSocketClient();
 		checkEchoRequest();
+	}
+
+	private static SslBundle createBundle(String certificate, String certificatePrivateKey) {
+		PemSslStoreDetails keyStoreDetails = PemSslStoreDetails.forCertificate("classpath:" + certificate)
+			.withPrivateKey("classpath:" + certificatePrivateKey);
+		return SslBundle.of(new PemSslStoreBundle(keyStoreDetails, null));
 	}
 
 	@Test


### PR DESCRIPTION
The RSocket WebSocket transport's `HttpServerSslCustomizer` returns `null`
from its SNI provider lookup when a server name has no mapped SSL bundle, so
reactor-netty calls `promise.setSuccess(null)` and throws a
`NullPointerException` during the TLS handshake.

This is the same failure fixed for the shared `SslServerCustomizer` in #50301,
but RSocket keeps its own copy of the lookup in the modularized layout and was
missed.

Changes:
- Fall back to the default `SslProvider` via `getOrDefault` for unmapped server names

Testing:
- `NettyRSocketServerFactoryTests.websocketTransportSslProviderFallsBackToDefaultWhenServerNameIsUnmapped`
- `NettyRSocketServerFactoryTests.websocketTransportSslProviderReturnsDefaultWhenServerNameIsNull`
