### PR TITLE
Context refresh fails when using Actuator on Jersey without spring-boot-health

### DIFF
--- a/module/spring-boot-jersey/src/main/java/org/springframework/boot/jersey/autoconfigure/actuate/web/JerseyWebEndpointManagementContextConfiguration.java
+++ b/module/spring-boot-jersey/src/main/java/org/springframework/boot/jersey/autoconfigure/actuate/web/JerseyWebEndpointManagementContextConfiguration.java
@@ -58,6 +58,7 @@ import org.springframework.boot.jersey.actuate.endpoint.web.JerseyEndpointResour
 import org.springframework.boot.jersey.actuate.endpoint.web.JerseyHealthEndpointAdditionalPathResourceFactory;
 import org.springframework.boot.jersey.autoconfigure.ResourceConfigCustomizer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
 
@@ -93,21 +94,6 @@ class JerseyWebEndpointManagementContextConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnManagementPort(ManagementPortType.DIFFERENT)
-	@ConditionalOnBean(HealthEndpoint.class)
-	@ConditionalOnAvailableEndpoint(endpoint = HealthEndpoint.class, exposure = EndpointExposure.WEB)
-	JerseyAdditionalHealthEndpointPathsManagementResourcesRegistrar jerseyDifferentPortAdditionalHealthEndpointPathsResourcesRegistrar(
-			WebEndpointsSupplier webEndpointsSupplier, HealthEndpointGroups healthEndpointGroups) {
-		Collection<ExposableWebEndpoint> webEndpoints = webEndpointsSupplier.getEndpoints();
-		ExposableWebEndpoint healthEndpoint = webEndpoints.stream()
-			.filter((endpoint) -> endpoint.getEndpointId().equals(HEALTH_ENDPOINT_ID))
-			.findFirst()
-			.orElse(null);
-		return new JerseyAdditionalHealthEndpointPathsManagementResourcesRegistrar(healthEndpoint,
-				healthEndpointGroups);
-	}
-
-	@Bean
 	@ConditionalOnBean(org.springframework.boot.actuate.endpoint.jackson.EndpointJackson2ObjectMapper.class)
 	@SuppressWarnings("removal")
 	ResourceConfigCustomizer endpointJackson2ObjectMapperResourceConfigCustomizer(
@@ -120,6 +106,27 @@ class JerseyWebEndpointManagementContextConfiguration {
 			String basePath) {
 		return properties.getDiscovery().isEnabled() && (StringUtils.hasText(basePath)
 				|| ManagementPortType.get(environment).equals(ManagementPortType.DIFFERENT));
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(HealthEndpoint.class)
+	static class HealthConfiguration {
+
+		@Bean
+		@ConditionalOnManagementPort(ManagementPortType.DIFFERENT)
+		@ConditionalOnBean(HealthEndpoint.class)
+		@ConditionalOnAvailableEndpoint(endpoint = HealthEndpoint.class, exposure = EndpointExposure.WEB)
+		JerseyAdditionalHealthEndpointPathsManagementResourcesRegistrar jerseyDifferentPortAdditionalHealthEndpointPathsResourcesRegistrar(
+				WebEndpointsSupplier webEndpointsSupplier, HealthEndpointGroups healthEndpointGroups) {
+			Collection<ExposableWebEndpoint> webEndpoints = webEndpointsSupplier.getEndpoints();
+			ExposableWebEndpoint healthEndpoint = webEndpoints.stream()
+				.filter((endpoint) -> endpoint.getEndpointId().equals(HEALTH_ENDPOINT_ID))
+				.findFirst()
+				.orElse(null);
+			return new JerseyAdditionalHealthEndpointPathsManagementResourcesRegistrar(healthEndpoint,
+					healthEndpointGroups);
+		}
+
 	}
 
 	/**
@@ -178,7 +185,7 @@ class JerseyWebEndpointManagementContextConfiguration {
 
 	}
 
-	class JerseyAdditionalHealthEndpointPathsManagementResourcesRegistrar
+	static class JerseyAdditionalHealthEndpointPathsManagementResourcesRegistrar
 			implements ManagementContextResourceConfigCustomizer {
 
 		private final @Nullable ExposableWebEndpoint healthEndpoint;

--- a/module/spring-boot-jersey/src/test/java/org/springframework/boot/jersey/autoconfigure/actuate/web/JerseyWebEndpointManagementContextConfigurationTests.java
+++ b/module/spring-boot-jersey/src/test/java/org/springframework/boot/jersey/autoconfigure/actuate/web/JerseyWebEndpointManagementContextConfigurationTests.java
@@ -30,6 +30,7 @@ import org.springframework.boot.jersey.autoconfigure.actuate.web.JerseyWebEndpoi
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,6 +51,12 @@ class JerseyWebEndpointManagementContextConfigurationTests {
 	@Test
 	void jerseyWebEndpointsResourcesRegistrarForEndpointsIsAutoConfigured() {
 		this.runner.run((context) -> assertThat(context).hasSingleBean(JerseyWebEndpointsResourcesRegistrar.class));
+	}
+
+	@Test
+	@ClassPathExclusions(packages = "org.springframework.boot.health.actuate.endpoint")
+	void refreshSucceedsWithoutHealth() {
+		this.runner.run((context) -> assertThat(context).hasNotFailed());
 	}
 
 	@Test


### PR DESCRIPTION
See #50794.

Previously, `JerseyWebEndpointManagementContextConfiguration` failed to parse
when `spring-boot-health` was absent because the
`jerseyDifferentPortAdditionalHealthEndpointPathsResourcesRegistrar` `@Bean`
method referenced `HealthEndpointGroups` directly.

## Changes
- Move the additional health endpoint paths registrar into a nested `HealthConfiguration`
- Make `JerseyAdditionalHealthEndpointPathsManagementResourcesRegistrar` static

## Testing
- `JerseyWebEndpointManagementContextConfigurationTests.refreshSucceedsWithoutHealth`
- `JerseyWebEndpointManagementContextConfigurationTests`
- `:module:spring-boot-jersey:checkFormatMain`
- `:module:spring-boot-jersey:checkFormatTest`
