### PR TITLE
Start DevTools file watcher asynchronously

### DIFF
--- a/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/classpath/ClassPathFileSystemWatcher.java
+++ b/module/spring-boot-devtools/src/main/java/org/springframework/boot/devtools/classpath/ClassPathFileSystemWatcher.java
@@ -43,10 +43,14 @@ public class ClassPathFileSystemWatcher implements InitializingBean, DisposableB
 
 	private final @Nullable ClassPathRestartStrategy restartStrategy;
 
+	private final Object lifecycleMonitor = new Object();
+
 	@SuppressWarnings("NullAway.Init")
 	private ApplicationContext applicationContext;
 
 	private boolean stopWatcherOnRestart;
+
+	private @Nullable Thread startupThread;
 
 	/**
 	 * Create a new {@link ClassPathFileSystemWatcher} instance.
@@ -87,12 +91,38 @@ public class ClassPathFileSystemWatcher implements InitializingBean, DisposableB
 			this.fileSystemWatcher.addListener(
 					new ClassPathFileChangeListener(this.applicationContext, this.restartStrategy, watcherToStop));
 		}
-		this.fileSystemWatcher.start();
+		synchronized (this.lifecycleMonitor) {
+			this.startupThread = new Thread(this::startFileSystemWatcher);
+			this.startupThread.setName("File Watcher Startup");
+			this.startupThread.setDaemon(true);
+			this.startupThread.start();
+		}
 	}
 
 	@Override
 	public void destroy() throws Exception {
+		Thread startupThread;
+		synchronized (this.lifecycleMonitor) {
+			startupThread = this.startupThread;
+			if (startupThread != null) {
+				startupThread.interrupt();
+			}
+		}
+		if (startupThread != null) {
+			startupThread.join();
+		}
 		this.fileSystemWatcher.stop();
+	}
+
+	private void startFileSystemWatcher() {
+		try {
+			this.fileSystemWatcher.start();
+		}
+		finally {
+			synchronized (this.lifecycleMonitor) {
+				this.startupThread = null;
+			}
+		}
 	}
 
 }

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/classpath/ClassPathFileSystemWatcherTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/classpath/ClassPathFileSystemWatcherTests.java
@@ -23,7 +23,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -86,6 +89,41 @@ class ClassPathFileSystemWatcherTests {
 		assertThat(events.get(0).getChangeSet().iterator().next()).extracting(ChangedFile::getFile)
 			.containsExactly(classFile);
 		context.close();
+	}
+
+	@Test
+	void fileSystemWatcherStartupDoesNotBlockContextRefresh() throws Exception {
+		CountDownLatch startupStarted = new CountDownLatch(1);
+		CountDownLatch continueStartup = new CountDownLatch(1);
+		FileSystemWatcher fileSystemWatcher = new FileSystemWatcher() {
+
+			@Override
+			public void start() {
+				startupStarted.countDown();
+				try {
+					continueStartup.await();
+				}
+				catch (InterruptedException ex) {
+					Thread.currentThread().interrupt();
+				}
+				super.start();
+			}
+
+		};
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		context.registerBean(ClassPathFileSystemWatcher.class,
+				() -> new ClassPathFileSystemWatcher(new MockFileSystemWatcherFactory(fileSystemWatcher), null,
+						new URL[0]));
+		CompletableFuture<Void> refresh = CompletableFuture.runAsync(context::refresh);
+		try {
+			assertThat(startupStarted.await(5, TimeUnit.SECONDS)).isTrue();
+			assertThat(refresh).succeedsWithin(Duration.ofSeconds(1));
+		}
+		finally {
+			continueStartup.countDown();
+			refresh.join();
+			context.close();
+		}
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
This improves DevTools startup performance by starting the `FileSystemWatcher` asynchronously. Previously, creating the initial file-system snapshots occurred synchronously during application context refresh, increasing application startup time for projects with large classpaths.

The watcher is now started on a dedicated daemon thread. Shutdown waits for any startup in progress before stopping the watcher, preventing lifecycle races. The existing synchronous contract of `FileSystemWatcher.start()` is preserved for other callers.

A regression test verifies that file-system watcher startup no longer blocks application context refresh.

Closes #50898