### PR TITLE
Fix gRPC auto-configuration when protobuf is used without gRPC

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ProtobufPluginAction.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ProtobufPluginAction.java
@@ -30,6 +30,7 @@ import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencyResolveDetails;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -62,11 +63,27 @@ final class ProtobufPluginAction implements PluginApplicationAction {
 	public void execute(Project project) {
 		ProtobufExtension protobuf = project.getExtensions().getByType(ProtobufExtension.class);
 		protobuf.protoc(this::configureProtoc);
-		protobuf.plugins(this::configurePlugins);
-		protobuf.generateProtoTasks(this::configureGenerateProtoTasks);
 		project.getConfigurations()
 			.named(this::isProtobufToolsLocator)
 			.configureEach((configuration) -> configureProtobufToolsLocator(project, configuration));
+		// gRPC plugin configuration is deferred so we can check if gRPC is actually
+		// declared as a dependency before registering the protoc-gen-grpc-java artifact.
+		// Without this guard, Gradle would try to resolve io.grpc:protoc-gen-grpc-java:null
+		// for projects that use protobuf but not gRPC.
+		project.afterEvaluate((p) -> {
+			if (hasGrpcDependency(p)) {
+				protobuf.plugins(this::configurePlugins);
+				protobuf.generateProtoTasks(this::configureGenerateProtoTasks);
+			}
+		});
+	}
+
+	private boolean hasGrpcDependency(Project project) {
+		return project.getConfigurations()
+			.stream()
+			.flatMap((configuration) -> configuration.getDependencies().stream())
+			.map(Dependency::getGroup)
+			.anyMatch("io.grpc"::equals);
 	}
 
 	private void configureProtoc(ExecutableLocator protoc) {

--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/ProtobufPluginActionIntegrationTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/ProtobufPluginActionIntegrationTests.java
@@ -94,7 +94,12 @@ class ProtobufPluginActionIntegrationTests {
 	void usesVersionOfGrpcPluginDependencyWhenSpecified() {
 		assertThat(this.gradleBuild.build("dependencies", "--configuration", "protobufToolsLocator_grpc").getOutput())
 			.contains("io.grpc:protoc-gen-grpc-java:1.78.0");
+	}
 
+	@TestTemplate
+	void doesNotConfigureGrpcWhenGrpcIsNotPresent() {
+		assertThat(this.gradleBuild.build("grpcNotConfigured").getOutput())
+			.contains("grpc tools locator present: false");
 	}
 
 }

--- a/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/ProtobufPluginActionIntegrationTests-doesNotConfigureGrpcWhenGrpcIsNotPresent.gradle
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/ProtobufPluginActionIntegrationTests-doesNotConfigureGrpcWhenGrpcIsNotPresent.gradle
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+	id 'org.springframework.boot' version '{version}'
+	id 'java'
+}
+
+apply plugin: 'com.google.protobuf'
+
+group = 'com.example'
+version = '0.0.1'
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation("com.google.protobuf:protobuf-java:4.34.0")
+}
+
+tasks.register("grpcNotConfigured") {
+	doFirst {
+		def hasGrpcToolsLocator = project.configurations.names.any { it == "protobufToolsLocator_grpc" }
+		println "grpc tools locator present: $hasGrpcToolsLocator"
+	}
+}

--- a/module/spring-boot-test-classic-modules/build.gradle
+++ b/module/spring-boot-test-classic-modules/build.gradle
@@ -67,9 +67,6 @@ dependencies {
 	api(project(":module:spring-boot-graphql-test")) {
 		transitive = false
 	}
-	api(project(":module:spring-boot-grpc-test")) {
-		transitive = false
-	}
 	api(project(":module:spring-boot-jdbc-test")) {
 		transitive = false
 	}


### PR DESCRIPTION
## Problem

Two related regressions introduced in 4.1.0 around gRPC/protobuf:

### gh-50822 — `Could not find io.grpc:protoc-gen-grpc-java:null`

`ProtobufPluginAction` unconditionally registered a `grpc` plugin in the Protobuf extension whenever the `com.google.protobuf` Gradle plugin was detected. This caused Gradle to create a `protobufToolsLocator_grpc` configuration and try to resolve `io.grpc:protoc-gen-grpc-java` without a version. The version-alignment resolution strategy substitutes the version from the runtime classpath, but when gRPC is not in the project at all, no version is found and Gradle reports `io.grpc:protoc-gen-grpc-java:null`.

### gh-50825 — `TypeNotPresentException: Type GrpcServerStartedEvent not present`

`spring-boot-grpc-test` was added to `spring-boot-test-classic-modules` with `transitive = false`. This put the `GrpcPortInfoApplicationContextInitializer` class on the classpath but left its dependency `GrpcServerStartedEvent` (from `spring-grpc`) off the classpath. When Spring introspects application listeners at context startup it reads the generic type parameter of `ApplicationListener<GrpcServerStartedEvent>` via reflection, which throws `TypeNotPresentException` because the class is absent.

## Fix

**`ProtobufPluginAction`** — gRPC plugin configuration is now deferred to `afterEvaluate` and only applied when at least one dependency with group `io.grpc` is declared in any project configuration. Projects that use protobuf but not gRPC no longer have a `protobufToolsLocator_grpc` configuration created, so Gradle never attempts to resolve `protoc-gen-grpc-java:null`.

**`spring-boot-test-classic-modules`** — `spring-boot-grpc-test` has been removed from the classic modules aggregate. gRPC test support should be pulled in explicitly via `spring-boot-starter-grpc-server-test` or `spring-boot-starter-grpc-client-test`, not bundled into the classic test starter for all projects.

A new integration test (`doesNotConfigureGrpcWhenGrpcIsNotPresent`) verifies that the `protobufToolsLocator_grpc` configuration is absent when no gRPC dependency is declared.

Fixes gh-50822
Fixes gh-50825