### PR TITLE
Document OTLP SSL service connections

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/dev-services.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/dev-services.adoc
@@ -152,6 +152,7 @@ SSL is supported for the following service connections:
 * Cassandra
 * Elasticsearch
 * MongoDB
+* OpenTelemetry (OTLP logging, metrics, and tracing)
 * RabbitMQ
 * RabbitMQ Streams
 * Redis

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
@@ -241,6 +241,7 @@ The SSL annotations are supported for the following service connections:
 * Elasticsearch
 * Kafka
 * MongoDB
+* OpenTelemetry (OTLP logging, metrics, and tracing)
 * RabbitMQ
 * RabbitMQ Streams
 * Redis


### PR DESCRIPTION
I found one documentation issue that still appear to be present on current `main` as of https://github.com/spring-projects/spring-boot/commit/2edca39504f8e9c2943262d3e60ba34b0e7751ac.

#### 1. OTLP service connections are omitted from SSL support lists

The Docker Compose SSL support section lists supported service connections, but omits OpenTelemetry/OTLP logging, metrics, and tracing are omitted from [dev-services.adoc](https://github.com/spring-projects/spring-boot/blob/2edca39504f8e9c2943262d3e60ba34b0e7751ac/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/dev-services.adoc) and [testcontainers.adoc](https://github.com/spring-projects/spring-boot/blob/2edca39504f8e9c2943262d3e60ba34b0e7751ac/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc)

Introduced by:
- https://github.com/spring-projects/spring-boot/commit/06272143bf20ce613c425450e34c7f498271b026
- https://github.com/spring-projects/spring-boot/commit/d7f86aa07eac66e083bdde3d22d4d73944fbe396
- https://github.com/spring-projects/spring-boot/commit/166b88b9e197edc300fc6ce4e43993cdd13bfdba

This PR fixes the above issue.