### PR TITLE
JarFile is not closed when finding main class from archive

### DIFF
--- a/build-plugin/spring-boot-antlib/src/main/java/org/springframework/boot/ant/FindMainClass.java
+++ b/build-plugin/spring-boot-antlib/src/main/java/org/springframework/boot/ant/FindMainClass.java
@@ -71,8 +71,9 @@ public class FindMainClass extends Task {
 			if (this.classesRoot.isDirectory()) {
 				return MainClassFinder.findSingleMainClass(this.classesRoot, SPRING_BOOT_APPLICATION_CLASS_NAME);
 			}
-			return MainClassFinder.findSingleMainClass(new JarFile(this.classesRoot), "/",
-					SPRING_BOOT_APPLICATION_CLASS_NAME);
+			try (JarFile jarFile = new JarFile(this.classesRoot)) {
+				return MainClassFinder.findSingleMainClass(jarFile, "/", SPRING_BOOT_APPLICATION_CLASS_NAME);
+			}
 		}
 		catch (IOException ex) {
 			throw new BuildException(ex);


### PR DESCRIPTION
## What Problem This Solves

`FindMainClass` opens a `JarFile` when `@classesRoot` points at an archive and passes it to `MainClassFinder.findSingleMainClass(JarFile, ...)`. That API does not close the jar; the caller owns the resource. The Ant task never closed it, leaving a file handle open for the rest of the JVM lifetime (or until GC finalization).

Almost every other `new JarFile(...)` call site in this repository already uses try-with-resources (Gradle/Maven plugins, loader tools, buildSrc checks, etc.).

## Evidence

Red-green unit proof:

```text
# Red (buggy code still present)
./gradlew :build-plugin:spring-boot-antlib:test --tests \
  org.springframework.boot.ant.FindMainClassTests.closesJarFileWhenSearchingArchive
FindMainClassTests > closesJarFileWhenSearchingArchive(Path) FAILED
    java.lang.AssertionError at FindMainClassTests.java:71
# assertion: getJarEntry after task.execute should throw IllegalStateException when jar is closed

# Green (try-with-resources applied)
BUILD SUCCESSFUL
```

Also verified: `checkFormatMain`/`checkFormatTest`, `checkstyleMain`/`checkstyleTest`.

## Summary

Wrap the archive path in try-with-resources so the jar is closed after the main-class search returns.

## Related

- Same leak class as prior cleanups: https://github.com/spring-projects/spring-boot/pull/50639 (InspectingOutputStream), https://github.com/spring-projects/spring-boot/pull/50626 (URLClassLoader)
- Introduced on the archive branch of `FindMainClass` in `1595286e04` (2016-11-29; preferred `@SpringBootApplication` search). The unclosed `new JarFile` pattern has been present since the Ant task gained jar support.
- No open competing PR for this path.

## Test plan

- [x] Red: `FindMainClassTests.closesJarFileWhenSearchingArchive` fails without close
- [x] Green: same test passes with try-with-resources
- [x] Format + Checkstyle on main and test sources
