### PR TITLE
Fix forwarded headers property in cloud deployment docs

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/deployment/cloud.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/deployment/cloud.adoc
@@ -24,7 +24,7 @@ In this section, we look at what it takes to get the xref:tutorial:first-applica
 Support for xref:how-to:webserver.adoc#howto.webserver.use-behind-a-proxy-server[forwarded headers] should only be enabled when the application receives traffic from a trusted HTTP proxy, and is only directly accessible from a trusted network.
 When running on a cloud platform, forward headers are enabled automatically.
 This builds on the assumption that the platform will ensure that individual application instances will only be directly accessible from a trusted network.
-If that is not the case for your specific platform, set `spring.forward-headers-strategy` to `none`.
+If that is not the case for your specific platform, set `server.forward-headers-strategy` to `none`.
 
 
 [[howto.deployment.cloud.cloud-foundry]]

--- a/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/deployment/cloud.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/deployment/cloud.adoc
@@ -24,7 +24,7 @@ In this section, we look at what it takes to get the xref:tutorial:first-applica
 Support for xref:how-to:webserver.adoc#howto.webserver.use-behind-a-proxy-server[forwarded headers] should only be enabled when the application receives traffic from a trusted HTTP proxy, and is only directly accessible from a trusted network.
 When running on a cloud platform, forward headers are enabled automatically.
 This builds on the assumption that the platform will ensure that individual application instances will only be directly accessible from a trusted network.
-If that is not the case for your specific platform, set `server.forward-headers-strategy` to `none`.
+If that is not the case for your specific platform, set configprop:server.forward-headers-strategy[] to `none`.
 
 
 [[howto.deployment.cloud.cloud-foundry]]


### PR DESCRIPTION
A PR from https://github.com/spring-projects/spring-boot/pull/50759 that extracts only commits bounds to 4.0.x