### PR TITLE
PropertiesLauncher does not log nested archive paths

### DIFF
--- a/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/launch/PropertiesLauncher.java
+++ b/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/launch/PropertiesLauncher.java
@@ -289,11 +289,9 @@ public class PropertiesLauncher extends Launcher {
 		}
 	}
 
-	private List<String> getPaths() throws Exception {
+	private List<String> resolvePaths() throws Exception {
 		String path = getProperty(PATH);
-		List<String> paths = (path != null) ? parsePathsProperty(path) : Collections.emptyList();
-		debug.log("Nested archive paths: %s", paths);
-		return paths;
+		return (path != null) ? parsePathsProperty(path) : Collections.emptyList();
 	}
 
 	private List<String> parsePathsProperty(String commaSeparatedPaths) {
@@ -467,7 +465,9 @@ public class PropertiesLauncher extends Launcher {
 	@Override
 	protected Set<URL> getClassPathUrls() throws Exception {
 		Set<URL> urls = new LinkedHashSet<>();
-		for (String path : getPaths()) {
+		List<String> paths = resolvePaths();
+		debug.log("Nested archive paths: %s", paths);
+		for (String path : paths) {
 			path = cleanupPath(handleUrl(path));
 			urls.addAll(getClassPathUrlsForPath(path));
 		}

--- a/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/launch/PropertiesLauncher.java
+++ b/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/launch/PropertiesLauncher.java
@@ -136,8 +136,6 @@ public class PropertiesLauncher extends Launcher {
 
 	private final File homeDirectory;
 
-	private final List<String> paths;
-
 	private final Properties properties = new Properties();
 
 	public PropertiesLauncher() throws Exception {
@@ -148,7 +146,6 @@ public class PropertiesLauncher extends Launcher {
 		this.archive = archive;
 		this.homeDirectory = getHomeDirectory();
 		initializeProperties();
-		this.paths = getPaths();
 		this.classPathIndex = getClassPathIndex(this.archive);
 	}
 
@@ -295,7 +292,7 @@ public class PropertiesLauncher extends Launcher {
 	private List<String> getPaths() throws Exception {
 		String path = getProperty(PATH);
 		List<String> paths = (path != null) ? parsePathsProperty(path) : Collections.emptyList();
-		debug.log("Nested archive paths: %s", this.paths);
+		debug.log("Nested archive paths: %s", paths);
 		return paths;
 	}
 

--- a/loader/spring-boot-loader/src/test/java/org/springframework/boot/loader/launch/PropertiesLauncherTests.java
+++ b/loader/spring-boot-loader/src/test/java/org/springframework/boot/loader/launch/PropertiesLauncherTests.java
@@ -127,7 +127,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 		System.setProperty("loader.config.name", "foo");
 		this.launcher = new PropertiesLauncher();
 		assertThat(this.launcher.getMainClass()).isEqualTo("my.Application");
-		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths")).hasToString("[etc/]");
+		assertThat(resolvedPaths()).containsExactly("etc/");
 	}
 
 	@Test
@@ -141,14 +141,14 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 	void testUserSpecifiedDotPath() throws Exception {
 		System.setProperty("loader.path", ".");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths")).hasToString("[.]");
+		assertThat(resolvedPaths()).containsExactly(".");
 	}
 
 	@Test
 	void testUserSpecifiedSlashPath() throws Exception {
 		System.setProperty("loader.path", "jars/");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths")).hasToString("[jars/]");
+		assertThat(resolvedPaths()).containsExactly("jars/");
 		Set<URL> urls = this.launcher.getClassPathUrls();
 		assertThat(urls).areExactly(1, endingWith("app.jar"));
 	}
@@ -158,7 +158,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 		System.setProperty("loader.path", "jars/*");
 		System.setProperty("loader.main", "demo.Application");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths")).hasToString("[jars/]");
+		assertThat(resolvedPaths()).containsExactly("jars/");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello World");
 	}
@@ -168,7 +168,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 		System.setProperty("loader.path", "jars/app.jar");
 		System.setProperty("loader.main", "demo.Application");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths")).hasToString("[jars/app.jar]");
+		assertThat(resolvedPaths()).containsExactly("jars/app.jar");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello World");
 	}
@@ -177,8 +177,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 	void testUserSpecifiedRootOfJarPath() throws Exception {
 		System.setProperty("loader.path", "jar:file:./src/test/resources/nested-jars/app.jar!/");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths"))
-			.hasToString("[jar:file:./src/test/resources/nested-jars/app.jar!/]");
+		assertThat(resolvedPaths()).containsExactly("jar:file:./src/test/resources/nested-jars/app.jar!/");
 		Set<URL> urls = this.launcher.getClassPathUrls();
 		assertThat(urls).areExactly(1, endingWith("foo.jar!/"));
 		assertThat(urls).areExactly(1, endingWith("app.jar!/"));
@@ -216,8 +215,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 		System.setProperty("loader.path", "nested-jars/nested-jar-app.jar!/BOOT-INF/classes/");
 		System.setProperty("loader.main", "demo.Application");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths"))
-			.hasToString("[nested-jars/nested-jar-app.jar!/BOOT-INF/classes/]");
+		assertThat(resolvedPaths()).containsExactly("nested-jars/nested-jar-app.jar!/BOOT-INF/classes/");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello World");
 	}
@@ -236,7 +234,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 		System.setProperty("loader.path", "./jars/app.jar");
 		System.setProperty("loader.main", "demo.Application");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths")).hasToString("[jars/app.jar]");
+		assertThat(resolvedPaths()).containsExactly("jars/app.jar");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello World");
 	}
@@ -246,7 +244,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 		System.setProperty("loader.path", "jars/app.jar");
 		System.setProperty("loader.classLoader", URLClassLoader.class.getName());
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths")).hasToString("[jars/app.jar]");
+		assertThat(resolvedPaths()).containsExactly("jars/app.jar");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello World");
 	}
@@ -256,8 +254,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 		System.setProperty("loader.path", "more-jars/app.jar,jars/app.jar");
 		System.setProperty("loader.classLoader", URLClassLoader.class.getName());
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths"))
-			.hasToString("[more-jars/app.jar, jars/app.jar]");
+		assertThat(resolvedPaths()).containsExactly("more-jars/app.jar", "jars/app.jar");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello Other World");
 	}
@@ -309,7 +306,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 	void testArgsEnhanced() throws Exception {
 		System.setProperty("loader.args", "foo");
 		this.launcher = new PropertiesLauncher();
-		assertThat(Arrays.asList(this.launcher.getArgs("bar"))).hasToString("[foo, bar]");
+		assertThat(Arrays.asList(this.launcher.getArgs("bar"))).containsExactly("foo", "bar");
 	}
 
 	@Test
@@ -325,8 +322,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 			manifest.write(manifestStream);
 		}
 		this.launcher = new PropertiesLauncher();
-		assertThat((List<String>) ReflectionTestUtils.invokeMethod(this.launcher, "getPaths"))
-			.containsExactly("/foo.jar", "/bar/");
+		assertThat(resolvedPaths()).containsExactly("/foo.jar", "/bar/");
 	}
 
 	@Test
