### PR TITLE
Validate SSL keystore alias has key entry and certificate chain

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/ssl/SslBundleKey.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/ssl/SslBundleKey.java
@@ -29,6 +29,7 @@ import org.springframework.util.StringUtils;
  * A reference to a single key obtained via {@link SslBundle}.
  *
  * @author Phillip Webb
+ * @author Benedict
  * @since 3.1.0
  */
 public interface SslBundleKey {
@@ -52,7 +53,10 @@ public interface SslBundleKey {
 	@Nullable String getAlias();
 
 	/**
-	 * Assert that the alias is contained in the given keystore.
+	 * Assert that the alias is contained in the given keystore and that it is a valid
+	 * key entry with a certificate chain. Some JDK keystore implementations (notably
+	 * passwordless PKCS12) may load a key entry but silently drop its certificate
+	 * entries, causing cryptic handshake failures downstream.
 	 * @param keyStore the keystore to check
 	 */
 	default void assertContainsAlias(@Nullable KeyStore keyStore) {
@@ -61,6 +65,11 @@ public interface SslBundleKey {
 			try {
 				Assert.state(keyStore.containsAlias(alias),
 						() -> String.format("Keystore does not contain alias '%s'", alias));
+				Assert.state(keyStore.isKeyEntry(alias),
+						() -> String.format("Keystore alias '%s' is not a key entry", alias));
+				Assert.state(keyStore.getCertificateChain(alias) != null
+							&& keyStore.getCertificateChain(alias).length > 0,
+						() -> String.format("Keystore alias '%s' does not have a certificate chain", alias));
 			}
 			catch (KeyStoreException ex) {
 				throw new IllegalStateException(

--- a/core/spring-boot/src/main/java/org/springframework/boot/ssl/SslBundleKey.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/ssl/SslBundleKey.java
@@ -67,13 +67,13 @@ public interface SslBundleKey {
 						() -> String.format("Keystore does not contain alias '%s'", alias));
 				Assert.state(keyStore.isKeyEntry(alias),
 						() -> String.format("Keystore alias '%s' is not a key entry", alias));
-				Assert.state(keyStore.getCertificateChain(alias) != null
-							&& keyStore.getCertificateChain(alias).length > 0,
+				var chain = keyStore.getCertificateChain(alias);
+				Assert.state(chain != null && chain.length > 0,
 						() -> String.format("Keystore alias '%s' does not have a certificate chain", alias));
 			}
 			catch (KeyStoreException ex) {
 				throw new IllegalStateException(
-						String.format("Could not determine if keystore contains alias '%s'", alias), ex);
+						String.format("Could not validate keystore alias '%s'", alias), ex);
 			}
 		}
 	}

--- a/core/spring-boot/src/main/java/org/springframework/boot/ssl/SslBundleKey.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/ssl/SslBundleKey.java
@@ -18,6 +18,7 @@ package org.springframework.boot.ssl;
 
 import java.security.KeyStore;
 import java.security.KeyStoreException;
+import java.security.cert.Certificate;
 
 import org.jspecify.annotations.Nullable;
 
@@ -29,7 +30,6 @@ import org.springframework.util.StringUtils;
  * A reference to a single key obtained via {@link SslBundle}.
  *
  * @author Phillip Webb
- * @author Benedict
  * @since 3.1.0
  */
 public interface SslBundleKey {
@@ -65,15 +65,21 @@ public interface SslBundleKey {
 			try {
 				Assert.state(keyStore.containsAlias(alias),
 						() -> String.format("Keystore does not contain alias '%s'", alias));
+			}
+			catch (KeyStoreException ex) {
+				throw new IllegalStateException(
+						String.format("Could not determine if keystore contains alias '%s'", alias), ex);
+			}
+			try {
 				Assert.state(keyStore.isKeyEntry(alias),
 						() -> String.format("Keystore alias '%s' is not a key entry", alias));
-				var chain = keyStore.getCertificateChain(alias);
+				Certificate[] chain = keyStore.getCertificateChain(alias);
 				Assert.state(chain != null && chain.length > 0,
 						() -> String.format("Keystore alias '%s' does not have a certificate chain", alias));
 			}
 			catch (KeyStoreException ex) {
-				throw new IllegalStateException(
-						String.format("Could not validate keystore alias '%s'", alias), ex);
+				throw new IllegalStateException(String.format("Could not validate keystore alias '%s'", alias),
+						ex);
 			}
 		}
 	}

--- a/core/spring-boot/src/test/java/org/springframework/boot/ssl/DefaultSslManagerBundleTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/ssl/DefaultSslManagerBundleTests.java
@@ -102,7 +102,7 @@ class DefaultSslManagerBundleTests {
 		DefaultSslManagerBundle bundle = new TestDefaultSslManagerBundle(storeBundle,
 				SslBundleKey.of("secret", "alias"));
 		assertThatIllegalStateException().isThrownBy(bundle::getKeyManagerFactory)
-			.withMessage("Could not determine if keystore contains alias 'alias'");
+			.withMessage("Could not validate keystore alias 'alias'");
 	}
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/ssl/DefaultSslManagerBundleTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/ssl/DefaultSslManagerBundleTests.java
@@ -102,7 +102,7 @@ class DefaultSslManagerBundleTests {
 		DefaultSslManagerBundle bundle = new TestDefaultSslManagerBundle(storeBundle,
 				SslBundleKey.of("secret", "alias"));
 		assertThatIllegalStateException().isThrownBy(bundle::getKeyManagerFactory)
-			.withMessage("Could not validate keystore alias 'alias'");
+			.withMessage("Could not determine if keystore contains alias 'alias'");
 	}
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/ssl/SslBundleKeyTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/ssl/SslBundleKeyTests.java
@@ -72,7 +72,7 @@ class SslBundleKeyTests {
 		given(keyStore.containsAlias("alias")).willThrow(KeyStoreException.class);
 		SslBundleKey key = SslBundleKey.of("secret", "alias");
 		assertThatIllegalStateException().isThrownBy(() -> key.assertContainsAlias(keyStore))
-			.withMessage("Could not determine if keystore contains alias 'alias'");
+			.withMessage("Could not validate keystore alias 'alias'");
 	}
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/ssl/SslBundleKeyTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/ssl/SslBundleKeyTests.java
@@ -18,11 +18,13 @@ package org.springframework.boot.ssl;
 
 import java.security.KeyStore;
 import java.security.KeyStoreException;
+import java.security.cert.Certificate;
 
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -30,6 +32,7 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link SslBundleKey}.
  *
  * @author Phillip Webb
+ * @author Benedict
  */
 class SslBundleKeyTests {
 
@@ -70,6 +73,48 @@ class SslBundleKeyTests {
 		SslBundleKey key = SslBundleKey.of("secret", "alias");
 		assertThatIllegalStateException().isThrownBy(() -> key.assertContainsAlias(keyStore))
 			.withMessage("Could not determine if keystore contains alias 'alias'");
+	}
+
+	@Test
+	void assertContainsAliasWhenAliasIsNotKeyEntryThrowsException() throws Exception {
+		KeyStore keyStore = mock(KeyStore.class);
+		given(keyStore.containsAlias("alias")).willReturn(true);
+		given(keyStore.isKeyEntry("alias")).willReturn(false);
+		SslBundleKey key = SslBundleKey.of("secret", "alias");
+		assertThatIllegalStateException().isThrownBy(() -> key.assertContainsAlias(keyStore))
+			.withMessage("Keystore alias 'alias' is not a key entry");
+	}
+
+	@Test
+	void assertContainsAliasWhenAliasHasNoCertificateChainThrowsException() throws Exception {
+		KeyStore keyStore = mock(KeyStore.class);
+		given(keyStore.containsAlias("alias")).willReturn(true);
+		given(keyStore.isKeyEntry("alias")).willReturn(true);
+		given(keyStore.getCertificateChain("alias")).willReturn(null);
+		SslBundleKey key = SslBundleKey.of("secret", "alias");
+		assertThatIllegalStateException().isThrownBy(() -> key.assertContainsAlias(keyStore))
+			.withMessage("Keystore alias 'alias' does not have a certificate chain");
+	}
+
+	@Test
+	void assertContainsAliasWhenAliasHasEmptyCertificateChainThrowsException() throws Exception {
+		KeyStore keyStore = mock(KeyStore.class);
+		given(keyStore.containsAlias("alias")).willReturn(true);
+		given(keyStore.isKeyEntry("alias")).willReturn(true);
+		given(keyStore.getCertificateChain("alias")).willReturn(new Certificate[0]);
+		SslBundleKey key = SslBundleKey.of("secret", "alias");
+		assertThatIllegalStateException().isThrownBy(() -> key.assertContainsAlias(keyStore))
+			.withMessage("Keystore alias 'alias' does not have a certificate chain");
+	}
+
+	@Test
+	void assertContainsAliasWhenAliasIsValidKeyEntryDoesNotThrow() throws Exception {
+		KeyStore keyStore = mock(KeyStore.class);
+		given(keyStore.containsAlias("alias")).willReturn(true);
+		given(keyStore.isKeyEntry("alias")).willReturn(true);
+		given(keyStore.getCertificateChain("alias")).willReturn(new Certificate[] { mock(Certificate.class) });
+		SslBundleKey key = SslBundleKey.of("secret", "alias");
+		assertThatNoException().isThrownBy(() -> key.assertContainsAlias(keyStore));
 	}
 
 }

--- a/core/spring-boot/src/test/java/org/springframework/boot/ssl/SslBundleKeyTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/ssl/SslBundleKeyTests.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link SslBundleKey}.
  *
  * @author Phillip Webb
- * @author Benedict
  */
 class SslBundleKeyTests {
 
@@ -72,7 +71,7 @@ class SslBundleKeyTests {
 		given(keyStore.containsAlias("alias")).willThrow(KeyStoreException.class);
 		SslBundleKey key = SslBundleKey.of("secret", "alias");
 		assertThatIllegalStateException().isThrownBy(() -> key.assertContainsAlias(keyStore))
-			.withMessage("Could not validate keystore alias 'alias'");
+			.withMessage("Could not determine if keystore contains alias 'alias'");
 	}
 
 	@Test
@@ -80,6 +79,16 @@ class SslBundleKeyTests {
 		KeyStore keyStore = mock(KeyStore.class);
 		given(keyStore.containsAlias("alias")).willReturn(true);
 		given(keyStore.isKeyEntry("alias")).willReturn(false);
+		SslBundleKey key = SslBundleKey.of("secret", "alias");
+		assertThatIllegalStateException().isThrownBy(() -> key.assertContainsAlias(keyStore))
+			.withMessage("Keystore alias 'alias' is not a key entry");
+	}
+
+	@Test
+	void assertContainsAliasWhenAliasIsTrustedCertificateEntryThrowsException() throws Exception {
+		KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+		keyStore.load(null);
+		keyStore.setCertificateEntry("alias", mock(Certificate.class));
 		SslBundleKey key = SslBundleKey.of("secret", "alias");
 		assertThatIllegalStateException().isThrownBy(() -> key.assertContainsAlias(keyStore))
 			.withMessage("Keystore alias 'alias' is not a key entry");
@@ -115,6 +124,16 @@ class SslBundleKeyTests {
 		given(keyStore.getCertificateChain("alias")).willReturn(new Certificate[] { mock(Certificate.class) });
 		SslBundleKey key = SslBundleKey.of("secret", "alias");
 		assertThatNoException().isThrownBy(() -> key.assertContainsAlias(keyStore));
+	}
+
+	@Test
+	void assertContainsAliasWhenKeyEntryValidationFailsThrowsValidationException() throws Exception {
+		KeyStore keyStore = mock(KeyStore.class);
+		given(keyStore.containsAlias("alias")).willReturn(true);
+		given(keyStore.isKeyEntry("alias")).willThrow(KeyStoreException.class);
+		SslBundleKey key = SslBundleKey.of("secret", "alias");
+		assertThatIllegalStateException().isThrownBy(() -> key.assertContainsAlias(keyStore))
+			.withMessage("Could not validate keystore alias 'alias'");
 	}
 
 }


### PR DESCRIPTION
SslBundleKey.assertContainsAlias() now verifies not only that the
alias exists in the keystore but also that it is a genuine key entry
with a non-empty certificate chain.

This catches passwordless PKCS12 keystores where the JDK silently
drops certificate entries while keeping the key entry, causing
cryptic SSL_ERROR_NO_CYPHER_OVERLAP failures downstream.

Closes gh-25112