### PR TITLE
Resources are not cleaned up when resolving an image that is not yet present in the builder

### DIFF
--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/ImageBuildpack.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/ImageBuildpack.java
@@ -132,35 +132,41 @@ final class ImageBuildpack implements Buildpack {
 
 		private Path createLayerFile(TarArchive tarArchive) throws IOException {
 			Path sourceTarFile = Files.createTempFile("create-builder-scratch-source-", null);
-			try (OutputStream out = Files.newOutputStream(sourceTarFile)) {
-				tarArchive.writeTo(out);
-			}
-			Path layerFile = Files.createTempFile("create-builder-scratch-", null);
-			try (TarArchiveOutputStream out = new TarArchiveOutputStream(Files.newOutputStream(layerFile))) {
-				try (TarArchiveInputStream in = new TarArchiveInputStream(Files.newInputStream(sourceTarFile))) {
-					out.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
-					TarArchiveEntry entry = in.getNextEntry();
-					while (entry != null) {
-						String entryName = entry.getName();
-						Path entryPath = Path.of(entryName);
-						Assert.state(entryPath.toAbsolutePath().equals(entryPath.toAbsolutePath().normalize()),
-								() -> "Malformed zip entry name '%s'".formatted(entryName));
-						out.putArchiveEntry(entry);
-						StreamUtils.copy(in, out);
-						out.closeArchiveEntry();
-						entry = in.getNextEntry();
-					}
-					out.finish();
+			try {
+				try (OutputStream out = Files.newOutputStream(sourceTarFile)) {
+					tarArchive.writeTo(out);
 				}
+				Path layerFile = Files.createTempFile("create-builder-scratch-", null);
+				try (TarArchiveOutputStream out = new TarArchiveOutputStream(Files.newOutputStream(layerFile))) {
+					try (TarArchiveInputStream in = new TarArchiveInputStream(Files.newInputStream(sourceTarFile))) {
+						out.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+						TarArchiveEntry entry = in.getNextEntry();
+						while (entry != null) {
+							String entryName = entry.getName();
+							Path entryPath = Path.of(entryName);
+							Assert.state(entryPath.toAbsolutePath().equals(entryPath.toAbsolutePath().normalize()),
+									() -> "Malformed zip entry name '%s'".formatted(entryName));
+							out.putArchiveEntry(entry);
+							StreamUtils.copy(in, out);
+							out.closeArchiveEntry();
+							entry = in.getNextEntry();
+						}
+						out.finish();
+					}
+				}
+				return layerFile;
 			}
-			return layerFile;
+			finally {
+				Files.deleteIfExists(sourceTarFile);
+			}
 		}
 
 		void apply(IOConsumer<Layer> layers) throws IOException {
 			for (Path path : this.layerFiles) {
 				layers.accept(Layer.fromTarArchive((out) -> {
-					InputStream in = Files.newInputStream(path);
-					StreamUtils.copy(in, out);
+					try (InputStream in = Files.newInputStream(path)) {
+						StreamUtils.copy(in, out);
+					}
 				}));
 				Files.delete(path);
 			}

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/ImageBuildpackTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/ImageBuildpackTests.java
@@ -24,8 +24,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
@@ -195,6 +198,42 @@ class ImageBuildpackTests extends AbstractJsonTests {
 		BuildpackReference reference = BuildpackReference.of("example/buildpack1");
 		assertThatIllegalStateException().isThrownBy(() -> ImageBuildpack.resolve(resolverContext, reference))
 			.withMessage("Malformed zip entry name '../cnb/'");
+	}
+
+	@Test
+	void resolveDeletesIntermediateSourceTarTempFiles() throws Exception {
+		File tempDir = new File(System.getProperty("java.io.tmpdir"));
+		Set<String> tempsBefore = listTempFileNames(tempDir, "create-builder-scratch-");
+		Image image = Image.of(getContent("buildpack-image.json"));
+		ImageReference imageReference = ImageReference.of("example/buildpack1:1.0.0");
+		BuildpackResolverContext resolverContext = mock(BuildpackResolverContext.class);
+		given(resolverContext.getBuildpackLayersMetadata()).willReturn(BuildpackLayersMetadata.fromJson("{}"));
+		given(resolverContext.fetchImage(eq(imageReference), eq(ImageType.BUILDPACK))).willReturn(image);
+		willAnswer(this::withMockLayers).given(resolverContext).exportImageLayers(eq(imageReference), any());
+		BuildpackReference reference = BuildpackReference.of("docker://example/buildpack1:1.0.0");
+		Buildpack buildpack = ImageBuildpack.resolve(resolverContext, reference);
+		assertThat(buildpack).isNotNull();
+		Set<String> createdOnResolve = new HashSet<>(listTempFileNames(tempDir, "create-builder-scratch-"));
+		createdOnResolve.removeAll(tempsBefore);
+		assertThat(createdOnResolve).as("intermediate source tar temp files must be deleted after createLayerFile")
+			.noneMatch((name) -> name.startsWith("create-builder-scratch-source-"));
+		assertThat(createdOnResolve).isNotEmpty();
+		assertAppliesExpectedLayers(buildpack);
+		Set<String> remainingCreated = new HashSet<>(listTempFileNames(tempDir, "create-builder-scratch-"));
+		remainingCreated.retainAll(createdOnResolve);
+		assertThat(remainingCreated).as("layer temp files created on resolve must be deleted after apply").isEmpty();
+	}
+
+	private Set<String> listTempFileNames(File tempDir, String prefix) {
+		File[] files = tempDir.listFiles((dir, name) -> name.startsWith(prefix));
+		if (files == null) {
+			return Collections.emptySet();
+		}
+		Set<String> names = new HashSet<>();
+		for (File file : files) {
+			names.add(file.getName());
+		}
+		return names;
 	}
 
 	private @Nullable Object withMockLayers(InvocationOnMock invocation) {


### PR DESCRIPTION
## Summary

Close the layer `InputStream` and delete the intermediate source tar temp file in `ImageBuildpack.ExportedLayers` so image buildpack exports do not leak file handles or leave orphaned files under the system temp directory.

## Problem

When resolving an image buildpack that is not already present in the builder, `ExportedLayers` materializes each exported layer as temp files:

1. **Intermediate source tar never deleted.** `createLayerFile` writes `create-builder-scratch-source-*`, rewrites it into `create-builder-scratch-*`, then returns only the rebased file. The source temp is never deleted. Each OCI image buildpack export therefore leaves one orphaned source tar per layer in `java.io.tmpdir`.

2. **Layer stream not closed on apply.** `apply` opens the rebased layer with `Files.newInputStream` and copies with `StreamUtils.copy`, which does **not** close either stream. The open handle can prevent `Files.delete(path)` from succeeding on Windows and keeps a file descriptor open until GC.

Sibling paths in the same module (`TarGzipBuildpack`, the try-with-resources block earlier in `createLayerFile`) already close streams correctly.

### Failure scenario

1. `bootBuildImage` (or the buildpack platform API) resolves a `docker://…` buildpack that is not already in the builder.
2. `exportImageLayers` runs and `createLayerFile` creates both temp files per layer.
3. After construction, only the rebased `create-builder-scratch-*` file is tracked; the `create-builder-scratch-source-*` file remains on disk indefinitely.
4. On `apply`, the layer stream is left open after copy, which is unnecessary retention and can block deletion on Windows.

Observable impact: gradual growth of large tar files under the temp directory during repeated image builds, plus possible failed temp cleanup.

## Change

- Delete `sourceTarFile` in a `finally` block after the rebased layer file has been written (and its streams closed).
- Use try-with-resources for the `InputStream` in `apply` before `StreamUtils.copy`.

## Validation

```
Red step:  FAIL (expected) - resolveDeletesIntermediateSourceTarTempFiles without the production fix
  (asserted newly created create-builder-scratch-source-* files remain after resolve)

Green step: PASS - ./gradlew :buildpack:spring-boot-buildpack-platform:test \
  --tests "org.springframework.boot.buildpack.platform.build.ImageBuildpackTests"
  (11 tests)

Also: checkFormatMain, checkFormatTest, checkstyleMain, checkstyleTest for the module all pass.
```

## Origin

- Intermediate source temp pattern introduced while adding gzip / containerd-friendly layer export support ([`9e409702807e`](https://github.com/spring-projects/spring-boot/commit/9e409702807e), Phillip Webb, 2024-04-23, "Support gzip compressed image layers").
- Apply-path stream open pattern present since image-manifest-based layer export ([`7730eee43998`](https://github.com/spring-projects/spring-boot/commit/7730eee43998), Scott Frederick, 2023-02-27, "Use image manifest when exporting layers").

Related prior cleanup in the same module: #50639 (close `FileOutputStream` delegate in `InspectingOutputStream`).

## Related

- Same resource-cleanup theme as #50639 and #50626.
- `StreamUtils.copy` intentionally leaves streams open for the caller (Spring Framework contract).
