### PR TITLE
HttpService Client doesn't take spring.jackson properties into account

### DIFF
--- a/module/spring-boot-restclient/build.gradle
+++ b/module/spring-boot-restclient/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation(project(":module:spring-boot-http-converter"))
 
 	optional(project(":core:spring-boot-autoconfigure"))
+	optional(project(":module:spring-boot-jackson"))
 	optional(project(":module:spring-boot-micrometer-observation"))
 	optional("io.projectreactor.netty:reactor-netty-http")
 	optional("org.apache.httpcomponents.client5:httpclient5")

--- a/module/spring-boot-restclient/build.gradle
+++ b/module/spring-boot-restclient/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	optional("org.eclipse.jetty:jetty-client")
 
 	testImplementation(project(":core:spring-boot-test"))
+	testImplementation(project(":module:spring-boot-jackson"))
 	testImplementation(project(":module:spring-boot-micrometer-metrics-test"))
 	testImplementation(project(":module:spring-boot-tomcat"))
 	testImplementation(project(":test-support:spring-boot-test-support"))

--- a/module/spring-boot-restclient/src/main/java/org/springframework/boot/restclient/autoconfigure/RestClientAutoConfiguration.java
+++ b/module/spring-boot-restclient/src/main/java/org/springframework/boot/restclient/autoconfigure/RestClientAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.restclient.autoconfigure;
 
+import tools.jackson.databind.json.JsonMapper;
+
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -39,6 +41,7 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.converter.HttpMessageConverters;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClient.Builder;
 
