### PR TITLE
Embedded LDAP SSL should not be enabled when its bundle is empty

### DIFF
--- a/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/autoconfigure/embedded/EmbeddedLdapProperties.java
+++ b/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/autoconfigure/embedded/EmbeddedLdapProperties.java
@@ -24,6 +24,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.convert.Delimiter;
 import org.springframework.core.io.Resource;
+import org.springframework.util.StringUtils;
 
 /**
  * Configuration properties for Embedded LDAP.
@@ -150,7 +151,7 @@ public class EmbeddedLdapProperties {
 		private @Nullable String bundle;
 
 		public boolean isEnabled() {
-			return (this.enabled != null) ? this.enabled : this.bundle != null;
+			return (this.enabled != null) ? this.enabled : StringUtils.hasText(this.bundle);
 		}
 
 		public void setEnabled(boolean enabled) {

--- a/module/spring-boot-ldap/src/test/java/org/springframework/boot/ldap/autoconfigure/embedded/EmbeddedLdapAutoConfigurationTests.java
+++ b/module/spring-boot-ldap/src/test/java/org/springframework/boot/ldap/autoconfigure/embedded/EmbeddedLdapAutoConfigurationTests.java
@@ -411,6 +411,13 @@ class EmbeddedLdapAutoConfigurationTests {
 		});
 	}
 
+	@Test
+	void sslIsNotEnabledWhenBundleIsEmpty() {
+		EmbeddedLdapProperties properties = new EmbeddedLdapProperties();
+		properties.getSsl().setBundle("");
+		assertThat(properties.getSsl().isEnabled()).isFalse();
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	static class LdapClientConfiguration {
 


### PR DESCRIPTION
`EmbeddedLdapProperties.Ssl.isEnabled()` derives enablement from `this.bundle != null`, so it returns `true` even when the bundle is overridden to an empty string.

This was harmonized for the other SSL properties classes in #50624 (Cassandra, MongoDB, Redis, Mail), and Couchbase/RabbitMQ already used `StringUtils.hasText(...)`, but `EmbeddedLdapProperties` was missed. This aligns it with those classes and with its own Javadoc ("Enabled automatically if 'bundle' is provided").

Note: `EmbeddedLdapAutoConfiguration` additionally guards the bundle with `StringUtils.hasLength(...)`, so this corrects the property's contract rather than changing the end-to-end auto-configuration behaviour.
