### PR TITLE
Remove @Nullable from local variable declarations

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/json/BasicJsonParser.java
@@ -82,7 +82,7 @@ public class BasicJsonParser extends AbstractJsonParser {
 		Map<String, Object> map = new LinkedHashMap<>();
 		json = trimEdges(json, '{', '}').trim();
 		for (String pair : tokenize(json)) {
-			String @Nullable [] split = StringUtils.split(pair, ":");
+			String[] split = StringUtils.split(pair, ":");
 			Assert.state(split != null, () -> "Unable to parse '%s'".formatted(pair));
 			@Nullable String[] rawElement = StringUtils.trimArrayElements(split);
 			String rawKey = rawElement[0];

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/jsontest/app/ExampleJacksonComponent.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/jsontest/app/ExampleJacksonComponent.java
@@ -19,7 +19,6 @@ package org.springframework.boot.jackson.autoconfigure.jsontest.app;
 import java.util.Date;
 import java.util.UUID;
 
-import org.jspecify.annotations.Nullable;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
@@ -45,11 +44,11 @@ public class ExampleJacksonComponent {
 		@Override
 		protected void serializeObject(ExampleCustomObject value, JsonGenerator jgen, SerializationContext context) {
 			jgen.writeStringProperty("value", value.value());
-			@Nullable Date date = value.date();
+			Date date = value.date();
 			if (date != null) {
 				jgen.writeNumberProperty("date", date.getTime());
 			}
-			@Nullable UUID uuid = value.uuid();
+			UUID uuid = value.uuid();
 			if (uuid != null) {
 				jgen.writeStringProperty("uuid", uuid.toString());
 			}

--- a/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/PropertiesMeterFilter.java
+++ b/module/spring-boot-micrometer-metrics/src/main/java/org/springframework/boot/micrometer/metrics/autoconfigure/PropertiesMeterFilter.java
@@ -125,7 +125,7 @@ public class PropertiesMeterFilter implements MeterFilter {
 		if (values.isEmpty()) {
 			return defaultValue;
 		}
-		@Nullable T result = doLookup(values, id);
+		T result = doLookup(values, id);
 		return (result != null) ? result : values.getOrDefault("all", defaultValue);
 	}
 

--- a/smoke-test/spring-boot-smoke-test-integration/src/test/java/smoketest/integration/producer/ProducerApplication.java
+++ b/smoke-test/spring-boot-smoke-test-integration/src/test/java/smoketest/integration/producer/ProducerApplication.java
@@ -19,7 +19,6 @@ package smoketest.integration.producer;
 import java.io.File;
 import java.io.FileOutputStream;
 
-import org.jspecify.annotations.Nullable;
 import smoketest.integration.ServiceProperties;
 
 import org.springframework.boot.ApplicationArguments;
@@ -41,7 +40,7 @@ public class ProducerApplication implements ApplicationRunner {
 
 	@Override
 	public void run(ApplicationArguments args) throws Exception {
-		@Nullable File inputDir = this.serviceProperties.getInputDir();
+		File inputDir = this.serviceProperties.getInputDir();
 		Assert.notNull(inputDir, "No inputDir configured");
 		inputDir.mkdirs();
 		if (!args.getNonOptionArgs().isEmpty()) {

--- a/smoke-test/spring-boot-smoke-test-parent-context/src/test/java/smoketest/parent/producer/ProducerApplication.java
+++ b/smoke-test/spring-boot-smoke-test-parent-context/src/test/java/smoketest/parent/producer/ProducerApplication.java
@@ -19,7 +19,6 @@ package smoketest.parent.producer;
 import java.io.File;
 import java.io.FileOutputStream;
 
-import org.jspecify.annotations.Nullable;
 import smoketest.parent.ServiceProperties;
 
 import org.springframework.boot.ApplicationArguments;
@@ -41,7 +40,7 @@ public class ProducerApplication implements ApplicationRunner {
 
 	@Override
 	public void run(ApplicationArguments args) throws Exception {
-		@Nullable File inputDir = this.serviceProperties.getInputDir();
+		File inputDir = this.serviceProperties.getInputDir();
 		Assert.notNull(inputDir, "No inputDir configured");
 		inputDir.mkdirs();
 		if (!args.getNonOptionArgs().isEmpty()) {


### PR DESCRIPTION
>> `@Nullable` and `@NonNull` aren't applied to local variables—at least not their root types. (They should be applied to type arguments and array components.) The reason is that it is possible to infer whether a variable can be null based on the values that are assigned to the variable.