### PR TITLE
Refactor JdbcConnectionDetailsBeanPostProcessor to obtain dataSourceClass from generics

### DIFF
--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/Dbcp2JdbcConnectionDetailsBeanPostProcessor.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/Dbcp2JdbcConnectionDetailsBeanPostProcessor.java
@@ -27,11 +27,12 @@ import org.springframework.beans.factory.ObjectProvider;
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Yanming Zhou
  */
 class Dbcp2JdbcConnectionDetailsBeanPostProcessor extends JdbcConnectionDetailsBeanPostProcessor<BasicDataSource> {
 
 	Dbcp2JdbcConnectionDetailsBeanPostProcessor(ObjectProvider<JdbcConnectionDetails> connectionDetailsProvider) {
-		super(BasicDataSource.class, connectionDetailsProvider);
+		super(connectionDetailsProvider);
 	}
 
 	@Override

--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/HikariJdbcConnectionDetailsBeanPostProcessor.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/HikariJdbcConnectionDetailsBeanPostProcessor.java
@@ -27,11 +27,12 @@ import org.springframework.beans.factory.ObjectProvider;
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Yanming Zhou
  */
 class HikariJdbcConnectionDetailsBeanPostProcessor extends JdbcConnectionDetailsBeanPostProcessor<HikariDataSource> {
 
 	HikariJdbcConnectionDetailsBeanPostProcessor(ObjectProvider<JdbcConnectionDetails> connectionDetailsProvider) {
-		super(HikariDataSource.class, connectionDetailsProvider);
+		super(connectionDetailsProvider);
 	}
 
 	@Override

--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/JdbcConnectionDetailsBeanPostProcessor.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/JdbcConnectionDetailsBeanPostProcessor.java
@@ -16,11 +16,14 @@
 
 package org.springframework.boot.jdbc.autoconfigure;
 
+import java.util.Objects;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.core.Ordered;
 import org.springframework.core.PriorityOrdered;
+import org.springframework.core.ResolvableType;
 
 /**
  * Abstract base class for DataSource bean post processors which apply values from
@@ -33,6 +36,7 @@ import org.springframework.core.PriorityOrdered;
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Yanming Zhou
  */
 abstract class JdbcConnectionDetailsBeanPostProcessor<T> implements BeanPostProcessor, PriorityOrdered {
 
@@ -40,9 +44,12 @@ abstract class JdbcConnectionDetailsBeanPostProcessor<T> implements BeanPostProc
 
 	private final ObjectProvider<JdbcConnectionDetails> connectionDetailsProvider;
 
-	JdbcConnectionDetailsBeanPostProcessor(Class<T> dataSourceClass,
-			ObjectProvider<JdbcConnectionDetails> connectionDetailsProvider) {
-		this.dataSourceClass = dataSourceClass;
+	@SuppressWarnings("unchecked")
+	JdbcConnectionDetailsBeanPostProcessor(ObjectProvider<JdbcConnectionDetails> connectionDetailsProvider) {
+		Class<?> generic = ResolvableType.forClass(getClass())
+			.as(JdbcConnectionDetailsBeanPostProcessor.class)
+			.resolveGeneric();
+		this.dataSourceClass = (Class<T>) Objects.requireNonNull(generic);
 		this.connectionDetailsProvider = connectionDetailsProvider;
 	}
 

--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/OracleUcpJdbcConnectionDetailsBeanPostProcessor.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/OracleUcpJdbcConnectionDetailsBeanPostProcessor.java
@@ -29,12 +29,13 @@ import org.springframework.beans.factory.ObjectProvider;
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Yanming Zhou
  */
 class OracleUcpJdbcConnectionDetailsBeanPostProcessor
 		extends JdbcConnectionDetailsBeanPostProcessor<PoolDataSourceImpl> {
 
 	OracleUcpJdbcConnectionDetailsBeanPostProcessor(ObjectProvider<JdbcConnectionDetails> connectionDetailsProvider) {
-		super(PoolDataSourceImpl.class, connectionDetailsProvider);
+		super(connectionDetailsProvider);
 	}
 
 	@Override

--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/TomcatJdbcConnectionDetailsBeanPostProcessor.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/TomcatJdbcConnectionDetailsBeanPostProcessor.java
@@ -27,11 +27,12 @@ import org.springframework.beans.factory.ObjectProvider;
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Yanming Zhou
  */
 class TomcatJdbcConnectionDetailsBeanPostProcessor extends JdbcConnectionDetailsBeanPostProcessor<DataSource> {
 
 	TomcatJdbcConnectionDetailsBeanPostProcessor(ObjectProvider<JdbcConnectionDetails> connectionDetailsProvider) {
-		super(DataSource.class, connectionDetailsProvider);
+		super(connectionDetailsProvider);
 	}
 
 	@Override


### PR DESCRIPTION
It make codes more concise, and it's safe to change constructor signature since those classes aren't public API.