@@ -445,6 +441,10 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 		expected.add(new File(parent, "BOOT-INF/lib/bar.jar"));
 		expected.add(new File(parent, "BOOT-INF/lib/baz.jar"));
 		return expected;
+	}
+
+	private List<String> resolvedPaths() {
+		return ReflectionTestUtils.invokeMethod(this.launcher, "resolvePaths");
 	}
 
 	private Condition<URL> endingWith(String value) {

--- a/loader/spring-boot-loader/src/test/java/org/springframework/boot/loader/launch/PropertiesLauncherTests.java
+++ b/loader/spring-boot-loader/src/test/java/org/springframework/boot/loader/launch/PropertiesLauncherTests.java
@@ -127,7 +127,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 		System.setProperty("loader.config.name", "foo");
 		this.launcher = new PropertiesLauncher();
 		assertThat(this.launcher.getMainClass()).isEqualTo("my.Application");
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths")).hasToString("[etc/]");
+		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths")).hasToString("[etc/]");
 	}
 
 	@Test
@@ -141,14 +141,14 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 	void testUserSpecifiedDotPath() throws Exception {
 		System.setProperty("loader.path", ".");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths")).hasToString("[.]");
+		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths")).hasToString("[.]");
 	}
 
 	@Test
 	void testUserSpecifiedSlashPath() throws Exception {
 		System.setProperty("loader.path", "jars/");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths")).hasToString("[jars/]");
+		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths")).hasToString("[jars/]");
 		Set<URL> urls = this.launcher.getClassPathUrls();
 		assertThat(urls).areExactly(1, endingWith("app.jar"));
 	}
