### PR TITLE
Fix examples in Metadata Format documentation chapter

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/specification/pages/configuration-metadata/format.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/specification/pages/configuration-metadata/format.adoc
@@ -13,10 +13,10 @@ They use a JSON format with items categorized under either "`groups`" or "`prope
 		"sourceType": "org.springframework.boot.web.server.autoconfigure.ServerProperties"
 	},
 	{
-		"name": "spring.jpa.hibernate",
-		"type": "org.springframework.boot.jpa.autoconfigure.JpaProperties$Hibernate",
-		"sourceType": "org.springframework.boot.jpa.autoconfigure.JpaProperties",
-		"sourceMethod": "getHibernate()"
+		"name": "spring.jpa.hibernate.naming",
+		"type": "org.springframework.boot.hibernate.autoconfigure.HibernateProperties$Naming",
+		"sourceType": "org.springframework.boot.hibernate.autoconfigure.HibernateProperties",
+		"sourceMethod": "getNaming()"
 	}
 	...
 ],"properties": [
@@ -34,7 +34,7 @@ They use a JSON format with items categorized under either "`groups`" or "`prope
 		  "name": "spring.jpa.hibernate.ddl-auto",
 		  "type": "java.lang.String",
 		  "description": "DDL mode. This is actually a shortcut for the \"hibernate.hbm2ddl.auto\" property.",
-		  "sourceType": "org.springframework.boot.jpa.autoconfigure.JpaProperties$Hibernate"
+		  "sourceType": "org.springframework.boot.hibernate.autoconfigure.HibernateProperties"
 	}
 	...
 ],"hints": [


### PR DESCRIPTION
The examples related to Hibernate properties in the [Metadata Format chapter](https://docs.spring.io/spring-boot/specification/configuration-metadata/format.html) were still referring to [`JpaProperties`](https://github.com/spring-projects/spring-boot/blob/10a5cef4ef33e7c86d18e1f92793c2aaa57d5a82/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/JpaProperties.java) from Boot < 2.1, which had a nested [`Hibernate`](https://github.com/spring-projects/spring-boot/blob/382ea22759522b774649c749b6150738a0a5038e/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/orm/jpa/JpaProperties.java#L169) class.

This PR aligns the package names to version 4 and replaces the `spring.jpa.hibernate` group example with `spring.jpa.hibernate.naming` (the closest I could find, but let me know if you prefer something else there).

The same issue is also in older documentation before version 4, like [3.3](https://docs.spring.io/spring-boot/3.3/specification/configuration-metadata/format.html), but the fix would be slightly different due to the package names. Happy to raise a separate PR for that, or you might find it easier to backport and update the fix on your own, just let me know 🙂 