### PR TITLE
Docker Compose ProcessRunner can hang or leave orphan processes

### DIFF
--- a/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/ProcessRunner.java
+++ b/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/ProcessRunner.java
@@ -139,6 +139,7 @@ class ProcessRunner {
 		}
 		catch (InterruptedException ex) {
 			Thread.currentThread().interrupt();
+			process.destroy();
 			throw new IllegalStateException("Interrupted waiting for %s".formatted(process), ex);
 		}
 	}
@@ -177,10 +178,12 @@ class ProcessRunner {
 					}
 					line = reader.readLine();
 				}
-				this.latch.countDown();
 			}
 			catch (IOException ex) {
 				throw new UncheckedIOException("Failed to read process stream", ex);
+			}
+			finally {
+				this.latch.countDown();
 			}
 		}
 

--- a/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/ProcessRunner.java
+++ b/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/ProcessRunner.java
@@ -124,6 +124,7 @@ class ProcessRunner {
 		}
 		catch (InterruptedException ex) {
 			Thread.currentThread().interrupt();
+			process.destroy();
 			throw new IllegalStateException("Interrupted waiting for %s".formatted(process), ex);
 		}
 	}
@@ -162,10 +163,12 @@ class ProcessRunner {
 					}
 					line = reader.readLine();
 				}
-				this.latch.countDown();
 			}
 			catch (IOException ex) {
 				throw new UncheckedIOException("Failed to read process stream", ex);
+			}
+			finally {
+				this.latch.countDown();
 			}
 		}
 

--- a/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/ProcessRunnerTests.java
+++ b/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/ProcessRunnerTests.java
@@ -16,7 +16,16 @@
 
 package org.springframework.boot.docker.compose.core;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import org.springframework.boot.testsupport.process.DisabledIfProcessUnavailable;
 
@@ -29,19 +38,21 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Sebastien Tardif
  */
-@DisabledIfProcessUnavailable("docker")
 class ProcessRunnerTests {
 
-	private ProcessRunner processRunner = new ProcessRunner();
+	private final ProcessRunner processRunner = new ProcessRunner();
 
 	@Test
+	@DisabledIfProcessUnavailable("docker")
 	void run() {
 		String out = this.processRunner.run("docker", "--version");
 		assertThat(out).isNotEmpty();
 	}
 
 	@Test
+	@DisabledIfProcessUnavailable("docker")
 	void runWhenHasOutputConsumer() {
 		StringBuilder output = new StringBuilder();
 		this.processRunner.run(output::append, "docker", "--version");
@@ -55,6 +66,7 @@ class ProcessRunnerTests {
 	}
 
 	@Test
+	@DisabledIfProcessUnavailable("docker")
 	void runWhenProcessReturnsNonZeroExitCode() {
 		assertThatExceptionOfType(ProcessExitException.class)
 			.isThrownBy(() -> this.processRunner.run("docker", "-thisdoesntwork"))
@@ -63,6 +75,45 @@ class ProcessRunnerTests {
 				assertThat(ex.getStdOut()).isEmpty();
 				assertThat(ex.getStdErr()).isNotEmpty();
 			});
+	}
+
+	@Test
+	@DisabledOnOs(OS.WINDOWS)
+	@Timeout(value = 5, threadMode = ThreadMode.SEPARATE_THREAD)
+	void runWhenOutputConsumerThrowsDoesNotHang() {
+		this.processRunner.run((line) -> {
+			throw new IllegalStateException("boom");
+		}, "echo", "hello");
+	}
+
+	@Test
+	@DisabledOnOs(OS.WINDOWS)
+	@Timeout(value = 10, threadMode = ThreadMode.SEPARATE_THREAD)
+	void runWhenInterruptedDestroysChildProcess() throws Exception {
+		Path pidFile = Files.createTempFile("process-runner-", ".pid");
+		Files.delete(pidFile);
+		AtomicReference<Throwable> error = new AtomicReference<>();
+		Thread runner = new Thread(() -> {
+			try {
+				this.processRunner.run("sh", "-c", "echo $$ > '" + pidFile + "'; exec sleep 60");
+			}
+			catch (Throwable ex) {
+				error.set(ex);
+			}
+		}, "process-runner-interrupt-test");
+		runner.start();
+		long deadline = System.currentTimeMillis() + 5000;
+		while (!Files.exists(pidFile) && System.currentTimeMillis() < deadline) {
+			Thread.sleep(50);
+		}
+		assertThat(pidFile).exists();
+		long pid = Long.parseLong(Files.readString(pidFile).trim());
+		assertThat(ProcessHandle.of(pid)).isPresent().get().matches(ProcessHandle::isAlive);
+		runner.interrupt();
+		runner.join(Duration.ofSeconds(5).toMillis());
+		assertThat(runner.isAlive()).isFalse();
+		assertThat(error.get()).isInstanceOf(IllegalStateException.class);
+		assertThat(ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false)).isFalse();
 	}
 
 }

