### PR TITLE
Fix OAuth2 resource server web conditions

### DIFF
--- a/module/spring-boot-security-oauth2-resource-server/src/main/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/OAuth2ResourceServerAutoConfiguration.java
+++ b/module/spring-boot-security-oauth2-resource-server/src/main/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/OAuth2ResourceServerAutoConfiguration.java
@@ -18,10 +18,15 @@ package org.springframework.boot.security.oauth2.server.resource.autoconfigure;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnNotWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
 import org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
 
@@ -34,7 +39,26 @@ import org.springframework.security.oauth2.server.resource.authentication.Bearer
 @AutoConfiguration(before = { SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class })
 @EnableConfigurationProperties(OAuth2ResourceServerProperties.class)
 @ConditionalOnClass(BearerTokenAuthenticationToken.class)
+@Conditional(OAuth2ResourceServerAutoConfiguration.NotReactiveWebApplicationCondition.class)
 @Import({ JwtConverterConfiguration.class, JwtDecoderConfiguration.class, OpaqueTokenIntrospectionConfiguration.class })
 public final class OAuth2ResourceServerAutoConfiguration {
+
+	static class NotReactiveWebApplicationCondition extends AnyNestedCondition {
+
+		NotReactiveWebApplicationCondition() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@ConditionalOnWebApplication(type = Type.SERVLET)
+		static class ServletWebApplication {
+
+		}
+
+		@ConditionalOnNotWebApplication
+		static class NonWebApplication {
+
+		}
+
+	}
 
 }

--- a/module/spring-boot-security-oauth2-resource-server/src/main/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/reactive/ReactiveOAuth2ResourceServerAutoConfiguration.java
+++ b/module/spring-boot-security-oauth2-resource-server/src/main/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/reactive/ReactiveOAuth2ResourceServerAutoConfiguration.java
@@ -20,12 +20,17 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnNotWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.security.autoconfigure.ReactiveUserDetailsServiceAutoConfiguration;
 import org.springframework.boot.security.autoconfigure.actuate.web.reactive.ReactiveManagementWebSecurityAutoConfiguration;
 import org.springframework.boot.security.autoconfigure.web.reactive.ReactiveWebSecurityAutoConfiguration;
 import org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
 
@@ -39,9 +44,28 @@ import org.springframework.security.oauth2.server.resource.authentication.Bearer
 @AutoConfiguration(before = { ReactiveManagementWebSecurityAutoConfiguration.class,
 		ReactiveWebSecurityAutoConfiguration.class, ReactiveUserDetailsServiceAutoConfiguration.class })
 @ConditionalOnClass({ Mono.class, BearerTokenAuthenticationToken.class })
+@Conditional(ReactiveOAuth2ResourceServerAutoConfiguration.NotServletWebApplicationCondition.class)
 @EnableConfigurationProperties(OAuth2ResourceServerProperties.class)
 @Import({ ReactiveJwtDecoderConfiguration.class, ReactiveJwtConverterConfiguration.class,
 		ReactiveOpaqueTokenIntrospectionClientConfiguration.class })
 public final class ReactiveOAuth2ResourceServerAutoConfiguration {
+
+	static class NotServletWebApplicationCondition extends AnyNestedCondition {
+
+		NotServletWebApplicationCondition() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@ConditionalOnWebApplication(type = Type.REACTIVE)
+		static class ReactiveWebApplication {
+
+		}
+
+		@ConditionalOnNotWebApplication
+		static class NonWebApplication {
+
+		}
+
+	}
 
 }

--- a/module/spring-boot-security-oauth2-resource-server/src/test/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/OAuth2ResourceServerAutoConfigurationTests.java
+++ b/module/spring-boot-security-oauth2-resource-server/src/test/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/OAuth2ResourceServerAutoConfigurationTests.java
@@ -50,6 +50,8 @@ import org.springframework.boot.context.properties.source.InvalidConfigurationPr
 import org.springframework.boot.context.properties.source.MutuallyExclusiveConfigurationPropertiesException;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.assertj.AssertableWebApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.testsupport.classpath.resources.WithResource;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
