### PR TITLE
Add configurable timeout for JMS health indicator

### DIFF
--- a/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/autoconfigure/health/JmsHealthContributorAutoConfiguration.java
+++ b/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/autoconfigure/health/JmsHealthContributorAutoConfiguration.java
@@ -48,7 +48,7 @@ public final class JmsHealthContributorAutoConfiguration
 		extends CompositeHealthContributorConfiguration<JmsHealthIndicator, ConnectionFactory> {
 
 	JmsHealthContributorAutoConfiguration(JmsHealthIndicatorProperties properties) {
-		super((connectionFactory) -> new JmsHealthIndicator(connectionFactory, properties.getTimeout()));
+		super((connectionFactory) -> new JmsHealthIndicator(connectionFactory, properties.getStartTimeout()));
 	}
 
 	@Bean

--- a/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/autoconfigure/health/JmsHealthContributorAutoConfiguration.java
+++ b/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/autoconfigure/health/JmsHealthContributorAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.health.autoconfigure.contributor.CompositeHealthContributorConfiguration;
 import org.springframework.boot.health.autoconfigure.contributor.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.health.contributor.HealthContributor;
@@ -35,17 +36,19 @@ import org.springframework.context.annotation.Bean;
  * {@link EnableAutoConfiguration Auto-configuration} for {@link JmsHealthIndicator}.
  *
  * @author Stephane Nicoll
+ * @author Venkata Naga Sai Srikanth Gollapudi
  * @since 4.0.0
  */
 @AutoConfiguration(after = JmsAutoConfiguration.class)
 @ConditionalOnClass({ ConnectionFactory.class, JmsHealthIndicator.class })
 @ConditionalOnBean(ConnectionFactory.class)
 @ConditionalOnEnabledHealthIndicator("jms")
+@EnableConfigurationProperties(JmsHealthIndicatorProperties.class)
 public final class JmsHealthContributorAutoConfiguration
 		extends CompositeHealthContributorConfiguration<JmsHealthIndicator, ConnectionFactory> {
 
-	JmsHealthContributorAutoConfiguration() {
-		super(JmsHealthIndicator::new);
+	JmsHealthContributorAutoConfiguration(JmsHealthIndicatorProperties properties) {
+		super((connectionFactory) -> new JmsHealthIndicator(connectionFactory, properties.getTimeout()));
 	}
 
 	@Bean

--- a/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/autoconfigure/health/JmsHealthIndicatorProperties.java
+++ b/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/autoconfigure/health/JmsHealthIndicatorProperties.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jms.autoconfigure.health;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jms.health.JmsHealthIndicator;
+import org.springframework.util.Assert;
+
+/**
+ * External configuration properties for {@link JmsHealthIndicator}.
+ *
+ * @author Venkata Naga Sai Srikanth Gollapudi
+ * @since 4.x
+ */
+@ConfigurationProperties("management.health.jms")
+public class JmsHealthIndicatorProperties {
+
+	/**
+	 * Timeout to use when starting a connection for the health check.
+	 */
+	private Duration timeout = Duration.ofSeconds(5);
+
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		Assert.notNull(timeout, "'timeout' must not be null");
+		Assert.isTrue(timeout.compareTo(Duration.ZERO) > 0, "'timeout' must be greater than 0");
+		this.timeout = timeout;
+	}
+
+}

--- a/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/autoconfigure/health/JmsHealthIndicatorProperties.java
+++ b/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/autoconfigure/health/JmsHealthIndicatorProperties.java
@@ -20,13 +20,13 @@ import java.time.Duration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jms.health.JmsHealthIndicator;
-import org.springframework.util.Assert;
 
 /**
- * External configuration properties for {@link JmsHealthIndicator}.
+ * Configuration properties for {@link JmsHealthIndicator}.
  *
  * @author Venkata Naga Sai Srikanth Gollapudi
- * @since 4.x
+ * @author Stephane Nicoll
+ * @since 4.2.0
  */
 @ConfigurationProperties("management.health.jms")
 public class JmsHealthIndicatorProperties {
@@ -34,16 +34,14 @@ public class JmsHealthIndicatorProperties {
 	/**
 	 * Timeout to use when starting a connection for the health check.
 	 */
-	private Duration timeout = Duration.ofSeconds(5);
+	private Duration startTimeout = JmsHealthIndicator.DEFAULT_START_TIMEOUT;
 
-	public Duration getTimeout() {
-		return this.timeout;
+	public Duration getStartTimeout() {
+		return this.startTimeout;
 	}
 
-	public void setTimeout(Duration timeout) {
-		Assert.notNull(timeout, "'timeout' must not be null");
-		Assert.isTrue(timeout.compareTo(Duration.ZERO) > 0, "'timeout' must be greater than 0");
-		this.timeout = timeout;
+	public void setStartTimeout(Duration startTimeout) {
+		this.startTimeout = startTimeout;
 	}
 
 }

--- a/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/health/JmsHealthIndicator.java
+++ b/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/health/JmsHealthIndicator.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.jms.health;
 
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -25,25 +26,40 @@ import jakarta.jms.JMSException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.boot.convert.DurationStyle;
 import org.springframework.boot.health.contributor.AbstractHealthIndicator;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.core.log.LogMessage;
+import org.springframework.util.Assert;
 
 /**
  * {@link HealthIndicator} for a JMS {@link ConnectionFactory}.
  *
  * @author Stephane Nicoll
+ * @author Venkata Naga Sai Srikanth Gollapudi
  * @since 4.0.0
  */
 public class JmsHealthIndicator extends AbstractHealthIndicator {
+
+	private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
 
 	private final Log logger = LogFactory.getLog(JmsHealthIndicator.class);
 
 	private final ConnectionFactory connectionFactory;
 
+	private final Duration timeout;
+
 	public JmsHealthIndicator(ConnectionFactory connectionFactory) {
+		this(connectionFactory, DEFAULT_TIMEOUT);
+	}
+
+	public JmsHealthIndicator(ConnectionFactory connectionFactory, Duration timeout) {
 		super("JMS health check failed");
+		Assert.notNull(timeout, "'timeout' must not be null");
+		Assert.isTrue(timeout.compareTo(Duration.ZERO) > 0, "'timeout' must be greater than 0");
 		this.connectionFactory = connectionFactory;
+		this.timeout = timeout;
 	}
 
 	@Override
@@ -67,9 +83,10 @@ public class JmsHealthIndicator extends AbstractHealthIndicator {
 		void start() throws JMSException {
 			new Thread(() -> {
 				try {
-					if (!this.latch.await(5, TimeUnit.SECONDS)) {
+					if (!this.latch.await(JmsHealthIndicator.this.timeout.toNanos(), TimeUnit.NANOSECONDS)) {
 						JmsHealthIndicator.this.logger
-							.warn("Connection failed to start within 5 seconds and will be closed.");
+							.warn(LogMessage.format("Connection failed to start within %s and will be closed.",
+									DurationStyle.SIMPLE.print(JmsHealthIndicator.this.timeout)));
 						closeConnection();
 					}
 				}

--- a/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/health/JmsHealthIndicator.java
+++ b/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/health/JmsHealthIndicator.java
@@ -42,24 +42,39 @@ import org.springframework.util.Assert;
  */
 public class JmsHealthIndicator extends AbstractHealthIndicator {
 
-	private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+	/**
+	 * Default timeout to use when starting a connection for the health check.
+	 */
+	public static final Duration DEFAULT_START_TIMEOUT = Duration.ofSeconds(5);
 
 	private final Log logger = LogFactory.getLog(JmsHealthIndicator.class);
 
 	private final ConnectionFactory connectionFactory;
 
-	private final Duration timeout;
+	private final Duration startTimeout;
 
+	/**
+	 * Create a new {@link JmsHealthIndicator} instance with a
+	 * {@linkplain #DEFAULT_START_TIMEOUT default} start timeout.
+	 * @param connectionFactory the connection factory to use
+	 */
 	public JmsHealthIndicator(ConnectionFactory connectionFactory) {
-		this(connectionFactory, DEFAULT_TIMEOUT);
+		this(connectionFactory, DEFAULT_START_TIMEOUT);
 	}
 
-	public JmsHealthIndicator(ConnectionFactory connectionFactory, Duration timeout) {
+	/**
+	 * Create a new {@link JmsHealthIndicator} instance with the given
+	 * {@code startTimeout}.
+	 * @param connectionFactory the connection factory to use
+	 * @param startTimeout timeout to use when starting a connection for the health check
+	 * @since 4.2.0
+	 */
+	public JmsHealthIndicator(ConnectionFactory connectionFactory, Duration startTimeout) {
 		super("JMS health check failed");
-		Assert.notNull(timeout, "'timeout' must not be null");
-		Assert.isTrue(timeout.compareTo(Duration.ZERO) > 0, "'timeout' must be greater than 0");
+		Assert.notNull(startTimeout, "'startTimeout' must not be null");
+		Assert.isTrue(startTimeout.compareTo(Duration.ZERO) > 0, "'startTimeout' must be greater than 0");
 		this.connectionFactory = connectionFactory;
-		this.timeout = timeout;
+		this.startTimeout = startTimeout;
 	}
 
 	@Override
@@ -83,10 +98,11 @@ public class JmsHealthIndicator extends AbstractHealthIndicator {
 		void start() throws JMSException {
 			new Thread(() -> {
 				try {
-					if (!this.latch.await(JmsHealthIndicator.this.timeout.toNanos(), TimeUnit.NANOSECONDS)) {
+					Duration startTimeout1 = JmsHealthIndicator.this.startTimeout;
+					if (!this.latch.await(startTimeout1.toNanos(), TimeUnit.NANOSECONDS)) {
 						JmsHealthIndicator.this.logger
 							.warn(LogMessage.format("Connection failed to start within %s and will be closed.",
-									DurationStyle.SIMPLE.print(JmsHealthIndicator.this.timeout)));
+									DurationStyle.SIMPLE.print(startTimeout1)));
 						closeConnection();
 					}
 				}

--- a/module/spring-boot-jms/src/test/java/org/springframework/boot/jms/autoconfigure/health/JmsHealthContributorAutoConfigurationTests.java
+++ b/module/spring-boot-jms/src/test/java/org/springframework/boot/jms/autoconfigure/health/JmsHealthContributorAutoConfigurationTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.jms.autoconfigure.health;
 
+import java.time.Duration;
+
 import jakarta.jms.ConnectionFactory;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +33,7 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link JmsHealthContributorAutoConfiguration}.
  *
  * @author Phillip Webb
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 class JmsHealthContributorAutoConfigurationTests {
 
@@ -42,6 +45,27 @@ class JmsHealthContributorAutoConfigurationTests {
 	@Test
 	void runShouldCreateIndicator() {
 		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(JmsHealthIndicator.class));
+	}
+
+	@Test
+	void runWhenTimeoutIsConfiguredShouldCreateIndicatorWithConfiguredTimeout() {
+		this.contextRunner.withPropertyValues("management.health.jms.timeout=10ms").run((context) -> {
+			assertThat(context).hasSingleBean(JmsHealthIndicator.class);
+			assertThat(context).hasSingleBean(JmsHealthIndicatorProperties.class);
+			assertThat(context.getBean(JmsHealthIndicatorProperties.class).getTimeout())
+				.isEqualTo(Duration.ofMillis(10));
+			assertThat(context.getBean(JmsHealthIndicator.class)).hasFieldOrPropertyWithValue("timeout",
+					Duration.ofMillis(10));
+		});
+	}
+
+	@Test
+	void runWhenTimeoutIsZeroShouldFail() {
+		this.contextRunner.withPropertyValues("management.health.jms.timeout=0ms")
+			.run((context) -> assertThat(context).hasFailed()
+				.getFailure()
+				.rootCause()
+				.hasMessage("'timeout' must be greater than 0"));
 	}
 
 	@Test

--- a/module/spring-boot-jms/src/test/java/org/springframework/boot/jms/autoconfigure/health/JmsHealthContributorAutoConfigurationTests.java
+++ b/module/spring-boot-jms/src/test/java/org/springframework/boot/jms/autoconfigure/health/JmsHealthContributorAutoConfigurationTests.java
@@ -48,24 +48,24 @@ class JmsHealthContributorAutoConfigurationTests {
 	}
 
 	@Test
-	void runWhenTimeoutIsConfiguredShouldCreateIndicatorWithConfiguredTimeout() {
-		this.contextRunner.withPropertyValues("management.health.jms.timeout=10ms").run((context) -> {
+	void runWhenStartTimeoutIsConfiguredShouldCreateIndicatorWithConfiguredStartTimeout() {
+		this.contextRunner.withPropertyValues("management.health.jms.start-timeout=10ms").run((context) -> {
 			assertThat(context).hasSingleBean(JmsHealthIndicator.class);
 			assertThat(context).hasSingleBean(JmsHealthIndicatorProperties.class);
-			assertThat(context.getBean(JmsHealthIndicatorProperties.class).getTimeout())
+			assertThat(context.getBean(JmsHealthIndicatorProperties.class).getStartTimeout())
 				.isEqualTo(Duration.ofMillis(10));
-			assertThat(context.getBean(JmsHealthIndicator.class)).hasFieldOrPropertyWithValue("timeout",
+			assertThat(context.getBean(JmsHealthIndicator.class)).hasFieldOrPropertyWithValue("startTimeout",
 					Duration.ofMillis(10));
 		});
 	}
 
 	@Test
-	void runWhenTimeoutIsZeroShouldFail() {
-		this.contextRunner.withPropertyValues("management.health.jms.timeout=0ms")
+	void runWhenStartTimeoutIsZeroShouldFail() {
+		this.contextRunner.withPropertyValues("management.health.jms.start-timeout=0ms")
 			.run((context) -> assertThat(context).hasFailed()
 				.getFailure()
 				.rootCause()
-				.hasMessage("'timeout' must be greater than 0"));
+				.hasMessage("'startTimeout' must be greater than 0"));
 	}
 
 	@Test

--- a/module/spring-boot-jms/src/test/java/org/springframework/boot/jms/health/JmsHealthIndicatorTests.java
+++ b/module/spring-boot-jms/src/test/java/org/springframework/boot/jms/health/JmsHealthIndicatorTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.jms.health;
 
+import java.time.Duration;
+
 import jakarta.jms.Connection;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.ConnectionMetaData;
@@ -28,6 +30,7 @@ import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.Status;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willAnswer;
@@ -38,8 +41,32 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link JmsHealthIndicator}.
  *
  * @author Stephane Nicoll
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 class JmsHealthIndicatorTests {
+
+	@Test
+	@SuppressWarnings("NullAway") // Test null check
+	void createWhenTimeoutIsNullThrowsException() {
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		assertThatIllegalArgumentException().isThrownBy(() -> new JmsHealthIndicator(connectionFactory, null))
+			.withMessage("'timeout' must not be null");
+	}
+
+	@Test
+	void createWhenTimeoutIsZeroThrowsException() {
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		assertThatIllegalArgumentException().isThrownBy(() -> new JmsHealthIndicator(connectionFactory, Duration.ZERO))
+			.withMessage("'timeout' must be greater than 0");
+	}
+
+	@Test
+	void createWhenTimeoutIsNegativeThrowsException() {
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> new JmsHealthIndicator(connectionFactory, Duration.ofMillis(-1)))
+			.withMessage("'timeout' must be greater than 0");
+	}
 
 	@Test
 	void jmsBrokerIsUp() throws JMSException {
@@ -98,6 +125,19 @@ class JmsHealthIndicatorTests {
 
 	@Test
 	void whenConnectionStartIsUnresponsiveStatusIsDown() throws JMSException {
+		Health health = healthWhenConnectionStartIsUnresponsive(Duration.ofSeconds(5));
+		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+		assertThat((String) health.getDetails().get("error")).contains("Connection closed");
+	}
+
+	@Test
+	void whenConnectionStartIsUnresponsiveUsesConfiguredTimeout() throws JMSException {
+		Health health = healthWhenConnectionStartIsUnresponsive(Duration.ofMillis(10));
+		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+		assertThat((String) health.getDetails().get("error")).contains("Connection closed");
+	}
+
+	private Health healthWhenConnectionStartIsUnresponsive(Duration timeout) throws JMSException {
 		ConnectionMetaData connectionMetaData = mock(ConnectionMetaData.class);
 		given(connectionMetaData.getJMSProviderName()).willReturn("JMS test provider");
 		Connection connection = mock(Connection.class);
@@ -109,10 +149,8 @@ class JmsHealthIndicatorTests {
 		}).given(connection).close();
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		given(connectionFactory.createConnection()).willReturn(connection);
-		JmsHealthIndicator indicator = new JmsHealthIndicator(connectionFactory);
-		Health health = indicator.health();
-		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
-		assertThat((String) health.getDetails().get("error")).contains("Connection closed");
+		JmsHealthIndicator indicator = new JmsHealthIndicator(connectionFactory, timeout);
+		return indicator.health();
 	}
 
 	private static final class UnresponsiveStartAnswer implements Answer<Void> {

--- a/module/spring-boot-jms/src/test/java/org/springframework/boot/jms/health/JmsHealthIndicatorTests.java
+++ b/module/spring-boot-jms/src/test/java/org/springframework/boot/jms/health/JmsHealthIndicatorTests.java
@@ -47,25 +47,25 @@ class JmsHealthIndicatorTests {
 
 	@Test
 	@SuppressWarnings("NullAway") // Test null check
-	void createWhenTimeoutIsNullThrowsException() {
+	void createWhenStartTimeoutIsNullThrowsException() {
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		assertThatIllegalArgumentException().isThrownBy(() -> new JmsHealthIndicator(connectionFactory, null))
-			.withMessage("'timeout' must not be null");
+			.withMessage("'startTimeout' must not be null");
 	}
 
 	@Test
-	void createWhenTimeoutIsZeroThrowsException() {
+	void createWhenStartTimeoutIsZeroThrowsException() {
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		assertThatIllegalArgumentException().isThrownBy(() -> new JmsHealthIndicator(connectionFactory, Duration.ZERO))
-			.withMessage("'timeout' must be greater than 0");
+			.withMessage("'startTimeout' must be greater than 0");
 	}
 
 	@Test
-	void createWhenTimeoutIsNegativeThrowsException() {
+	void createWhenStartTimeoutIsNegativeThrowsException() {
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> new JmsHealthIndicator(connectionFactory, Duration.ofMillis(-1)))
-			.withMessage("'timeout' must be greater than 0");
+			.withMessage("'startTimeout' must be greater than 0");
 	}
 
 	@Test
@@ -131,13 +131,13 @@ class JmsHealthIndicatorTests {
 	}
 
 	@Test
-	void whenConnectionStartIsUnresponsiveUsesConfiguredTimeout() throws JMSException {
+	void whenConnectionStartIsUnresponsiveUsesConfiguredStartTimeout() throws JMSException {
 		Health health = healthWhenConnectionStartIsUnresponsive(Duration.ofMillis(10));
 		assertThat(health.getStatus()).isEqualTo(Status.DOWN);
 		assertThat((String) health.getDetails().get("error")).contains("Connection closed");
 	}
 
-	private Health healthWhenConnectionStartIsUnresponsive(Duration timeout) throws JMSException {
+	private Health healthWhenConnectionStartIsUnresponsive(Duration startTimeout) throws JMSException {
 		ConnectionMetaData connectionMetaData = mock(ConnectionMetaData.class);
 		given(connectionMetaData.getJMSProviderName()).willReturn("JMS test provider");
 		Connection connection = mock(Connection.class);
@@ -149,7 +149,7 @@ class JmsHealthIndicatorTests {
 		}).given(connection).close();
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		given(connectionFactory.createConnection()).willReturn(connection);
-		JmsHealthIndicator indicator = new JmsHealthIndicator(connectionFactory, timeout);
+		JmsHealthIndicator indicator = new JmsHealthIndicator(connectionFactory, startTimeout);
 		return indicator.health();
 	}
 


### PR DESCRIPTION
This PR adds configurable timeout support to `JmsHealthIndicator`.

Previously, the JMS health indicator used a fixed 5 second timeout when starting a JMS connection. This change keeps the existing 5 second default while allowing users to configure the timeout with:

`management.health.jms.timeout`

Changes:
- Added `JmsHealthIndicatorProperties` for `management.health.jms`.
- Added `JmsHealthIndicator(ConnectionFactory, Duration)`.
- Preserved the existing single-argument constructor with the 5 second default.
- Validates that the timeout is non-null and greater than zero.
- Wires the configured timeout through `JmsHealthContributorAutoConfiguration`.
- Adds tests for default behavior, configured timeout behavior, and invalid timeout values.

<img width="1394" height="404" alt="Screenshot 2026-07-15 at 9 31 30 PM" src="https://github.com/user-attachments/assets/9b1d56da-c18f-43d4-8068-b9e2b2617bfc" />


Closes #50926 