### PR TITLE
W3CHeaderParser's decoding is not compliant with RFC 3986

### DIFF
--- a/module/spring-boot-opentelemetry/src/main/java/org/springframework/boot/opentelemetry/autoconfigure/W3CHeaderParser.java
+++ b/module/spring-boot-opentelemetry/src/main/java/org/springframework/boot/opentelemetry/autoconfigure/W3CHeaderParser.java
@@ -16,7 +16,6 @@
 
 package org.springframework.boot.opentelemetry.autoconfigure;
 
-import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -71,7 +70,7 @@ final class W3CHeaderParser {
 		if (value.indexOf('%') == -1) {
 			return value;
 		}
-		return URLDecoder.decode(value, StandardCharsets.UTF_8);
+		return StringUtils.uriDecode(value, StandardCharsets.UTF_8);
 	}
 
 }

--- a/module/spring-boot-opentelemetry/src/test/java/org/springframework/boot/opentelemetry/autoconfigure/W3CHeaderParserTests.java
+++ b/module/spring-boot-opentelemetry/src/test/java/org/springframework/boot/opentelemetry/autoconfigure/W3CHeaderParserTests.java
@@ -55,8 +55,10 @@ class W3CHeaderParserTests {
 
 	@Test
 	void shouldPercentDecodeValues() {
-		Map<String, String> result = W3CHeaderParser.parse("serverNode=DF%2028,userId=Am%C3%A9lie");
-		assertThat(result).containsExactly(Map.entry("serverNode", "DF 28"), Map.entry("userId", "Amélie"));
+		Map<String, String> result = W3CHeaderParser
+			.parse("serverNode=DF%2028,userId=Am%C3%A9lie,application=%20spring+boot%20");
+		assertThat(result).containsExactly(Map.entry("serverNode", "DF 28"), Map.entry("userId", "Amélie"),
+				Map.entry("application", " spring+boot "));
 	}
 
 	@Test


### PR DESCRIPTION
Replace `URLDecoder.decode` with `StringUtils.uriDecode` to ensure RFC 3986-compliant decoding. Unlike `URLDecoder`, URI decoding does not treat `+` as a space and only decodes percent-encoded sequences.

https://www.w3.org/TR/baggage/#value
https://datatracker.ietf.org/doc/html/rfc3986#section-2.1

