### PR TITLE
Fix Jetty virtual threads configuration

### DIFF
--- a/module/spring-boot-jetty/src/main/java/org/springframework/boot/jetty/autoconfigure/JettyVirtualThreadsWebServerFactoryCustomizer.java
+++ b/module/spring-boot-jetty/src/main/java/org/springframework/boot/jetty/autoconfigure/JettyVirtualThreadsWebServerFactoryCustomizer.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.jetty.autoconfigure;
 
 import org.eclipse.jetty.util.VirtualThreads;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.VirtualThreadPool;
 import org.jspecify.annotations.Nullable;
 
@@ -61,11 +62,15 @@ public class JettyVirtualThreadsWebServerFactoryCustomizer
 	@Override
 	public void customize(ConfigurableJettyWebServerFactory factory) {
 		Assert.state(VirtualThreads.areSupported(), "Virtual threads are not supported");
+		JettyServerProperties.Threads threadProperties = (this.serverProperties != null)
+				? this.serverProperties.getThreads() : new JettyServerProperties.Threads();
 		Integer maxTasks = getMaxTasks();
 		VirtualThreadPool virtualThreadPool = (maxTasks != null) ? new VirtualThreadPool(maxTasks)
 				: new VirtualThreadPool();
 		virtualThreadPool.setName("jetty-");
-		factory.setThreadPool(virtualThreadPool);
+		QueuedThreadPool threadPool = JettyThreadPool.create(threadProperties);
+		threadPool.setVirtualThreadsExecutor(virtualThreadPool);
+		factory.setThreadPool(threadPool);
 	}
 
 	private @Nullable Integer getMaxTasks() {

--- a/module/spring-boot-jetty/src/test/java/org/springframework/boot/jetty/autoconfigure/JettyVirtualThreadsWebServerFactoryCustomizerTests.java
+++ b/module/spring-boot-jetty/src/test/java/org/springframework/boot/jetty/autoconfigure/JettyVirtualThreadsWebServerFactoryCustomizerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.jetty.autoconfigure;
 
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.VirtualThreadPool;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
@@ -45,8 +46,11 @@ class JettyVirtualThreadsWebServerFactoryCustomizerTests {
 		ConfigurableJettyWebServerFactory factory = mock(ConfigurableJettyWebServerFactory.class);
 		customizer.customize(factory);
 		then(factory).should().setThreadPool(assertArg((threadPool) -> {
-			assertThat(threadPool).isInstanceOf(VirtualThreadPool.class);
-			VirtualThreadPool virtualThreadPool = (VirtualThreadPool) threadPool;
+			assertThat(threadPool).isInstanceOf(QueuedThreadPool.class);
+			QueuedThreadPool queuedThreadPool = (QueuedThreadPool) threadPool;
+			assertThat(queuedThreadPool.getMaxThreads()).isEqualTo(100);
+			assertThat(queuedThreadPool.getVirtualThreadsExecutor()).isInstanceOf(VirtualThreadPool.class);
+			VirtualThreadPool virtualThreadPool = (VirtualThreadPool) queuedThreadPool.getVirtualThreadsExecutor();
 			assertThat(virtualThreadPool.getName()).isEqualTo("jetty-");
 			assertThat(virtualThreadPool.getMaxConcurrentTasks()).isEqualTo(100);
 		}));


### PR DESCRIPTION
Fixes #50929.

When Jetty and virtual threads are used with Actuator configured on a separate management port, the application can stop responding on Windows after 60 seconds of inactivity.

This change configures Jetty with a `QueuedThreadPool` and sets the `VirtualThreadPool` as its virtual-threads executor, rather than using the `VirtualThreadPool` directly as the server thread pool. This keeps Jetty infrastructure tasks on platform threads while application tasks can use virtual threads.

The existing test has been updated to verify the new thread-pool arrangement and that the configured maximum thread count is retained.