### PR TITLE
Optimize issue lookup in UpgradeDependencies task

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/bomr/UpgradeDependencies.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/bomr/UpgradeDependencies.java
@@ -25,7 +25,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -130,11 +132,23 @@ public abstract class UpgradeDependencies extends DefaultTask {
 
 	private void applyUpgrades(GitHubRepository repository, List<String> issueLabels, Milestone milestone,
 			List<Upgrade> upgrades) {
-		List<Issue> existingUpgradeIssues = repository.findIssues(issueLabels, milestone);
+		List<Issue> existingUpgradeIssuesList = repository.findIssues(issueLabels, milestone);
+
+		Map<String, Issue> existingUpgradeIssues = new HashMap<>(existingUpgradeIssuesList.size());
+		for (Issue issue : existingUpgradeIssuesList) {
+			String title = issue.getTitle();
+			int lastSpaceIndex = title.lastIndexOf(' ');
+			if (lastSpaceIndex > -1) {
+				title = title.substring(0, lastSpaceIndex);
+			}
+			existingUpgradeIssues.put(title, issue);
+		}
+
 		System.out.println("Applying upgrades...");
 		System.out.println("");
 		for (Upgrade upgrade : upgrades) {
 			System.out.println(upgrade.to().getNameAndVersion());
+			// Agora passa o Dicionário em vez da Lista
 			Issue existingUpgradeIssue = findExistingUpgradeIssue(existingUpgradeIssues, upgrade);
 			try {
 				Path modified = this.upgradeApplicator.apply(upgrade);
@@ -222,19 +236,9 @@ public abstract class UpgradeDependencies extends DefaultTask {
 		return matchingMilestone.get();
 	}
 
-	private Issue findExistingUpgradeIssue(List<Issue> existingUpgradeIssues, Upgrade upgrade) {
+	private Issue findExistingUpgradeIssue(Map<String, Issue> existingUpgradeIssues, Upgrade upgrade) {
 		String toMatch = "Upgrade to " + upgrade.toRelease().getName();
-		for (Issue existingUpgradeIssue : existingUpgradeIssues) {
-			String title = existingUpgradeIssue.getTitle();
-			int lastSpaceIndex = title.lastIndexOf(' ');
-			if (lastSpaceIndex > -1) {
-				title = title.substring(0, lastSpaceIndex);
-			}
-			if (title.equals(toMatch)) {
-				return existingUpgradeIssue;
-			}
-		}
-		return null;
+		return existingUpgradeIssues.get(toMatch);
 	}
 
 	@SuppressWarnings("deprecation")

--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/bomr/UpgradeDependencies.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/bomr/UpgradeDependencies.java
@@ -148,7 +148,6 @@ public abstract class UpgradeDependencies extends DefaultTask {
 		System.out.println("");
 		for (Upgrade upgrade : upgrades) {
 			System.out.println(upgrade.to().getNameAndVersion());
-			// Agora passa o Dicionário em vez da Lista
 			Issue existingUpgradeIssue = findExistingUpgradeIssue(existingUpgradeIssues, upgrade);
 			try {
 				Path modified = this.upgradeApplicator.apply(upgrade);


### PR DESCRIPTION
# Replace linear search with HashMap lookup in `UpgradeDependencies.findExistingUpgradeIssue`

This PR refactors the issue lookup logic in `UpgradeDependencies` to use a `HashMap` instead of a linear search, reducing the algorithmic complexity from O(N * M) to O(N + M).

## Problem
The method `findExistingUpgradeIssue` iterates through the entire list of existing issues for each upgrade, resulting in O(N * M) complexity where N is the number of upgrades and M is the number of existing issues. While functionally correct, this pattern doesn't scale well and doesn't clearly express the intent of finding an issue by its title.

## Solution
- Pre-index existing upgrade issues into a `HashMap<String, Issue>` keyed by normalized title, at a cost of O(M).
- Replace the loop in `findExistingUpgradeIssue` with a direct `Map.get()` call, reducing the per-upgrade lookup from O(M) to O(1).
- Change method signature to accept `Map<String, Issue>` instead of `List<Issue>`.
- Overall complexity reduced from O(N * M) to O(N + M).

## Why this is better
- **Complexity**: O(N * M) → O(N + M)
- **Intent**: A map clearly signals "I want to find an issue by its title"
- **Readability**: One line instead of a loop with string manipulation
- **Consistency**: Follows the principle of using the right data structure for the job

## Testing
All existing tests in `buildSrc` pass successfully.