--- a/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/ProcessRunnerTests.java
+++ b/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/ProcessRunnerTests.java
@@ -16,7 +16,15 @@
 
 package org.springframework.boot.docker.compose.core;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import org.springframework.boot.testsupport.process.DisabledIfProcessUnavailable;
 
@@ -29,24 +37,11 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Moritz Halbritter
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Sebastien Tardif
  */
-@DisabledIfProcessUnavailable("docker")
 class ProcessRunnerTests {
 
-	private ProcessRunner processRunner = new ProcessRunner();
-
-	@Test
-	void run() {
-		String out = this.processRunner.run("docker", "--version");
-		assertThat(out).isNotEmpty();
-	}
-
-	@Test
-	void runWhenHasOutputConsumer() {
-		StringBuilder output = new StringBuilder();
-		this.processRunner.run(output::append, "docker", "--version");
-		assertThat(output.toString()).isNotEmpty();
-	}
+	private final ProcessRunner processRunner = new ProcessRunner();
 
 	@Test
 	void runWhenProcessDoesNotStart() {
@@ -55,14 +50,73 @@ class ProcessRunnerTests {
 	}
 
 	@Test
-	void runWhenProcessReturnsNonZeroExitCode() {
-		assertThatExceptionOfType(ProcessExitException.class)
-			.isThrownBy(() -> this.processRunner.run("docker", "-thisdoesntwork"))
-			.satisfies((ex) -> {
-				assertThat(ex.getExitCode()).isGreaterThan(0);
-				assertThat(ex.getStdOut()).isEmpty();
-				assertThat(ex.getStdErr()).isNotEmpty();
-			});
+	@DisabledOnOs(OS.WINDOWS)
+	void runWhenOutputConsumerThrowsDoesNotHang() throws InterruptedException {
+		Thread runner = new Thread(() -> this.processRunner.run((line) -> {
+			throw new IllegalStateException("boom");
+		}, "echo", "hello"), "process-runner-consumer-throw-test");
+		runner.start();
+		runner.join(Duration.ofSeconds(5).toMillis());
+		assertThat(runner.isAlive()).isFalse();
+	}
+
+	@Test
+	@DisabledOnOs(OS.WINDOWS)
+	void runWhenInterruptedDestroysChildProcess() throws Exception {
+		Path pidFile = Files.createTempFile("process-runner-", ".pid");
+		Files.delete(pidFile);
+		AtomicReference<Throwable> error = new AtomicReference<>();
+		Thread runner = new Thread(() -> {
+			try {
+				this.processRunner.run("sh", "-c", "echo $$ > '" + pidFile + "'; exec sleep 60");
+			}
+			catch (Throwable ex) {
+				error.set(ex);
+			}
+		}, "process-runner-interrupt-test");
+		runner.start();
+		long deadline = System.currentTimeMillis() + 5000;
+		while (!Files.exists(pidFile) && System.currentTimeMillis() < deadline) {
+			Thread.sleep(50);
+		}
+		assertThat(pidFile).exists();
+		long pid = Long.parseLong(Files.readString(pidFile).trim());
+		assertThat(ProcessHandle.of(pid)).isPresent().get().matches(ProcessHandle::isAlive);
+		runner.interrupt();
+		runner.join(Duration.ofSeconds(5).toMillis());
+		assertThat(runner.isAlive()).isFalse();
+		assertThat(error.get()).isInstanceOf(IllegalStateException.class);
+		assertThat(ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false)).isFalse();
+	}
+
+	@Nested
+	@DisabledIfProcessUnavailable("docker")
+	class WhenDockerIsAvailable {
+
+		@Test
+		void run() {
+			String out = ProcessRunnerTests.this.processRunner.run("docker", "--version");
+			assertThat(out).isNotEmpty();
+		}
+
+		@Test
+		void runWhenHasOutputConsumer() {
+			StringBuilder output = new StringBuilder();
+			ProcessRunnerTests.this.processRunner.run(output::append, "docker", "--version");
+			assertThat(output.toString()).isNotEmpty();
+		}
+
+		@Test
+		void runWhenProcessReturnsNonZeroExitCode() {
+			assertThatExceptionOfType(ProcessExitException.class)
+				.isThrownBy(() -> ProcessRunnerTests.this.processRunner.run("docker", "-thisdoesntwork"))
+				.satisfies((ex) -> {
+					assertThat(ex.getExitCode()).isGreaterThan(0);
+					assertThat(ex.getStdOut()).isEmpty();
+					assertThat(ex.getStdErr()).isNotEmpty();
+				});
+		}
+
 	}
 
 }

--- a/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/ProcessRunnerTests.java
+++ b/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/ProcessRunnerTests.java
@@ -17,10 +17,12 @@
 package org.springframework.boot.docker.compose.core;
 
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -75,11 +77,7 @@ class ProcessRunnerTests {
 			}
 		}, "process-runner-interrupt-test");
 		runner.start();
