### PR TITLE
Harmonize order of standard customizers

### DIFF
--- a/module/spring-boot-gson/src/main/java/org/springframework/boot/gson/autoconfigure/GsonAutoConfiguration.java
+++ b/module/spring-boot-gson/src/main/java/org/springframework/boot/gson/autoconfigure/GsonAutoConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -38,6 +38,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author David Liu
  * @author Ivan Golovko
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration
@@ -60,21 +61,17 @@ public final class GsonAutoConfiguration {
 	}
 
 	@Bean
+	@Order(0)
 	StandardGsonBuilderCustomizer standardGsonBuilderCustomizer(GsonProperties gsonProperties) {
 		return new StandardGsonBuilderCustomizer(gsonProperties);
 	}
 
-	static final class StandardGsonBuilderCustomizer implements GsonBuilderCustomizer, Ordered {
+	static final class StandardGsonBuilderCustomizer implements GsonBuilderCustomizer {
 
 		private final GsonProperties properties;
 
 		StandardGsonBuilderCustomizer(GsonProperties properties) {
 			this.properties = properties;
-		}
-
-		@Override
-		public int getOrder() {
-			return 0;
 		}
 
 		@Override

--- a/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration.java
+++ b/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration.java
@@ -82,6 +82,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Scope;
 import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.converter.json.ProblemDetailJacksonMixin;
 import org.springframework.http.converter.json.ProblemDetailJacksonXmlMixin;
@@ -173,11 +174,13 @@ public final class JacksonAutoConfiguration {
 		}
 
 		@Bean
+		@Order(0)
 		StandardJsonFactoryBuilderCustomizer standardJsonFactoryBuilderCustomizer() {
 			return new StandardJsonFactoryBuilderCustomizer(this.jacksonProperties);
 		}
 
 		@Bean
+		@Order(0)
 		StandardJsonMapperBuilderCustomizer standardJsonMapperBuilderCustomizer(ObjectProvider<JacksonModule> modules,
 				AutowireCapableBeanFactory beanFactory) {
 			return new StandardJsonMapperBuilderCustomizer(this.jacksonProperties, modules.stream().toList(),
@@ -280,11 +283,13 @@ public final class JacksonAutoConfiguration {
 		}
 
 		@Bean
+		@Order(0)
 		StandardCborFactoryBuilderCustomizer standardCborFactoryBuilderCustomizer() {
 			return new StandardCborFactoryBuilderCustomizer(this.jacksonProperties);
 		}
 
 		@Bean
+		@Order(0)
 		StandardCborMapperBuilderCustomizer standardCborMapperBuilderCustomizer(ObjectProvider<JacksonModule> modules,
 				JacksonCborProperties cborProperties, AutowireCapableBeanFactory beanFactory) {
 			return new StandardCborMapperBuilderCustomizer(this.jacksonProperties, modules.stream().toList(),
@@ -370,11 +375,13 @@ public final class JacksonAutoConfiguration {
 		}
 
 		@Bean
+		@Order(0)
 		StandardXmlFactoryBuilderCustomizer standardXmlFactoryBuilderCustomizer() {
 			return new StandardXmlFactoryBuilderCustomizer(this.jacksonProperties);
 		}
 
 		@Bean
+		@Order(0)
 		StandardXmlMapperBuilderCustomizer standardXmlMapperBuilderCustomizer(ObjectProvider<JacksonModule> modules,
 				JacksonXmlProperties xmlProperties, AutowireCapableBeanFactory beanFactory) {
 			return new StandardXmlMapperBuilderCustomizer(this.jacksonProperties, modules.stream().toList(),

--- a/module/spring-boot-jackson2/src/main/java/org/springframework/boot/jackson2/autoconfigure/Jackson2AutoConfiguration.java
+++ b/module/spring-boot-jackson2/src/main/java/org/springframework/boot/jackson2/autoconfigure/Jackson2AutoConfiguration.java
@@ -59,7 +59,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Scope;
-import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
@@ -82,6 +82,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Phillip Webb
  * @author Eddú Meléndez
  * @author Ralf Ueberfuhr
+ * @author Yanming Zhou
  * @since 4.0.0
  * @deprecated since 4.0.0 for removal in 4.3.0 in favor of Jackson 3.
  */
@@ -179,13 +180,14 @@ public final class Jackson2AutoConfiguration {
 	static class Jackson2ObjectMapperBuilderCustomizerConfiguration {
 
 		@Bean
+		@Order(0)
 		StandardJackson2ObjectMapperBuilderCustomizer standardJackson2ObjectMapperBuilderCustomizer(
 				Jackson2Properties jacksonProperties, ObjectProvider<Module> modules) {
 			return new StandardJackson2ObjectMapperBuilderCustomizer(jacksonProperties, modules.stream().toList());
 		}
 
 		static final class StandardJackson2ObjectMapperBuilderCustomizer
-				implements Jackson2ObjectMapperBuilderCustomizer, Ordered {
+				implements Jackson2ObjectMapperBuilderCustomizer {
 
 			private final Jackson2Properties jacksonProperties;
 
@@ -195,11 +197,6 @@ public final class Jackson2AutoConfiguration {
 					Collection<Module> modules) {
 				this.jacksonProperties = jacksonProperties;
 				this.modules = modules;
-			}
-
-			@Override
-			public int getOrder() {
-				return 0;
 			}
 
 			@Override

--- a/module/spring-boot-kotlinx-serialization-json/src/main/java/org/springframework/boot/kotlinx/serialization/json/autoconfigure/KotlinxSerializationJsonAutoConfiguration.java
+++ b/module/spring-boot-kotlinx-serialization-json/src/main/java/org/springframework/boot/kotlinx/serialization/json/autoconfigure/KotlinxSerializationJsonAutoConfiguration.java
@@ -33,12 +33,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Kotlinx Serialization JSON.
  *
  * @author Dmitry Sulman
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration
@@ -57,23 +58,19 @@ public final class KotlinxSerializationJsonAutoConfiguration {
 	}
 
 	@Bean
+	@Order(0)
 	StandardKotlinSerializationJsonBuilderCustomizer standardKotlinSerializationJsonBuilderCustomizer(
 			KotlinxSerializationJsonProperties kotlinSerializationProperties) {
 		return new StandardKotlinSerializationJsonBuilderCustomizer(kotlinSerializationProperties);
 	}
 
 	static final class StandardKotlinSerializationJsonBuilderCustomizer
-			implements KotlinxSerializationJsonBuilderCustomizer, Ordered {
+			implements KotlinxSerializationJsonBuilderCustomizer {
 
 		private final KotlinxSerializationJsonProperties properties;
 
 		StandardKotlinSerializationJsonBuilderCustomizer(KotlinxSerializationJsonProperties properties) {
 			this.properties = properties;
-		}
-
-		@Override
-		public int getOrder() {
-			return 0;
 		}
 
 		@Override

--- a/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoAutoConfiguration.java
+++ b/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoAutoConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.ssl.SslBundles;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Mongo.
@@ -70,6 +71,7 @@ public final class MongoAutoConfiguration {
 		}
 
 		@Bean
+		@Order(0)
 		StandardMongoClientSettingsBuilderCustomizer standardMongoSettingsCustomizer(MongoProperties properties,
 				MongoConnectionDetails connectionDetails) {
 			return new StandardMongoClientSettingsBuilderCustomizer(connectionDetails,

--- a/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoReactiveAutoConfiguration.java
+++ b/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoReactiveAutoConfiguration.java
@@ -79,6 +79,7 @@ public final class MongoReactiveAutoConfiguration {
 		}
 
 		@Bean
+		@Order(0)
 		StandardMongoClientSettingsBuilderCustomizer standardMongoSettingsCustomizer(MongoProperties properties,
 				MongoConnectionDetails connectionDetails) {
 			return new StandardMongoClientSettingsBuilderCustomizer(connectionDetails,


### PR DESCRIPTION
1. Move order to `@Order` on factory bean method, Customizer should focus on customization and shouldn't care about order.
2. Add missing `@Order(0)` to allow user defined customizers run after standard customer.