### PR TITLE
Fix MongoDB health indicator key in documentation

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/endpoints.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/endpoints.adoc
@@ -660,7 +660,7 @@ with the `key` listed in the following table:
 | javadoc:org.springframework.boot.mail.health.MailHealthIndicator[]
 | Checks that a mail server is up.
 
-| `mongo`
+| `mongodb`
 | javadoc:org.springframework.boot.mongodb.health.MongoHealthIndicator[]
 | Checks that a Mongo database is up.
 


### PR DESCRIPTION
Fixes #50930

The auto-configured health indicators table listed `mongo` as the key for `MongoHealthIndicator`.

This updates the documentation to use `mongodb`, matching the actual health indicator key.

