### PR TITLE
Handle missing gRPC server event type in test initializer

### DIFF
--- a/module/spring-boot-grpc-test/src/main/java/org/springframework/boot/grpc/test/autoconfigure/GrpcPortInfoApplicationContextInitializer.java
+++ b/module/spring-boot-grpc-test/src/main/java/org/springframework/boot/grpc/test/autoconfigure/GrpcPortInfoApplicationContextInitializer.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.grpc.test.autoconfigure;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,6 +25,7 @@ import io.grpc.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -33,7 +35,8 @@ import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
 import org.springframework.grpc.server.GrpcServerFactory;
 import org.springframework.grpc.server.InProcessGrpcServerFactory;
-import org.springframework.grpc.server.lifecycle.GrpcServerStartedEvent;
+import org.springframework.grpc.server.lifecycle.GrpcServerLifecycle;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * {@link ApplicationContextInitializer} that sets {@link Environment} properties for the
@@ -55,7 +58,10 @@ class GrpcPortInfoApplicationContextInitializer
 		applicationContext.addApplicationListener(new Listener(applicationContext));
 	}
 
-	private static class Listener implements ApplicationListener<GrpcServerStartedEvent> {
+	private static class Listener implements ApplicationListener<ApplicationEvent> {
+
+		private static final String GRPC_SERVER_STARTED_EVENT_CLASS_NAME =
+				"org.springframework.grpc.server.lifecycle.GrpcServerStartedEvent";
 
 		private static final String PROPERTY_NAME = "local.grpc.server.port";
 
@@ -68,13 +74,29 @@ class GrpcPortInfoApplicationContextInitializer
 		}
 
 		@Override
-		public void onApplicationEvent(GrpcServerStartedEvent event) {
-			GrpcServerFactory factory = event.getSource().getFactory();
-			if (factory instanceof InProcessGrpcServerFactory || factory instanceof TestGrpcServerFactory
-					|| event.getPort() == -1) {
+		public void onApplicationEvent(ApplicationEvent event) {
+			if (!GRPC_SERVER_STARTED_EVENT_CLASS_NAME.equals(event.getClass().getName())) {
 				return;
 			}
-			setPortProperty(this.applicationContext, event.getPort());
+			GrpcServerFactory factory = ((GrpcServerLifecycle) event.getSource()).getFactory();
+			int port = getPort(event);
+			if (factory instanceof InProcessGrpcServerFactory || factory instanceof TestGrpcServerFactory
+					|| port == -1) {
+				return;
+			}
+			setPortProperty(this.applicationContext, port);
+		}
+
+		private int getPort(ApplicationEvent event) {
+			Method getPort = ReflectionUtils.findMethod(event.getClass(), "getPort");
+			if (getPort == null) {
+				throw new IllegalStateException("No getPort method found on gRPC server started event");
+			}
+			Object port = ReflectionUtils.invokeMethod(getPort, event);
+			if (!(port instanceof Integer portValue)) {
+				throw new IllegalStateException("gRPC server started event getPort method did not return an integer");
+			}
+			return portValue;
 		}
 
 		private void setPortProperty(ApplicationContext context, int port) {

--- a/module/spring-boot-grpc-test/src/main/java/org/springframework/boot/grpc/test/autoconfigure/GrpcPortInfoApplicationContextInitializer.java
+++ b/module/spring-boot-grpc-test/src/main/java/org/springframework/boot/grpc/test/autoconfigure/GrpcPortInfoApplicationContextInitializer.java
@@ -60,8 +60,7 @@ class GrpcPortInfoApplicationContextInitializer
 
 	private static class Listener implements ApplicationListener<ApplicationEvent> {
 
-		private static final String GRPC_SERVER_STARTED_EVENT_CLASS_NAME =
-				"org.springframework.grpc.server.lifecycle.GrpcServerStartedEvent";
+		private static final String GRPC_SERVER_STARTED_EVENT_CLASS_NAME = "org.springframework.grpc.server.lifecycle.GrpcServerStartedEvent";
 
 		private static final String PROPERTY_NAME = "local.grpc.server.port";
 

--- a/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/GrpcPortInfoApplicationContextInitializerTests.java
+++ b/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/GrpcPortInfoApplicationContextInitializerTests.java
@@ -16,10 +16,15 @@
 
 package org.springframework.boot.grpc.test.autoconfigure;
 
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
 import io.grpc.Server;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -31,6 +36,7 @@ import org.springframework.grpc.server.lifecycle.GrpcServerLifecycle;
 import org.springframework.grpc.server.lifecycle.GrpcServerStartedEvent;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -65,6 +71,29 @@ class GrpcPortInfoApplicationContextInitializerTests {
 	void whenTestGrpcServerFactorySetsNoPortProperty() {
 		TestGrpcServerFactory factory = mock();
 		testListener(factory, 65535, null);
+	}
+
+	@Test
+	void whenGrpcServerStartedEventIsNotPresentInitializerDoesNotFailOnRefresh() throws Exception {
+		try (FilteredClassLoader classLoader = new FilteredClassLoader(GrpcServerStartedEvent.class);
+				ConfigurableApplicationContext context = new AnnotationConfigApplicationContext()) {
+			Class<?> initializerClass = defineClass(classLoader, GrpcPortInfoApplicationContextInitializer.class.getName());
+			defineClass(classLoader, GrpcPortInfoApplicationContextInitializer.class.getName() + "$Listener");
+			Constructor<?> constructor = initializerClass.getDeclaredConstructor();
+			constructor.setAccessible(true);
+			Object initializer = constructor.newInstance();
+			Method initialize = initializerClass.getDeclaredMethod("initialize", ConfigurableApplicationContext.class);
+			initialize.setAccessible(true);
+			initialize.invoke(initializer, context);
+			assertThatNoException().isThrownBy(context::refresh);
+		}
+	}
+
+	private Class<?> defineClass(FilteredClassLoader classLoader, String name) throws Exception {
+		String resourceName = name.replace('.', '/') + ".class";
+		try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(resourceName)) {
+			return classLoader.publicDefineClass(name, inputStream.readAllBytes(), getClass().getProtectionDomain());
+		}
 	}
 
 	private void testListener(GrpcServerFactory factory, int port, @Nullable String expected) {

--- a/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/GrpcPortInfoApplicationContextInitializerTests.java
+++ b/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/GrpcPortInfoApplicationContextInitializerTests.java
@@ -77,7 +77,8 @@ class GrpcPortInfoApplicationContextInitializerTests {
 	void whenGrpcServerStartedEventIsNotPresentInitializerDoesNotFailOnRefresh() throws Exception {
 		try (FilteredClassLoader classLoader = new FilteredClassLoader(GrpcServerStartedEvent.class);
 				ConfigurableApplicationContext context = new AnnotationConfigApplicationContext()) {
-			Class<?> initializerClass = defineClass(classLoader, GrpcPortInfoApplicationContextInitializer.class.getName());
+			Class<?> initializerClass = defineClass(classLoader,
+					GrpcPortInfoApplicationContextInitializer.class.getName());
 			defineClass(classLoader, GrpcPortInfoApplicationContextInitializer.class.getName() + "$Listener");
 			Constructor<?> constructor = initializerClass.getDeclaredConstructor();
 			constructor.setAccessible(true);


### PR DESCRIPTION
Closes gh-50825

`spring-boot-starter-test-classic` can include `spring-boot-grpc-test` without the Spring gRPC server classes. The gRPC test initializer currently adds a listener whose generic event type references `GrpcServerStartedEvent`; refreshing any context then asks Spring to resolve the listener event type and fails when that class is not on the classpath.

This changes the listener to accept application events and only handle gRPC server-started events by class name. It keeps the existing port-property behavior when Spring gRPC is present and avoids resolving the event type when it is absent.

Verification:
- RED: `GrpcPortInfoApplicationContextInitializerTests.whenGrpcServerStartedEventIsNotPresentInitializerDoesNotFailOnRefresh` failed before the fix with `TypeNotPresentException: Type org.springframework.grpc.server.lifecycle.GrpcServerStartedEvent not present`
- `./gradlew --no-daemon :module:spring-boot-grpc-test:test --tests org.springframework.boot.grpc.test.autoconfigure.GrpcPortInfoApplicationContextInitializerTests`
- `./gradlew --no-daemon :module:spring-boot-grpc-test:test :module:spring-boot-grpc-test:checkstyleMain :module:spring-boot-grpc-test:checkstyleTest`
- `git diff --check HEAD`
