### PR TITLE
spring.grpc.server.health.include-overall-health is not taken into account

### DIFF
--- a/module/spring-boot-grpc-server/src/main/java/org/springframework/boot/grpc/server/autoconfigure/health/AutoConfiguredHealthCheckedGrpcComponents.java
+++ b/module/spring-boot-grpc-server/src/main/java/org/springframework/boot/grpc/server/autoconfigure/health/AutoConfiguredHealthCheckedGrpcComponents.java
@@ -68,10 +68,8 @@ class AutoConfiguredHealthCheckedGrpcComponents implements HealthCheckedGrpcComp
 				() -> StatusAggregator.of(properties.getStatus().getOrder()));
 		StatusMapper statusMapper = getNonQualifiedBean(beanFactory, StatusMapper.class,
 				() -> StatusMapper.of(properties.getStatus().getMapping()));
-		this.server = (properties.isIncludeOverallHealth())
-				? new AutoConfiguredHealthCheckedGrpcComponent(HealthContributorMembership.always(), statusAggregator,
-						statusMapper)
-				: null;
+		this.server = (properties.isIncludeOverallHealth()) ? new AutoConfiguredHealthCheckedGrpcComponent(
+				HealthContributorMembership.always(), statusAggregator, statusMapper) : null;
 		this.services = createServices(properties.getService(), beanFactory, statusAggregator, statusMapper);
 	}
 

--- a/module/spring-boot-grpc-server/src/main/java/org/springframework/boot/grpc/server/autoconfigure/health/AutoConfiguredHealthCheckedGrpcComponents.java
+++ b/module/spring-boot-grpc-server/src/main/java/org/springframework/boot/grpc/server/autoconfigure/health/AutoConfiguredHealthCheckedGrpcComponents.java
@@ -51,7 +51,7 @@ import org.springframework.util.ObjectUtils;
  */
 class AutoConfiguredHealthCheckedGrpcComponents implements HealthCheckedGrpcComponents {
 
-	private final HealthCheckedGrpcComponent server;
+	private final @Nullable HealthCheckedGrpcComponent server;
 
 	private final Map<String, HealthCheckedGrpcComponent> services;
 
@@ -68,8 +68,10 @@ class AutoConfiguredHealthCheckedGrpcComponents implements HealthCheckedGrpcComp
 				() -> StatusAggregator.of(properties.getStatus().getOrder()));
 		StatusMapper statusMapper = getNonQualifiedBean(beanFactory, StatusMapper.class,
 				() -> StatusMapper.of(properties.getStatus().getMapping()));
-		this.server = new AutoConfiguredHealthCheckedGrpcComponent(HealthContributorMembership.always(),
-				statusAggregator, statusMapper);
+		this.server = (properties.isIncludeOverallHealth())
+				? new AutoConfiguredHealthCheckedGrpcComponent(HealthContributorMembership.always(), statusAggregator,
+						statusMapper)
+				: null;
 		this.services = createServices(properties.getService(), beanFactory, statusAggregator, statusMapper);
 	}
 

--- a/module/spring-boot-grpc-server/src/test/java/org/springframework/boot/grpc/server/autoconfigure/health/AutoConfiguredHealthCheckedGrpcComponentsTests.java
+++ b/module/spring-boot-grpc-server/src/test/java/org/springframework/boot/grpc/server/autoconfigure/health/AutoConfiguredHealthCheckedGrpcComponentsTests.java
@@ -60,6 +60,15 @@ class AutoConfiguredHealthCheckedGrpcComponentsTests {
 	}
 
 	@Test
