### PR TITLE
Methods that return the result of Map#remove are not declared with a @Nullable return type

### DIFF
--- a/core/spring-boot-testcontainers/src/dockerTest/java/org/springframework/boot/testcontainers/lifecycle/TestcontainersLifecycleOrderWithScopeIntegrationTests.java
+++ b/core/spring-boot-testcontainers/src/dockerTest/java/org/springframework/boot/testcontainers/lifecycle/TestcontainersLifecycleOrderWithScopeIntegrationTests.java
@@ -164,7 +164,7 @@ class TestcontainersLifecycleOrderWithScopeIntegrationTests {
 		}
 
 		@Override
-		public Object remove(String name) {
+		public @Nullable Object remove(String name) {
 			synchronized (this) {
 				Object removed = this.instances.remove(name);
 				List<Runnable> destructor = this.destructors.get(name);

--- a/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/RestartScopeInitializer.java
+++ b/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/RestartScopeInitializer.java
@@ -47,7 +47,7 @@ public class RestartScopeInitializer implements ApplicationContextInitializer<Co
 		}
 
 		@Override
-		public Object remove(String name) {
+		public @Nullable Object remove(String name) {
 			return Restarter.getInstance().removeAttribute(name);
 		}
 

--- a/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/Restarter.java
+++ b/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/restart/Restarter.java
@@ -450,7 +450,7 @@ public class Restarter {
 		return value;
 	}
 
-	public Object removeAttribute(String name) {
+	public @Nullable Object removeAttribute(String name) {
 		return this.attributes.remove(name);
 	}
 

--- a/module/spring-boot-webmvc-test/src/main/java/org/springframework/boot/webmvc/test/autoconfigure/WebDriverScope.java
+++ b/module/spring-boot-webmvc-test/src/main/java/org/springframework/boot/webmvc/test/autoconfigure/WebDriverScope.java
@@ -68,7 +68,7 @@ public class WebDriverScope implements Scope {
 	}
 
 	@Override
-	public Object remove(String name) {
+	public @Nullable Object remove(String name) {
 		synchronized (this.instances) {
 			return this.instances.remove(name);
 		}


### PR DESCRIPTION
The next release of NullAway treats `Map.remove` as returning `@Nullable`, leading to errors at these locations.  Fix them by marking the return type as `@Nullable`.
