### PR TITLE
Prevent unbounded indexed binding

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Binder.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Binder.java
@@ -403,6 +403,9 @@ public class Binder {
 			result = context.getConverter().convert(result, target);
 		}
 		handler.onFinish(name, target, context, result);
+		if (result == null && context.depth != 0) {
+			return null;
+		}
 		return context.getConverter().convert(result, target);
 	}
 

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/CollectionBinderTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/CollectionBinderTests.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.jspecify.annotations.Nullable;
@@ -196,6 +197,14 @@ class CollectionBinderTests {
 		this.sources.add(source.nonIterable());
 		List<Integer> result = this.binder.bind("foo", INTEGER_LIST).get();
 		assertThat(result).containsExactly(1, 2, 3);
+	}
+
+	@Test
+	void bindToCollectionOfBeansWithOptionalPropertyWhenNonIterableSourceHasNoValueShouldNotBind() {
+		this.sources.add(new MockConfigurationPropertySource().nonIterable());
+		BindResult<List<BeanWithOptionalProperty>> result = this.binder.bind("foo",
+				Bindable.listOf(BeanWithOptionalProperty.class));
+		assertThat(result.isBound()).isFalse();
 	}
 
 	@Test
@@ -647,6 +656,20 @@ class CollectionBinderTests {
 
 		@Nullable List<EnumSet<ExampleEnum>> getValues() {
 			return this.values;
+		}
+
+	}
+
+	static class BeanWithOptionalProperty {
+
+		private Optional<String> value = Optional.empty();
+
+		Optional<String> getValue() {
+			return this.value;
+		}
+
+		void setValue(Optional<String> value) {
+			this.value = value;
 		}
 
 	}


### PR DESCRIPTION
This fixes #50831.

When binding an indexed collection of JavaBeans from a non-iterable configuration property source, a missing nested `Optional` property was converted from `null` to `Optional.empty()`. This made each JavaBean appear to have been successfully bound, causing indexed binding to continue indefinitely until the JVM exhausted its heap.

Nested binding now preserves a `null` result while determining whether the parent object is bound. Top-level binding retains its existing behavior of converting a missing `Optional` value to `Optional.empty()`.

A regression test verifies that a collection of JavaBeans with an `Optional` property remains unbound when a non-iterable source contains no applicable value.