### PR TITLE
Add `@Order` for built-in customizer beans

### DIFF
--- a/module/spring-boot-data-commons/src/main/java/org/springframework/boot/data/autoconfigure/web/DataWebAutoConfiguration.java
+++ b/module/spring-boot-data-commons/src/main/java/org/springframework/boot/data/autoconfigure/web/DataWebAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.data.autoconfigure.web.DataWebProperties.Pageable;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
@@ -60,6 +61,7 @@ public final class DataWebAutoConfiguration {
 	}
 
 	@Bean
+	@Order(0)
 	@ConditionalOnMissingBean
 	PageableHandlerMethodArgumentResolverCustomizer pageableCustomizer() {
 		return (resolver) -> {
@@ -75,6 +77,7 @@ public final class DataWebAutoConfiguration {
 	}
 
 	@Bean
+	@Order(0)
 	@ConditionalOnMissingBean
 	SortHandlerMethodArgumentResolverCustomizer sortCustomizer() {
 		return (resolver) -> resolver.setSortParameter(this.properties.getSort().getSortParameter());

--- a/module/spring-boot-data-jpa/src/main/java/org/springframework/boot/data/jpa/autoconfigure/DataJpaRepositoriesAutoConfiguration.java
+++ b/module/spring-boot-data-jpa/src/main/java/org/springframework/boot/data/jpa/autoconfigure/DataJpaRepositoriesAutoConfiguration.java
@@ -38,6 +38,7 @@ import org.springframework.boot.jpa.autoconfigure.EntityManagerFactoryBuilderCus
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportSelector;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.data.envers.repository.config.EnableEnversRepositories;
@@ -70,6 +71,7 @@ import org.springframework.util.ClassUtils;
  * @author Josh Long
  * @author Scott Frederick
  * @author Stefano Cordio
+ * @author Yanming Zhou
  * @since 4.0.0
  * @see EnableJpaRepositories
  */
@@ -82,6 +84,7 @@ import org.springframework.util.ClassUtils;
 public final class DataJpaRepositoriesAutoConfiguration {
 
 	@Bean
+	@Order(0)
 	@ConditionalOnProperty(name = "spring.data.jpa.repositories.bootstrap-mode", havingValue = "deferred")
 	EntityManagerFactoryBuilderCustomizer entityManagerFactoryBootstrapExecutorCustomizer(
 			Map<String, AsyncTaskExecutor> taskExecutors) {

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/observation/LettuceObservationAutoConfiguration.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/observation/LettuceObservationAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.data.redis.autoconfigure.ClientResourcesBuilderCustomizer;
 import org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 
 /**
  * Auto-configuration for Lettuce observability.
@@ -33,6 +34,7 @@ import org.springframework.context.annotation.Bean;
  * @author Antonin Arquey
  * @author Yanming Zhou
  * @author Dũng Đăng Minh
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration(before = DataRedisAutoConfiguration.class,
@@ -42,6 +44,7 @@ import org.springframework.context.annotation.Bean;
 public final class LettuceObservationAutoConfiguration {
 
 	@Bean
+	@Order(0)
 	ClientResourcesBuilderCustomizer lettuceObservation(ObservationRegistry observationRegistry) {
 		return (client) -> client.tracing(new MicrometerTracing(observationRegistry, "Redis"));
 	}

--- a/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/GraphQlAutoConfiguration.java
+++ b/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/GraphQlAutoConfiguration.java
@@ -44,6 +44,7 @@ import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportRuntimeHints;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.core.log.LogMessage;
@@ -72,6 +73,7 @@ import org.springframework.graphql.execution.SubscriptionExceptionResolver;
  * infrastructure.
  *
  * @author Brian Clozel
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration
@@ -180,6 +182,7 @@ public final class GraphQlAutoConfiguration {
 		}
 
 		@Bean
+		@Order(0)
 		@SuppressWarnings("unchecked")
 		GraphQlSourceBuilderCustomizer cursorStrategyCustomizer(CursorStrategy<?> cursorStrategy) {
 			if (cursorStrategy.supports(ScrollPosition.class)) {

--- a/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/data/GraphQlQueryByExampleAutoConfiguration.java
+++ b/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/data/GraphQlQueryByExampleAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.graphql.autoconfigure.GraphQlAutoConfiguration;
 import org.springframework.boot.graphql.autoconfigure.GraphQlSourceBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.data.repository.query.QueryByExampleExecutor;
 import org.springframework.graphql.data.query.QueryByExampleDataFetcher;
 import org.springframework.graphql.execution.GraphQlSource;
@@ -41,6 +42,7 @@ import org.springframework.graphql.execution.RuntimeWiringConfigurer;
  * matching return type.
  *
  * @author Rossen Stoyanchev
+ * @author Yanming Zhou
  * @since 4.0.0
  * @see QueryByExampleDataFetcher#autoRegistrationConfigurer(List, List)
  */
@@ -50,6 +52,7 @@ import org.springframework.graphql.execution.RuntimeWiringConfigurer;
 public final class GraphQlQueryByExampleAutoConfiguration {
 
 	@Bean
+	@Order(0)
 	GraphQlSourceBuilderCustomizer queryByExampleRegistrar(ObjectProvider<QueryByExampleExecutor<?>> executors) {
 		RuntimeWiringConfigurer configurer = QueryByExampleDataFetcher
 			.autoRegistrationConfigurer(executors.orderedStream().toList(), Collections.emptyList());

--- a/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/data/GraphQlQuerydslAutoConfiguration.java
+++ b/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/data/GraphQlQuerydslAutoConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.graphql.autoconfigure.GraphQlAutoConfiguration;
 import org.springframework.boot.graphql.autoconfigure.GraphQlSourceBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.graphql.data.query.QuerydslDataFetcher;
 import org.springframework.graphql.execution.GraphQlSource;
@@ -43,6 +44,7 @@ import org.springframework.graphql.execution.RuntimeWiringConfigurer;
  *
  * @author Rossen Stoyanchev
  * @author Brian Clozel
+ * @author Yanming Zhou
  * @since 4.0.0
  * @see QuerydslDataFetcher#autoRegistrationConfigurer(List, List)
  */
@@ -52,6 +54,7 @@ import org.springframework.graphql.execution.RuntimeWiringConfigurer;
 public final class GraphQlQuerydslAutoConfiguration {
 
 	@Bean
+	@Order(0)
 	GraphQlSourceBuilderCustomizer querydslRegistrar(ObjectProvider<QuerydslPredicateExecutor<?>> executors) {
 		RuntimeWiringConfigurer configurer = QuerydslDataFetcher
 			.autoRegistrationConfigurer(executors.orderedStream().toList(), Collections.emptyList());

--- a/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/data/GraphQlReactiveQueryByExampleAutoConfiguration.java
+++ b/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/data/GraphQlReactiveQueryByExampleAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.graphql.autoconfigure.GraphQlAutoConfiguration;
 import org.springframework.boot.graphql.autoconfigure.GraphQlSourceBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
 import org.springframework.graphql.data.query.QueryByExampleDataFetcher;
 import org.springframework.graphql.execution.GraphQlSource;
@@ -41,6 +42,7 @@ import org.springframework.graphql.execution.RuntimeWiringConfigurer;
  * matching return type.
  *
  * @author Rossen Stoyanchev
+ * @author Yanming Zhou
  * @since 4.0.0
  * @see QueryByExampleDataFetcher#autoRegistrationConfigurer(List, List)
  */
@@ -50,6 +52,7 @@ import org.springframework.graphql.execution.RuntimeWiringConfigurer;
 public final class GraphQlReactiveQueryByExampleAutoConfiguration {
 
 	@Bean
+	@Order(0)
 	GraphQlSourceBuilderCustomizer reactiveQueryByExampleRegistrar(
 			ObjectProvider<ReactiveQueryByExampleExecutor<?>> reactiveExecutors) {
 		RuntimeWiringConfigurer configurer = QueryByExampleDataFetcher

--- a/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/data/GraphQlReactiveQuerydslAutoConfiguration.java
+++ b/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/data/GraphQlReactiveQuerydslAutoConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.graphql.autoconfigure.GraphQlAutoConfiguration;
 import org.springframework.boot.graphql.autoconfigure.GraphQlSourceBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.data.querydsl.ReactiveQuerydslPredicateExecutor;
 import org.springframework.graphql.data.query.QuerydslDataFetcher;
 import org.springframework.graphql.execution.GraphQlSource;
@@ -43,6 +44,7 @@ import org.springframework.graphql.execution.RuntimeWiringConfigurer;
  *
  * @author Rossen Stoyanchev
  * @author Brian Clozel
+ * @author Yanming Zhou
  * @since 4.0.0
  * @see QuerydslDataFetcher#autoRegistrationConfigurer(List, List)
  */
@@ -52,6 +54,7 @@ import org.springframework.graphql.execution.RuntimeWiringConfigurer;
 public final class GraphQlReactiveQuerydslAutoConfiguration {
 
 	@Bean
+	@Order(0)
 	GraphQlSourceBuilderCustomizer reactiveQuerydslRegistrar(
 			ObjectProvider<ReactiveQuerydslPredicateExecutor<?>> reactiveExecutors) {
 		RuntimeWiringConfigurer configurer = QuerydslDataFetcher.autoRegistrationConfigurer(Collections.emptyList(),

--- a/module/spring-boot-http-codec/src/main/java/org/springframework/boot/http/codec/autoconfigure/CodecsAutoConfiguration.java
+++ b/module/spring-boot-http-codec/src/main/java/org/springframework/boot/http/codec/autoconfigure/CodecsAutoConfiguration.java
@@ -52,6 +52,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * {@link org.springframework.core.codec.Decoder Decoders}.
  *
  * @author Brian Clozel
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration(afterName = { "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration",
@@ -103,6 +104,7 @@ public final class CodecsAutoConfiguration {
 	static class KotlinxSerializationJsonCodecConfiguration {
 
 		@Bean
+		@Order(0)
 		@ConditionalOnBean(Json.class)
 		CodecCustomizer kotlinxJsonCodecCustomizer(Json json, ResourceLoader resourceLoader) {
 			ClassLoader classLoader = resourceLoader.getClassLoader();

--- a/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/HttpMessageConvertersAutoConfiguration.java
+++ b/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/HttpMessageConvertersAutoConfiguration.java
@@ -50,6 +50,7 @@ import org.springframework.http.converter.StringHttpMessageConverter;
  * @author Eddú Meléndez
  * @author Dmitry Sulman
  * @author Brian Clozel
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @SuppressWarnings("removal")
@@ -92,6 +93,7 @@ public final class HttpMessageConvertersAutoConfiguration {
 	protected static class StringHttpMessageConverterConfiguration {
 
 		@Bean
+		@Order(0)
 		@ConditionalOnMissingBean(StringHttpMessageConverter.class)
 		StringHttpMessageConvertersCustomizer stringHttpMessageConvertersCustomizer(
 				HttpMessageConvertersProperties properties) {

--- a/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration.java
+++ b/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration.java
@@ -82,6 +82,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Scope;
 import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.converter.json.ProblemDetailJacksonMixin;
 import org.springframework.http.converter.json.ProblemDetailJacksonXmlMixin;
@@ -100,6 +101,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Phillip Webb
  * @author Eddú Meléndez
  * @author Ralf Ueberfuhr
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration
@@ -221,6 +223,7 @@ public final class JacksonAutoConfiguration {
 	@ConditionalOnClass(ProblemDetail.class)
 	static class JsonProblemDetailsConfiguration {
 
+		@Order(0)
 		@Bean
 		ProblemDetailJsonMapperBuilderCustomizer problemDetailJsonMapperBuilderCustomizer() {
 			return new ProblemDetailJsonMapperBuilderCustomizer();
@@ -386,6 +389,7 @@ public final class JacksonAutoConfiguration {
 		static class XmlProblemDetailsConfiguration {
 
 			@Bean
+			@Order(0)
 			ProblemDetailXmlMapperBuilderCustomizer problemDetailXmlMapperBuilderCustomizer() {
 				return new ProblemDetailXmlMapperBuilderCustomizer();
 			}

--- a/module/spring-boot-jersey/src/main/java/org/springframework/boot/jersey/autoconfigure/JerseyAutoConfiguration.java
+++ b/module/spring-boot-jersey/src/main/java/org/springframework/boot/jersey/autoconfigure/JerseyAutoConfiguration.java
@@ -66,6 +66,7 @@ import org.springframework.web.filter.RequestContextFilter;
  * @author Andy Wilkinson
  * @author Eddú Meléndez
  * @author Stephane Nicoll
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration(afterName = { "org.springframework.boot.jackson2.autoconfigure.Jackson2AutoConfiguration" })
@@ -181,6 +182,7 @@ public final class JerseyAutoConfiguration implements ServletContextAware {
 	static class Jackson2ResourceConfigCustomizerConfiguration {
 
 		@Bean
+		@Order(0)
 		ResourceConfigCustomizer jacksonResourceConfigCustomizer(
 				com.fasterxml.jackson.databind.ObjectMapper objectMapper) {
 			return (ResourceConfig config) -> {

--- a/module/spring-boot-jersey/src/main/java/org/springframework/boot/jersey/autoconfigure/metrics/JerseyServerMetricsAutoConfiguration.java
+++ b/module/spring-boot-jersey/src/main/java/org/springframework/boot/jersey/autoconfigure/metrics/JerseyServerMetricsAutoConfiguration.java
@@ -43,6 +43,7 @@ import org.springframework.core.annotation.Order;
  * @author Michael Simons
  * @author Andy Wilkinson
  * @author Moritz Halbritter
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration(
@@ -60,6 +61,7 @@ public final class JerseyServerMetricsAutoConfiguration {
 	}
 
 	@Bean
+	@Order(0)
 	ResourceConfigCustomizer jerseyServerObservationResourceConfigCustomizer(ObservationRegistry observationRegistry,
 			ObjectProvider<JerseyObservationConvention> jerseyObservationConvention) {
 		String metricName = this.observationProperties.getHttp().getServer().getRequests().getName();

--- a/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/metrics/KafkaMetricsAutoConfiguration.java
+++ b/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/metrics/KafkaMetricsAutoConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.boot.kafka.autoconfigure.DefaultKafkaProducerFactoryC
 import org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.kafka.config.StreamsBuilderFactoryBean;
 import org.springframework.kafka.config.StreamsBuilderFactoryBeanConfigurer;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
@@ -43,6 +44,7 @@ import org.springframework.kafka.streams.KafkaStreamsMicrometerListener;
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  * @author Eddú Meléndez
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration(before = KafkaAutoConfiguration.class,
@@ -53,11 +55,13 @@ import org.springframework.kafka.streams.KafkaStreamsMicrometerListener;
 public final class KafkaMetricsAutoConfiguration {
 
 	@Bean
+	@Order(0)
 	DefaultKafkaProducerFactoryCustomizer kafkaProducerMetrics(MeterRegistry meterRegistry) {
 		return (producerFactory) -> addListener(producerFactory, meterRegistry);
 	}
 
 	@Bean
+	@Order(0)
 	DefaultKafkaConsumerFactoryCustomizer kafkaConsumerMetrics(MeterRegistry meterRegistry) {
 		return (consumerFactory) -> addListener(consumerFactory, meterRegistry);
 	}

--- a/module/spring-boot-liquibase/src/main/java/org/springframework/boot/liquibase/autoconfigure/LiquibaseAutoConfiguration.java
+++ b/module/spring-boot-liquibase/src/main/java/org/springframework/boot/liquibase/autoconfigure/LiquibaseAutoConfiguration.java
@@ -50,6 +50,7 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportRuntimeHints;
+import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 import org.springframework.util.Assert;
@@ -71,6 +72,7 @@ import org.springframework.util.StringUtils;
  * @author Evgeniy Cheban
  * @author Moritz Halbritter
  * @author Ahmed Ashour
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration(after = DataSourceAutoConfiguration.class)
@@ -193,6 +195,7 @@ public final class LiquibaseAutoConfiguration {
 	static class CustomizerConfiguration {
 
 		@Bean
+		@Order(0)
 		@ConditionalOnBean(Customizer.class)
 		SpringLiquibaseCustomizer springLiquibaseCustomizer(Customizer<Liquibase> customizer) {
 			return (springLiquibase) -> springLiquibase.setCustomizer(customizer);

--- a/module/spring-boot-micrometer-tracing-brave/src/main/java/org/springframework/boot/micrometer/tracing/brave/autoconfigure/BraveAutoConfiguration.java
+++ b/module/spring-boot-micrometer-tracing-brave/src/main/java/org/springframework/boot/micrometer/tracing/brave/autoconfigure/BraveAutoConfiguration.java
@@ -64,6 +64,7 @@ import org.springframework.core.env.Environment;
  * @author Moritz Halbritter
  * @author Marcin Grzejszczak
  * @author Jonatan Ivanov
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration(before = { MicrometerTracingAutoConfiguration.class, NoopTracerAutoConfiguration.class })
@@ -173,12 +174,14 @@ public final class BraveAutoConfiguration {
 	}
 
 	@Bean
+	@Order(0)
 	@ConditionalOnMissingBean(SpanCustomizer.class)
 	CurrentSpanCustomizer currentSpanCustomizer(Tracing tracing) {
 		return CurrentSpanCustomizer.create(tracing);
 	}
 
 	@Bean
+	@Order(0)
 	@ConditionalOnMissingBean(io.micrometer.tracing.SpanCustomizer.class)
 	BraveSpanCustomizer braveSpanCustomizer(SpanCustomizer spanCustomizer) {
 		return new BraveSpanCustomizer(spanCustomizer);

--- a/module/spring-boot-micrometer-tracing-opentelemetry/src/main/java/org/springframework/boot/micrometer/tracing/opentelemetry/autoconfigure/OpenTelemetryTracingAutoConfiguration.java
+++ b/module/spring-boot-micrometer-tracing-opentelemetry/src/main/java/org/springframework/boot/micrometer/tracing/opentelemetry/autoconfigure/OpenTelemetryTracingAutoConfiguration.java
@@ -67,6 +67,7 @@ import org.springframework.boot.micrometer.tracing.opentelemetry.autoconfigure.O
 import org.springframework.boot.opentelemetry.autoconfigure.ConditionalOnEnabledOpenTelemetry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -223,6 +224,7 @@ public final class OpenTelemetryTracingAutoConfiguration {
 	}
 
 	@Bean
+	@Order(0)
 	@ConditionalOnMissingBean(SpanCustomizer.class)
 	OtelSpanCustomizer otelSpanCustomizer() {
 		return new OtelSpanCustomizer();

--- a/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/metrics/MongoMetricsAutoConfiguration.java
+++ b/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/metrics/MongoMetricsAutoConfiguration.java
@@ -35,12 +35,14 @@ import org.springframework.boot.mongodb.autoconfigure.MongoAutoConfiguration;
 import org.springframework.boot.mongodb.autoconfigure.MongoClientSettingsBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Mongo metrics.
  *
  * @author Chris Bono
  * @author Jonatan Ivanov
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration(before = MongoAutoConfiguration.class,
@@ -68,6 +70,7 @@ public final class MongoMetricsAutoConfiguration {
 		}
 
 		@Bean
+		@Order(0)
 		MongoClientSettingsBuilderCustomizer mongoMetricsCommandListenerClientSettingsBuilderCustomizer(
 				MongoMetricsCommandListener mongoMetricsCommandListener) {
 			return (clientSettingsBuilder) -> clientSettingsBuilder.addCommandListener(mongoMetricsCommandListener);
@@ -94,6 +97,7 @@ public final class MongoMetricsAutoConfiguration {
 		}
 
 		@Bean
+		@Order(0)
 		MongoClientSettingsBuilderCustomizer mongoMetricsConnectionPoolListenerClientSettingsBuilderCustomizer(
 				MongoMetricsConnectionPoolListener mongoMetricsConnectionPoolListener) {
 			return (clientSettingsBuilder) -> clientSettingsBuilder

--- a/module/spring-boot-restclient-test/src/main/java/org/springframework/boot/restclient/test/autoconfigure/MockRestServiceServerAutoConfiguration.java
+++ b/module/spring-boot-restclient-test/src/main/java/org/springframework/boot/restclient/test/autoconfigure/MockRestServiceServerAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.restclient.test.MockServerRestClientCustomizer;
 import org.springframework.boot.restclient.test.MockServerRestTemplateCustomizer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.test.web.client.ExpectedCount;
@@ -54,12 +55,14 @@ import org.springframework.web.client.RestTemplate;
 public final class MockRestServiceServerAutoConfiguration {
 
 	@Bean
+	@Order(0)
 	@ConditionalOnMissingBean
 	MockServerRestTemplateCustomizer mockServerRestTemplateCustomizer() {
 		return new MockServerRestTemplateCustomizer();
 	}
 
 	@Bean
+	@Order(0)
 	@ConditionalOnMissingBean
 	MockServerRestClientCustomizer mockServerRestClientCustomizer() {
 		return new MockServerRestClientCustomizer();

--- a/module/spring-boot-restclient/src/main/java/org/springframework/boot/restclient/autoconfigure/RestClientObservationAutoConfiguration.java
+++ b/module/spring-boot-restclient/src/main/java/org/springframework/boot/restclient/autoconfigure/RestClientObservationAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.micrometer.observation.autoconfigure.Observation
 import org.springframework.boot.restclient.RestClientCustomizer;
 import org.springframework.boot.restclient.observation.ObservationRestClientCustomizer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.client.observation.ClientRequestObservationConvention;
 import org.springframework.http.client.observation.DefaultClientRequestObservationConvention;
 import org.springframework.web.client.RestClient;
@@ -35,6 +36,7 @@ import org.springframework.web.client.RestClient;
  * Configure the instrumentation of {@link RestClient}.
  *
  * @author Moritz Halbritter
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration
@@ -45,6 +47,7 @@ import org.springframework.web.client.RestClient;
 public final class RestClientObservationAutoConfiguration {
 
 	@Bean
+	@Order(0)
 	RestClientCustomizer observationRestClientCustomizer(ObservationRegistry observationRegistry,
 			ObjectProvider<ClientRequestObservationConvention> customConvention,
 			ObservationProperties observationProperties) {

--- a/module/spring-boot-restclient/src/main/java/org/springframework/boot/restclient/autoconfigure/RestTemplateObservationAutoConfiguration.java
+++ b/module/spring-boot-restclient/src/main/java/org/springframework/boot/restclient/autoconfigure/RestTemplateObservationAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.micrometer.observation.autoconfigure.Observation
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.boot.restclient.observation.ObservationRestTemplateCustomizer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.client.observation.ClientRequestObservationConvention;
 import org.springframework.http.client.observation.DefaultClientRequestObservationConvention;
 import org.springframework.web.client.RestTemplate;
@@ -35,6 +36,7 @@ import org.springframework.web.client.RestTemplate;
  * Configure the instrumentation of {@link RestTemplate}.
  *
  * @author Brian Clozel
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration
@@ -45,6 +47,7 @@ import org.springframework.web.client.RestTemplate;
 public final class RestTemplateObservationAutoConfiguration {
 
 	@Bean
+	@Order(0)
 	ObservationRestTemplateCustomizer observationRestTemplateCustomizer(ObservationRegistry observationRegistry,
 			ObjectProvider<ClientRequestObservationConvention> customConvention,
 			ObservationProperties observationProperties) {

--- a/module/spring-boot-restdocs/src/main/java/org/springframework/boot/restdocs/test/autoconfigure/RestDocsAutoConfiguration.java
+++ b/module/spring-boot-restdocs/src/main/java/org/springframework/boot/restdocs/test/autoconfigure/RestDocsAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.webtestclient.autoconfigure.WebTestClientBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentationConfigurer;
@@ -40,6 +41,7 @@ import org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation
  * @author Andy Wilkinson
  * @author Eddú Meléndez
  * @author Roman Zaynetdinov
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration
@@ -65,6 +67,7 @@ public final class RestDocsAutoConfiguration {
 		}
 
 		@Bean
+		@Order(0)
 		RestDocsMockMvcBuilderCustomizer restDocumentationConfigurer(RestDocsProperties properties,
 				MockMvcRestDocumentationConfigurer configurer,
 				ObjectProvider<RestDocumentationResultHandler> resultHandler) {
@@ -92,6 +95,7 @@ public final class RestDocsAutoConfiguration {
 		}
 
 		@Bean
+		@Order(0)
 		RestDocsWebTestClientBuilderCustomizer restDocumentationConfigurer(RestDocsProperties properties,
 				WebTestClientRestDocumentationConfigurer configurer) {
 			return new RestDocsWebTestClientBuilderCustomizer(properties, configurer);

--- a/module/spring-boot-resttestclient/src/main/java/org/springframework/boot/resttestclient/autoconfigure/RestTestClientTestAutoConfiguration.java
+++ b/module/spring-boot-resttestclient/src/main/java/org/springframework/boot/resttestclient/autoconfigure/RestTestClientTestAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.http.converter.autoconfigure.ClientHttpMessageCo
 import org.springframework.boot.test.http.server.LocalTestWebServer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.client.RestTestClient;
 import org.springframework.web.client.RestClient;
@@ -38,6 +39,7 @@ import org.springframework.web.context.WebApplicationContext;
  * @author Stephane Nicoll
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Yanming Zhou
  * @see AutoConfigureRestTestClient
  */
 @AutoConfiguration
@@ -45,6 +47,7 @@ import org.springframework.web.context.WebApplicationContext;
 final class RestTestClientTestAutoConfiguration {
 
 	@Bean
+	@Order(0)
 	SpringBootRestTestClientBuilderCustomizer springBootRestTestClientBuilderCustomizer(
 			ObjectProvider<ClientHttpMessageConvertersCustomizer> httpMessageConverterCustomizers) {
 		return new SpringBootRestTestClientBuilderCustomizer(httpMessageConverterCustomizers.orderedStream().toList());

--- a/module/spring-boot-rsocket/src/main/java/org/springframework/boot/rsocket/autoconfigure/RSocketMessagingAutoConfiguration.java
+++ b/module/spring-boot-rsocket/src/main/java/org/springframework/boot/rsocket/autoconfigure/RSocketMessagingAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.messaging.handler.MessagingAdviceBean;
 import org.springframework.messaging.rsocket.RSocketRequester;
 import org.springframework.messaging.rsocket.RSocketStrategies;
@@ -40,6 +41,7 @@ import org.springframework.web.method.ControllerAdviceBean;
  * @author Brian Clozel
  * @author Dmitry Sulman
  * @author Stephane Nicoll
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration(after = RSocketStrategiesAutoConfiguration.class)
@@ -62,6 +64,7 @@ public final class RSocketMessagingAutoConfiguration {
 	static class MessagingAdviceConfiguration {
 
 		@Bean
+		@Order(0)
 		MessagingAdviceRSocketMessageHandlerCustomizer messagingAdviceRSocketMessageHandlerCustomizer(
 				ApplicationContext applicationContext) {
 			return new MessagingAdviceRSocketMessageHandlerCustomizer(applicationContext);

--- a/module/spring-boot-rsocket/src/main/java/org/springframework/boot/rsocket/autoconfigure/RSocketServerAutoConfiguration.java
+++ b/module/spring-boot-rsocket/src/main/java/org/springframework/boot/rsocket/autoconfigure/RSocketServerAutoConfiguration.java
@@ -47,6 +47,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.io.buffer.NettyDataBufferFactory;
 import org.springframework.http.client.ReactorResourceFactory;
 import org.springframework.messaging.rsocket.RSocketStrategies;
@@ -63,6 +64,7 @@ import org.springframework.util.unit.DataSize;
  *
  * @author Brian Clozel
  * @author Scott Frederick
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration(after = RSocketStrategiesAutoConfiguration.class)
@@ -128,6 +130,7 @@ public final class RSocketServerAutoConfiguration {
 		}
 
 		@Bean
+		@Order(0)
 		RSocketServerCustomizer frameDecoderRSocketServerCustomizer(RSocketMessageHandler rSocketMessageHandler) {
 			return (server) -> {
 				if (rSocketMessageHandler.getRSocketStrategies()

--- a/module/spring-boot-security-test/src/main/java/org/springframework/boot/security/test/autoconfigure/webmvc/SecurityMockMvcAutoConfiguration.java
+++ b/module/spring-boot-security-test/src/main/java/org/springframework/boot/security/test/autoconfigure/webmvc/SecurityMockMvcAutoConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.MockMvcBuilderCustomiz
 import org.springframework.boot.webmvc.test.autoconfigure.MockMvcHtmlUnitDriverCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.concurrent.DelegatingSecurityContextExecutor;
 import org.springframework.security.test.context.TestSecurityContextHolder;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
@@ -42,6 +43,7 @@ import org.springframework.web.context.WebApplicationContext;
  * Auto-configuration for Spring Security's MockMvc integration.
  *
  * @author Andy Wilkinson
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration(after = ServletWebSecurityAutoConfiguration.class)
@@ -51,6 +53,7 @@ public final class SecurityMockMvcAutoConfiguration {
 	private static final String DEFAULT_SECURITY_FILTER_NAME = AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME;
 
 	@Bean
+	@Order(0)
 	@ConditionalOnBean(name = DEFAULT_SECURITY_FILTER_NAME)
 	SecurityMockMvcBuilderCustomizer securityMockMvcBuilderCustomizer() {
 		return new SecurityMockMvcBuilderCustomizer();
@@ -61,6 +64,7 @@ public final class SecurityMockMvcAutoConfiguration {
 	static class SecurityMockMvcHtmlUnitDriverConfiguration {
 
 		@Bean
+		@Order(0)
 		MockMvcHtmlUnitDriverCustomizer securityDelegateMockMvcHtmlUnitDriverCustomizer() {
 			return (driver) -> driver
 				.setExecutor(new DelegatingSecurityContextExecutor(Executors.newSingleThreadExecutor()));

--- a/module/spring-boot-security/src/main/java/org/springframework/boot/security/autoconfigure/rsocket/RSocketSecurityAutoConfiguration.java
+++ b/module/spring-boot-security/src/main/java/org/springframework/boot/security/autoconfigure/rsocket/RSocketSecurityAutoConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.boot.rsocket.autoconfigure.RSocketMessageHandlerCusto
 import org.springframework.boot.rsocket.server.RSocketServerCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.rsocket.EnableRSocketSecurity;
 import org.springframework.security.messaging.handler.invocation.reactive.AuthenticationPrincipalArgumentResolver;
 import org.springframework.security.rsocket.core.SecuritySocketAcceptorInterceptor;
@@ -34,6 +35,7 @@ import org.springframework.security.rsocket.core.SecuritySocketAcceptorIntercept
  * @author Madhura Bhave
  * @author Brian Clozel
  * @author Guirong Hu
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration
@@ -42,6 +44,7 @@ import org.springframework.security.rsocket.core.SecuritySocketAcceptorIntercept
 public final class RSocketSecurityAutoConfiguration {
 
 	@Bean
+	@Order(0)
 	RSocketServerCustomizer springSecurityRSocketSecurity(SecuritySocketAcceptorInterceptor interceptor) {
 		return (server) -> server.interceptors((registry) -> registry.forSocketAcceptor(interceptor));
 	}
@@ -51,6 +54,7 @@ public final class RSocketSecurityAutoConfiguration {
 	static class RSocketSecurityMessageHandlerConfiguration {
 
 		@Bean
+		@Order(0)
 		RSocketMessageHandlerCustomizer rSocketAuthenticationPrincipalMessageHandlerCustomizer() {
 			return (messageHandler) -> messageHandler.getArgumentResolverConfigurer()
 				.addCustomResolver(new AuthenticationPrincipalArgumentResolver());

--- a/module/spring-boot-session/src/main/java/org/springframework/boot/session/autoconfigure/SessionAutoConfiguration.java
+++ b/module/spring-boot-session/src/main/java/org/springframework/boot/session/autoconfigure/SessionAutoConfiguration.java
@@ -42,6 +42,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.web.authentication.RememberMeServices;
 import org.springframework.session.Session;
 import org.springframework.session.security.web.authentication.SpringSessionRememberMeServices;
@@ -61,6 +62,7 @@ import org.springframework.web.context.ServletContextAware;
  * @author Stephane Nicoll
  * @author Vedran Pavic
  * @author Weix Sun
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration
@@ -84,6 +86,7 @@ public final class SessionAutoConfiguration {
 		static class RememberMeServicesConfiguration {
 
 			@Bean
+			@Order(0)
 			DefaultCookieSerializerCustomizer rememberMeServicesCookieSerializerCustomizer() {
 				return (cookieSerializer) -> cookieSerializer
 					.setRememberMeRequestAttribute(SpringSessionRememberMeServices.REMEMBER_ME_LOGIN_ATTR);

--- a/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/autoconfigure/servlet/TomcatServletWebServerAutoConfiguration.java
+++ b/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/autoconfigure/servlet/TomcatServletWebServerAutoConfiguration.java
@@ -42,12 +42,14 @@ import org.springframework.boot.web.server.autoconfigure.servlet.ServletWebServe
 import org.springframework.boot.web.server.servlet.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for a Tomcat-based servlet web
  * server.
  *
  * @author Andy Wilkinson
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration
@@ -83,6 +85,7 @@ public final class TomcatServletWebServerAutoConfiguration {
 	}
 
 	@Bean
+	@Order(0)
 	@ConditionalOnProperty(name = "server.forward-headers-strategy", havingValue = "framework")
 	ForwardedHeaderFilterCustomizer tomcatForwardedHeaderFilterCustomizer(ServerProperties serverProperties) {
 		return (filter) -> filter.setRelativeRedirects(this.tomcatProperties.isUseRelativeRedirects());

--- a/module/spring-boot-transaction/src/main/java/org/springframework/boot/transaction/autoconfigure/TransactionManagerCustomizationAutoConfiguration.java
+++ b/module/spring-boot-transaction/src/main/java/org/springframework/boot/transaction/autoconfigure/TransactionManagerCustomizationAutoConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.transaction.TransactionManager;
  * Auto-configuration for the customization of a {@link TransactionManager}.
  *
  * @author Andy Wilkinson
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @ConditionalOnClass(PlatformTransactionManager.class)
@@ -45,6 +46,7 @@ public final class TransactionManagerCustomizationAutoConfiguration {
 	}
 
 	@Bean
+	@Order(0)
 	ExecutionListenersTransactionManagerCustomizer transactionExecutionListeners(
 			ObjectProvider<TransactionExecutionListener> listeners) {
 		return new ExecutionListenersTransactionManagerCustomizer(listeners.orderedStream().toList());

--- a/module/spring-boot-webclient/src/main/java/org/springframework/boot/webclient/autoconfigure/WebClientObservationAutoConfiguration.java
+++ b/module/spring-boot-webclient/src/main/java/org/springframework/boot/webclient/autoconfigure/WebClientObservationAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.micrometer.observation.autoconfigure.ObservationProperties;
 import org.springframework.boot.webclient.observation.ObservationWebClientCustomizer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.web.reactive.function.client.ClientRequestObservationConvention;
 import org.springframework.web.reactive.function.client.DefaultClientRequestObservationConvention;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -33,6 +34,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * Configure the instrumentation of {@link WebClient}.
  *
  * @author Brian Clozel
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration(
@@ -43,6 +45,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 public final class WebClientObservationAutoConfiguration {
 
 	@Bean
+	@Order(0)
 	ObservationWebClientCustomizer observationWebClientCustomizer(ObservationRegistry observationRegistry,
 			ObjectProvider<ClientRequestObservationConvention> customConvention,
 			ObservationProperties observationProperties) {

--- a/module/spring-boot-webflux/src/main/java/org/springframework/boot/webflux/autoconfigure/WebFluxAutoConfiguration.java
+++ b/module/spring-boot-webflux/src/main/java/org/springframework/boot/webflux/autoconfigure/WebFluxAutoConfiguration.java
@@ -121,6 +121,7 @@ import org.springframework.web.server.session.WebSessionManager;
  * @author Artsiom Yudovin
  * @author Chris Bono
  * @author Weix Sun
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration(
@@ -426,6 +427,7 @@ public final class WebFluxAutoConfiguration {
 	static class ResourceChainCustomizerConfiguration {
 
 		@Bean
+		@Order(0)
 		ResourceChainResourceHandlerRegistrationCustomizer resourceHandlerRegistrationCustomizer(
 				WebProperties webProperties) {
 			return new ResourceChainResourceHandlerRegistrationCustomizer(webProperties.getResources());

--- a/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/WebMvcAutoConfiguration.java
+++ b/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/autoconfigure/WebMvcAutoConfiguration.java
@@ -152,6 +152,7 @@ import org.springframework.web.util.UrlPathHelper;
  * @author Bruce Brouwer
  * @author Artsiom Yudovin
  * @author Scott Frederick
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration(after = { DispatcherServletAutoConfiguration.class, TaskExecutionAutoConfiguration.class },
@@ -661,6 +662,7 @@ public final class WebMvcAutoConfiguration {
 	static class ResourceChainCustomizerConfiguration {
 
 		@Bean
+		@Order(0)
 		ResourceChainResourceHandlerRegistrationCustomizer resourceHandlerRegistrationCustomizer(
 				WebProperties webProperties) {
 			return new ResourceChainResourceHandlerRegistrationCustomizer(webProperties.getResources());

--- a/module/spring-boot-webservices-test/src/main/java/org/springframework/boot/webservices/test/autoconfigure/client/MockWebServiceServerAutoConfiguration.java
+++ b/module/spring-boot-webservices-test/src/main/java/org/springframework/boot/webservices/test/autoconfigure/client/MockWebServiceServerAutoConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.ws.client.core.WebServiceTemplate;
 import org.springframework.ws.test.client.MockWebServiceMessageSender;
 import org.springframework.ws.test.client.MockWebServiceServer;
@@ -28,6 +29,7 @@ import org.springframework.ws.test.client.MockWebServiceServer;
  * Auto-configuration for {@link MockWebServiceServer} support.
  *
  * @author Dmytro Nosan
+ * @author Yanming Zhou
  * @since 2.3.0
  * @see AutoConfigureMockWebServiceServer
  */
@@ -42,6 +44,7 @@ public final class MockWebServiceServerAutoConfiguration {
 	}
 
 	@Bean
+	@Order(0)
 	MockWebServiceServerWebServiceTemplateCustomizer mockWebServiceServerWebServiceTemplateCustomizer(
 			TestMockWebServiceServer mockWebServiceServer) {
 		return new MockWebServiceServerWebServiceTemplateCustomizer(mockWebServiceServer);

--- a/module/spring-boot-webtestclient/src/main/java/org/springframework/boot/webtestclient/autoconfigure/WebTestClientAutoConfiguration.java
+++ b/module/spring-boot-webtestclient/src/main/java/org/springframework/boot/webtestclient/autoconfigure/WebTestClientAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.boot.http.codec.autoconfigure.CodecsAutoConfiguration
 import org.springframework.boot.test.http.server.LocalTestWebServer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.test.web.reactive.server.MockServerConfigurer;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.test.web.reactive.server.WebTestClient.MockServerSpec;
@@ -45,6 +46,7 @@ import org.springframework.web.server.adapter.WebHttpHandlerBuilder;
  * @author Stephane Nicoll
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Yanming Zhou
  * @since 4.0.0
  */
 @AutoConfiguration(after = CodecsAutoConfiguration.class)
@@ -55,6 +57,7 @@ public final class WebTestClientAutoConfiguration {
 	private static final String WEB_APPLICATION_CONTEXT_CLASS = "org.springframework.web.context.WebApplicationContext";
 
 	@Bean
+	@Order(0)
 	@ConfigurationProperties("spring.test.webtestclient")
 	SpringBootWebTestClientBuilderCustomizer springBootWebTestClientBuilderCustomizer(
 			ObjectProvider<CodecCustomizer> codecCustomizers) {


### PR DESCRIPTION
To allow user defined customizers running after them.

See https://github.com/spring-projects/spring-boot/pull/50910#issuecomment-4874475583