-		long deadline = System.currentTimeMillis() + 5000;
-		while (!Files.exists(pidFile) && System.currentTimeMillis() < deadline) {
-			Thread.sleep(50);
-		}
-		assertThat(pidFile).exists();
+		Awaitility.await().until(() -> Files.exists(pidFile, LinkOption.NOFOLLOW_LINKS));
 		long pid = Long.parseLong(Files.readString(pidFile).trim());
 		assertThat(ProcessHandle.of(pid)).isPresent().get().matches(ProcessHandle::isAlive);
 		runner.interrupt();


### PR DESCRIPTION
## Summary

ProcessRunner can hang forever if a stream reader fails, and can leave orphan Docker Compose child processes when waitFor is interrupted.

## Problem

`ReaderThread` only calls `CountDownLatch.countDown()` on the success path. If reading fails with `IOException`, or if the optional `outputConsumer` throws, the latch is never released. After the child process exits, `ProcessRunner.run` blocks forever on `latch.await()` in `ReaderThread.toString()`.

Separately, when `process.waitFor()` is interrupted, the interrupt flag is restored and an exception is thrown (fixed in #50451), but the child process is not destroyed. Docker Compose commands can remain as orphans.

## Change

- Move `latch.countDown()` into a `finally` block in `ReaderThread.run()`.
- Call `process.destroy()` after restoring the interrupt flag when `waitFor` is interrupted.

## Failure scenario

1. Docker Compose support runs a process via `ProcessRunner.run(consumer, command...)`.
2. The consumer throws (or stream read fails) after partial output.
3. The process exits, but the reader never counts down the latch.
4. The calling thread blocks indefinitely on `toString()` / `await()`.

For interrupt: a long-running compose command is interrupted during `waitFor`; without `destroy()`, the child keeps running after the Spring Boot thread has aborted.

## Origin

Introduced with Docker Compose support in [`842e17ecedaf`](https://github.com/spring-projects/spring-boot/commit/842e17ecedaf) (2023-04-07, Moritz Halbritter). Present for ~3 years. Related prior fix: #50451 (interrupt flag restore only).

## Validation

- Red/green:
  - `runWhenOutputConsumerThrowsDoesNotHang`: timed out without the latch fix; passes with it.
  - `runWhenInterruptedDestroysChildProcess`: child `sleep` stayed alive without destroy; process is dead with the fix.
- `./gradlew :core:spring-boot-docker-compose:test --tests ProcessRunnerTests`
- `checkFormatMain` / `checkFormatTest` / `checkstyleMain` / `checkstyleTest`

## Related

- #50451 Restore interrupt flag in ProcessRunner
- Sibling kill pattern: `RunProcess.destroy()` in loader-tools