### PR TITLE
Write ResponseStatusException headers in WebFlux error responses

### DIFF
--- a/module/spring-boot-webflux/src/main/java/org/springframework/boot/webflux/autoconfigure/error/AbstractErrorWebExceptionHandler.java
+++ b/module/spring-boot-webflux/src/main/java/org/springframework/boot/webflux/autoconfigure/error/AbstractErrorWebExceptionHandler.java
@@ -45,6 +45,7 @@ import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import org.springframework.web.reactive.result.view.ViewResolver;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.util.DisconnectedClientHelper;
 import org.springframework.web.util.HtmlUtils;
@@ -55,6 +56,7 @@ import org.springframework.web.util.HtmlUtils;
  * @author Brian Clozel
  * @author Scott Frederick
  * @author Moritz Halbritter
+ * @author US JUN
  * @since 4.0.0
  * @see ErrorAttributes
  */
@@ -296,7 +298,7 @@ public abstract class AbstractErrorWebExceptionHandler implements ErrorWebExcept
 			.switchIfEmpty(Mono.error(throwable))
 			.flatMap((handler) -> handler.handle(request))
 			.doOnNext((response) -> logError(request, response, throwable))
-			.flatMap((response) -> write(exchange, response));
+			.flatMap((response) -> write(exchange, response, throwable));
 	}
 
 	private boolean isDisconnectedClientError(Throwable ex) {
@@ -333,7 +335,12 @@ public abstract class AbstractErrorWebExceptionHandler implements ErrorWebExcept
 		return "HTTP " + request.method() + " \"" + request.path() + query + "\"";
 	}
 
-	private Mono<? extends Void> write(ServerWebExchange exchange, ServerResponse response) {
+	private Mono<? extends Void> write(ServerWebExchange exchange, ServerResponse response, Throwable throwable) {
+		if (throwable instanceof ResponseStatusException responseStatusException) {
+			responseStatusException.getHeaders()
+				.forEach((name, values) -> values
+					.forEach((value) -> exchange.getResponse().getHeaders().add(name, value)));
+		}
 		// force content-type since writeTo won't overwrite response header values
 		exchange.getResponse().getHeaders().setContentType(response.headers().getContentType());
 		return response.writeTo(exchange, new ResponseContext());

--- a/module/spring-boot-webflux/src/test/java/org/springframework/boot/webflux/autoconfigure/error/DefaultErrorWebExceptionHandlerIntegrationTests.java
+++ b/module/spring-boot-webflux/src/test/java/org/springframework/boot/webflux/autoconfigure/error/DefaultErrorWebExceptionHandlerIntegrationTests.java
@@ -50,6 +50,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerCodecConfigurer;
@@ -75,6 +77,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  *
  * @author Brian Clozel
  * @author Scott Frederick
+ * @author US JUN
  */
 @ExtendWith(OutputCaptureExtension.class)
 class DefaultErrorWebExceptionHandlerIntegrationTests {
@@ -378,6 +381,20 @@ class DefaultErrorWebExceptionHandlerIntegrationTests {
 				.isEqualTo(ResponseStatusException.class.getName())
 				.jsonPath("requestId")
 				.isEqualTo(this.logIdFilter.getLogId());
+		});
+	}
+
+	@Test // gh-18831
+	void responseStatusExceptionHeaders() {
+		this.contextRunner.run((context) -> {
+			WebTestClient client = getWebClient(context);
+			client.post()
+				.uri("/badRequest")
+				.exchange()
+				.expectStatus()
+				.isEqualTo(HttpStatus.METHOD_NOT_ALLOWED)
+				.expectHeader()
+				.valueEquals(HttpHeaders.ALLOW, HttpMethod.GET.name());
 		});
 	}
 


### PR DESCRIPTION
`AbstractErrorWebExceptionHandler` renders a `ResponseStatusException` before
Spring Framework's `ResponseStatusExceptionHandler` can apply its response
headers. As a result, exception-contributed headers such as `Allow` on a 405
response are lost.

This change applies headers contributed by a direct `ResponseStatusException`
before writing the generated `ServerResponse`, matching Spring Framework's
existing behavior. It deliberately leaves the broader error-handling
infrastructure unchanged.

Closes gh-18831

Tests:

- `DefaultErrorWebExceptionHandlerIntegrationTests.responseStatusExceptionHeaders`
- `:module:spring-boot-webflux:test`
- `checkFormatMain`, `checkFormatTest`, `checkstyleMain`, and `checkstyleTest`
- `git diff --check`
