### PR TITLE
Only configure protobuf gRPC generation for gRPC dependencies

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/reacting.adoc
+++ b/build-plugin/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/reacting.adoc
@@ -114,4 +114,4 @@ When the {url-protobuf-docs-gradle-plugin}[Protobuf plugin] is applied to a proj
 
 . Configures `protoc` to use the artifact `com.google.protobuf:protoc`, aligning its version with that of Protobuf dependencies on the runtime classpath.
 . Configures the `grpc` plugin to use the artifact `io.grpc:protoc-gen-grpc-java`, aligning its version with that of gRPC dependencies on the runtime classpath.
-. Configures the `grpc` plugin of all generate proto tasks with the option `@generated=omit`.
+. When gRPC dependencies are declared, configures the `grpc` plugin of all generate proto tasks with the option `@generated=omit`.

--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ProtobufPluginAction.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ProtobufPluginAction.java
@@ -63,7 +63,7 @@ final class ProtobufPluginAction implements PluginApplicationAction {
 		ProtobufExtension protobuf = project.getExtensions().getByType(ProtobufExtension.class);
 		protobuf.protoc(this::configureProtoc);
 		protobuf.plugins(this::configurePlugins);
-		protobuf.generateProtoTasks(this::configureGenerateProtoTasks);
+		protobuf.generateProtoTasks((tasks) -> configureGenerateProtoTasks(project, tasks));
 		project.getConfigurations()
 			.named(this::isProtobufToolsLocator)
 			.configureEach((configuration) -> configureProtobufToolsLocator(project, configuration));
@@ -77,12 +77,30 @@ final class ProtobufPluginAction implements PluginApplicationAction {
 		return plugins.create("grpc", (grpc) -> grpc.setArtifact(grpcDependency.asDependencySpec()));
 	}
 
-	private void configureGenerateProtoTasks(GenerateProtoTaskCollection tasks) {
-		tasks.all().configureEach(this::configureGenerateProtoTask);
+	private void configureGenerateProtoTasks(Project project, GenerateProtoTaskCollection tasks) {
+		tasks.all().configureEach((task) -> configureGenerateProtoTask(project, task));
 	}
 
-	private void configureGenerateProtoTask(GenerateProtoTask task) {
-		task.plugins((plugins) -> plugins.create("grpc", this::configureGrpcOptions));
+	private boolean hasGrpcDependency(Project project) {
+		return project.getConfigurations()
+			.getByName("runtimeClasspath")
+			.getAllDependencies()
+			.stream()
+			.anyMatch(this::isGrpcDependency);
+	}
+
+	private boolean isGrpcDependency(org.gradle.api.artifacts.Dependency dependency) {
+		String group = dependency.getGroup();
+		String name = dependency.getName();
+		return "io.grpc".equals(group) || "org.springframework.grpc".equals(group)
+				|| ("org.springframework.boot".equals(group) && name.startsWith("spring-boot-grpc"))
+				|| ("org.springframework.boot".equals(group) && name.startsWith("spring-boot-starter-grpc"));
+	}
+
+	private void configureGenerateProtoTask(Project project, GenerateProtoTask task) {
+		if (hasGrpcDependency(project)) {
+			task.plugins((plugins) -> plugins.create("grpc", this::configureGrpcOptions));
+		}
 	}
 
 	private void configureGrpcOptions(PluginOptions grpc) {

--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/ProtobufPluginActionIntegrationTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/ProtobufPluginActionIntegrationTests.java
@@ -79,6 +79,20 @@ class ProtobufPluginActionIntegrationTests {
 	}
 
 	@TestTemplate
+	void generatesProtoSourcesWhenGrpcIsNotOnTheClasspath() throws IOException {
+		File proto = new File(this.gradleBuild.getProjectDir(), "src/main/proto/example.proto");
+		proto.getParentFile().mkdirs();
+		Files.writeString(proto.toPath(), """
+				syntax = "proto3";
+				option java_package = "com.example";
+				message Example {
+				  string name = 1;
+				}
+				""");
+		this.gradleBuild.build("generateProto");
+	}
+
+	@TestTemplate
 	void alignsVersionOfGrpcDependency() {
 		assertThat(this.gradleBuild.build("dependencies", "--configuration", "protobufToolsLocator_grpc").getOutput())
 			.contains("io.grpc:protoc-gen-grpc-java:null -> 1.79.0");

--- a/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/ProtobufPluginActionIntegrationTests-generatesProtoSourcesWhenGrpcIsNotOnTheClasspath.gradle
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/ProtobufPluginActionIntegrationTests-generatesProtoSourcesWhenGrpcIsNotOnTheClasspath.gradle
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+	id 'org.springframework.boot' version '{version}'
+	id 'java'
+}
+
+apply plugin: 'com.google.protobuf'
+
+group = 'com.example'
+version = '0.0.1'
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation("com.google.protobuf:protobuf-java:4.34.0")
+}


### PR DESCRIPTION
Closes gh-50822

Spring Boot's Gradle plugin currently adds the protobuf `grpc` plugin to every generate proto task whenever the protobuf plugin is applied. In a protobuf-only build that has no gRPC dependencies, this makes `generateProto` try to resolve `io.grpc:protoc-gen-grpc-java:null`.

This updates the protobuf plugin reaction so the `grpc` plugin is only added to generate proto tasks when a gRPC dependency is declared. Protobuf-only builds still get the managed `protoc` artifact, while gRPC builds keep the existing `@generated=omit` configuration.

Verification:
- `./gradlew --no-daemon :build-plugin:spring-boot-gradle-plugin:test --tests org.springframework.boot.gradle.plugin.ProtobufPluginActionIntegrationTests`
- `./gradlew --no-daemon :build-plugin:spring-boot-gradle-plugin:checkstyleMain :build-plugin:spring-boot-gradle-plugin:checkstyleTest`
- `git diff --check HEAD^ HEAD`
