### PR TITLE
Fix typo in DataSourceBuilderTests

### DIFF
--- a/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/DataSourceBuilderTests.java
+++ b/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/DataSourceBuilderTests.java
@@ -484,7 +484,7 @@ class DataSourceBuilderTests {
 	}
 
 	@Test
-	void buildWhenDerivedFromCustomTypeDeriveDriverClassNameFromOverridenUrl() {
+	void buildWhenDerivedFromCustomTypeDeriveDriverClassNameFromOverriddenUrl() {
 		NoDriverClassNameDataSource dataSource = new NoDriverClassNameDataSource();
 		dataSource.setUsername("test");
 		dataSource.setPassword("secret");


### PR DESCRIPTION
Rename buildWhenDerivedFromCustomTypeDeriveDriverClassNameFromOverridenUrl to buildWhenDerivedFromCustomTypeDeriveDriverClassNameFromOverriddenUrl to fix a typo.