@@ -109,6 +111,22 @@ class OAuth2ResourceServerAutoConfigurationTests {
 			+ "uLvolxsDncc2UrhyMBY6DVQVgMSVYaPCTgW76iYEKGgzTEw5IBRQL9w3SRJWd3VJTZZQjkXef48Ocz06PGF3lhbz4t5UEZtd"
 			+ "F4rIe7u-977QwHuh7yRPBQ3sII-cVoOUMgaXB9SHcGF2iZCtPzL_IffDUcfhLQteGebhW8A6eUHgpD5A1PQ-JCw_G7UOzZAj"
 			+ "jDjtNM2eqm8j-Ms_gqnm4MiCZ4E-9pDN77CAAPVN7kuX6ejs9KBXpk01z48i9fORYk9u7rAkh1HuQw\"}]}";
+
+	@Test
+	void autoConfigurationShouldNotApplyToReactiveWebApplication() {
+		new ReactiveWebApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(OAuth2ResourceServerAutoConfiguration.class))
+			.withPropertyValues("spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://jwk-set-uri.com")
+			.run((context) -> assertThat(context).doesNotHaveBean(JwtDecoder.class));
+	}
+
+	@Test
+	void autoConfigurationShouldApplyToNonWebApplication() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(OAuth2ResourceServerAutoConfiguration.class))
+			.withPropertyValues("spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://jwk-set-uri.com")
+			.run((context) -> assertThat(context).hasSingleBean(JwtDecoder.class));
+	}
 
 	@AfterEach
 	void cleanup() throws Exception {

--- a/module/spring-boot-security-oauth2-resource-server/src/test/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
+++ b/module/spring-boot-security-oauth2-resource-server/src/test/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
@@ -52,7 +52,9 @@ import org.springframework.boot.context.properties.source.MutuallyExclusiveConfi
 import org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtConverterCustomizationsArgumentsProvider;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.assertj.AssertableReactiveWebApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
 import org.springframework.boot.testsupport.classpath.resources.WithResource;
 import org.springframework.context.annotation.Bean;
@@ -118,6 +120,22 @@ class ReactiveOAuth2ResourceServerAutoConfigurationTests {
 			+ "uLvolxsDncc2UrhyMBY6DVQVgMSVYaPCTgW76iYEKGgzTEw5IBRQL9w3SRJWd3VJTZZQjkXef48Ocz06PGF3lhbz4t5UEZtd"
 			+ "F4rIe7u-977QwHuh7yRPBQ3sII-cVoOUMgaXB9SHcGF2iZCtPzL_IffDUcfhLQteGebhW8A6eUHgpD5A1PQ-JCw_G7UOzZAj"
 			+ "jDjtNM2eqm8j-Ms_gqnm4MiCZ4E-9pDN77CAAPVN7kuX6ejs9KBXpk01z48i9fORYk9u7rAkh1HuQw\"}]}";
+
+	@Test
+	void autoConfigurationShouldNotApplyToServletWebApplication() {
+		new WebApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(ReactiveOAuth2ResourceServerAutoConfiguration.class))
+			.withPropertyValues("spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://jwk-set-uri.com")
+			.run((context) -> assertThat(context).doesNotHaveBean(ReactiveJwtDecoder.class));
+	}
+
+	@Test
+	void autoConfigurationShouldApplyToNonWebApplication() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(ReactiveOAuth2ResourceServerAutoConfiguration.class))
+			.withPropertyValues("spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://jwk-set-uri.com")
+			.run((context) -> assertThat(context).hasSingleBean(ReactiveJwtDecoder.class));
+	}
 
 	@AfterEach
 	void cleanup() throws Exception {


### PR DESCRIPTION
## Summary
- Prevent the servlet OAuth2 resource server auto-configuration from applying to reactive web applications.
- Prevent the reactive OAuth2 resource server auto-configuration from applying to servlet web applications.
- Keep both auto-configurations available for non-web applications.

Closes #50479

## Verification
- `./gradlew :module:spring-boot-security-oauth2-resource-server:check --no-daemon`
- `git diff --check HEAD^ HEAD`
