### PR TITLE
Fix duplicate word typos in documentation

### DIFF
--- a/documentation/spring-boot-actuator-docs/src/test/java/org/springframework/boot/actuate/docs/info/InfoEndpointDocumentationTests.java
+++ b/documentation/spring-boot-actuator-docs/src/test/java/org/springframework/boot/actuate/docs/info/InfoEndpointDocumentationTests.java
@@ -119,7 +119,7 @@ class InfoEndpointDocumentationTests extends MockMvcEndpointDocumentationTests {
 				fieldWithPath("memory.nonHeap.max")
 					.description("Maximum number of bytes that can be used by the JVM (or -1)."),
 				fieldWithPath("memory.garbageCollectors").description("Details for garbage collectors."),
-				fieldWithPath("memory.garbageCollectors[].name").description("Name of of the garbage collector."),
+				fieldWithPath("memory.garbageCollectors[].name").description("Name of the garbage collector."),
 				fieldWithPath("memory.garbageCollectors[].collectionCount")
 					.description("Total number of collections that have occurred."),
 				fieldWithPath("virtualThreads")


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Removes duplicated words ("the the" and "of of") found in two documentation-related files.
