### PR TITLE
Context refresh fails on reactive Cloud Foundry when using Actuator without spring-boot-health

### DIFF
--- a/module/spring-boot-cloudfoundry/src/main/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryReactiveActuatorAutoConfiguration.java
+++ b/module/spring-boot-cloudfoundry/src/main/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryReactiveActuatorAutoConfiguration.java
@@ -86,15 +86,6 @@ public final class CloudFoundryReactiveActuatorAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnAvailableEndpoint
-	@ConditionalOnBean({ HealthEndpoint.class, ReactiveHealthEndpointWebExtension.class })
-	CloudFoundryReactiveHealthEndpointWebExtension cloudFoundryReactiveHealthEndpointWebExtension(
-			ReactiveHealthEndpointWebExtension reactiveHealthEndpointWebExtension) {
-		return new CloudFoundryReactiveHealthEndpointWebExtension(reactiveHealthEndpointWebExtension);
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
-	@ConditionalOnAvailableEndpoint
 	@ConditionalOnBean({ InfoEndpoint.class, GitProperties.class })
 	CloudFoundryInfoEndpointWebExtension cloudFoundryInfoEndpointWebExtension(GitProperties properties,
 			ObjectProvider<InfoContributor> infoContributors) {
@@ -149,6 +140,21 @@ public final class CloudFoundryReactiveActuatorAutoConfiguration {
 		corsConfiguration
 			.setAllowedHeaders(Arrays.asList(HttpHeaders.AUTHORIZATION, "X-Cf-App-Instance", HttpHeaders.CONTENT_TYPE));
 		return corsConfiguration;
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(HealthEndpoint.class)
+	static class HealthConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean
+		@ConditionalOnAvailableEndpoint
+		@ConditionalOnBean({ HealthEndpoint.class, ReactiveHealthEndpointWebExtension.class })
+		CloudFoundryReactiveHealthEndpointWebExtension cloudFoundryReactiveHealthEndpointWebExtension(
+				ReactiveHealthEndpointWebExtension reactiveHealthEndpointWebExtension) {
+			return new CloudFoundryReactiveHealthEndpointWebExtension(reactiveHealthEndpointWebExtension);
+		}
+
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryReactiveActuatorAutoConfigurationTests.java
+++ b/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryReactiveActuatorAutoConfigurationTests.java
@@ -97,27 +97,18 @@ class CloudFoundryReactiveActuatorAutoConfigurationTests {
 
 	private static final String V3_JSON = ApiVersion.V3.getProducedMimeType().toString();
 
-	private final ReactiveWebApplicationContextRunner contextRunner = new ReactiveWebApplicationContextRunner()
-		.withConfiguration(AutoConfigurations.of(ReactiveWebSecurityAutoConfiguration.class,
-				WebFluxAutoConfiguration.class, JacksonAutoConfiguration.class,
-				HttpMessageConvertersAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class,
-				WebClientCustomizerConfig.class, WebClientAutoConfiguration.class,
-				ManagementContextAutoConfiguration.class, EndpointAutoConfiguration.class,
-				WebEndpointAutoConfiguration.class, HealthContributorAutoConfiguration.class,
-				HealthContributorRegistryAutoConfiguration.class, HealthEndpointAutoConfiguration.class,
-				InfoContributorAutoConfiguration.class, InfoEndpointAutoConfiguration.class,
-				ProjectInfoAutoConfiguration.class, CloudFoundryReactiveActuatorAutoConfiguration.class))
-		.withUserConfiguration(UserDetailsServiceConfiguration.class);
+	private static final AutoConfigurations MANDATORY_AUTO_CONFIGURATIONS = AutoConfigurations.of(
+			ReactiveWebSecurityAutoConfiguration.class, WebFluxAutoConfiguration.class, JacksonAutoConfiguration.class,
+			HttpMessageConvertersAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class,
+			WebClientCustomizerConfig.class, WebClientAutoConfiguration.class, ManagementContextAutoConfiguration.class,
+			EndpointAutoConfiguration.class, WebEndpointAutoConfiguration.class, InfoContributorAutoConfiguration.class,
+			InfoEndpointAutoConfiguration.class, ProjectInfoAutoConfiguration.class,
+			CloudFoundryReactiveActuatorAutoConfiguration.class);
 
-	private final ReactiveWebApplicationContextRunner withoutHealthContextRunner = new ReactiveWebApplicationContextRunner()
-		.withConfiguration(
-				AutoConfigurations.of(ReactiveWebSecurityAutoConfiguration.class, WebFluxAutoConfiguration.class,
-						JacksonAutoConfiguration.class, HttpMessageConvertersAutoConfiguration.class,
-						PropertyPlaceholderAutoConfiguration.class, WebClientCustomizerConfig.class,
-						WebClientAutoConfiguration.class, ManagementContextAutoConfiguration.class,
-						EndpointAutoConfiguration.class, WebEndpointAutoConfiguration.class,
-						InfoContributorAutoConfiguration.class, InfoEndpointAutoConfiguration.class,
-						ProjectInfoAutoConfiguration.class, CloudFoundryReactiveActuatorAutoConfiguration.class))
+	private final ReactiveWebApplicationContextRunner contextRunner = new ReactiveWebApplicationContextRunner()
+		.withConfiguration(MANDATORY_AUTO_CONFIGURATIONS)
+		.withConfiguration(AutoConfigurations.of(HealthContributorAutoConfiguration.class,
+				HealthContributorRegistryAutoConfiguration.class, HealthEndpointAutoConfiguration.class))
 		.withUserConfiguration(UserDetailsServiceConfiguration.class);
 
 	private static final String BASE_PATH = "/cloudfoundryapplication";
@@ -130,7 +121,8 @@ class CloudFoundryReactiveActuatorAutoConfigurationTests {
 	@Test
 	@ClassPathExclusions(packages = "org.springframework.boot.health.actuate.endpoint")
 	void refreshSucceedsWithoutHealth() {
-		this.withoutHealthContextRunner
+		new ReactiveWebApplicationContextRunner().withConfiguration(MANDATORY_AUTO_CONFIGURATIONS)
+			.withUserConfiguration(UserDetailsServiceConfiguration.class)
 			.withPropertyValues("VCAP_APPLICATION:---", "vcap.application.application_id:my-app-id",
 					"vcap.application.cf_api:https://my-cloud-controller.com")
 			.run((context) -> assertThat(context).hasNotFailed());

--- a/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryReactiveActuatorAutoConfigurationTests.java
+++ b/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryReactiveActuatorAutoConfigurationTests.java
@@ -59,6 +59,7 @@ import org.springframework.boot.ssl.SslBundle;
 import org.springframework.boot.ssl.jks.JksSslStoreBundle;
 import org.springframework.boot.ssl.jks.JksSslStoreDetails;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
 import org.springframework.boot.testsupport.classpath.resources.WithPackageResources;
 import org.springframework.boot.testsupport.classpath.resources.WithResource;
 import org.springframework.boot.webclient.WebClientCustomizer;
@@ -108,11 +109,31 @@ class CloudFoundryReactiveActuatorAutoConfigurationTests {
 				ProjectInfoAutoConfiguration.class, CloudFoundryReactiveActuatorAutoConfiguration.class))
 		.withUserConfiguration(UserDetailsServiceConfiguration.class);
 
+	private final ReactiveWebApplicationContextRunner withoutHealthContextRunner = new ReactiveWebApplicationContextRunner()
+		.withConfiguration(
+				AutoConfigurations.of(ReactiveWebSecurityAutoConfiguration.class, WebFluxAutoConfiguration.class,
+						JacksonAutoConfiguration.class, HttpMessageConvertersAutoConfiguration.class,
+						PropertyPlaceholderAutoConfiguration.class, WebClientCustomizerConfig.class,
+						WebClientAutoConfiguration.class, ManagementContextAutoConfiguration.class,
+						EndpointAutoConfiguration.class, WebEndpointAutoConfiguration.class,
+						InfoContributorAutoConfiguration.class, InfoEndpointAutoConfiguration.class,
+						ProjectInfoAutoConfiguration.class, CloudFoundryReactiveActuatorAutoConfiguration.class))
+		.withUserConfiguration(UserDetailsServiceConfiguration.class);
+
 	private static final String BASE_PATH = "/cloudfoundryapplication";
 
 	@AfterEach
 	void close() {
 		HttpResources.reset();
+	}
+
+	@Test
+	@ClassPathExclusions(packages = "org.springframework.boot.health.actuate.endpoint")
+	void refreshSucceedsWithoutHealth() {
+		this.withoutHealthContextRunner
+			.withPropertyValues("VCAP_APPLICATION:---", "vcap.application.application_id:my-app-id",
+					"vcap.application.cf_api:https://my-cloud-controller.com")
+			.run((context) -> assertThat(context).hasNotFailed());
 	}
 
 	@Test


### PR DESCRIPTION
Follow-up to #50857, which fixed the servlet Cloud Foundry actuator
auto-configuration. #50794 noted
`CloudFoundryReactiveActuatorAutoConfiguration` as an unverified sibling.

This PR confirms the reactive sibling with a failing test. When
`spring-boot-health` is absent, parsing the reactive Cloud Foundry actuator
configuration resolves `ReactiveHealthEndpointWebExtension` from the health
`@Bean` method signature, causing context refresh to fail before
`/cloudfoundryapplication` can be registered.

## Changes

- Move `cloudFoundryReactiveHealthEndpointWebExtension` into a nested
  `HealthConfiguration` guarded by `@ConditionalOnClass(HealthEndpoint.class)`

## Testing

- `CloudFoundryReactiveActuatorAutoConfigurationTests.refreshSucceedsWithoutHealth` (new; fails before this change)
- `CloudFoundryReactiveActuatorAutoConfigurationTests` and `CloudFoundryActuatorAutoConfigurationTests` pass