### PR TITLE
Use semantic versioning to determine latest GitHub release

### DIFF
--- a/.github/actions/create-github-release/action.yml
+++ b/.github/actions/create-github-release/action.yml
@@ -27,4 +27,4 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
-      run: gh release create ${{ format('v{0}', inputs.milestone) }} --notes-file changelog.md ${{ inputs.pre-release == 'true' && '--prerelease' || '' }}
+      run: gh api --method POST repos/${GITHUB_REPOSITORY}/releases -f tag_name=${{ format('v{0}', inputs.milestone) }} -F body=@changelog.md -F prerelease=${{ inputs.pre-release }} -f make_latest=legacy


### PR DESCRIPTION
GitHub currently marks every newly published Spring Boot release as the latest release. As a result, a maintenance release from an older generation, such as 3.5.16, can displace a newer generation, such as 4.1.0.

This change creates GitHub releases through the REST API with `make_latest` set to `legacy`. GitHub will therefore determine the latest stable release using release creation dates and semantic versioning. Milestone and release candidate handling remains unchanged.

Closes #50927