### PR TITLE
Make ResourceHandlerRegistrationCustomizer public

### DIFF
--- a/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/ResourceHandlerRegistrationCustomizer.java
+++ b/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/ResourceHandlerRegistrationCustomizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.webmvc.autoconfigure;
+
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistration;
+
+/**
+ * Callback interface that can be used to customize {@link ResourceHandlerRegistration}.
+ *
+ * @author Brian Clozel
+ * @since 4.2.0
+ */
+@FunctionalInterface
+public interface ResourceHandlerRegistrationCustomizer {
+
+	/**
+	 * Customize the given {@link ResourceHandlerRegistration}.
+	 * @param registration the registration to customize
+	 */
+	void customize(ResourceHandlerRegistration registration);
+
+}

--- a/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/WebMvcAutoConfiguration.java
+++ b/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/WebMvcAutoConfiguration.java
@@ -676,13 +676,6 @@ public final class WebMvcAutoConfiguration {
 
 	}
 
-	@FunctionalInterface
-	interface ResourceHandlerRegistrationCustomizer {
-
-		void customize(ResourceHandlerRegistration registration);
-
-	}
-
 	static class ResourceChainResourceHandlerRegistrationCustomizer implements ResourceHandlerRegistrationCustomizer {
 
 		private final Resources resourceProperties;


### PR DESCRIPTION
Makes the WebMvc `ResourceHandlerRegistrationCustomizer` a public top-level interface, aligning it with the equivalent WebFlux callback that was exposed in #14587.

Closes #50792