### PR TITLE
Fix Javadoc for GraylogExtendedLogFormatProperties

### DIFF
--- a/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/structured/GraylogExtendedLogFormatProperties.java
+++ b/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/logging/structured/GraylogExtendedLogFormatProperties.java
@@ -25,10 +25,10 @@ import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
 
 /**
- * Service details for Graylog Extended Log Format structured logging.
+ * Properties for Graylog Extended Log Format structured logging.
  *
  * @param host the application name
- * @param service the version of the application
+ * @param service service details
  * @author Samuel Lissner
  * @author Phillip Webb
  * @since 3.4.0


### PR DESCRIPTION
The class-level Javadoc and the `service` component description of `GraylogExtendedLogFormatProperties` were copied from the nested `Service` record and not adapted:

- the type is described as "Service details for …" although it is a properties record;
- `@param service` is described as "the version of the application", which is the description of `Service.version`, not the `service` component (a `Service`).

Align both with the parallel `ElasticCommonSchemaProperties` ("Properties for … structured logging." / `@param service service details`).

Javadoc only — no behavior change.
