### PR TITLE
Map properties bound from empty strings fail with ConverterNotFoundException

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
@@ -33,6 +33,7 @@ import org.springframework.boot.context.properties.source.ConfigurationPropertyS
 import org.springframework.boot.context.properties.source.IterableConfigurationPropertySource;
 import org.springframework.core.CollectionFactory;
 import org.springframework.core.ResolvableType;
+import org.springframework.util.ObjectUtils;
 
 /**
  * {@link AggregateBinder} for Maps.
@@ -64,6 +65,9 @@ class MapBinder extends AggregateBinder<Map<Object, Object>> {
 				if (property != null) {
 					getContext().setConfigurationProperty(property);
 					Object result = getContext().getPlaceholdersResolver().resolvePlaceholders(property.getValue());
+					if (ObjectUtils.isEmpty(result)) {
+						return createMap(target);
+					}
 					return getContext().getConverter().convert(result, target);
 				}
 			}

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/MapBinder.java
@@ -33,13 +33,13 @@ import org.springframework.boot.context.properties.source.ConfigurationPropertyS
 import org.springframework.boot.context.properties.source.IterableConfigurationPropertySource;
 import org.springframework.core.CollectionFactory;
 import org.springframework.core.ResolvableType;
-import org.springframework.util.ObjectUtils;
 
 /**
  * {@link AggregateBinder} for Maps.
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Ahmed El Amraouiyine
  */
 class MapBinder extends AggregateBinder<Map<Object, Object>> {
 
@@ -65,7 +65,7 @@ class MapBinder extends AggregateBinder<Map<Object, Object>> {
 				if (property != null) {
 					getContext().setConfigurationProperty(property);
 					Object result = getContext().getPlaceholdersResolver().resolvePlaceholders(property.getValue());
-					if (ObjectUtils.isEmpty(result)) {
+					if (result instanceof CharSequence charSequence && charSequence.isEmpty()) {
 						return createMap(target);
 					}
 					return getContext().getConverter().convert(result, target);

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/MapBinderTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/MapBinderTests.java
@@ -65,6 +65,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Ahmed El Amraouiyine
  */
 class MapBinderTests {
 

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/MapBinderTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/MapBinderTests.java
@@ -275,6 +275,15 @@ class MapBinderTests {
 	}
 
 	@Test
+	void bindToMapWhenEmptyStringShouldReturnEmptyMap() {
+		MockConfigurationPropertySource source = new MockConfigurationPropertySource();
+		source.put("foo", "");
+		this.sources.add(source);
+		Map<String, String> result = this.binder.bind("foo", STRING_STRING_MAP).get();
+		assertThat(result).isEmpty();
+	}
+
+	@Test
 	void bindToMapShouldConvertKey() {
 		MockConfigurationPropertySource source = new MockConfigurationPropertySource();
 		source.put("foo[0]", "1");
@@ -508,6 +517,17 @@ class MapBinderTests {
 		NestableFoo foo2 = foo.get().getFoos().get("foo2");
 		assertThat(foo2).isNotNull();
 		assertThat(foo2.getValue()).isEqualTo("three");
+	}
+
+	@Test
+	void nestedMapsWhenEmptyStringShouldReturnEmptyMap() {
+		MockConfigurationPropertySource source = new MockConfigurationPropertySource();
+		source.put("foo.value", "one");
+		source.put("foo.foos", "");
+		this.sources.add(source);
+		BindResult<NestableFoo> foo = this.binder.bind("foo", NestableFoo.class);
+		assertThat(foo.get().getValue()).isEqualTo("one");
+		assertThat(foo.get().getFoos()).isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #50756

Map binding now treats an empty direct property value as an explicitly empty map, matching the existing behavior for empty collections and arrays. Non-empty direct values still use the existing scalar conversion path.

Tests:
- ./gradlew :core:spring-boot:test --tests org.springframework.boot.context.properties.bind.MapBinderTests --tests org.springframework.boot.env.OriginTrackedYamlLoaderTests
- ./gradlew :core:spring-boot:checkstyleMain :core:spring-boot:checkstyleTest
- git diff --check