### PR TITLE
PropertiesWebClientHttpServiceGroupConfigurer has highest precedence, preventing other configurers from being ordered ahead of it

### DIFF
--- a/module/spring-boot-webclient/src/main/java/org/springframework/boot/webclient/autoconfigure/service/PropertiesWebClientHttpServiceGroupConfigurer.java
+++ b/module/spring-boot-webclient/src/main/java/org/springframework/boot/webclient/autoconfigure/service/PropertiesWebClientHttpServiceGroupConfigurer.java
@@ -47,6 +47,11 @@ import org.springframework.web.service.registry.HttpServiceGroup;
  */
 class PropertiesWebClientHttpServiceGroupConfigurer implements WebClientHttpServiceGroupConfigurer {
 
+	/**
+	 * The default order for the PropertiesWebClientHttpServiceGroupConfigurer.
+	 */
+	private static final int DEFAULT_ORDER = Ordered.HIGHEST_PRECEDENCE + 10;
+
 	private final HttpServiceClientProperties properties;
 
 	private final HttpClientSettingsPropertyMapper clientSettingsPropertyMapper;
@@ -65,7 +70,7 @@ class PropertiesWebClientHttpServiceGroupConfigurer implements WebClientHttpServ
 
 	@Override
 	public int getOrder() {
-		return Ordered.HIGHEST_PRECEDENCE;
+		return DEFAULT_ORDER;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #50736. `PropertiesWebClientHttpServiceGroupConfigurer#getOrder()` still returned `Ordered.HIGHEST_PRECEDENCE`, so other configurers could not be ordered ahead of it.

## Changes
- `PropertiesWebClientHttpServiceGroupConfigurer` order changed to `Ordered.HIGHEST_PRECEDENCE + 10`, mirroring 72eaeecd5cd (`PropertiesRestClientHttpServiceGroupConfigurer`)

## Testing
- `./gradlew :module:spring-boot-webclient:test`
