### PR TITLE
Fix StackOverflowError in TomcatEmbeddedWebappClassLoader with ECS logging and ValueProcessor #50651

### DIFF
--- a/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/TomcatEmbeddedWebappClassLoader.java
+++ b/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/TomcatEmbeddedWebappClassLoader.java
@@ -127,4 +127,27 @@ public class TomcatEmbeddedWebappClassLoader extends ParallelWebappClassLoader {
 		}
 	}
 
+	private static final ThreadLocal<Boolean> checkingState = ThreadLocal.withInitial(() -> false);
+
+	@Override
+	protected void checkStateForResourceLoading(String name) throws IllegalStateException {
+		// 1. If this thread is already executing this method, break the recursive loop
+		// immediately!
+		if (checkingState.get()) {
+			return;
+		}
+		try {
+			// 2. Mark this thread as "actively checking"
+			checkingState.set(true);
+
+			// 3. Forward the execution to Tomcat's original lifecycle behavior
+			super.checkStateForResourceLoading(name);
+		}
+		finally {
+			// 4. Always clear the flag when leaving so the thread can reuse it safely
+			// later
+			checkingState.remove();
+		}
+	}
+
 }

--- a/module/spring-boot-tomcat/src/test/java/org/springframework/boot/tomcat/TomcatEmbeddedWebappClassLoaderTests.java
+++ b/module/spring-boot-tomcat/src/test/java/org/springframework/boot/tomcat/TomcatEmbeddedWebappClassLoaderTests.java
@@ -30,12 +30,14 @@ import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.loader.ParallelWebappClassLoader;
 import org.apache.catalina.webresources.StandardRoot;
 import org.apache.catalina.webresources.WarResourceSet;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import org.springframework.util.CollectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
  * Tests for {@link TomcatEmbeddedWebappClassLoader}.
@@ -105,6 +107,30 @@ class TomcatEmbeddedWebappClassLoaderTests {
 			out.putNextEntry(new ZipEntry(name));
 			out.closeEntry();
 		}
+	}
+
+	@Test
+	void checkStateForResourceLoadingDoesNotRecursivelyLoop() throws Exception {
+		URLClassLoader parent = new URLClassLoader(new URL[0], null);
+		try (TomcatEmbeddedWebappClassLoader classLoader = new TomcatEmbeddedWebappClassLoader(parent) {
+			@Override
+			public @Nullable URL findResource(String name) {
+				checkStateForResourceLoading(name);
+				return null;
+			}
+		}) {
+			StandardContext context = new StandardContext();
+			context.setName("test");
+			StandardRoot resources = new StandardRoot();
+			resources.setContext(context);
+			resources.start();
+			classLoader.setResources(resources);
+			classLoader.start();
+			classLoader.stop();
+			assertThatIllegalStateException().isThrownBy(() -> classLoader.getResource("test.properties"));
+			resources.stop();
+		}
+		parent.close();
 	}
 
 	interface ClassLoaderConsumer {


### PR DESCRIPTION
### Fixes
Closes #50651

### Problem
When Spring Boot applications start with Tomcat embedded, ECS structured logging enabled, debug logging level, and a custom ValueProcessor in the JSON customizer, a StackOverflowError occurs during startup. The issue stems from infinite recursion between TomcatEmbeddedWebappClassLoader#loadClass(String) and ThrowableProxy#calculatePackagingData().

### Root Cause Analysis
During exception handling at startup, ThrowableProxy#calculatePackagingData() attempts to calculate packaging data for the exception stack trace. This triggers resource loading through the Tomcat classloader. When the classloader has been stopped, Tomcat attempts to throw an IllegalStateException. To retrieve the localized exception message, Tomcat's StringManager initiates resource bundle loading, which recursively invokes the stopped classloader's checkStateForResourceLoading() method. This cyclical invocation leads to unbounded recursion and a StackOverflowError.

### Solution
Implemented a recursion guard in the TomcatEmbeddedWebappClassLoader#checkStateForResourceLoading(String) method using a ThreadLocal<Boolean> flag. The guard detects when a thread is already executing checkStateForResourceLoading() and returns early for nested calls, effectively breaking the recursive cycle while allowing the initial IllegalStateException to propagate correctly.

### Changes
* **Modified:** `TomcatEmbeddedWebappClassLoader` - Overrode `checkStateForResourceLoading(String name)` method with a recursion guard using a `ThreadLocal<Boolean>` flag.
* **Added:** `TomcatEmbeddedWebappClassLoaderTests#checkStateForResourceLoadingDoesNotRecursivelyLoop()` - Unit test verifying the fix prevents infinite recursion.

### Testing
* **Unit Test:** Added `checkStateForResourceLoadingDoesNotRecursivelyLoop` test to verify that `getResource()` throws `IllegalStateException` without entering infinite recursion.
* **Build Verification:** All tests, Checkstyle, and formatting checks pass using:
  ```bash
  ./gradlew :spring-boot-tomcat:check -Dorg.gradle.java.home=./jdk-25

### Environment: 
Tested on Java 21 and Java 25.

Affected Versions
Spring Boot 4.0.0 - 4.0.6

Regression introduced in Spring Boot 4.0.0 (not present in 3.5.14)