### PR TITLE
Table of auto-configured HealthIndicators lists the wrong key for MongoHealthIndicator

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/endpoints.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/endpoints.adoc
@@ -660,7 +660,7 @@ with the `key` listed in the following table:
 | javadoc:org.springframework.boot.mail.health.MailHealthIndicator[]
 | Checks that a mail server is up.
 
-| `mongo`
+| `mongodb`
 | javadoc:org.springframework.boot.mongodb.health.MongoHealthIndicator[]
 | Checks that a Mongo database is up.
 
@@ -825,7 +825,7 @@ When appropriate, Spring Boot auto-configures the following javadoc:org.springfr
 | javadoc:org.springframework.boot.data.elasticsearch.health.DataElasticsearchReactiveHealthIndicator[]
 | Checks that an Elasticsearch cluster is up.
 
-| `mongo`
+| `mongodb`
 | javadoc:org.springframework.boot.mongodb.health.MongoReactiveHealthIndicator[]
 | Checks that a Mongo database is up.
 


### PR DESCRIPTION
Closes gh-50930