+	void getServerWhenIncludeOverallHealthIsFalseReturnsNull() {
+		this.contextRunner.withPropertyValues("spring.grpc.server.health.include-overall-health=false")
+			.run((context) -> {
+				HealthCheckedGrpcComponents components = context.getBean(HealthCheckedGrpcComponents.class);
+				assertThat(components.getServer()).isNull();
+			});
+	}
+
+	@Test
 	void getServiceNamesReturnsServiceNames() {
 		this.contextRunner
 			.withPropertyValues("spring.grpc.server.health.service.a.include=*",

--- a/module/spring-boot-grpc-server/src/test/java/org/springframework/boot/grpc/server/autoconfigure/health/GrpcServerHealthAutoConfigurationTests.java
+++ b/module/spring-boot-grpc-server/src/test/java/org/springframework/boot/grpc/server/autoconfigure/health/GrpcServerHealthAutoConfigurationTests.java
@@ -303,6 +303,16 @@ class GrpcServerHealthAutoConfigurationTests {
 	}
 
 	@Test
+	void whenIncludeOverallHealthIsFalseDoesNotReportOverallHealth() {
+		this.contextRunner.withPropertyValues("spring.grpc.server.health.include-overall-health=false").run((context) -> {
+			GrpcServerHealth serverHealth = context.getBean(GrpcServerHealth.class);
+			Map<String, ServingStatus> result = new LinkedHashMap<>();
+			serverHealth.update(result::put);
+			assertThat(result).isEmpty();
+		});
+	}
+
+	@Test
 	void whenHasGrpcServerHealthBeanDoesNotCreateAdditional() {
 		this.contextRunner.withUserConfiguration(GrpcServerHealthConfiguration.class).run((context) -> {
 			GrpcServerHealth serverHealth = context.getBean(GrpcServerHealth.class);

--- a/module/spring-boot-grpc-server/src/test/java/org/springframework/boot/grpc/server/autoconfigure/health/GrpcServerHealthAutoConfigurationTests.java
+++ b/module/spring-boot-grpc-server/src/test/java/org/springframework/boot/grpc/server/autoconfigure/health/GrpcServerHealthAutoConfigurationTests.java
@@ -304,12 +304,13 @@ class GrpcServerHealthAutoConfigurationTests {
 
 	@Test
 	void whenIncludeOverallHealthIsFalseDoesNotReportOverallHealth() {
-		this.contextRunner.withPropertyValues("spring.grpc.server.health.include-overall-health=false").run((context) -> {
-			GrpcServerHealth serverHealth = context.getBean(GrpcServerHealth.class);
-			Map<String, ServingStatus> result = new LinkedHashMap<>();
-			serverHealth.update(result::put);
-			assertThat(result).isEmpty();
-		});
+		this.contextRunner.withPropertyValues("spring.grpc.server.health.include-overall-health=false")
+			.run((context) -> {
+				GrpcServerHealth serverHealth = context.getBean(GrpcServerHealth.class);
+				Map<String, ServingStatus> result = new LinkedHashMap<>();
+				serverHealth.update(result::put);
+				assertThat(result).isEmpty();
+			});
 	}
 
 	@Test


### PR DESCRIPTION
Fixes gh-50791

`spring.grpc.server.health.include-overall-health=false` was bound but not used by the auto-configured gRPC health components. The overall server component was always created, so scheduled gRPC health updates still evaluated all health contributors even when overall health reporting was disabled.

This change makes the auto-configured server component nullable and omits it when overall health reporting is disabled. Service-specific health components continue to be created from `spring.grpc.server.health.service.*` settings.

Verification:
- RED: `./gradlew :module:spring-boot-grpc-server:test --tests org.springframework.boot.grpc.server.autoconfigure.health.AutoConfiguredHealthCheckedGrpcComponentsTests.getServerWhenIncludeOverallHealthIsFalseReturnsNull --no-daemon` failed before the fix.
- GREEN: `./gradlew :module:spring-boot-grpc-server:test --tests org.springframework.boot.grpc.server.autoconfigure.health.AutoConfiguredHealthCheckedGrpcComponentsTests.getServerWhenIncludeOverallHealthIsFalseReturnsNull --tests org.springframework.boot.grpc.server.autoconfigure.health.GrpcServerHealthAutoConfigurationTests.whenIncludeOverallHealthIsFalseDoesNotReportOverallHealth --no-daemon`
- GREEN: `./gradlew :module:spring-boot-grpc-server:test --tests org.springframework.boot.grpc.server.autoconfigure.health.AutoConfiguredHealthCheckedGrpcComponentsTests --tests org.springframework.boot.grpc.server.autoconfigure.health.GrpcServerHealthAutoConfigurationTests --no-daemon`
- GREEN: `./gradlew :module:spring-boot-grpc-server:checkstyleMain :module:spring-boot-grpc-server:checkstyleTest --no-daemon`
- GREEN: `git diff --check HEAD^ HEAD`
