### PR TITLE
Setting 'server.servlet.session.cookie.partitioned' to false still emits the 'Partitioned' cookie attribute

### DIFF
--- a/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/servlet/ServletContextInitializers.java
+++ b/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/servlet/ServletContextInitializers.java
@@ -97,7 +97,7 @@ public final class ServletContextInitializers implements Iterable<ServletContext
 			map.from(cookie::getHttpOnly).to(config::setHttpOnly);
 			map.from(cookie::getSecure).to(config::setSecure);
 			map.from(cookie::getMaxAge).asInt(Duration::getSeconds).to(config::setMaxAge);
-			map.from(cookie::getPartitioned).to((partitioned) -> config.setAttribute("Partitioned", ""));
+			map.from(cookie::getPartitioned).whenTrue().to((partitioned) -> config.setAttribute("Partitioned", ""));
 		}
 
 		@Contract("!null -> !null")

--- a/module/spring-boot-web-server/src/testFixtures/java/org/springframework/boot/web/server/servlet/AbstractServletWebServerFactoryTests.java
+++ b/module/spring-boot-web-server/src/testFixtures/java/org/springframework/boot/web/server/servlet/AbstractServletWebServerFactoryTests.java
@@ -899,6 +899,20 @@ public abstract class AbstractServletWebServerFactoryTests {
 				(header) -> assertThat(header).isEqualTo("test=test"));
 	}
 
+	@Test
+	void sessionCookieNotPartitionedAttribute() throws Exception {
+		ConfigurableServletWebServerFactory factory = getFactory();
+		factory.getSettings().getSession().getCookie().setPartitioned(false);
+		factory.addInitializers(new ServletRegistrationBean<>(new CookieServlet(false), "/"));
+		this.webServer = factory.getWebServer();
+		this.webServer.start();
+		ClientHttpResponse clientResponse = getClientResponse(getLocalUrl("/"));
+		List<String> setCookieHeaders = clientResponse.getHeaders().get("Set-Cookie");
+		assertThat(setCookieHeaders).satisfiesExactlyInAnyOrder(
+				(header) -> assertThat(header).startsWith("JSESSIONID=").doesNotContain("; Partitioned"),
+				(header) -> assertThat(header).isEqualTo("test=test"));
+	}
+
 	@ParameterizedTest
 	@EnumSource(mode = EnumSource.Mode.EXCLUDE, names = "OMITTED")
 	void sessionCookieSameSiteAttributeCanBeConfiguredAndOnlyAffectsSessionCookies(SameSite sameSite) throws Exception {
@@ -1226,7 +1240,7 @@ public abstract class AbstractServletWebServerFactoryTests {
 		assertThat(sessionCookieConfig.isHttpOnly()).isTrue();
 		assertThat(sessionCookieConfig.isSecure()).isTrue();
 		assertThat(sessionCookieConfig.getMaxAge()).isEqualTo(60);
-		assertThat(sessionCookieConfig.getAttribute("Partitioned")).isEqualTo("");
+		assertThat(sessionCookieConfig.getAttribute("Partitioned")).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #50774. This regressed from the `partitioned=true` fix in #50201. An explicit `server.servlet.session.cookie.partitioned=false` still emits `; Partitioned`, because `PropertyMapper.to()` only filters `null` and the lambda set the `Partitioned` attribute to `""` for any non-null value.

## Changes
- `ServletContextInitializers` uses `whenTrue()` so the attribute is set only when `partitioned` is `true`

## Testing
- `AbstractServletWebServerFactoryTests.sessionCookieNotPartitionedAttribute` (new, header-level)
- `AbstractServletWebServerFactoryTests.sessionConfiguration` (assertion updated to `isNull()`)
