### PR TITLE
IllegalStateException when binding properties to a @Validated class that contains a map whose value type is a wildcard

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/validation/ValidationBindHandler.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/validation/ValidationBindHandler.java
@@ -34,7 +34,6 @@ import org.springframework.boot.context.properties.source.ConfigurationProperty;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName.Form;
 import org.springframework.core.ResolvableType;
-import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.validation.AbstractBindingResult;
 import org.springframework.validation.BeanPropertyBindingResult;
@@ -115,8 +114,7 @@ public class ValidationBindHandler extends AbstractBindHandler {
 		if (this.exception == null) {
 			Object validationTarget = getValidationTarget(target, context, result);
 			Class<?> validationType = target.getBoxedType().resolve();
-			if (validationTarget != null) {
-				Assert.state(validationType != null, "'validationType' must not be null");
+			if (validationTarget != null && validationType != null) {
 				validateAndPush(name, validationTarget, validationType);
 			}
 		}

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/validation/ValidationBindHandlerTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/validation/ValidationBindHandlerTests.java
@@ -238,6 +238,15 @@ class ValidationBindHandlerTests {
 		this.binder.bind(ConfigurationPropertyName.of("test"), Bindable.of(ExampleWithMap.class), this.handler);
 	}
 
+	@Test
+	void bindShouldValidateMapWithWildcardValue() {
+		this.sources.add(new MockConfigurationPropertySource("test.params.toto", "titi"));
+		ExampleWithWildcardMap result = this.binder
+			.bind(ConfigurationPropertyName.of("test"), Bindable.of(ExampleWithWildcardMap.class), this.handler)
+			.get();
+		assertThat(result.getParams().get("toto")).isEqualTo("titi");
+	}
+
 	private Validator getMapValidator() {
 		return new Validator() {
 
@@ -421,6 +430,21 @@ class ValidationBindHandlerTests {
 
 		Map<String, ExampleMapValue> getItems() {
 			return this.items;
+		}
+
+	}
+
+	@Validated
+	static class ExampleWithWildcardMap {
+
+		private Map<String, ?> params = new LinkedHashMap<>();
+
+		Map<String, ?> getParams() {
+			return this.params;
+		}
+
+		void setParams(Map<String, ?> params) {
+			this.params = params;
 		}
 
 	}


### PR DESCRIPTION
Fixes #50795

Validation binding now skips validator invocation for bound values whose target type cannot be resolved, such as wildcard map values. This avoids turning a successfully bound value into an `IllegalStateException` while preserving validation for concrete target types.

Tests:
- RED: `./gradlew --no-daemon :core:spring-boot:test --tests org.springframework.boot.context.properties.bind.validation.ValidationBindHandlerTests.bindShouldValidateMapWithWildcardValue` failed before the fix with `Failed to bind properties under 'test.params.toto' to ?` / `'validationType' must not be null`
- `./gradlew --no-daemon :core:spring-boot:test --tests org.springframework.boot.context.properties.bind.validation.ValidationBindHandlerTests.bindShouldValidateMapWithWildcardValue`
- `./gradlew --no-daemon :core:spring-boot:test --tests org.springframework.boot.context.properties.bind.validation.ValidationBindHandlerTests`
- `./gradlew --no-daemon :core:spring-boot:checkstyleMain :core:spring-boot:checkstyleTest`
- `git diff --check`
