### PR TITLE
Condition OAuth2 client auto-config on CommonOAuth2Provider

### DIFF
--- a/module/spring-boot-security-oauth2-client/src/main/java/org/springframework/boot/security/oauth2/client/autoconfigure/OAuth2ClientAutoConfiguration.java
+++ b/module/spring-boot-security-oauth2-client/src/main/java/org/springframework/boot/security/oauth2/client/autoconfigure/OAuth2ClientAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
 import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientAutoConfiguration.NonReactiveWebApplicationCondition;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.config.oauth2.client.CommonOAuth2Provider;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 
 /**
@@ -36,7 +37,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
  */
 @AutoConfiguration
 @Conditional(NonReactiveWebApplicationCondition.class)
-@ConditionalOnClass(ClientRegistration.class)
+@ConditionalOnClass({ ClientRegistration.class, CommonOAuth2Provider.class })
 @Import({ OAuth2ClientConfigurations.ClientRegistrationRepositoryConfiguration.class,
 		OAuth2ClientConfigurations.OAuth2AuthorizedClientServiceConfiguration.class })
 public final class OAuth2ClientAutoConfiguration {

--- a/module/spring-boot-security-oauth2-client/src/main/java/org/springframework/boot/security/oauth2/client/autoconfigure/reactive/ReactiveOAuth2ClientAutoConfiguration.java
+++ b/module/spring-boot-security-oauth2-client/src/main/java/org/springframework/boot/security/oauth2/client/autoconfigure/reactive/ReactiveOAuth2ClientAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.config.oauth2.client.CommonOAuth2Provider;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 
 /**
@@ -37,7 +38,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
  */
 @AutoConfiguration
 @Conditional(ReactiveOAuth2ClientAutoConfiguration.NonServletApplicationCondition.class)
-@ConditionalOnClass({ Flux.class, ClientRegistration.class })
+@ConditionalOnClass({ Flux.class, ClientRegistration.class, CommonOAuth2Provider.class })
 @Import({ ReactiveOAuth2ClientConfigurations.ReactiveClientRegistrationRepositoryConfiguration.class,
 		ReactiveOAuth2ClientConfigurations.ReactiveOAuth2AuthorizedClientServiceConfiguration.class })
 public final class ReactiveOAuth2ClientAutoConfiguration {

--- a/module/spring-boot-security-oauth2-client/src/test/java/org/springframework/boot/security/oauth2/client/autoconfigure/OAuth2ClientAutoConfigurationTests.java
+++ b/module/spring-boot-security-oauth2-client/src/test/java/org/springframework/boot/security/oauth2/client/autoconfigure/OAuth2ClientAutoConfigurationTests.java
@@ -19,7 +19,9 @@ package org.springframework.boot.security.oauth2.client.autoconfigure;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.security.config.oauth2.client.CommonOAuth2Provider;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
@@ -80,6 +82,24 @@ class OAuth2ClientAutoConfigurationTests {
 			.withBean(ClientRegistrationRepository.class,
 					() -> new InMemoryClientRegistrationRepository(getClientRegistration("test", "test")))
 			.run((context) -> assertThat(context).hasSingleBean(OAuth2AuthorizedClientService.class));
+	}
+
+	@Test
+	void autoConfigurationConditionalOnClassClientRegistration() {
+		assertWhenClassNotPresent(ClientRegistration.class);
+	}
+
+	@Test
+	void autoConfigurationConditionalOnClassCommonOAuth2Provider() {
+		assertWhenClassNotPresent(CommonOAuth2Provider.class);
+	}
+
+	private void assertWhenClassNotPresent(Class<?> classToFilter) {
+		FilteredClassLoader classLoader = new FilteredClassLoader(classToFilter);
+		this.contextRunner.withClassLoader(classLoader)
+			.withPropertyValues(REGISTRATION_PREFIX + ".foo.client-id=abcd",
+					REGISTRATION_PREFIX + ".foo.client-secret=secret", REGISTRATION_PREFIX + ".foo.provider=github")
+			.run((context) -> assertThat(context).doesNotHaveBean(OAuth2ClientAutoConfiguration.class));
 	}
 
 	private ClientRegistration getClientRegistration(String id, String userInfoUri) {

--- a/module/spring-boot-security-oauth2-client/src/test/java/org/springframework/boot/security/oauth2/client/autoconfigure/reactive/ReactiveOAuth2ClientAutoConfigurationTests.java
+++ b/module/spring-boot-security-oauth2-client/src/test/java/org/springframework/boot/security/oauth2/client/autoconfigure/reactive/ReactiveOAuth2ClientAutoConfigurationTests.java
@@ -26,6 +26,7 @@ import org.springframework.boot.security.autoconfigure.web.reactive.ReactiveWebS
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.security.config.oauth2.client.CommonOAuth2Provider;
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.InMemoryReactiveClientRegistrationRepository;
@@ -105,6 +106,11 @@ class ReactiveOAuth2ClientAutoConfigurationTests {
 	@Test
 	void autoConfigurationConditionalOnClassClientRegistration() {
 		assertWhenClassNotPresent(ClientRegistration.class);
+	}
+
+	@Test
+	void autoConfigurationConditionalOnClassCommonOAuth2Provider() {
+		assertWhenClassNotPresent(CommonOAuth2Provider.class);
 	}
 
 	private void assertWhenClassNotPresent(Class<?> classToFilter) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

This PR updates the servlet and reactive OAuth2 client auto-configurations to require `CommonOAuth2Provider` in addition to `ClientRegistration`.

Without this condition, the auto-configuration can still match when `spring-security-oauth2-client` is present but `spring-security-config` is absent, even though provider-based client registration support depends on `CommonOAuth2Provider`.

Tests have been added for both servlet and reactive auto-configurations to verify that the auto-configuration backs off when either `ClientRegistration` or `CommonOAuth2Provider` is not available.

Fixes #50603 