### PR TITLE
Let Kotlin serialization back off for JSON-B

### DIFF
--- a/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/KotlinSerializationHttpMessageConvertersConfiguration.java
+++ b/module/spring-boot-http-converter/src/main/java/org/springframework/boot/http/converter/autoconfigure/KotlinSerializationHttpMessageConvertersConfiguration.java
@@ -18,10 +18,13 @@ package org.springframework.boot.http.converter.autoconfigure;
 
 import kotlinx.serialization.Serializable;
 import kotlinx.serialization.json.Json;
+import org.jspecify.annotations.Nullable;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.http.converter.autoconfigure.JsonbHttpMessageConvertersConfiguration.JsonbHttpMessageConvertersCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -46,8 +49,8 @@ class KotlinSerializationHttpMessageConvertersConfiguration {
 	@Order(0)
 	@ConditionalOnMissingBean(KotlinSerializationJsonHttpMessageConverter.class)
 	KotlinSerializationJsonConvertersCustomizer kotlinSerializationJsonConvertersCustomizer(Json json,
-			ResourceLoader resourceLoader) {
-		return new KotlinSerializationJsonConvertersCustomizer(json, resourceLoader);
+			ResourceLoader resourceLoader, ObjectProvider<JsonbHttpMessageConvertersCustomizer> jsonbCustomizer) {
+		return new KotlinSerializationJsonConvertersCustomizer(json, resourceLoader, jsonbCustomizer.getIfAvailable());
 	}
 
 	static class KotlinSerializationJsonConvertersCustomizer
@@ -55,11 +58,12 @@ class KotlinSerializationHttpMessageConvertersConfiguration {
 
 		private final KotlinSerializationJsonHttpMessageConverter converter;
 
-		KotlinSerializationJsonConvertersCustomizer(Json json, ResourceLoader resourceLoader) {
+		KotlinSerializationJsonConvertersCustomizer(Json json, ResourceLoader resourceLoader,
+				@Nullable JsonbHttpMessageConvertersCustomizer jsonbCustomizer) {
 			ClassLoader classLoader = resourceLoader.getClassLoader();
 			boolean hasAnyJsonSupport = ClassUtils.isPresent("tools.jackson.databind.json.JsonMapper", classLoader)
 					|| ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", classLoader)
-					|| ClassUtils.isPresent("com.google.gson.Gson", classLoader);
+					|| ClassUtils.isPresent("com.google.gson.Gson", classLoader) || jsonbCustomizer != null;
 			this.converter = hasAnyJsonSupport ? new KotlinSerializationJsonHttpMessageConverter(json)
 					: new KotlinSerializationJsonHttpMessageConverter(json, (type) -> true);
 		}

--- a/module/spring-boot-http-converter/src/test/java/org/springframework/boot/http/converter/autoconfigure/HttpMessageConvertersAutoConfigurationTests.java
+++ b/module/spring-boot-http-converter/src/test/java/org/springframework/boot/http/converter/autoconfigure/HttpMessageConvertersAutoConfigurationTests.java
@@ -314,6 +314,32 @@ class HttpMessageConvertersAutoConfigurationTests {
 	}
 
 	@Test
+	void kotlinSerializationUsesLimitedPredicateWhenJsonbConverterIsAvailable() {
+		allOptionsRunner()
+			.withClassLoader(new FilteredClassLoader(JsonMapper.class.getPackage().getName(),
+					ObjectMapper.class.getPackage().getName(), Gson.class.getPackage().getName()))
+			.run((context) -> {
+				assertConverterIsRegistered(context, JsonbHttpMessageConverter.class);
+				KotlinSerializationJsonHttpMessageConverter converter = findConverter(getServerConverters(context),
+						KotlinSerializationJsonHttpMessageConverter.class);
+				assertThat(converter.canWrite(Map.class, MediaType.APPLICATION_JSON)).isFalse();
+			});
+	}
+
+	@Test
+	void kotlinSerializationUsesUnrestrictedPredicateWhenJsonbBeanIsNotAvailable() {
+		this.contextRunner
+			.withClassLoader(new FilteredClassLoader(JsonMapper.class.getPackage().getName(),
+					ObjectMapper.class.getPackage().getName(), Gson.class.getPackage().getName()))
+			.withBean(Json.class, () -> Json.Default)
+			.run((context) -> {
+				KotlinSerializationJsonHttpMessageConverter converter = findConverter(getServerConverters(context),
+						KotlinSerializationJsonHttpMessageConverter.class);
+				assertThat(converter.canWrite(Map.class, MediaType.APPLICATION_JSON)).isTrue();
+			});
+	}
+
+	@Test
 	void stringDefaultConverter() {
 		this.contextRunner.run((context) -> assertConverterIsRegistered(context, StringHttpMessageConverter.class));
 	}


### PR DESCRIPTION
Fixes #50953.

Kotlin Serialization currently uses an unrestricted type predicate when JSON-B is the only alternative JSON converter. As a result, it claims non-`@Serializable` types such as `Map` before `JsonbHttpMessageConverter` can handle them.

This change uses the existing JSON-B converter customizer as the availability signal. When JSON-B is configured, Kotlin Serialization uses its limited predicate and backs off for non-`@Serializable` types. When only the JSON-B API is present without a configured JSON-B converter, Kotlin Serialization remains unrestricted.

Tests cover both active JSON-B support and the API-without-JSON-B-bean case.