### PR TITLE
Application-managed JUL bridge handler should only be removed if installed

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystem.java
@@ -76,6 +76,7 @@ import org.springframework.util.StringUtils;
  * @author Ben Hale
  * @author Ralph Goers
  * @author Piotr P. Karwasz
+ * @author Dhruv Rastogi
  * @since 1.2.0
  */
 public class Log4J2LoggingSystem extends AbstractLoggingSystem {
@@ -117,6 +118,8 @@ public class Log4J2LoggingSystem extends AbstractLoggingSystem {
 	private static final org.apache.logging.log4j.Logger statusLogger = StatusLogger.getLogger();
 
 	private final LoggerContext loggerContext;
+
+	private boolean bridgeHandlerInstalled;
 
 	/**
 	 * Create a new {@link Log4J2LoggingSystem} instance.
@@ -189,6 +192,7 @@ public class Log4J2LoggingSystem extends AbstractLoggingSystem {
 					&& isLog4jBridgeHandlerAvailable()) {
 				removeDefaultRootHandler();
 				Log4jBridgeHandler.install(false, null, true);
+				this.bridgeHandlerInstalled = true;
 				return true;
 			}
 		}
@@ -454,8 +458,9 @@ public class Log4J2LoggingSystem extends AbstractLoggingSystem {
 
 	@Override
 	public void cleanUp() {
-		if (isLog4jBridgeHandlerAvailable()) {
+		if (this.bridgeHandlerInstalled) {
 			removeLog4jBridgeHandler();
+			this.bridgeHandlerInstalled = false;
 		}
 		super.cleanUp();
 		LoggerContext loggerContext = getLoggerContext();

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -75,6 +75,7 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Andy Wilkinson
  * @author Ben Hale
+ * @author Dhruv Rastogi
  * @since 1.0.0
  */
 public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanFactoryInitializationAotProcessor {
@@ -111,6 +112,8 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 
 	private final StatusPrinter2 statusPrinter = new StatusPrinter2();
 
+	private boolean bridgeHandlerInstalled;
+
 	public LogbackLoggingSystem(ClassLoader classLoader) {
 		super(classLoader);
 	}
@@ -141,6 +144,7 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 			if (isBridgeJulIntoSlf4j()) {
 				removeJdkLoggingBridgeHandler();
 				SLF4JBridgeHandler.install();
+				this.bridgeHandlerInstalled = true;
 			}
 		}
 		catch (Throwable ex) {
@@ -334,8 +338,9 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 		LoggerContext context = getLoggerContext();
 		markAsUninitialized(context);
 		super.cleanUp();
-		if (isBridgeHandlerAvailable()) {
+		if (this.bridgeHandlerInstalled) {
 			removeJdkLoggingBridgeHandler();
+			this.bridgeHandlerInstalled = false;
 		}
 		context.getStatusManager().clear();
 		context.getTurboFilterList().remove(SUPPRESS_ALL_FILTER);

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
@@ -88,6 +88,7 @@ import static org.mockito.Mockito.times;
  * @author Ben Hale
  * @author Madhura Bhave
  * @author Piotr P. Karwasz
+ * @author Dhruv Rastogi
  */
 @ExtendWith(OutputCaptureExtension.class)
 @ClassPathExclusions("logback-*.jar")
@@ -404,6 +405,25 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 		assertThat(logger.getLevel()).isNull();
 		loggingSystem.setLogLevel(Log4J2LoggingSystemTests.class.getName(), LogLevel.DEBUG);
 		assertThat(logger.getLevel()).isEqualTo(Level.FINE);
+	}
+
+	@Test
+	void cleanUpLeavesBridgeHandlerInstalledByTheApplicationInPlace() {
+		java.util.logging.Logger rootLogger = java.util.logging.Logger.getLogger("");
+		Log4jBridgeHandler.install(false, null, true);
+		try {
+			assertThat(rootLogger.getHandlers()).hasAtLeastOneElementOfType(Log4jBridgeHandler.class);
+			this.loggingSystem.beforeInitialize();
+			this.loggingSystem.cleanUp();
+			assertThat(rootLogger.getHandlers()).hasAtLeastOneElementOfType(Log4jBridgeHandler.class);
+		}
+		finally {
+			for (Handler handler : rootLogger.getHandlers()) {
+				if (handler instanceof Log4jBridgeHandler) {
+					rootLogger.removeHandler(handler);
+				}
+			}
+		}
 	}
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4J2LoggingSystemTests.java
@@ -408,6 +408,16 @@ class Log4J2LoggingSystemTests extends AbstractLoggingSystemTests {
 	}
 
 	@Test
+	void cleanUpCleansBridgeHandlerInstalledByTheLoggingSystem() {
+		this.loggingSystem.beforeInitialize();
+		java.util.logging.Logger rootLogger = java.util.logging.Logger.getLogger("");
+		assertThat(rootLogger.getHandlers()).hasAtLeastOneElementOfType(Log4jBridgeHandler.class);
+		this.loggingSystem.cleanUp();
+		java.util.logging.Logger rootLoggerAfterCleanUp = java.util.logging.Logger.getLogger("");
+		assertThat(rootLoggerAfterCleanUp.getHandlers()).doesNotHaveAnyElementsOfTypes(Log4jBridgeHandler.class);
+	}
+
+	@Test
 	void cleanUpLeavesBridgeHandlerInstalledByTheApplicationInPlace() {
 		java.util.logging.Logger rootLogger = java.util.logging.Logger.getLogger("");
 		Log4jBridgeHandler.install(false, null, true);

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/LogbackLoggingSystemTests.java
@@ -107,6 +107,7 @@ import static org.mockito.Mockito.times;
  * @author Scott Frederick
  * @author Jonatan Ivanov
  * @author Moritz Halbritter
+ * @author Dhruv Rastogi
  */
 @ExtendWith(OutputCaptureExtension.class)
 @ClassPathExclusions({ "log4j-core-*.jar", "log4j-api-*.jar" })
@@ -338,6 +339,20 @@ class LogbackLoggingSystemTests extends AbstractLoggingSystemTests {
 		assertThat(bridgeHandlerInstalled()).isTrue();
 		this.loggingSystem.cleanUp();
 		assertThat(bridgeHandlerInstalled()).isFalse();
+	}
+
+	@Test
+	void cleanUpLeavesBridgeHandlerInstalledByTheApplicationInPlace() {
+		SLF4JBridgeHandler.install();
+		try {
+			assertThat(bridgeHandlerInstalled()).isTrue();
+			this.loggingSystem.beforeInitialize();
+			this.loggingSystem.cleanUp();
+			assertThat(bridgeHandlerInstalled()).isTrue();
+		}
+		finally {
+			SLF4JBridgeHandler.uninstall();
+		}
 	}
 
 	@Test


### PR DESCRIPTION
This addresses the install/uninstall asymmetry described in #33697.

`LogbackLoggingSystem` and `Log4J2LoggingSystem` install a JUL bridge handler (`SLF4JBridgeHandler` / `Log4jBridgeHandler`) only when the application is not already managing `java.util.logging` itself (i.e. when the JUL root logger is using at most a single `ConsoleHandler`). However, `cleanUp()` removed the bridge handler whenever the bridge class was merely present on the classpath.

As a result, when an application installs and manages its own JUL bridge handler, Spring Boot would still uninstall it during context shutdown — tearing down a handler it never installed.

This change tracks whether the bridge handler was installed by Spring Boot and only removes it during cleanup when that is the case, making install and uninstall symmetric.

A test is added to each logging system verifying that an application-installed bridge handler is left in place after `cleanUp()`. Both tests fail without the corresponding production change.

Note: this PR is scoped to the install/uninstall asymmetry. The separate question of *when* the bridge handler is removed during the context lifecycle (also discussed in the issue) is intentionally left out of scope.
