### PR TITLE
Correct function types in ClassPath to avoid nullability warning

### DIFF
--- a/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/ClassPath.java
+++ b/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/ClassPath.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.function.UnaryOperator;
+import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
@@ -123,16 +123,16 @@ final class ClassPath {
 
 	/**
 	 * Factory method to create a {@link ClassPath} of the given URLs.
-	 * @param getSystemProperty {@link UnaryOperator} allowing access to system properties
+	 * @param getSystemProperty {@link Function} allowing access to system properties
 	 * @param urls the class path URLs
 	 * @return a new {@link ClassPath} instance
 	 */
-	static ClassPath of(UnaryOperator<@Nullable String> getSystemProperty, List<URL> urls) {
+	static ClassPath of(Function<String, @Nullable String> getSystemProperty, List<URL> urls) {
 		boolean preferArgFile = urls.size() > 1 && isWindows(getSystemProperty);
 		return new ClassPath(preferArgFile, urls.stream().map(ClassPath::toPathString).collect(JOIN_BY_PATH_SEPARATOR));
 	}
 
-	private static boolean isWindows(UnaryOperator<@Nullable String> getSystemProperty) {
+	private static boolean isWindows(Function<String, @Nullable String> getSystemProperty) {
 		String os = getSystemProperty.apply("os.name");
 		return StringUtils.hasText(os) && os.toLowerCase(Locale.ROOT).contains("win");
 	}

--- a/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ClassPathTests.java
+++ b/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ClassPathTests.java
@@ -22,7 +22,7 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.UnaryOperator;
+import java.util.function.Function;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -94,11 +94,11 @@ class ClassPathTests {
 		assertThat(classPath.toString()).isEqualTo(path1 + File.pathSeparator + path2);
 	}
 
-	private UnaryOperator<@Nullable String> onWindows() {
+	private Function<String, @Nullable String> onWindows() {
 		return Map.of("os.name", "windows")::get;
 	}
 
-	private UnaryOperator<@Nullable String> onLinux() {
+	private Function<String, @Nullable String> onLinux() {
 		return Map.of("os.name", "linux")::get;
 	}
 


### PR DESCRIPTION
Previously, the first parameter of `ClassPath.of` was `UnaryOperator<@Nullable String>`, which is equivalent to `Function<@Nullable String, @Nullable String>`.  But, `System::getProperty` was passed in at a call, and that function cannot accept `null` as a parameter.  Address by changing the relevant parameter types to `Function<String, @Nullable String>`.

This issue was discovered while working on NullAway, and will cause a warning in a future version of NullAway.
