### PR TITLE
Webmvc resource handler registration callback

### DIFF
--- a/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/WebMvcAutoConfiguration.java
+++ b/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/WebMvcAutoConfiguration.java
@@ -221,6 +221,8 @@ public final class WebMvcAutoConfiguration {
 
 		private final ObjectProvider<ApiVersionDeprecationHandler> apiVersionDeprecationHandler;
 
+		private final ObjectProvider<WebMvcResourceHandlerRegistryCustomizer> webMvcResourceHandlerRegistryCustomizer;
+
 		WebMvcAutoConfigurationAdapter(WebProperties webProperties, WebMvcProperties mvcProperties,
 				ListableBeanFactory beanFactory,
 				ObjectProvider<ServerHttpMessageConvertersCustomizer> httpMessageConvertersCustomizerProvider,
@@ -229,7 +231,8 @@ public final class WebMvcAutoConfiguration {
 				ObjectProvider<ServletRegistrationBean<?>> servletRegistrations,
 				ObjectProvider<ApiVersionResolver> apiVersionResolvers,
 				ObjectProvider<ApiVersionParser<?>> apiVersionParser,
-				ObjectProvider<ApiVersionDeprecationHandler> apiVersionDeprecationHandler) {
+				ObjectProvider<ApiVersionDeprecationHandler> apiVersionDeprecationHandler,
+				ObjectProvider<WebMvcResourceHandlerRegistryCustomizer> webMvcResourceHandlerRegistryCustomizer) {
 			this.resourceProperties = webProperties.getResources();
 			this.mvcProperties = mvcProperties;
 			this.beanFactory = beanFactory;
@@ -240,6 +243,7 @@ public final class WebMvcAutoConfiguration {
 			this.apiVersionResolvers = apiVersionResolvers;
 			this.apiVersionParser = apiVersionParser;
 			this.apiVersionDeprecationHandler = apiVersionDeprecationHandler;
+			this.webMvcResourceHandlerRegistryCustomizer = webMvcResourceHandlerRegistryCustomizer;
 		}
 
 		@Override
@@ -358,6 +362,8 @@ public final class WebMvcAutoConfiguration {
 				logger.debug("Default resource handling disabled");
 				return;
 			}
+			customizeResourceHandlerRegistry(registry);
+
 			addResourceHandler(registry, this.mvcProperties.getWebjarsPathPattern(),
 					"classpath:/META-INF/resources/webjars/");
 			addResourceHandler(registry, this.mvcProperties.getStaticPathPattern(), (registration) -> {
@@ -390,6 +396,12 @@ public final class WebMvcAutoConfiguration {
 			}
 			registration.setUseLastModified(this.resourceProperties.getCache().isUseLastModified());
 			customizeResourceHandlerRegistration(registration);
+		}
+
+		private void customizeResourceHandlerRegistry(ResourceHandlerRegistry registry) {
+			this.webMvcResourceHandlerRegistryCustomizer
+					.orderedStream()
+					.forEach(customizer -> customizer.customize(registry));
 		}
 
 		@Contract("!null -> !null")

--- a/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/WebMvcResourceHandlerRegistryCustomizer.java
+++ b/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/WebMvcResourceHandlerRegistryCustomizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.webmvc.autoconfigure;
+
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+
+/**
+ * Callback interface that can be used to customize a
+ * {@link ResourceHandlerRegistry}.
+ *
+ * @since 4.0.0
+ */
+@FunctionalInterface
+public interface WebMvcResourceHandlerRegistryCustomizer {
+
+	/**
+	 * Customize the given {@link ResourceHandlerRegistry}.
+	 *
+	 * @param registry the resource handler registry to customize
+	 */
+	void customize(ResourceHandlerRegistry registry);
+}

--- a/module/spring-boot-webmvc/src/test/java/org/springframework/boot/webmvc/autoconfigure/WebMvcAutoConfigurationTests.java
+++ b/module/spring-boot-webmvc/src/test/java/org/springframework/boot/webmvc/autoconfigure/WebMvcAutoConfigurationTests.java
@@ -70,6 +70,7 @@ import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration.Mvc
 import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration.WebMvcAutoConfigurationAdapter;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfigurationTests.OrderedControllerAdviceBeansConfiguration.HighestOrderedControllerAdvice;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfigurationTests.OrderedControllerAdviceBeansConfiguration.LowestOrderedControllerAdvice;
+import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfigurationTests.WebMcvResourceHandlerCustomizersConfiguration.TestWebMcvResourceHandlerRegistryCustomizer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -1196,6 +1197,18 @@ class WebMvcAutoConfigurationTests {
 		assertThat(RuntimeHintsPredicates.reflection().onType(ValidatorAdapter.class)).accepts(hints);
 	}
 
+	@Test
+	void resourceHandlerRegistryCustomizerIsInvoked() {
+		this.contextRunner
+				.withUserConfiguration(WebMcvResourceHandlerCustomizersConfiguration.class)
+				.run((context) -> {
+					WebMvcResourceHandlerRegistryCustomizer customizer =
+							context.getBean(WebMvcResourceHandlerRegistryCustomizer.class);
+
+					assertThat(((TestWebMcvResourceHandlerRegistryCustomizer) customizer).invoked).isTrue();
+				});
+	}
+
 	private void assertResourceHttpRequestHandler(AssertableWebApplicationContext context,
 			Consumer<ResourceHttpRequestHandler> handlerConsumer) {
 		Map<String, Object> handlerMap = getHandlerMap(context.getBean("resourceHandlerMapping", HandlerMapping.class));
@@ -1803,6 +1816,25 @@ class WebMvcAutoConfigurationTests {
 			return mock(ServerHttpMessageConvertersCustomizer.class);
 		}
 
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class WebMcvResourceHandlerCustomizersConfiguration {
+
+		@Bean
+		WebMvcResourceHandlerRegistryCustomizer customizer() {
+			return new WebMvcAutoConfigurationTests.WebMcvResourceHandlerCustomizersConfiguration.TestWebMcvResourceHandlerRegistryCustomizer();
+		}
+
+		static class TestWebMcvResourceHandlerRegistryCustomizer implements WebMvcResourceHandlerRegistryCustomizer {
+
+			public boolean invoked;
+
+			@Override
+			public void customize(ResourceHandlerRegistry registry) {
+				this.invoked = true;
+			}
+		}
 	}
 
 	static class FormattedDate {


### PR DESCRIPTION
Introduce a `WebMvcResourceHandlerRegistryCustomizer` callback interface that allows customization of the `ResourceHandlerRegistry` before Spring Boot registers its default resource handlers.

The customizer is detected as a bean and invoked during WebMvcAutoConfiguration.

Related to #50792