### PR TITLE
Prevent management child context from applying parent WebMvcConfigurer beans

### DIFF
--- a/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/actuate/web/ManagementChildDelegatingWebMvcConfiguration.java
+++ b/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/actuate/web/ManagementChildDelegatingWebMvcConfiguration.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.webmvc.autoconfigure.actuate.web;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.web.servlet.config.annotation.DelegatingWebMvcConfiguration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * A {@link DelegatingWebMvcConfiguration} for the management child context that only
+ * delegates to {@link WebMvcConfigurer} beans defined in the local context, ignoring any
+ * such beans from the parent (main) application context.
+ * <p>
+ * When the management server runs on a different port, the child context has the main
+ * context as its parent. {@code DelegatingWebMvcConfiguration} uses {@code @Autowired}
+ * to collect all {@code WebMvcConfigurer} beans, which resolves from both the child and
+ * parent bean factories. This subclass overrides the injection to filter out parent
+ * configurers, preventing duplicate execution of callback methods such as
+ * {@code addResourceHandlers} and {@code addViewControllers}.
+ * <p>
+ * Filtering is deferred to {@link InitializingBean#afterPropertiesSet()} because
+ * {@code @Autowired} injection occurs during {@code populateBean()}, before the
+ * {@code ApplicationContextAware} callback sets the application context. The application
+ * context is guaranteed to be available by the time {@code afterPropertiesSet()} is
+ * called.
+ *
+ * @author sawirricardo
+ * @since 4.0.0
+ */
+class ManagementChildDelegatingWebMvcConfiguration extends DelegatingWebMvcConfiguration
+		implements InitializingBean {
+
+	@Override
+	@Autowired(required = false)
+	void setConfigurers(List<WebMvcConfigurer> configurers) {
+		// No-op: defer to afterPropertiesSet() where ApplicationContext is available.
+		// The injected list contains beans from both child and parent contexts;
+		// we filter to local-only in afterPropertiesSet().
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		super.setConfigurers(getLocalConfigurers());
+	}
+
+	private List<WebMvcConfigurer> getLocalConfigurers() {
+		ConfigurableListableBeanFactory beanFactory = ((ConfigurableApplicationContext) getApplicationContext())
+			.getBeanFactory();
+		String[] localNames = beanFactory.getBeanNamesForType(WebMvcConfigurer.class);
+		List<WebMvcConfigurer> localConfigurers = new ArrayList<>(localNames.length);
+		for (String name : localNames) {
+			localConfigurers.add(beanFactory.getBean(name, WebMvcConfigurer.class));
+		}
+		return localConfigurers;
+	}
+
+}

--- a/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/actuate/web/WebMvcEndpointChildContextConfiguration.java
+++ b/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/actuate/web/WebMvcEndpointChildContextConfiguration.java
@@ -37,12 +37,18 @@ import org.springframework.core.Ordered;
 import org.springframework.web.context.request.RequestContextListener;
 import org.springframework.web.filter.RequestContextFilter;
 import org.springframework.web.servlet.DispatcherServlet;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.context.annotation.Import;
 
 /**
  * {@link ManagementContextConfiguration @ManagementContextConfiguration} for Spring MVC
  * infrastructure when a separate management context with a web server running on a
  * different port is required.
+ * <p>
+ * Uses {@link ManagementChildDelegatingWebMvcConfiguration} rather than
+ * {@code @EnableWebMvc}/{@code DelegatingWebMvcConfiguration} to prevent
+ * {@code WebMvcConfigurer} beans from the parent (main) application context from being
+ * applied to the management context. This avoids duplicate execution of callback methods
+ * such as {@code addResourceHandlers} and {@code addViewControllers}.
  *
  * @author Stephane Nicoll
  * @author Andy Wilkinson
@@ -51,7 +57,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @ManagementContextConfiguration(value = ManagementContextType.CHILD, proxyBeanMethods = false)
 @ConditionalOnWebApplication(type = Type.SERVLET)
 @ConditionalOnClass(DispatcherServlet.class)
-@EnableWebMvc
+@Import(ManagementChildDelegatingWebMvcConfiguration.class)
 class WebMvcEndpointChildContextConfiguration {
 
 	/*

--- a/module/spring-boot-webmvc/src/test/java/org/springframework/boot/webmvc/autoconfigure/actuate/web/WebMvcEndpointChildContextConfigurationTests.java
+++ b/module/spring-boot-webmvc/src/test/java/org/springframework/boot/webmvc/autoconfigure/actuate/web/WebMvcEndpointChildContextConfigurationTests.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.context.request.RequestContextListener;
 import org.springframework.web.filter.RequestContextFilter;
+import org.springframework.web.servlet.config.annotation.DelegatingWebMvcConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -67,6 +68,16 @@ class WebMvcEndpointChildContextConfigurationTests {
 	void contextShouldConfigureDispatcherServletPathWithRootPath() {
 		this.contextRunner.withUserConfiguration(WebMvcEndpointChildContextConfiguration.class)
 			.run((context) -> assertThat(context.getBean(DispatcherServletPath.class).getPath()).isEqualTo("/"));
+	}
+
+	@Test // gh-4929
+	void contextShouldUseManagementChildDelegatingWebMvcConfiguration() {
+		this.contextRunner.withUserConfiguration(WebMvcEndpointChildContextConfiguration.class)
+			.run((context) -> {
+				assertThat(context).hasSingleBean(DelegatingWebMvcConfiguration.class);
+				assertThat(context.getBean(DelegatingWebMvcConfiguration.class))
+					.isInstanceOf(ManagementChildDelegatingWebMvcConfiguration.class);
+			});
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
## Problem

When `management.server.port` is set to a different port from `server.port`, Spring Boot creates a child `ApplicationContext` for the actuator endpoints. This child context has the main context as its parent.

`WebMvcEndpointChildContextConfiguration` uses `@EnableWebMvc`, which imports `DelegatingWebMvcConfiguration`. This class collects all `WebMvcConfigurer` beans from the bean factory hierarchy (both child and parent contexts) via `@Autowired`. As a result, callback methods such as `addViewControllers`, `addResourceHandlers`, and `configurePathMatch` are invoked on parent-defined `WebMvcConfigurer` beans within the management context, causing duplicate and unintended configuration.

## Solution

Replace `@EnableWebMvc` with `@Import(ManagementChildDelegatingWebMvcConfiguration.class)` in `WebMvcEndpointChildContextConfiguration`.

`ManagementChildDelegatingWebMvcConfiguration` extends `DelegatingWebMvcConfiguration` but overrides `setConfigurers()` to only collect `WebMvcConfigurer` beans defined in the local (child) bean factory, excluding any from the parent context. This is done by calling `getBeanNamesForType(WebMvcConfigurer.class)` on the local `ConfigurableListableBeanFactory`, which does not walk the parent hierarchy.

Child-context `WebMvcConfigurer` beans such as `EndpointJsonMapperWebMvcConfigurer` (which customizes Jackson serialization for `OperationResponseBody`) continue to work correctly since they are defined in the local factory.

The `DispatcherServlet` in the child context is already configured with `setDetectAllHandlerMappings(false)`, `setDetectAllHandlerAdapters(false)`, etc., so it only uses the explicitly-defined `CompositeHandlerMapping`, `CompositeHandlerAdapter`, and `CompositeHandlerExceptionResolver` beans.

## Files Changed

- `ManagementChildDelegatingWebMvcConfiguration.java` — new class: subclass of `DelegatingWebMvcConfiguration` that filters configurers to local-only
- `WebMvcEndpointChildContextConfiguration.java` — replace `@EnableWebMvc` with `@Import(ManagementChildDelegatingWebMvcConfiguration.class)`
- `WebMvcEndpointChildContextConfigurationTests.java` — test verifying the management context uses `ManagementChildDelegatingWebMvcConfiguration`

Fixes #4929