@@ -158,7 +158,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 		System.setProperty("loader.path", "jars/*");
 		System.setProperty("loader.main", "demo.Application");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths")).hasToString("[jars/]");
+		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths")).hasToString("[jars/]");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello World");
 	}
@@ -168,7 +168,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 		System.setProperty("loader.path", "jars/app.jar");
 		System.setProperty("loader.main", "demo.Application");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths")).hasToString("[jars/app.jar]");
+		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths")).hasToString("[jars/app.jar]");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello World");
 	}
@@ -177,7 +177,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 	void testUserSpecifiedRootOfJarPath() throws Exception {
 		System.setProperty("loader.path", "jar:file:./src/test/resources/nested-jars/app.jar!/");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths"))
+		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths"))
 			.hasToString("[jar:file:./src/test/resources/nested-jars/app.jar!/]");
 		Set<URL> urls = this.launcher.getClassPathUrls();
 		assertThat(urls).areExactly(1, endingWith("foo.jar!/"));
@@ -216,7 +216,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 		System.setProperty("loader.path", "nested-jars/nested-jar-app.jar!/BOOT-INF/classes/");
 		System.setProperty("loader.main", "demo.Application");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths"))
+		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths"))
 			.hasToString("[nested-jars/nested-jar-app.jar!/BOOT-INF/classes/]");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello World");
@@ -236,7 +236,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 		System.setProperty("loader.path", "./jars/app.jar");
 		System.setProperty("loader.main", "demo.Application");
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths")).hasToString("[jars/app.jar]");
+		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths")).hasToString("[jars/app.jar]");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello World");
 	}
@@ -246,7 +246,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 		System.setProperty("loader.path", "jars/app.jar");
 		System.setProperty("loader.classLoader", URLClassLoader.class.getName());
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths")).hasToString("[jars/app.jar]");
+		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths")).hasToString("[jars/app.jar]");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello World");
 	}
@@ -256,7 +256,7 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 		System.setProperty("loader.path", "more-jars/app.jar,jars/app.jar");
 		System.setProperty("loader.classLoader", URLClassLoader.class.getName());
 		this.launcher = new PropertiesLauncher();
-		assertThat(ReflectionTestUtils.getField(this.launcher, "paths"))
+		assertThat(ReflectionTestUtils.<Object>invokeMethod(this.launcher, "getPaths"))
 			.hasToString("[more-jars/app.jar, jars/app.jar]");
 		this.launcher.launch(new String[0]);
 		waitFor("Hello Other World");
@@ -325,8 +325,8 @@ class PropertiesLauncherTests extends AbstractLauncherTests {
 			manifest.write(manifestStream);
 		}
 		this.launcher = new PropertiesLauncher();
-		assertThat((List<String>) ReflectionTestUtils.getField(this.launcher, "paths")).containsExactly("/foo.jar",
-				"/bar/");
+		assertThat((List<String>) ReflectionTestUtils.invokeMethod(this.launcher, "getPaths"))
+			.containsExactly("/foo.jar", "/bar/");
 	}
 
 	@Test


### PR DESCRIPTION
I've been playing around with the `PropertiesLauncher` and I noticed then the logging looks like:

```
...PropertiesLauncher : Property 'loader.path'[Loader-Path]  from environment: WEB-INF/classes,WEB-INF/lib,WEB-INF/lib-provided,file:/dummy
...PropertiesLauncher : Nested archive paths: null
...PropertiesLauncher : Property 'loader.path'[Loader-Path]  from environment: WEB-INF/classes,WEB-INF/lib,WEB-INF/lib-provided,file:/dummy
...PropertiesLauncher : Nested archive paths: [WEB-INF/classes/, WEB-INF/lib/, WEB-INF/lib-provided/, file:/dummy/]
```

I was confused by 

>Nested archive paths: null

and that's how I realized that the logging is using `this.paths` always, and that this is the only place using the `paths` field. 