### PR TITLE
Provide plugin management for hibernate-maven-plugin

### DIFF
--- a/platform/spring-boot-dependencies/build.gradle
+++ b/platform/spring-boot-dependencies/build.gradle
@@ -660,6 +660,9 @@ bom {
 				"hibernate-testing",
 				"hibernate-vector",
 			]
+			plugins = [
+					"hibernate-maven-plugin"
+			]
 		}
 		links {
 			site("https://hibernate.org/orm")


### PR DESCRIPTION
Closes gh-50888

This adds the hibernate-maven-plugin to the plugin management of
spring-boot-dependencies, managed at the same version as the rest of
Hibernate via the org.hibernate.orm group. This means projects using
spring-boot-starter-parent no longer needs to specify an explicit
<version>${hibernate.version}</version> when configuring the plugin,
matching how flyway-maven-plugin and liquibase-maven-plugin are already
handled.
