### PR TITLE
Context refresh fails on Cloud Foundry when using Actuator without spring-boot-health

### DIFF
--- a/module/spring-boot-cloudfoundry/src/main/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/servlet/CloudFoundryActuatorAutoConfiguration.java
+++ b/module/spring-boot-cloudfoundry/src/main/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/servlet/CloudFoundryActuatorAutoConfiguration.java
@@ -90,15 +90,6 @@ public final class CloudFoundryActuatorAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnAvailableEndpoint
-	@ConditionalOnBean({ HealthEndpoint.class, HealthEndpointWebExtension.class })
-	CloudFoundryHealthEndpointWebExtension cloudFoundryHealthEndpointWebExtension(
-			HealthEndpointWebExtension healthEndpointWebExtension) {
-		return new CloudFoundryHealthEndpointWebExtension(healthEndpointWebExtension);
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
-	@ConditionalOnAvailableEndpoint
 	@ConditionalOnBean({ InfoEndpoint.class, GitProperties.class })
 	CloudFoundryInfoEndpointWebExtension cloudFoundryInfoEndpointWebExtension(GitProperties properties,
 			ObjectProvider<InfoContributor> infoContributors) {
@@ -155,6 +146,21 @@ public final class CloudFoundryActuatorAutoConfiguration {
 		corsConfiguration
 			.setAllowedHeaders(Arrays.asList(HttpHeaders.AUTHORIZATION, "X-Cf-App-Instance", HttpHeaders.CONTENT_TYPE));
 		return corsConfiguration;
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(HealthEndpoint.class)
+	static class HealthConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean
+		@ConditionalOnAvailableEndpoint
+		@ConditionalOnBean({ HealthEndpoint.class, HealthEndpointWebExtension.class })
+		CloudFoundryHealthEndpointWebExtension cloudFoundryHealthEndpointWebExtension(
+				HealthEndpointWebExtension healthEndpointWebExtension) {
+			return new CloudFoundryHealthEndpointWebExtension(healthEndpointWebExtension);
+		}
+
 	}
 
 	/**

--- a/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/servlet/CloudFoundryActuatorAutoConfigurationTests.java
+++ b/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/servlet/CloudFoundryActuatorAutoConfigurationTests.java
@@ -47,6 +47,7 @@ import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSec
 import org.springframework.boot.servlet.autoconfigure.actuate.web.ServletManagementContextAutoConfiguration;
 import org.springframework.boot.test.context.assertj.AssertableWebApplicationContext;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
 import org.springframework.boot.webmvc.autoconfigure.DispatcherServletAutoConfiguration;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
 import org.springframework.context.ApplicationContext;
@@ -91,6 +92,15 @@ class CloudFoundryActuatorAutoConfigurationTests {
 				/* RestTemplateAutoConfiguration.class, */ ManagementContextAutoConfiguration.class,
 				ServletManagementContextAutoConfiguration.class, EndpointAutoConfiguration.class,
 				WebEndpointAutoConfiguration.class, CloudFoundryActuatorAutoConfiguration.class));
+
+	@Test
+	@ClassPathExclusions(packages = "org.springframework.boot.health.actuate.endpoint")
+	void refreshSucceedsWithoutHealth() {
+		this.contextRunner
+			.withPropertyValues("VCAP_APPLICATION:---", "vcap.application.application_id:my-app-id",
+					"vcap.application.cf_api:https://my-cloud-controller.com")
+			.run((context) -> assertThat(context).hasNotFailed());
+	}
 
 	@Test
 	void cloudFoundryPlatformActive() {


### PR DESCRIPTION
See #50794.

Previously, `CloudFoundryActuatorAutoConfiguration` failed to parse when
`spring-boot-health` was absent because the
`cloudFoundryHealthEndpointWebExtension` `@Bean` method referenced
`HealthEndpointWebExtension` directly.

## Changes
- Move `cloudFoundryHealthEndpointWebExtension` into a nested `HealthConfiguration`

## Testing
- `CloudFoundryActuatorAutoConfigurationTests.refreshSucceedsWithoutHealth`
- `CloudFoundryActuatorAutoConfigurationTests`
- `:module:spring-boot-cloudfoundry:checkFormatMain`
- `:module:spring-boot-cloudfoundry:checkFormatTest`
