### PR TITLE
JpaBaseConfiguration#entityManagerConfiguration can cause a dependency loop on beans declaring AsyncTaskExecutor

### DIFF
--- a/module/spring-boot-data-jpa/src/main/java/org/springframework/boot/data/jpa/autoconfigure/DataJpaRepositoriesAutoConfiguration.java
+++ b/module/spring-boot-data-jpa/src/main/java/org/springframework/boot/data/jpa/autoconfigure/DataJpaRepositoriesAutoConfiguration.java
@@ -16,11 +16,7 @@
 
 package org.springframework.boot.data.jpa.autoconfigure;
 
-import java.util.Map;
-
 import javax.sql.DataSource;
-
-import org.jspecify.annotations.Nullable;
 
 import org.springframework.boot.LazyInitializationExcludeFilter;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -38,7 +34,6 @@ import org.springframework.boot.jpa.autoconfigure.EntityManagerFactoryBuilderCus
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportSelector;
-import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.data.envers.repository.config.EnableEnversRepositories;
 import org.springframework.data.envers.repository.support.EnversRevisionRepositoryFactoryBean;
@@ -83,8 +78,7 @@ public final class DataJpaRepositoriesAutoConfiguration {
 
 	@Bean
 	@ConditionalOnProperty(name = "spring.data.jpa.repositories.bootstrap-mode", havingValue = "deferred")
-	EntityManagerFactoryBuilderCustomizer entityManagerFactoryBootstrapExecutorCustomizer(
-			Map<String, AsyncTaskExecutor> taskExecutors) {
+	EntityManagerFactoryBuilderCustomizer entityManagerFactoryBootstrapExecutorCustomizer() {
 		return (builder) -> builder.requireBootstrapExecutor(() -> BootstrapExecutorRequiredException
 			.ofProperty("spring.data.jpa.repositories.bootstrap-mode", "deferred"));
 	}
@@ -92,13 +86,6 @@ public final class DataJpaRepositoriesAutoConfiguration {
 	@Bean
 	static LazyInitializationExcludeFilter eagerJpaMetamodelCacheCleanup() {
 		return (name, definition, type) -> "org.springframework.data.jpa.util.JpaMetamodelCacheCleanup".equals(name);
-	}
-
-	private @Nullable AsyncTaskExecutor determineBootstrapExecutor(Map<String, AsyncTaskExecutor> taskExecutors) {
-		if (taskExecutors.size() == 1) {
-			return taskExecutors.values().iterator().next();
-		}
-		return taskExecutors.get(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME);
 	}
 
 	static class JpaRepositoriesImportSelector implements ImportSelector {

--- a/module/spring-boot-hibernate/src/test/java/org/springframework/boot/hibernate/autoconfigure/HibernateJpaAutoConfigurationTests.java
+++ b/module/spring-boot-hibernate/src/test/java/org/springframework/boot/hibernate/autoconfigure/HibernateJpaAutoConfigurationTests.java
@@ -104,6 +104,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.SQLExceptionTranslator;
@@ -304,11 +305,11 @@ class HibernateJpaAutoConfigurationTests {
 	}
 
 	@Test
-	void whenAsyncTaskExecutorIsDefinedInJpaDependentConfigurationDoesNotTriggerABeanCurrentlyInCreationException() {
-		this.contextRunner.withUserConfiguration(AsyncTaskExecutorDependingOnEntityManagerFactoryConfiguration.class)
+	void whenAsyncTaskExecutorIsDefinedInJpaDependentConfigurationDoesNotFail() {
+		this.contextRunner.withUserConfiguration(TaskExecutorDependingOnEntityManagerFactoryConfiguration.class)
 			.run((context) -> {
 				assertThat(context).hasNotFailed();
-				assertThat(context).hasSingleBean(EntityManagerFactory.class);
+				assertThat(context).hasSingleBean(EntityManagerFactory.class).hasSingleBean(AsyncTaskExecutor.class);
 			});
 	}
 
@@ -1484,9 +1485,9 @@ class HibernateJpaAutoConfigurationTests {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	static class AsyncTaskExecutorDependingOnEntityManagerFactoryConfiguration {
+	static class TaskExecutorDependingOnEntityManagerFactoryConfiguration {
 
-		AsyncTaskExecutorDependingOnEntityManagerFactoryConfiguration(EntityManagerFactory entityManagerFactory) {
+		TaskExecutorDependingOnEntityManagerFactoryConfiguration(EntityManagerFactory entityManagerFactory) {
 		}
 
 		@Bean

--- a/module/spring-boot-hibernate/src/test/java/org/springframework/boot/hibernate/autoconfigure/HibernateJpaAutoConfigurationTests.java
+++ b/module/spring-boot-hibernate/src/test/java/org/springframework/boot/hibernate/autoconfigure/HibernateJpaAutoConfigurationTests.java
@@ -304,6 +304,15 @@ class HibernateJpaAutoConfigurationTests {
 	}
 
 	@Test
+	void whenAsyncTaskExecutorIsDefinedInJpaDependentConfigurationDoesNotTriggerABeanCurrentlyInCreationException() {
+		this.contextRunner.withUserConfiguration(AsyncTaskExecutorDependingOnEntityManagerFactoryConfiguration.class)
+			.run((context) -> {
+				assertThat(context).hasNotFailed();
+				assertThat(context).hasSingleBean(EntityManagerFactory.class);
+			});
+	}
+
+	@Test
 	void customJpaProperties() {
 		this.contextRunner
 			.withPropertyValues("spring.jpa.properties.a:b", "spring.jpa.properties.a.b:c", "spring.jpa.properties.c:d")
@@ -1469,6 +1478,19 @@ class HibernateJpaAutoConfigurationTests {
 
 		@Bean
 		SimpleAsyncTaskExecutor applicationTaskExecutor() {
+			return new SimpleAsyncTaskExecutor();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class AsyncTaskExecutorDependingOnEntityManagerFactoryConfiguration {
+
+		AsyncTaskExecutorDependingOnEntityManagerFactoryConfiguration(EntityManagerFactory entityManagerFactory) {
+		}
+
+		@Bean
+		SimpleAsyncTaskExecutor exampleTaskExecutor() {
 			return new SimpleAsyncTaskExecutor();
 		}
 

--- a/module/spring-boot-jpa/src/main/java/org/springframework/boot/jpa/EntityManagerFactoryBuilder.java
+++ b/module/spring-boot-jpa/src/main/java/org/springframework/boot/jpa/EntityManagerFactoryBuilder.java
@@ -121,7 +121,10 @@ public class EntityManagerFactoryBuilder {
 	 * @param fallbackBootstrapExecutor the fallback executor to use when background
 	 * bootstrapping is required but no explicit executor has been set
 	 * @since 4.1.0
+	 * @deprecated since 4.1.1 for removal in 4.3.0 in favor of
+	 * {@link #EntityManagerFactoryBuilder(JpaVendorAdapter, Function, PersistenceUnitManager, URL, Supplier)}
 	 */
+	@Deprecated(since = "4.1.1", forRemoval = true)
 	public EntityManagerFactoryBuilder(JpaVendorAdapter jpaVendorAdapter,
 			Function<DataSource, Map<String, ?>> jpaPropertiesFactory,
 			@Nullable PersistenceUnitManager persistenceUnitManager, @Nullable URL persistenceUnitRootLocation,
@@ -141,8 +144,7 @@ public class EntityManagerFactoryBuilder {
 	 * @param persistenceUnitRootLocation the persistence unit root location to use as a
 	 * fallback or {@code null}
 	 * @param fallbackBootstrapExecutor a supplier of the fallback executor to use when
-	 * background bootstrapping is required but no explicit executor has been set. The
-	 * supplier is only invoked when background bootstrapping is actually required.
+	 * background bootstrapping is required, but no explicit executor has been set.
 	 * @since 4.1.1
 	 */
 	public EntityManagerFactoryBuilder(JpaVendorAdapter jpaVendorAdapter,

--- a/module/spring-boot-jpa/src/main/java/org/springframework/boot/jpa/EntityManagerFactoryBuilder.java
+++ b/module/spring-boot-jpa/src/main/java/org/springframework/boot/jpa/EntityManagerFactoryBuilder.java
@@ -68,7 +68,7 @@ public class EntityManagerFactoryBuilder {
 
 	private final @Nullable URL persistenceUnitRootLocation;
 
-	private final @Nullable AsyncTaskExecutor fallbackBootstrapExecutor;
+	private final Supplier<? extends @Nullable AsyncTaskExecutor> fallbackBootstrapExecutor;
 
 	private @Nullable AsyncTaskExecutor bootstrapExecutor;
 
@@ -105,7 +105,7 @@ public class EntityManagerFactoryBuilder {
 	public EntityManagerFactoryBuilder(JpaVendorAdapter jpaVendorAdapter,
 			Function<DataSource, Map<String, ?>> jpaPropertiesFactory,
 			@Nullable PersistenceUnitManager persistenceUnitManager, @Nullable URL persistenceUnitRootLocation) {
-		this(jpaVendorAdapter, jpaPropertiesFactory, persistenceUnitManager, persistenceUnitRootLocation, null);
+		this(jpaVendorAdapter, jpaPropertiesFactory, persistenceUnitManager, persistenceUnitRootLocation, () -> null);
 	}
 
 	/**
@@ -126,6 +126,29 @@ public class EntityManagerFactoryBuilder {
 			Function<DataSource, Map<String, ?>> jpaPropertiesFactory,
 			@Nullable PersistenceUnitManager persistenceUnitManager, @Nullable URL persistenceUnitRootLocation,
 			@Nullable AsyncTaskExecutor fallbackBootstrapExecutor) {
+		this(jpaVendorAdapter, jpaPropertiesFactory, persistenceUnitManager, persistenceUnitRootLocation,
+				() -> fallbackBootstrapExecutor);
+	}
+
+	/**
+	 * Create a new instance passing in the common pieces that will be shared if multiple
+	 * EntityManagerFactory instances are created.
+	 * @param jpaVendorAdapter a vendor adapter
+	 * @param jpaPropertiesFactory the JPA properties to be passed to the persistence
+	 * provider, based on the {@linkplain #dataSource(DataSource) configured data source}
+	 * @param persistenceUnitManager optional source of persistence unit information (can
+	 * be null)
+	 * @param persistenceUnitRootLocation the persistence unit root location to use as a
+	 * fallback or {@code null}
+	 * @param fallbackBootstrapExecutor a supplier of the fallback executor to use when
+	 * background bootstrapping is required but no explicit executor has been set. The
+	 * supplier is only invoked when background bootstrapping is actually required.
+	 * @since 4.1.1
+	 */
+	public EntityManagerFactoryBuilder(JpaVendorAdapter jpaVendorAdapter,
+			Function<DataSource, Map<String, ?>> jpaPropertiesFactory,
+			@Nullable PersistenceUnitManager persistenceUnitManager, @Nullable URL persistenceUnitRootLocation,
+			Supplier<? extends @Nullable AsyncTaskExecutor> fallbackBootstrapExecutor) {
 		this.jpaVendorAdapter = jpaVendorAdapter;
 		this.persistenceUnitManager = persistenceUnitManager;
 		this.jpaPropertiesFactory = jpaPropertiesFactory;
@@ -343,8 +366,9 @@ public class EntityManagerFactoryBuilder {
 				return EntityManagerFactoryBuilder.this.bootstrapExecutor;
 			}
 			if (EntityManagerFactoryBuilder.this.requireBootstrapExecutorExceptionSupplier != null) {
-				if (EntityManagerFactoryBuilder.this.fallbackBootstrapExecutor != null) {
-					return EntityManagerFactoryBuilder.this.fallbackBootstrapExecutor;
+				@Nullable AsyncTaskExecutor fallback = EntityManagerFactoryBuilder.this.fallbackBootstrapExecutor.get();
+				if (fallback != null) {
+					return fallback;
 				}
 				RuntimeException ex = EntityManagerFactoryBuilder.this.requireBootstrapExecutorExceptionSupplier.get();
 				throw (ex != null) ? ex : new IllegalStateException("A bootstrap executor is required");

--- a/module/spring-boot-jpa/src/main/java/org/springframework/boot/jpa/autoconfigure/JpaBaseConfiguration.java
+++ b/module/spring-boot-jpa/src/main/java/org/springframework/boot/jpa/autoconfigure/JpaBaseConfiguration.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -123,11 +124,10 @@ public abstract class JpaBaseConfiguration {
 	@ConditionalOnMissingBean
 	public EntityManagerFactoryBuilder entityManagerFactoryBuilder(JpaVendorAdapter jpaVendorAdapter,
 			ObjectProvider<PersistenceUnitManager> persistenceUnitManager,
-			ObjectProvider<EntityManagerFactoryBuilderCustomizer> customizers,
-			Map<String, AsyncTaskExecutor> taskExecutors) {
-		AsyncTaskExecutor bootstrapExecutor = determineBootstrapExecutor(taskExecutors);
+			ObjectProvider<EntityManagerFactoryBuilderCustomizer> customizers, ListableBeanFactory beanFactory) {
 		EntityManagerFactoryBuilder builder = new EntityManagerFactoryBuilder(jpaVendorAdapter,
-				this::buildJpaProperties, persistenceUnitManager.getIfAvailable(), null, bootstrapExecutor);
+				this::buildJpaProperties, persistenceUnitManager.getIfAvailable(), null,
+				() -> determineBootstrapExecutor(beanFactory));
 		if (this.properties.getBootstrap() == Bootstrap.ASYNC) {
 			builder.requireBootstrapExecutor(
 					() -> BootstrapExecutorRequiredException.ofProperty("spring.jpa.bootstrap", "async"));
@@ -136,7 +136,8 @@ public abstract class JpaBaseConfiguration {
 		return builder;
 	}
 
-	private @Nullable AsyncTaskExecutor determineBootstrapExecutor(Map<String, AsyncTaskExecutor> taskExecutors) {
+	private @Nullable AsyncTaskExecutor determineBootstrapExecutor(ListableBeanFactory beanFactory) {
+		Map<String, AsyncTaskExecutor> taskExecutors = beanFactory.getBeansOfType(AsyncTaskExecutor.class);
 		return (taskExecutors.size() == 1) ? taskExecutors.values().iterator().next()
 				: taskExecutors.get(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME);
 	}

--- a/module/spring-boot-jpa/src/test/java/org/springframework/boot/jpa/EntityManagerFactoryBuilderTests.java
+++ b/module/spring-boot-jpa/src/test/java/org/springframework/boot/jpa/EntityManagerFactoryBuilderTests.java
@@ -18,7 +18,9 @@ package org.springframework.boot.jpa;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import javax.sql.DataSource;
 
@@ -125,6 +127,26 @@ class EntityManagerFactoryBuilderTests {
 			.withMessage("A bootstrap executor is required");
 	}
 
+	@Test
+	void requireBootstrapExecutorWhenFallbackExecutorSupplierProvidesExecutorDoesNotThrow() {
+		EntityManagerFactoryBuilder builder = createEmptyBuilderWithFallbackSupplier(SimpleAsyncTaskExecutor::new);
+		builder.requireBootstrapExecutor(() -> new IllegalStateException("BAD"));
+		DataSource dataSource = mock();
+		assertThatNoException().isThrownBy(builder.dataSource(dataSource)::build);
+	}
+
+	@Test
+	void fallbackExecutorSupplierIsNotInvokedWhenBootstrapExecutorNotRequired() {
+		AtomicBoolean invoked = new AtomicBoolean();
+		EntityManagerFactoryBuilder builder = createEmptyBuilderWithFallbackSupplier(() -> {
+			invoked.set(true);
+			return new SimpleAsyncTaskExecutor();
+		});
+		DataSource dataSource = mock();
+		builder.dataSource(dataSource).build();
+		assertThat(invoked).isFalse();
+	}
+
 	private EntityManagerFactoryBuilder createEmptyBuilder() {
 		return createEmptyBuilder(null);
 	}
@@ -133,6 +155,13 @@ class EntityManagerFactoryBuilderTests {
 		Function<DataSource, Map<String, ?>> jpaPropertiesFactory = (dataSource) -> Collections.emptyMap();
 		return new EntityManagerFactoryBuilder(new TestJpaVendorAdapter(), jpaPropertiesFactory, null, null,
 				fallbackBootstrapExecutor);
+	}
+
+	private EntityManagerFactoryBuilder createEmptyBuilderWithFallbackSupplier(
+			Supplier<? extends @Nullable AsyncTaskExecutor> fallbackBootstrapExecutorSupplier) {
+		Function<DataSource, Map<String, ?>> jpaPropertiesFactory = (dataSource) -> Collections.emptyMap();
+		return new EntityManagerFactoryBuilder(new TestJpaVendorAdapter(), jpaPropertiesFactory, null, null,
+				fallbackBootstrapExecutorSupplier);
 	}
 
 	static class TestJpaVendorAdapter extends AbstractJpaVendorAdapter {

--- a/module/spring-boot-jpa/src/test/java/org/springframework/boot/jpa/EntityManagerFactoryBuilderTests.java
+++ b/module/spring-boot-jpa/src/test/java/org/springframework/boot/jpa/EntityManagerFactoryBuilderTests.java
@@ -104,7 +104,7 @@ class EntityManagerFactoryBuilderTests {
 
 	@Test
 	void requireBootstrapExecutorWhenFallbackExecutorProvidesExecutorDoesNotThrow() {
-		EntityManagerFactoryBuilder builder = createEmptyBuilder(new SimpleAsyncTaskExecutor());
+		EntityManagerFactoryBuilder builder = createEmptyBuilder(SimpleAsyncTaskExecutor::new);
 		builder.requireBootstrapExecutor(() -> new IllegalStateException("BAD"));
 		DataSource dataSource = mock();
 		assertThatNoException().isThrownBy(builder.dataSource(dataSource)::build);
@@ -129,7 +129,7 @@ class EntityManagerFactoryBuilderTests {
 
 	@Test
 	void requireBootstrapExecutorWhenFallbackExecutorSupplierProvidesExecutorDoesNotThrow() {
-		EntityManagerFactoryBuilder builder = createEmptyBuilderWithFallbackSupplier(SimpleAsyncTaskExecutor::new);
+		EntityManagerFactoryBuilder builder = createEmptyBuilder(SimpleAsyncTaskExecutor::new);
 		builder.requireBootstrapExecutor(() -> new IllegalStateException("BAD"));
 		DataSource dataSource = mock();
 		assertThatNoException().isThrownBy(builder.dataSource(dataSource)::build);
@@ -138,7 +138,7 @@ class EntityManagerFactoryBuilderTests {
 	@Test
 	void fallbackExecutorSupplierIsNotInvokedWhenBootstrapExecutorNotRequired() {
 		AtomicBoolean invoked = new AtomicBoolean();
-		EntityManagerFactoryBuilder builder = createEmptyBuilderWithFallbackSupplier(() -> {
+		EntityManagerFactoryBuilder builder = createEmptyBuilder(() -> {
 			invoked.set(true);
 			return new SimpleAsyncTaskExecutor();
 		});
@@ -148,16 +148,10 @@ class EntityManagerFactoryBuilderTests {
 	}
 
 	private EntityManagerFactoryBuilder createEmptyBuilder() {
-		return createEmptyBuilder(null);
+		return createEmptyBuilder(() -> null);
 	}
 
-	private EntityManagerFactoryBuilder createEmptyBuilder(@Nullable AsyncTaskExecutor fallbackBootstrapExecutor) {
-		Function<DataSource, Map<String, ?>> jpaPropertiesFactory = (dataSource) -> Collections.emptyMap();
-		return new EntityManagerFactoryBuilder(new TestJpaVendorAdapter(), jpaPropertiesFactory, null, null,
-				fallbackBootstrapExecutor);
-	}
-
-	private EntityManagerFactoryBuilder createEmptyBuilderWithFallbackSupplier(
+	private EntityManagerFactoryBuilder createEmptyBuilder(
 			Supplier<? extends @Nullable AsyncTaskExecutor> fallbackBootstrapExecutorSupplier) {
 		Function<DataSource, Map<String, ?>> jpaPropertiesFactory = (dataSource) -> Collections.emptyMap();
 		return new EntityManagerFactoryBuilder(new TestJpaVendorAdapter(), jpaPropertiesFactory, null, null,


### PR DESCRIPTION
This addresses #50797.

## Broken behavior

`JpaBaseConfiguration#entityManagerFactoryBuilder` injects a `Map<String, AsyncTaskExecutor>` parameter to pick the fallback executor used for background JPA bootstrapping. A `Map` method parameter is resolved eagerly by the container, so creating the `EntityManagerFactoryBuilder` forces every `AsyncTaskExecutor` bean to be initialized early — even when background bootstrapping is not enabled (`spring.jpa.bootstrap` defaults to `default`).

When an application defines an `AsyncTaskExecutor` that depends, directly or transitively, on the `EntityManagerFactory`, this premature initialization produces a `BeanCurrentlyInCreationException` and the context fails to start. This is a regression in 4.1.0.

## Fix

The fallback executor is now resolved lazily:

- `EntityManagerFactoryBuilder` stores the fallback as a `Supplier<? extends @Nullable AsyncTaskExecutor>` and only invokes it when background bootstrapping is actually required (at `build()` time). A new `Supplier`-based constructor is added (`@since 4.1.1`); the existing `AsyncTaskExecutor` constructor is retained for backwards compatibility and delegates to it.
- `JpaBaseConfiguration#entityManagerFactoryBuilder` no longer injects a `Map`. It now takes a `ListableBeanFactory` and resolves the executor via `getBeansOfType(...)` inside the supplier, so the lookup runs only when needed and no longer forces eager initialization.
- `DataJpaRepositoriesAutoConfiguration` carried the same eager `Map<String, AsyncTaskExecutor>` injection plus an unused private method left over from the same change; both are removed.

The executor selection logic is unchanged: a single `AsyncTaskExecutor` is used if exactly one is present, otherwise the one named `applicationTaskExecutor` is used.

## Tests

- A regression test in `HibernateJpaAutoConfigurationTests` reproduces the dependency loop (an `AsyncTaskExecutor` depending on the `EntityManagerFactory`) and verifies the context now starts.
- `EntityManagerFactoryBuilderTests` adds coverage for the new `Supplier`-based fallback, including verifying that the supplier is not invoked when background bootstrapping is not required.

The default (synchronous), `spring.jpa.bootstrap=async`, and `spring.data.jpa.repositories.bootstrap-mode=deferred` paths were all exercised.
