### PR TITLE
Use virtual threads for auto-configured RedisMessageListenerContainer

### DIFF
--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/DataRedisAnnotationDrivenConfiguration.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/DataRedisAnnotationDrivenConfiguration.java
@@ -19,8 +19,11 @@ package org.springframework.boot.data.redis.autoconfigure;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnThreading;
+import org.springframework.boot.thread.Threading;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.data.redis.annotation.EnableRedisListeners;
 import org.springframework.data.redis.config.RedisListenerConfigUtils;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -46,8 +49,21 @@ class DataRedisAnnotationDrivenConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
+	@ConditionalOnThreading(Threading.PLATFORM)
 	RedisMessageListenerContainerConfigurer redisMessageListenerContainerConfigurer() {
 		return new RedisMessageListenerContainerConfigurer(this.properties);
+	}
+
+	@Bean(name = "redisMessageListenerContainerConfigurer")
+	@ConditionalOnMissingBean
+	@ConditionalOnThreading(Threading.VIRTUAL)
+	RedisMessageListenerContainerConfigurer redisMessageListenerContainerConfigurerVirtualThreads() {
+		RedisMessageListenerContainerConfigurer configurer = new RedisMessageListenerContainerConfigurer(
+				this.properties);
+		SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor("redis-");
+		executor.setVirtualThreads(true);
+		configurer.setTaskExecutor(executor);
+		return configurer;
 	}
 
 	@Bean(name = DEFAULT_MESSAGE_LISTENER_BEAN_NAME)

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/RedisMessageListenerContainerConfigurer.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/RedisMessageListenerContainerConfigurer.java
@@ -23,8 +23,10 @@ import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.boot.data.redis.autoconfigure.DataRedisProperties.Listener;
 import org.springframework.boot.data.redis.autoconfigure.DataRedisProperties.Recovery;
 import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.lang.Nullable;
 import org.springframework.util.backoff.BackOff;
 
 /**
@@ -42,8 +44,19 @@ public class RedisMessageListenerContainerConfigurer {
 
 	private final DataRedisProperties properties;
 
+	@Nullable
+	private TaskExecutor taskExecutor;
+
 	public RedisMessageListenerContainerConfigurer(DataRedisProperties properties) {
 		this.properties = properties;
+	}
+
+	/**
+	 * Set the {@link TaskExecutor} used to run listener callbacks.
+	 * @param taskExecutor the task executor
+	 */
+	public void setTaskExecutor(@Nullable TaskExecutor taskExecutor) {
+		this.taskExecutor = taskExecutor;
 	}
 
 	/**
@@ -54,6 +67,9 @@ public class RedisMessageListenerContainerConfigurer {
 	 */
 	public void configure(RedisMessageListenerContainer container, RedisConnectionFactory connectionFactory) {
 		container.setConnectionFactory(connectionFactory);
+		if (this.taskExecutor != null) {
+			container.setTaskExecutor(this.taskExecutor);
+		}
 		PropertyMapper map = PropertyMapper.get();
 		Listener listenerProperties = this.properties.getListener();
 		map.from(listenerProperties::isAutoStartup).to(container::setAutoStartup);


### PR DESCRIPTION
## Summary

Auto-configured `RedisMessageListenerContainer` ignored `spring.threads.virtual.enabled`. Kafka and Rabbit listener auto-configuration already use virtual-thread executors when that property is true.

## Change

- Add optional `TaskExecutor` support on `RedisMessageListenerContainerConfigurer`.
- Provide a `@ConditionalOnThreading(Threading.VIRTUAL)` configurer bean that sets a virtual-thread `SimpleAsyncTaskExecutor` (same pattern as Kafka listeners).

## Testing

Manual review against Kafka/Rabbit virtual-thread patterns. Format with project formatter in CI.

## AI assistance

This change was developed with AI coding assistance. I reviewed the code.

Related to https://github.com/spring-projects/spring-boot/issues/50884