@@ -55,7 +58,8 @@ import org.springframework.web.client.RestClient.Builder;
  * @since 4.0.0
  */
 @AutoConfiguration(after = { ImperativeHttpClientAutoConfiguration.class, TaskExecutionAutoConfiguration.class,
-		SslAutoConfiguration.class, HttpMessageConvertersAutoConfiguration.class })
+		SslAutoConfiguration.class, HttpMessageConvertersAutoConfiguration.class },
+		afterName = "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration")
 @ConditionalOnClass(RestClient.class)
 public final class RestClientAutoConfiguration {
 
@@ -90,6 +94,21 @@ public final class RestClientAutoConfiguration {
 	@ConditionalOnMissingBean
 	RestClient.Builder restClientBuilder(RestClientBuilderConfigurer restClientBuilderConfigurer) {
 		return restClientBuilderConfigurer.configure(RestClient.builder());
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(JsonMapper.class)
+	static class JacksonConfiguration {
+
+		@Bean
+		@ConditionalOnBean(JsonMapper.class)
+		@ConditionalOnMissingBean(ClientHttpMessageConvertersCustomizer.class)
+		@Order(Ordered.LOWEST_PRECEDENCE)
+		RestClientCustomizer jacksonRestClientCustomizer(JsonMapper jsonMapper) {
+			return (builder) -> builder.configureMessageConverters(
+					(converters) -> converters.withJsonConverter(new JacksonJsonHttpMessageConverter(jsonMapper)));
+		}
+
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/module/spring-boot-restclient/src/test/java/org/springframework/boot/restclient/autoconfigure/service/HttpServiceClientAutoConfigurationTests.java
+++ b/module/spring-boot-restclient/src/test/java/org/springframework/boot/restclient/autoconfigure/service/HttpServiceClientAutoConfigurationTests.java
@@ -30,6 +30,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.function.Resolver;
 import org.apache.hc.core5.util.Timeout;
 import org.assertj.core.extractor.Extractors;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -41,19 +42,24 @@ import org.springframework.boot.http.client.HttpRedirects;
 import org.springframework.boot.http.client.autoconfigure.HttpClientAutoConfiguration;
 import org.springframework.boot.http.client.autoconfigure.imperative.ImperativeHttpClientAutoConfiguration;
 import org.springframework.boot.http.client.autoconfigure.service.HttpServiceClientPropertiesAutoConfiguration;
+import org.springframework.boot.http.converter.autoconfigure.HttpMessageConvertersAutoConfiguration;
+import org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration;
 import org.springframework.boot.restclient.RestClientCustomizer;
 import org.springframework.boot.restclient.autoconfigure.RestClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClient.Builder;
 import org.springframework.web.client.support.RestClientHttpServiceGroupConfigurer;
 import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.PostExchange;
 import org.springframework.web.service.registry.HttpServiceGroup;
 import org.springframework.web.service.registry.HttpServiceGroupConfigurer.ClientCallback;
 import org.springframework.web.service.registry.HttpServiceGroupConfigurer.Groups;
@@ -64,6 +70,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
@@ -79,6 +86,12 @@ class HttpServiceClientAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withConfiguration(AutoConfigurations.of(HttpServiceClientPropertiesAutoConfiguration.class,
+				HttpServiceClientAutoConfiguration.class, ImperativeHttpClientAutoConfiguration.class,
+				RestClientAutoConfiguration.class));
+
+	private final ReactiveWebApplicationContextRunner reactiveContextRunner = new ReactiveWebApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(JacksonAutoConfiguration.class,
+				HttpMessageConvertersAutoConfiguration.class, HttpServiceClientPropertiesAutoConfiguration.class,
 				HttpServiceClientAutoConfiguration.class, ImperativeHttpClientAutoConfiguration.class,
 				RestClientAutoConfiguration.class));
 
@@ -108,6 +121,24 @@ class HttpServiceClientAutoConfigurationTests {
 					.andRespond(withSuccess().body("boot!"));
 				TestClientTwo clientTwo = context.getBean(TestClientTwo.class);
 				assertThat(clientTwo.there()).isEqualTo("boot!");
+			});
+	}
+
+	@Test // gh-50695
+	void configuresClientMessageConvertersInReactiveWebApplication() {
+		this.reactiveContextRunner
+			.withPropertyValues("spring.jackson.default-property-inclusion=non_empty",
+					"spring.http.serviceclient.one.base-url=https://example.com")
+			.withUserConfiguration(HttpClientConfiguration.class, MockRestServiceServerConfiguration.class)
+			.run((context) -> {
+				MockRestServiceServerConfiguration mockServers = context
+					.getBean(MockRestServiceServerConfiguration.class);
+				MockRestServiceServer serverOne = mockServers.getMock("one");
+				serverOne.expect(requestTo("https://example.com/items"))
+					.andExpect(content().string("{\"name\":\"spring\"}"))
+					.andRespond(withSuccess());
+				TestClientOne clientOne = context.getBean(TestClientOne.class);
+				clientOne.create(new TestPayload("spring", null, new String[0]));
 			});
 	}
 
@@ -308,6 +339,9 @@ class HttpServiceClientAutoConfigurationTests {
 		@GetExchange("/hello")
 		String hello();
 
+		@PostExchange("/items")
+		void create(@RequestBody TestPayload payload);
+
 	}
 
 	interface TestClientTwo {
@@ -315,6 +349,9 @@ class HttpServiceClientAutoConfigurationTests {
 		@GetExchange("/there")
 		String there();
 
+	}
+
+	record TestPayload(String name, @Nullable String description, String[] tags) {
 	}
 
 }


### PR DESCRIPTION
Closes gh-50695

When a reactive web application uses RestClient-backed HTTP service clients, `HttpMessageConvertersAutoConfiguration` is not active and no `ClientHttpMessageConvertersCustomizer` is available. As a result, the group-created `RestClient.Builder` falls back to its default Jackson converter instead of using Boot's auto-configured `JsonMapper`.

This adds a fallback `RestClientCustomizer` that applies the auto-configured Jackson `JsonMapper` when client HTTP message converter customizers are not available.

External repro: https://github.com/jyt6640/spring-boot-gh-50695-repro

Verification:
- `JAVA_HOME=$(/usr/libexec/java_home -v 25) ./gradlew :module:spring-boot-restclient:test --tests org.springframework.boot.restclient.autoconfigure.service.HttpServiceClientAutoConfigurationTests.configuresClientMessageConvertersInReactiveWebApplication`
- `JAVA_HOME=$(/usr/libexec/java_home -v 25) ./gradlew :module:spring-boot-restclient:test`