### PR TITLE
Generate test gRPC transport address per application context

### DIFF
--- a/module/spring-boot-grpc-test/src/main/java/org/springframework/boot/grpc/test/autoconfigure/TestGrpcTransportAutoConfiguration.java
+++ b/module/spring-boot-grpc-test/src/main/java/org/springframework/boot/grpc/test/autoconfigure/TestGrpcTransportAutoConfiguration.java
@@ -57,7 +57,13 @@ import org.springframework.grpc.server.service.GrpcServiceDiscoverer;
 @ConditionalOnClass({ InProcessServerBuilder.class, InProcessGrpcServerFactory.class })
 public final class TestGrpcTransportAutoConfiguration {
 
-	private static final String address = InProcessServerBuilder.generateName();
+	record TestGrpcTransportAddress(String value) {
+	}
+
+	@Bean
+	TestGrpcTransportAddress testGrpcTransportAddress() {
+		return new TestGrpcTransportAddress(InProcessServerBuilder.generateName());
+	}
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(GrpcServerFactory.class)
@@ -67,8 +73,9 @@ public final class TestGrpcTransportAutoConfiguration {
 		@Bean
 		@Order(Ordered.HIGHEST_PRECEDENCE)
 		TestGrpcServerFactory testGrpcServerFactory(GrpcServiceDiscoverer serviceDiscoverer,
-				GrpcServiceConfigurer serviceConfigurer, ObjectProvider<ServerServiceDefinitionFilter> serviceFilter) {
-			TestGrpcServerFactory factory = new TestGrpcServerFactory(address);
+				GrpcServiceConfigurer serviceConfigurer, ObjectProvider<ServerServiceDefinitionFilter> serviceFilter,
+				TestGrpcTransportAddress address) {
+			TestGrpcServerFactory factory = new TestGrpcServerFactory(address.value());
 			serviceFilter.ifAvailable(factory::setServiceFilter);
 			serviceDiscoverer.findServices()
 				.stream()
@@ -99,8 +106,9 @@ public final class TestGrpcTransportAutoConfiguration {
 
 		@Bean
 		@Order(Ordered.HIGHEST_PRECEDENCE)
-		TestGrpcChannelFactory testGrpcChannelFactory(ClientInterceptorsConfigurer interceptorsConfigurer) {
-			return new TestGrpcChannelFactory(address, interceptorsConfigurer);
+		TestGrpcChannelFactory testGrpcChannelFactory(ClientInterceptorsConfigurer interceptorsConfigurer,
+				TestGrpcTransportAddress address) {
+			return new TestGrpcChannelFactory(address.value(), interceptorsConfigurer);
 		}
 
 	}

--- a/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/TestGrpcTransportAutoConfigurationTests.java
+++ b/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/TestGrpcTransportAutoConfigurationTests.java
@@ -104,4 +104,12 @@ class TestGrpcTransportAutoConfigurationTests {
 			.run((context) -> assertThat(context).doesNotHaveBean(TestGrpcChannelFactory.class));
 	}
 
+	@Test
+	void createsDifferentInProcessServerNamesForDifferentApplicationContexts() {
+		this.contextRunner.run((firstContext) -> {
+			assertThat(firstContext).hasNotFailed();
+			this.contextRunner.run((secondContext) -> assertThat(secondContext).hasNotFailed());
+		});
+	}
+
 }


### PR DESCRIPTION
This updates `TestGrpcTransportAutoConfiguration` to generate the in-process test gRPC transport address as an application-context bean rather than a static field.

Previously, the generated address was shared for the lifetime of the JVM. When multiple application contexts were created in the same test run, such as with nested tests using different profiles, the second context could attempt to register an in-process gRPC server with the same name and fail with `java.io.IOException: name already registered`.

The generated address is now context-specific and injected into both the test server factory and test channel factory, so each application context gets a unique address while the server and client within the same context still share one.

A regression test has been added to start two contexts while the first remains active.

Fixes #50860

Tests:

* `./gradlew :module:spring-boot-grpc-test:format`
* `./gradlew :module:spring-boot-grpc-test:test --tests "*TestGrpcTransportAutoConfigurationTests"`
* `./gradlew :module:spring-boot-grpc-test:test --tests "*Grpc*"`
