### PR TITLE
Add OverrideNestedTestConfigurationTests for nested test configuration

### DIFF
--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/nestedtests/OverrideNestedTestConfigurationTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/nestedtests/OverrideNestedTestConfigurationTests.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.context.nestedtests;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.NestedTestConfiguration;
+import org.springframework.test.context.NestedTestConfiguration.EnclosingConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+/**
+ * Tests for nested test configuration when the configuration is overridden in the nested
+ * class using {@link NestedTestConfiguration @NestedTestConfiguration(OVERRIDE)}.
+ *
+ * @author Muhammadjon Saidov
+ */
+@SpringBootTest(classes = OverrideNestedTestConfigurationTests.AppConfiguration.class)
+@Import(OverrideNestedTestConfigurationTests.ActionPerformer.class)
+class OverrideNestedTestConfigurationTests {
+
+	@MockitoBean
+	Action action;
+
+	@Autowired
+	ActionPerformer performer;
+
+	@Test
+	void mockWasInvokedOnce() {
+		this.performer.run();
+		then(this.action).should().perform();
+	}
+
+	@Test
+	void mockWasInvokedTwice() {
+		this.performer.run();
+		this.performer.run();
+		then(this.action).should(times(2)).perform();
+	}
+
+	@Nested
+	@NestedTestConfiguration(EnclosingConfiguration.OVERRIDE)
+	@SpringBootTest(classes = OverrideNestedTestConfigurationTests.InnerAppConfiguration.class)
+	@Import(OverrideNestedTestConfigurationTests.ActionPerformer.class)
+	class InnerTests {
+
+		@MockitoBean
+		Action action;
+
+		@Autowired
+		ActionPerformer performer;
+
+		@Test
+		void mockWasInvokedOnce() {
+			this.performer.run();
+			then(this.action).should().perform();
+		}
+
+		@Test
+		void mockWasInvokedTwice() {
+			this.performer.run();
+			this.performer.run();
+			then(this.action).should(times(2)).perform();
+		}
+
+	}
+
+	@Component
+	static class ActionPerformer {
+
+		private final Action action;
+
+		ActionPerformer(Action action) {
+			this.action = action;
+		}
+
+		void run() {
+			this.action.perform();
+		}
+
+	}
+
+	public interface Action {
+
+		void perform();
+
+	}
+
+	@SpringBootConfiguration
+	static class AppConfiguration {
+
+	}
+
+	@SpringBootConfiguration
+	static class InnerAppConfiguration {
+
+	}
+
+}


### PR DESCRIPTION
Add tests verifying @NestedTestConfiguration(OVERRIDE) semantics where
a nested test class uses its own independent Spring application context
rather than inheriting configuration from the enclosing class.

This adds `OverrideNestedTestConfigurationTests` to the `nestedtests`
package alongside the existing `InheritedNestedTestConfigurationTests`,
completing coverage for both `INHERIT` (default) and `OVERRIDE` modes
of `@NestedTestConfiguration`.

Closes gh-23929

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
