### PR TITLE
Add AOT cache recording to build plugins and bootBuildImage

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/aot.adoc
+++ b/build-plugin/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/aot.adoc
@@ -68,3 +68,35 @@ As with application AOT processing, the `BeanFactory` is fully prepared at build
 As with `processAot`, the `processTestAot` task is `JavaExec` subclass and can be configured as needed to influence this processing.
 
 The `nativeTest` task of the GraalVM Native Image plugin is automatically configured to use the output of the `processAot` and `processTestAot` tasks.
+
+
+[[aot.aot-cache-recording]]
+== Recording AOT Cache from Integration Tests
+
+The Spring Boot Gradle plugin can configure test tasks to generate a Leyden AOT cache during integration test execution.
+The cache file is written by the JVM on clean exit.
+
+To enable AOT cache recording, set the `aotCacheRecord` option on the `bootBuildImage` task:
+
+[source,groovy,indent=0,subs="verbatim,attributes"]
+----
+bootBuildImage {
+    aotCacheRecord = true
+}
+----
+
+Cache recording is tied to the `bootBuildImage` task. Tests produce the cache only
+when `bootBuildImage` is included in the execution:
+
+* `./gradlew test bootBuildImage` — tests run with `-XX:AOTCacheOutput`, producing the
+  cache file, which is then bundled into the image
+* `./gradlew bootBuildImage` — tests do not run, no cache is produced
+* `./gradlew test` — no cache is produced (`bootBuildImage` is not in the execution plan)
+
+When enabled, the plugin:
+
+* Injects `-XX:AOTCacheOutput=<path>` into all test task JVM arguments
+* Writes the cache file to `build/aot-cache/application.aot`
+* Bundles the cache file into the built image when it is present
+
+NOTE: This feature requires Java 25 or above.

--- a/build-plugin/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/packaging-oci-image.adoc
+++ b/build-plugin/spring-boot-gradle-plugin/src/docs/antora/modules/gradle-plugin/pages/packaging-oci-image.adoc
@@ -285,6 +285,14 @@ Some examples:
 * `example.com/my-repository/my-image:1.0.0` will be used as is
 
 
+[[build-image.aot-cache-recording]]
+== AOT Cache Recording
+
+The `bootBuildImage` task can record a Leyden AOT cache during integration test execution.
+When enabled, the cache file is bundled into the built image automatically.
+See xref:aot.adoc#aot.aot-cache-recording[Recording AOT Cache from Integration Tests] for details.
+
+
 
 [[build-image.examples]]
 == Examples

--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/JavaPluginAction.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/JavaPluginAction.java
@@ -42,6 +42,7 @@ import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.tasks.testing.Test;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.jspecify.annotations.Nullable;
@@ -92,6 +93,7 @@ final class JavaPluginAction implements PluginApplicationAction {
 		configureParametersCompilerArg(project);
 		configureAdditionalMetadataLocations(project);
 		configureSpringBootStarterTestToDependOnJUnitPlatformLauncher(project);
+		configureTestAotCacheRecording(project);
 	}
 
 	private void classifyJarTask(Project project) {
@@ -238,6 +240,31 @@ final class JavaPluginAction implements PluginApplicationAction {
 		JavaToolchainSpec toolchain = project.getExtensions().getByType(JavaPluginExtension.class).getToolchain();
 		JavaToolchainService toolchainService = project.getExtensions().getByType(JavaToolchainService.class);
 		run.getJavaLauncher().convention(toolchainService.launcherFor(toolchain));
+	}
+
+	private void configureTestAotCacheRecording(Project project) {
+		TaskProvider<BootBuildImage> buildImage = project.getTasks()
+			.named(SpringBootPlugin.BOOT_BUILD_IMAGE_TASK_NAME, BootBuildImage.class);
+		project.afterEvaluate((p) -> {
+			Boolean record = buildImage.flatMap(BootBuildImage::getAotCacheRecord).getOrElse(false);
+			if (!record) {
+				return;
+			}
+			p.getGradle().getTaskGraph().whenReady((graph) -> {
+				if (graph.getAllTasks().stream().noneMatch((t) -> t.getName().equals(buildImage.getName()))) {
+					return;
+				}
+				String outputPath = p.getLayout()
+					.getBuildDirectory()
+					.file("aot-cache/application.aot")
+					.get()
+					.getAsFile()
+					.getAbsolutePath();
+				p.getTasks()
+					.withType(Test.class)
+					.configureEach((test) -> test.jvmArgs("-XX:AOTCacheOutput=" + outputPath));
+			});
+		});
 	}
 
 	private JavaPluginExtension javaPluginExtension(Project project) {

--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImage.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImage.java
@@ -17,6 +17,8 @@
 package org.springframework.boot.gradle.tasks.bundling;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -100,6 +102,7 @@ public abstract class BootBuildImage extends DefaultTask {
 		getCleanCache().convention(false);
 		getVerboseLogging().convention(false);
 		getPublish().convention(false);
+		getAotCacheRecord().convention(false);
 		this.buildWorkspace = getProject().getObjects().newInstance(CacheSpec.class);
 		this.buildCache = getProject().getObjects().newInstance(CacheSpec.class);
 		this.launchCache = getProject().getObjects().newInstance(CacheSpec.class);
@@ -238,6 +241,17 @@ public abstract class BootBuildImage extends DefaultTask {
 	@Input
 	@Option(option = "publishImage", description = "Publish the built image to a registry")
 	public abstract Property<Boolean> getPublish();
+
+	/**
+	 * Returns whether AOT cache should be recorded from integration tests during the
+	 * image build. When enabled, the build will run tests with {@code -XX:AOTCacheOutput}
+	 * to produce the cache file, which is then bundled into the image.
+	 * @return whether AOT cache recording is enabled
+	 */
+	@Input
+	@Optional
+	@Option(option = "aotCacheRecord", description = "Record AOT cache from integration tests")
+	public abstract Property<Boolean> getAotCacheRecord();
 
 	/**
 	 * Returns the buildpacks that will be used when building the image.
@@ -427,6 +441,7 @@ public abstract class BootBuildImage extends DefaultTask {
 		if (getImagePlatform().isPresent()) {
 			request = request.withImagePlatform(getImagePlatform().get());
 		}
+		request = customizeAotCache(request);
 		return request;
 	}
 
@@ -532,6 +547,18 @@ public abstract class BootBuildImage extends DefaultTask {
 			if (securityOptions != null) {
 				return request.withSecurityOptions(securityOptions);
 			}
+		}
+		return request;
+	}
+
+	private BuildRequest customizeAotCache(BuildRequest request) {
+		if (!getAotCacheRecord().getOrElse(false)) {
+			return request;
+		}
+		Path cacheDir = getProject().getLayout().getBuildDirectory().dir("aot-cache").get().getAsFile().toPath();
+		if (Files.isDirectory(cacheDir)) {
+			request = request.withEnv("BP_JVM_AOTCACHE_ENABLED", "true");
+			request = request.withAdditionalContent(cacheDir, "aot-cache");
 		}
 		return request;
 	}

--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/JavaPluginActionIntegrationTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/JavaPluginActionIntegrationTests.java
@@ -243,6 +243,18 @@ class JavaPluginActionIntegrationTests {
 		}
 	}
 
+	@TestTemplate
+	void aotCacheRecordingConfiguresTestJvmArgs() {
+		// Gradle build succeeds only if the assert passes (jvmArgs contain AOTCacheOutput)
+		this.gradleBuild.build("verifyAotCache");
+	}
+
+	@TestTemplate
+	void aotCacheRecordingDoesNotConfigureTestJvmArgsByDefault() {
+		String output = this.gradleBuild.build("help").getOutput();
+		assertThat(output).doesNotContain("-XX:AOTCacheOutput=");
+	}
+
 	private void createMinimalMainSource() throws IOException {
 		File examplePackage = new File(this.gradleBuild.getProjectDir(), "src/main/java/com/example");
 		examplePackage.mkdirs();

--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/BootBuildImageTests.java
@@ -17,10 +17,16 @@
 package org.springframework.boot.gradle.tasks.bundling;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import org.gradle.api.Project;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +39,9 @@ import org.springframework.boot.buildpack.platform.build.PullPolicy;
 import org.springframework.boot.buildpack.platform.docker.ImagePlatform;
 import org.springframework.boot.buildpack.platform.docker.type.Binding;
 import org.springframework.boot.buildpack.platform.docker.type.ImageReference;
+import org.springframework.boot.buildpack.platform.io.CompositeTarArchive;
+import org.springframework.boot.buildpack.platform.io.Owner;
+import org.springframework.boot.buildpack.platform.io.TarArchive;
 import org.springframework.boot.gradle.junit.GradleProjectBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -355,6 +364,32 @@ class BootBuildImageTests {
 	void whenImagePlatformIsConfiguredThenRequestHasImagePlatform() {
 		this.buildImage.getImagePlatform().set("linux/arm64/v1");
 		assertThat(this.buildImage.createRequest().getImagePlatform()).isEqualTo(ImagePlatform.of("linux/arm64/v1"));
+	}
+
+	@Test
+	void aotCacheRecordSetsBPJvmAotcacheEnabledWhenCacheDirExists() throws IOException {
+		this.buildImage.getAotCacheRecord().set(true);
+		Path cacheDir = this.project.getLayout().getBuildDirectory().dir("aot-cache").get().getAsFile().toPath();
+		Files.createDirectories(cacheDir);
+		BuildRequest request = this.buildImage.createRequest();
+		assertThat(request.getEnv()).containsEntry("BP_JVM_AOTCACHE_ENABLED", "true");
+	}
+
+	@Test
+	void aotCacheRecordIncludesCacheFiles() throws IOException {
+		this.buildImage.getAotCacheRecord().set(true);
+		Path cacheDir = this.project.getLayout().getBuildDirectory().dir("aot-cache").get().getAsFile().toPath();
+		Files.createDirectories(cacheDir);
+		Files.writeString(cacheDir.resolve("application.aot"), "cache-data");
+		File jarFile = new File(this.project.getLayout().getBuildDirectory().get().getAsFile(), "test-app.jar");
+		try (ZipOutputStream zip = new ZipOutputStream(new FileOutputStream(jarFile))) {
+			zip.putNextEntry(new ZipEntry("META-INF/"));
+			zip.closeEntry();
+		}
+		this.buildImage.getArchiveFile().set(jarFile);
+		BuildRequest request = this.buildImage.createRequest();
+		TarArchive content = request.getApplicationContent(Owner.ROOT);
+		assertThat(content).isInstanceOf(CompositeTarArchive.class);
 	}
 
 }

--- a/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/JavaPluginActionIntegrationTests-aotCacheRecordingConfiguresTestJvmArgs.gradle
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/JavaPluginActionIntegrationTests-aotCacheRecordingConfiguresTestJvmArgs.gradle
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+	id 'java'
+	id 'org.springframework.boot' version '{version}'
+}
+
+bootBuildImage {
+	aotCacheRecord = true
+}
+
+tasks.register('verifyAotCache') {
+	dependsOn 'test'
+	dependsOn 'bootBuildImage'
+	doLast {
+		tasks.withType(Test).each { test ->
+			assert test.jvmArgs.any { it.contains('-XX:AOTCacheOutput=') } : "${test.name} missing -XX:AOTCacheOutput in jvmArgs: ${test.jvmArgs}"
+		}
+	}
+}
+
+afterEvaluate {
+	tasks.getByName('bootBuildImage').enabled = false
+}

--- a/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/JavaPluginActionIntegrationTests-aotCacheRecordingDoesNotConfigureTestJvmArgsByDefault.gradle
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/JavaPluginActionIntegrationTests-aotCacheRecordingDoesNotConfigureTestJvmArgsByDefault.gradle
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+	id 'java'
+	id 'org.springframework.boot' version '{version}'
+}
+

--- a/build-plugin/spring-boot-maven-plugin/build.gradle
+++ b/build-plugin/spring-boot-maven-plugin/build.gradle
@@ -146,6 +146,7 @@ prepareMavenBinaries {
 
 tasks.named("documentPluginGoals") {
 	goalSections = [
+		"aot-cache-record": "aot",
 		"build-image": "build-image",
 		"build-image-no-fork": "build-image",
 		"build-info": "build-info",

--- a/build-plugin/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/pages/aot.adoc
+++ b/build-plugin/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/pages/aot.adoc
@@ -122,3 +122,37 @@ $ mvn test -PnativeTest
 NOTE: As with application AOT processing, the `BeanFactory` is fully prepared at build-time.
 
 include::partial$goals/process-test-aot.adoc[leveloffset=+1]
+
+
+[[aot.aot-cache-recording]]
+== Recording AOT Cache from Integration Tests
+
+The `aot-cache-record` goal configures the Maven Surefire Plugin to generate a Leyden AOT cache during integration test execution.
+The cache file is written by the JVM on clean exit.
+
+To enable AOT cache recording, set the `spring-boot.aot-cache-record` property:
+
+[source,xml,indent=0,subs="verbatim,attributes"]
+----
+<properties>
+    <spring-boot.aot-cache-record>true</spring-boot.aot-cache-record>
+</properties>
+----
+
+The cache is only recorded when the `spring-boot:build-image` or
+`spring-boot:build-image-no-fork` goal is in the execution plan:
+
+* `mvn spring-boot:build-image` — tests run with `-XX:AOTCacheOutput`, producing the
+  cache file, which is then bundled into the image
+* `mvn spring-boot:build-image-no-fork` — same effect, using a non-forked lifecycle
+* `mvn verify` — tests do not run, no cache is produced
+* `mvn test` — no cache is produced (`build-image` is not in the execution plan)
+
+When enabled, the goal injects `-XX:AOTCacheOutput=<path>` into the Surefire `argLine`,
+and the cache file is bundled into the image when built with `spring-boot:build-image`:
+
+* Injects `-XX:AOTCacheOutput=<path>` into the Surefire `argLine`
+* Writes the cache file to `target/aot-cache/application.aot`
+* Bundles the cache file into the built image when it is present
+
+NOTE: This feature requires Java 25 or above.

--- a/build-plugin/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/pages/build-image.adoc
+++ b/build-plugin/spring-boot-maven-plugin/src/docs/antora/modules/maven-plugin/pages/build-image.adoc
@@ -274,6 +274,15 @@ You can override this behaviour as shown in the xref:build-image.adoc#build-imag
 For more details, see also xref:build-image.adoc#build-image.examples[examples].
 
 
+[[build-image.aot-cache-recording]]
+== AOT Cache Recording
+
+The `aot-cache-record` goal can be used to record a Leyden AOT cache during integration test execution.
+When enabled, the cache file is bundled into the built image automatically.
+See xref:aot.adoc#aot.aot-cache-recording[Recording AOT Cache from Integration Tests] for details.
+
+
+
 
 [[build-image.customization.tags]]
 === Tags Format

--- a/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AotCacheRecordMojo.java
+++ b/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AotCacheRecordMojo.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.maven;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Records the Leyden AOT cache for integration tests.
+ *
+ * <p>
+ * This goal injects the JVM arguments required to record the Leyden AOT cache into the
+ * {@code maven-surefire-plugin} {@code argLine}. The cache file is written by the JVM on
+ * clean exit.
+ *
+ * <p>
+ * Enable by setting the {@code spring-boot.aot-cache-record} property:
+ *
+ * <pre>{@code
+ * &lt;properties&gt;
+ *     &lt;spring-boot.aot-cache-record&gt;true&lt;/spring-boot.aot-cache-record&gt;
+ * &lt;/properties&gt;
+ * }</pre>
+ *
+ * @author Vasily Pelikh
+ * @since 4.2.0
+ */
+@Mojo(name = "aot-cache-record", defaultPhase = LifecyclePhase.INITIALIZE)
+public class AotCacheRecordMojo extends AbstractMojo {
+
+	@Parameter(defaultValue = "${project}", readonly = true, required = true)
+	@SuppressWarnings("NullAway.Init")
+	private MavenProject project;
+
+	@Parameter(defaultValue = "${session}", readonly = true)
+	@SuppressWarnings("NullAway.Init")
+	private MavenSession session;
+
+	@Parameter(property = "spring-boot.aot-cache-record", defaultValue = "false")
+	private boolean aotCacheRecord;
+
+	void setAotCacheRecord(boolean aotCacheRecord) {
+		this.aotCacheRecord = aotCacheRecord;
+	}
+
+	void setProject(MavenProject project) {
+		this.project = project;
+	}
+
+	void setSession(MavenSession session) {
+		this.session = session;
+	}
+
+	@Override
+	public void execute() throws MojoExecutionException {
+		if (!this.aotCacheRecord) {
+			getLog().debug("AOT cache recording is not enabled (spring-boot.aot-cache-record is not true).");
+			return;
+		}
+		if (!hasBuildImageGoal()) {
+			getLog().warn("AOT cache recording enabled but spring-boot:build-image goal is not in the execution plan. "
+					+ "Cache recording will be skipped.");
+			return;
+		}
+		String outputPath = resolveOutputPath();
+		String argLine = buildArgLine(outputPath);
+		appendToProjectArgLine(argLine);
+		getLog().info("Configured test AOT cache recording with argLine: " + argLine);
+	}
+
+	private boolean hasBuildImageGoal() {
+		List<String> goals = (this.session != null && this.session.getGoals() != null) ? this.session.getGoals()
+				: Collections.emptyList();
+		return goals.stream()
+			.anyMatch((g) -> g.equals("spring-boot:build-image") || g.equals("spring-boot:build-image-no-fork"));
+	}
+
+	private String resolveOutputPath() {
+		return Path.of(this.project.getBuild().getDirectory(), "aot-cache")
+			.resolve("application.aot")
+			.toAbsolutePath()
+			.toString();
+	}
+
+	private String buildArgLine(String outputPath) {
+		return "-XX:AOTCacheOutput=" + outputPath;
+	}
+
+	private void appendToProjectArgLine(String additionalArgs) {
+		String existing = this.project.getProperties().getProperty("argLine", "").trim();
+		String combined = existing.isEmpty() ? additionalArgs : existing + " " + additionalArgs;
+		this.project.getProperties().put("argLine", combined);
+	}
+
+}

--- a/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildImageMojo.java
+++ b/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/BuildImageMojo.java
@@ -19,6 +19,7 @@ package org.springframework.boot.maven;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.function.Consumer;
@@ -305,6 +306,9 @@ public abstract class BuildImageMojo extends AbstractPackagerMojo {
 		}
 		if (image.imagePlatform == null && this.imagePlatform != null) {
 			image.setImagePlatform(this.imagePlatform);
+		}
+		if (Boolean.TRUE.equals(image.getAotCacheRecord())) {
+			image.cacheDirectory = Path.of(this.project.getBuild().getDirectory(), "aot-cache");
 		}
 		return customize(image.getBuildRequest(this.project.getArtifact(), content));
 	}

--- a/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/Image.java
+++ b/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/Image.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.maven;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -87,6 +89,10 @@ public class Image {
 	@Nullable List<String> securityOptions;
 
 	@Nullable String imagePlatform;
+
+	@Nullable private Boolean aotCacheRecord;
+
+	@Nullable Path cacheDirectory;
 
 	/**
 	 * The name of the created image.
@@ -238,6 +244,20 @@ public class Image {
 		this.imagePlatform = imagePlatform;
 	}
 
+	/**
+	 * If AOT cache should be recorded from integration tests during the image build. When
+	 * enabled, the build will bundle the cache file from {@code target/aot-cache} into
+	 * the image.
+	 * @return {@code true} if AOT cache recording is enabled
+	 */
+	public @Nullable Boolean getAotCacheRecord() {
+		return this.aotCacheRecord;
+	}
+
+	public void setAotCacheRecord(@Nullable Boolean aotCacheRecord) {
+		this.aotCacheRecord = aotCacheRecord;
+	}
+
 	BuildRequest getBuildRequest(Artifact artifact, Function<Owner, TarArchive> applicationContent) {
 		return customize(BuildRequest.of(getOrDeduceName(artifact), applicationContent));
 	}
@@ -309,6 +329,14 @@ public class Image {
 		}
 		if (StringUtils.hasText(this.imagePlatform)) {
 			request = request.withImagePlatform(this.imagePlatform);
+		}
+		if (Boolean.TRUE.equals(this.aotCacheRecord)) {
+			Path cacheDir = (this.cacheDirectory != null) ? this.cacheDirectory
+					: Path.of("target", "aot-cache").toAbsolutePath();
+			if (Files.isDirectory(cacheDir)) {
+				request = request.withEnv("BP_JVM_AOTCACHE_ENABLED", "true");
+				request = request.withAdditionalContent(cacheDir, "aot-cache");
+			}
 		}
 		return request;
 	}

--- a/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/AotCacheRecordMojoTests.java
+++ b/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/AotCacheRecordMojoTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.maven;
+
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Model;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link AotCacheRecordMojo}.
+ *
+ * @author Vasily Pelikh
+ */
+class AotCacheRecordMojoTests {
+
+	private final Properties properties = new Properties();
+
+	private final MavenProject project = new MavenProject(new Model());
+
+	private final AotCacheRecordMojo mojo = new AotCacheRecordMojo();
+
+	@BeforeEach
+	void setup() {
+		this.project.getModel().setProperties(this.properties);
+		Build build = new Build();
+		build.setDirectory("/project/target");
+		this.project.getModel().setBuild(build);
+		MavenSession session = mock(MavenSession.class);
+		given(session.getGoals()).willReturn(List.of("spring-boot:build-image", "test"));
+		this.mojo.setLog(mock(Log.class));
+		this.mojo.setProject(this.project);
+		this.mojo.setSession(session);
+	}
+
+	@Test
+	void doesNothingWhenPropertyIsAbsent() throws Exception {
+		this.mojo.execute();
+		assertThat(this.properties).doesNotContainKey("argLine");
+	}
+
+	@Test
+	void setsArgLineWhenPropertyIsPresent() throws Exception {
+		this.mojo.setAotCacheRecord(true);
+		this.mojo.execute();
+		String argLine = this.properties.getProperty("argLine");
+		assertThat(argLine).contains("-XX:AOTCacheOutput=");
+	}
+
+	@Test
+	void appendsToExistingArgLine() throws Exception {
+		this.properties.setProperty("argLine", "-javaagent:mockito.jar");
+		this.mojo.setAotCacheRecord(true);
+		this.mojo.execute();
+		String argLine = this.properties.getProperty("argLine");
+		assertThat(argLine).startsWith("-javaagent:mockito.jar");
+		assertThat(argLine).contains("-XX:AOTCacheOutput=");
+	}
+
+	@Test
+	void doesNothingWhenBuildImageGoalIsNotPresent() throws Exception {
+		MavenSession session = mock(MavenSession.class);
+		given(session.getGoals()).willReturn(List.of("compile", "test"));
+		this.mojo.setSession(session);
+		this.mojo.setAotCacheRecord(true);
+		this.mojo.execute();
+		assertThat(this.properties).doesNotContainKey("argLine");
+	}
+
+}

--- a/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ImageTests.java
+++ b/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ImageTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.boot.maven;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -34,6 +37,7 @@ import org.springframework.boot.buildpack.platform.build.PullPolicy;
 import org.springframework.boot.buildpack.platform.docker.ImagePlatform;
 import org.springframework.boot.buildpack.platform.docker.type.Binding;
 import org.springframework.boot.buildpack.platform.docker.type.ImageReference;
+import org.springframework.boot.buildpack.platform.io.CompositeTarArchive;
 import org.springframework.boot.buildpack.platform.io.Owner;
 import org.springframework.boot.buildpack.platform.io.TarArchive;
 import org.springframework.boot.maven.CacheInfo.BindCacheInfo;
@@ -298,6 +302,47 @@ class ImageTests {
 		image.imagePlatform = "";
 		BuildRequest request = image.getBuildRequest(createArtifact(), mockApplicationContent());
 		assertThat(request.getImagePlatform()).isNull();
+	}
+
+	@Test
+	void getBuildRequestWhenAotCacheRecordTrueBundlesCacheWhenDirExists() throws IOException {
+		Image image = new Image();
+		image.setAotCacheRecord(true);
+		Path cacheDir = Path.of("target/aot-cache");
+		try {
+			Files.createDirectories(cacheDir);
+			Files.writeString(cacheDir.resolve("application.aot"), "cache-data");
+			BuildRequest request = image.getBuildRequest(createArtifact(), mockApplicationContent());
+			assertThat(request.getEnv()).containsEntry("BP_JVM_AOTCACHE_ENABLED", "true");
+			TarArchive content = request.getApplicationContent(Owner.ROOT);
+			assertThat(content).isInstanceOf(CompositeTarArchive.class);
+		}
+		finally {
+			Files.deleteIfExists(cacheDir.resolve("application.aot"));
+			Files.deleteIfExists(cacheDir);
+		}
+	}
+
+	@Test
+	void getBuildRequestWhenAotCacheRecordTrueDoesNotSetEnvWhenCacheDirMissing() {
+		Image image = new Image();
+		image.setAotCacheRecord(true);
+		BuildRequest request = image.getBuildRequest(createArtifact(), mockApplicationContent());
+		assertThat(request.getEnv()).doesNotContainKey("BP_JVM_AOTCACHE_ENABLED");
+	}
+
+	@Test
+	void getBuildRequestWhenAotCacheRecordFalseDoesNothing() {
+		Image image = new Image();
+		BuildRequest request = image.getBuildRequest(createArtifact(), mockApplicationContent());
+		assertThat(request.getEnv()).doesNotContainKey("BP_JVM_AOTCACHE_ENABLED");
+	}
+
+	@Test
+	void getBuildRequestWhenAotCacheRecordNullDoesNothing() {
+		Image image = new Image();
+		BuildRequest request = image.getBuildRequest(createArtifact(), mockApplicationContent());
+		assertThat(request.getEnv()).doesNotContainKey("BP_JVM_AOTCACHE_ENABLED");
 	}
 
 	private Artifact createArtifact() {

--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildRequest.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/BuildRequest.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.buildpack.platform.build;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
@@ -24,6 +25,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.jspecify.annotations.Nullable;
@@ -31,6 +33,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.boot.buildpack.platform.docker.ImagePlatform;
 import org.springframework.boot.buildpack.platform.docker.type.Binding;
 import org.springframework.boot.buildpack.platform.docker.type.ImageReference;
+import org.springframework.boot.buildpack.platform.io.CompositeTarArchive;
 import org.springframework.boot.buildpack.platform.io.Owner;
 import org.springframework.boot.buildpack.platform.io.TarArchive;
 import org.springframework.util.Assert;
@@ -109,6 +112,10 @@ public class BuildRequest {
 
 	private final @Nullable ImagePlatform platform;
 
+	private final @Nullable Path additionalContent;
+
+	private final @Nullable String additionalContentPrefix;
+
 	BuildRequest(ImageReference name, Function<Owner, TarArchive> applicationContent) {
 		Assert.notNull(name, "'name' must not be null");
 		Assert.notNull(applicationContent, "'applicationContent' must not be null");
@@ -134,6 +141,8 @@ public class BuildRequest {
 		this.applicationDirectory = null;
 		this.securityOptions = null;
 		this.platform = null;
+		this.additionalContent = null;
+		this.additionalContentPrefix = null;
 	}
 
 	BuildRequest(ImageReference name, Function<Owner, TarArchive> applicationContent, ImageReference builder,
@@ -142,7 +151,8 @@ public class BuildRequest {
 			List<BuildpackReference> buildpacks, List<Binding> bindings, @Nullable String network,
 			List<ImageReference> tags, @Nullable Cache buildWorkspace, @Nullable Cache buildCache,
 			@Nullable Cache launchCache, @Nullable Instant createdDate, @Nullable String applicationDirectory,
-			@Nullable List<String> securityOptions, @Nullable ImagePlatform platform) {
+			@Nullable List<String> securityOptions, @Nullable ImagePlatform platform, @Nullable Path additionalContent,
+			@Nullable String additionalContentPrefix) {
 		this.name = name;
 		this.applicationContent = applicationContent;
 		this.builder = builder;
@@ -165,6 +175,8 @@ public class BuildRequest {
 		this.applicationDirectory = applicationDirectory;
 		this.securityOptions = securityOptions;
 		this.platform = platform;
+		this.additionalContent = additionalContent;
+		this.additionalContentPrefix = additionalContentPrefix;
 	}
 
 	/**
@@ -178,7 +190,7 @@ public class BuildRequest {
 				this.runImage, this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy,
 				this.publish, this.buildpacks, this.bindings, this.network, this.tags, this.buildWorkspace,
 				this.buildCache, this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions,
-				this.platform);
+				this.platform, this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -192,7 +204,8 @@ public class BuildRequest {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, trustBuilder, this.runImage,
 				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish,
 				this.buildpacks, this.bindings, this.network, this.tags, this.buildWorkspace, this.buildCache,
-				this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions, this.platform);
+				this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions, this.platform,
+				this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -205,7 +218,7 @@ public class BuildRequest {
 				runImageName.inTaggedOrDigestForm(), this.creator, this.env, this.cleanCache, this.verboseLogging,
 				this.pullPolicy, this.publish, this.buildpacks, this.bindings, this.network, this.tags,
 				this.buildWorkspace, this.buildCache, this.launchCache, this.createdDate, this.applicationDirectory,
-				this.securityOptions, this.platform);
+				this.securityOptions, this.platform, this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -218,7 +231,8 @@ public class BuildRequest {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.trustBuilder, this.runImage,
 				creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish, this.buildpacks,
 				this.bindings, this.network, this.tags, this.buildWorkspace, this.buildCache, this.launchCache,
-				this.createdDate, this.applicationDirectory, this.securityOptions, this.platform);
+				this.createdDate, this.applicationDirectory, this.securityOptions, this.platform,
+				this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -236,7 +250,7 @@ public class BuildRequest {
 				this.creator, Collections.unmodifiableMap(env), this.cleanCache, this.verboseLogging, this.pullPolicy,
 				this.publish, this.buildpacks, this.bindings, this.network, this.tags, this.buildWorkspace,
 				this.buildCache, this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions,
-				this.platform);
+				this.platform, this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -252,7 +266,7 @@ public class BuildRequest {
 				this.creator, Collections.unmodifiableMap(updatedEnv), this.cleanCache, this.verboseLogging,
 				this.pullPolicy, this.publish, this.buildpacks, this.bindings, this.network, this.tags,
 				this.buildWorkspace, this.buildCache, this.launchCache, this.createdDate, this.applicationDirectory,
-				this.securityOptions, this.platform);
+				this.securityOptions, this.platform, this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -264,7 +278,8 @@ public class BuildRequest {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.trustBuilder, this.runImage,
 				this.creator, this.env, cleanCache, this.verboseLogging, this.pullPolicy, this.publish, this.buildpacks,
 				this.bindings, this.network, this.tags, this.buildWorkspace, this.buildCache, this.launchCache,
-				this.createdDate, this.applicationDirectory, this.securityOptions, this.platform);
+				this.createdDate, this.applicationDirectory, this.securityOptions, this.platform,
+				this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -276,7 +291,8 @@ public class BuildRequest {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.trustBuilder, this.runImage,
 				this.creator, this.env, this.cleanCache, verboseLogging, this.pullPolicy, this.publish, this.buildpacks,
 				this.bindings, this.network, this.tags, this.buildWorkspace, this.buildCache, this.launchCache,
-				this.createdDate, this.applicationDirectory, this.securityOptions, this.platform);
+				this.createdDate, this.applicationDirectory, this.securityOptions, this.platform,
+				this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -288,7 +304,8 @@ public class BuildRequest {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.trustBuilder, this.runImage,
 				this.creator, this.env, this.cleanCache, this.verboseLogging, pullPolicy, this.publish, this.buildpacks,
 				this.bindings, this.network, this.tags, this.buildWorkspace, this.buildCache, this.launchCache,
-				this.createdDate, this.applicationDirectory, this.securityOptions, this.platform);
+				this.createdDate, this.applicationDirectory, this.securityOptions, this.platform,
+				this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -300,7 +317,8 @@ public class BuildRequest {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.trustBuilder, this.runImage,
 				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, publish, this.buildpacks,
 				this.bindings, this.network, this.tags, this.buildWorkspace, this.buildCache, this.launchCache,
-				this.createdDate, this.applicationDirectory, this.securityOptions, this.platform);
+				this.createdDate, this.applicationDirectory, this.securityOptions, this.platform,
+				this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -325,7 +343,8 @@ public class BuildRequest {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.trustBuilder, this.runImage,
 				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish, buildpacks,
 				this.bindings, this.network, this.tags, this.buildWorkspace, this.buildCache, this.launchCache,
-				this.createdDate, this.applicationDirectory, this.securityOptions, this.platform);
+				this.createdDate, this.applicationDirectory, this.securityOptions, this.platform,
+				this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -350,7 +369,8 @@ public class BuildRequest {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.trustBuilder, this.runImage,
 				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish,
 				this.buildpacks, bindings, this.network, this.tags, this.buildWorkspace, this.buildCache,
-				this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions, this.platform);
+				this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions, this.platform,
+				this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -363,7 +383,8 @@ public class BuildRequest {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.trustBuilder, this.runImage,
 				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish,
 				this.buildpacks, this.bindings, network, this.tags, this.buildWorkspace, this.buildCache,
-				this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions, this.platform);
+				this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions, this.platform,
+				this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -386,7 +407,8 @@ public class BuildRequest {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.trustBuilder, this.runImage,
 				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish,
 				this.buildpacks, this.bindings, this.network, tags, this.buildWorkspace, this.buildCache,
-				this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions, this.platform);
+				this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions, this.platform,
+				this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -400,7 +422,8 @@ public class BuildRequest {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.trustBuilder, this.runImage,
 				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish,
 				this.buildpacks, this.bindings, this.network, this.tags, buildWorkspace, this.buildCache,
-				this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions, this.platform);
+				this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions, this.platform,
+				this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -413,7 +436,8 @@ public class BuildRequest {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.trustBuilder, this.runImage,
 				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish,
 				this.buildpacks, this.bindings, this.network, this.tags, this.buildWorkspace, buildCache,
-				this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions, this.platform);
+				this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions, this.platform,
+				this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -426,7 +450,8 @@ public class BuildRequest {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.trustBuilder, this.runImage,
 				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish,
 				this.buildpacks, this.bindings, this.network, this.tags, this.buildWorkspace, this.buildCache,
-				launchCache, this.createdDate, this.applicationDirectory, this.securityOptions, this.platform);
+				launchCache, this.createdDate, this.applicationDirectory, this.securityOptions, this.platform,
+				this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -440,7 +465,7 @@ public class BuildRequest {
 				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish,
 				this.buildpacks, this.bindings, this.network, this.tags, this.buildWorkspace, this.buildCache,
 				this.launchCache, parseCreatedDate(createdDate), this.applicationDirectory, this.securityOptions,
-				this.platform);
+				this.platform, this.additionalContent, this.additionalContentPrefix);
 	}
 
 	private Instant parseCreatedDate(String createdDate) {
@@ -465,7 +490,8 @@ public class BuildRequest {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.trustBuilder, this.runImage,
 				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish,
 				this.buildpacks, this.bindings, this.network, this.tags, this.buildWorkspace, this.buildCache,
-				this.launchCache, this.createdDate, applicationDirectory, this.securityOptions, this.platform);
+				this.launchCache, this.createdDate, applicationDirectory, this.securityOptions, this.platform,
+				this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -479,7 +505,8 @@ public class BuildRequest {
 		return new BuildRequest(this.name, this.applicationContent, this.builder, this.trustBuilder, this.runImage,
 				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish,
 				this.buildpacks, this.bindings, this.network, this.tags, this.buildWorkspace, this.buildCache,
-				this.launchCache, this.createdDate, this.applicationDirectory, securityOptions, this.platform);
+				this.launchCache, this.createdDate, this.applicationDirectory, securityOptions, this.platform,
+				this.additionalContent, this.additionalContentPrefix);
 	}
 
 	/**
@@ -494,7 +521,26 @@ public class BuildRequest {
 				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish,
 				this.buildpacks, this.bindings, this.network, this.tags, this.buildWorkspace, this.buildCache,
 				this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions,
-				ImagePlatform.of(platform));
+				ImagePlatform.of(platform), this.additionalContent, this.additionalContentPrefix);
+	}
+
+	/**
+	 * Return a new {@link BuildRequest} with additional content to merge into the
+	 * application content. The additional content is prepended with the given prefix
+	 * and placed under that directory in the final image.
+	 * @param path the path to the additional content directory
+	 * @param prefix the prefix to apply to entries in the additional content archive
+	 * @return an updated build request
+	 * @since 4.1.0
+	 */
+	public BuildRequest withAdditionalContent(Path path, String prefix) {
+		Assert.notNull(path, "'path' must not be null");
+		Assert.hasText(prefix, "'prefix' must not be empty");
+		return new BuildRequest(this.name, this.applicationContent, this.builder, this.trustBuilder, this.runImage,
+				this.creator, this.env, this.cleanCache, this.verboseLogging, this.pullPolicy, this.publish,
+				this.buildpacks, this.bindings, this.network, this.tags, this.buildWorkspace, this.buildCache,
+				this.launchCache, this.createdDate, this.applicationDirectory, this.securityOptions, this.platform,
+				path, prefix);
 	}
 
 	/**
@@ -513,7 +559,12 @@ public class BuildRequest {
 	 * @see TarArchive#fromZip(File, Owner)
 	 */
 	public TarArchive getApplicationContent(Owner owner) {
-		return this.applicationContent.apply(owner);
+		TarArchive archive = this.applicationContent.apply(owner);
+		if (this.additionalContent != null) {
+			return new CompositeTarArchive(archive, this.additionalContent,
+					Objects.requireNonNull(this.additionalContentPrefix));
+		}
+		return archive;
 	}
 
 	/**

--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/io/CompositeTarArchive.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/io/CompositeTarArchive.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.buildpack.platform.io;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+
+import org.springframework.util.Assert;
+
+/**
+ * A {@link TarArchive} that merges entries from a primary archive with entries from an
+ * additional content directory. Additional entries are prefixed with a directory path.
+ *
+ * @author Vasily Pelikh
+ * @since 4.2.0
+ */
+public class CompositeTarArchive implements TarArchive {
+
+	private final TarArchive primary;
+
+	private final Path additionalContent;
+
+	private final String prefix;
+
+	public CompositeTarArchive(TarArchive primary, Path additionalContent, String prefix) {
+		Assert.notNull(primary, "'primary' must not be null");
+		Assert.notNull(additionalContent, "'additionalContent' must not be null");
+		Assert.hasText(prefix, "'prefix' must not be empty");
+		this.primary = primary;
+		this.additionalContent = additionalContent;
+		this.prefix = prefix;
+	}
+
+	@Override
+	public void writeTo(OutputStream outputStream) throws IOException {
+		ByteArrayOutputStream primaryBuffer = new ByteArrayOutputStream();
+		this.primary.writeTo(primaryBuffer);
+		TarArchive composite = TarArchive.of((layout) -> {
+			writePrimaryEntries(layout, primaryBuffer);
+			if (Files.isDirectory(this.additionalContent)) {
+				collectAdditionalEntries(layout, this.additionalContent, this.prefix);
+			}
+		});
+		composite.writeTo(outputStream);
+	}
+
+	private void writePrimaryEntries(Layout layout, ByteArrayOutputStream primaryBuffer) throws IOException {
+		try (TarArchiveInputStream tarIn = new TarArchiveInputStream(
+				new ByteArrayInputStream(primaryBuffer.toByteArray()))) {
+			TarArchiveEntry entry = tarIn.getNextEntry();
+			while (entry != null) {
+				if (entry.isDirectory()) {
+					layout.directory(entry.getName(), Owner.of(entry.getLongUserId(), entry.getLongGroupId()),
+							entry.getMode());
+				}
+				else {
+					Content content = Content.of((int) entry.getSize(), () -> tarIn);
+					layout.file(entry.getName(), Owner.of(entry.getLongUserId(), entry.getLongGroupId()),
+							entry.getMode(), content);
+				}
+				entry = tarIn.getNextEntry();
+			}
+		}
+	}
+
+	private void collectAdditionalEntries(Layout layout, Path directory, String prefix) throws IOException {
+		try (DirectoryStream<Path> stream = Files.newDirectoryStream(directory)) {
+			for (Path entry : stream) {
+				String relativePath = directory.relativize(entry).toString().replace('\\', '/');
+				String entryName = prefix + "/" + relativePath;
+				if (Files.isRegularFile(entry)) {
+					layout.file(entryName, Owner.ROOT, Content.of(entry.toFile()));
+				}
+				else if (Files.isDirectory(entry)) {
+					collectAdditionalEntries(layout, entry, entryName);
+				}
+			}
+		}
+	}
+
+}

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildRequestTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildRequestTests.java
@@ -21,6 +21,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -41,6 +43,7 @@ import org.springframework.boot.buildpack.platform.docker.ImagePlatform;
 import org.springframework.boot.buildpack.platform.docker.type.Binding;
 import org.springframework.boot.buildpack.platform.docker.type.ImageName;
 import org.springframework.boot.buildpack.platform.docker.type.ImageReference;
+import org.springframework.boot.buildpack.platform.io.CompositeTarArchive;
 import org.springframework.boot.buildpack.platform.io.Owner;
 import org.springframework.boot.buildpack.platform.io.TarArchive;
 
@@ -407,6 +410,24 @@ class BuildRequestTests {
 		BuildRequest request = BuildRequest.forJarFile(writeTestJarFile("my-app-0.0.1.jar"));
 		BuildRequest withAppDir = request.withImagePlatform("linux/arm64");
 		assertThat(withAppDir.getImagePlatform()).isEqualTo(ImagePlatform.of("linux/arm64"));
+	}
+
+	@Test
+	void withAdditionalContentMergesArchives() throws IOException {
+		Path additionalDir = this.tempDir.toPath().resolve("aot-cache");
+		Files.createDirectories(additionalDir);
+		Files.writeString(additionalDir.resolve("cache-data.bin"), "cached");
+		BuildRequest request = BuildRequest.forJarFile(writeTestJarFile("my-app-0.0.1.jar"))
+			.withAdditionalContent(additionalDir, "aot-cache");
+		TarArchive content = request.getApplicationContent(Owner.ROOT);
+		assertThat(content).isInstanceOf(CompositeTarArchive.class);
+	}
+
+	@Test
+	void withoutAdditionalContentReturnsOriginalArchive() throws IOException {
+		BuildRequest request = BuildRequest.forJarFile(writeTestJarFile("my-app-0.0.1.jar"));
+		TarArchive content = request.getApplicationContent(Owner.ROOT);
+		assertThat(content).isNotInstanceOf(CompositeTarArchive.class);
 	}
 
 	private void hasExpectedJarContent(TarArchive archive) {

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/CompositeTarArchiveTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/CompositeTarArchiveTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.buildpack.platform.io;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CompositeTarArchive}.
+ *
+ * @author Vasily Pelikh
+ */
+class CompositeTarArchiveTests {
+
+	@TempDir
+	@SuppressWarnings("NullAway.Init")
+	Path tempDir;
+
+	@Test
+	void mergesPrimaryAndAdditionalEntries() throws IOException {
+		TarArchive primary = TarArchive
+			.of((layout) -> layout.file("/BOOT-INF/classes/Main.class", Owner.ROOT, Content.of("classbytes")));
+		Path additional = this.tempDir.resolve("aot-cache");
+		Files.createDirectories(additional);
+		Files.writeString(additional.resolve("application.aot"), "cache-data");
+		CompositeTarArchive composite = new CompositeTarArchive(primary, additional, "aot-cache");
+		List<TarArchiveEntry> entries = readEntries(composite);
+		assertThat(entries).hasSize(2);
+		assertThat(entries.get(0).getName()).isEqualTo("/BOOT-INF/classes/Main.class");
+		assertThat(entries.get(1).getName()).isEqualTo("aot-cache/application.aot");
+	}
+
+	@Test
+	void additionalDirectoryNotFoundIsNoOp() throws IOException {
+		TarArchive primary = TarArchive
+			.of((layout) -> layout.file("/BOOT-INF/classes/Main.class", Owner.ROOT, Content.of("classbytes")));
+		Path missing = this.tempDir.resolve("nonexistent");
+		CompositeTarArchive composite = new CompositeTarArchive(primary, missing, "aot-cache");
+		List<TarArchiveEntry> entries = readEntries(composite);
+		assertThat(entries).hasSize(1);
+		assertThat(entries.get(0).getName()).isEqualTo("/BOOT-INF/classes/Main.class");
+	}
+
+	@Test
+	void additionalEntriesUseRootOwner() throws IOException {
+		TarArchive primary = TarArchive.of((layout) -> layout.directory("/BOOT-INF", Owner.ROOT));
+		Path additional = this.tempDir.resolve("extra");
+		Files.createDirectories(additional);
+		Files.writeString(additional.resolve("file.txt"), "content");
+		CompositeTarArchive composite = new CompositeTarArchive(primary, additional, "extra");
+		List<TarArchiveEntry> entries = readEntries(composite);
+		assertThat(entries).hasSize(2);
+		assertThat(entries.get(1).getName()).isEqualTo("extra/file.txt");
+		assertThat(entries.get(1).getLongUserId()).isZero();
+		assertThat(entries.get(1).getLongGroupId()).isZero();
+	}
+
+	@Test
+	void handlesNestedAdditionalDirectories() throws IOException {
+		TarArchive primary = TarArchive.of((layout) -> layout.file("/root.txt", Owner.ROOT, Content.of("root")));
+		Path additional = this.tempDir.resolve("nested");
+		Path subDir = additional.resolve("sub/deep");
+		Files.createDirectories(subDir);
+		Files.writeString(additional.resolve("top.txt"), "top");
+		Files.writeString(subDir.resolve("deep.txt"), "deep");
+		CompositeTarArchive composite = new CompositeTarArchive(primary, additional, "cache");
+		List<TarArchiveEntry> entries = readEntries(composite);
+		assertThat(entries).hasSizeGreaterThanOrEqualTo(3);
+		List<String> names = new ArrayList<>();
+		for (TarArchiveEntry entry : entries) {
+			names.add(entry.getName());
+		}
+		assertThat(names).contains("cache/top.txt", "cache/sub/deep/deep.txt");
+	}
+
+	@Test
+	void emptyAdditionalDirectoryMergesOnlyPrimary() throws IOException {
+		TarArchive primary = TarArchive.of((layout) -> layout.file("/file.txt", Owner.ROOT, Content.of("data")));
+		Path additional = this.tempDir.resolve("empty");
+		Files.createDirectories(additional);
+		CompositeTarArchive composite = new CompositeTarArchive(primary, additional, "prefix");
+		List<TarArchiveEntry> entries = readEntries(composite);
+		assertThat(entries).hasSize(1);
+		assertThat(entries.get(0).getName()).isEqualTo("/file.txt");
+	}
+
+	private List<TarArchiveEntry> readEntries(TarArchive archive) throws IOException {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		archive.writeTo(out);
+		List<TarArchiveEntry> entries = new ArrayList<>();
+		try (TarArchiveInputStream tarIn = new TarArchiveInputStream(new ByteArrayInputStream(out.toByteArray()))) {
+			TarArchiveEntry entry = tarIn.getNextEntry();
+			while (entry != null) {
+				entries.add(entry);
+				entry = tarIn.getNextEntry();
+			}
+		}
+		return entries;
+	}
+
+}

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/aot-cache.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/packaging/aot-cache.adoc
@@ -39,6 +39,54 @@ NOTE: You have to use the cache file with the extracted form of the application,
 
 If you want to know how to leverage AOT Cache with Buildpacks, take a look at the xref:how-to:aot-cache.adoc[AOT Cache How-to guide].
 
+[[packaging.aot-cache.integration-tests]]
+== Generating AOT Cache from Integration Tests
+
+Spring Boot provides Maven and Gradle integration to generate the AOT cache from your integration test suite.
+This approach leverages existing tests as the training workload, avoiding the need for a separate training run.
+
+NOTE: This feature requires Java 25 or above.
+
+To enable AOT cache recording, set the `spring-boot.aot-cache-record` property (Maven) or the `aotCacheRecord` option (Gradle):
+
+[tabs]
+======
+Maven::
++
+[source,xml,indent=0,subs="verbatim,attributes"]
+----
+<properties>
+    <spring-boot.aot-cache-record>true</spring-boot.aot-cache-record>
+</properties>
+----
+
+Gradle::
++
+[source,groovy,indent=0,subs="verbatim,attributes"]
+----
+bootBuildImage {
+    aotCacheRecord = true
+}
+----
+======
+
+Cache recording only activates when the image build goals or tasks are in the execution plan.
+See the Maven plugin and Gradle plugin documentation for the exact invocation details.
+
+When enabled, the build plugin:
+
+* Injects `-XX:AOTCacheOutput=<path>` into the test JVM arguments
+* Writes the cache file to `target/aot-cache/application.aot` (Maven) or `build/aot-cache/application.aot` (Gradle)
+* Bundles the cache file into the built image when it is present
+
+The cache file can then be used in production:
+
+[source,shell]
+----
+$ java -XX:AOTCache=application.aot -jar my-app.jar
+----
+
+NOTE: You have to use the cache file with the extracted form of the application, otherwise it has no effect.
 
 
 [[packaging.aot-cache.cds]]


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Integrates Leyden AOT cache (JEP 483) recording into the Spring Boot Maven and Gradle build plugins, configured declaratively with a single switch. When enabled, the build records an AOT cache from the integration tests and bundles it into the OCI image, so the application reuses the pre-recorded cache at container startup.

## Configuration

**Maven** — bind the `aot-cache-record` goal to the `initialize` phase and set the `spring-boot.aot-cache-record` property, then run tests together with the image build:

```xml
<plugin>
    <groupId>org.springframework.boot</groupId>
    <artifactId>spring-boot-maven-plugin</artifactId>
    <executions>
        <execution>
            <id>aot-cache-record</id>
            <goals>
                <goal>aot-cache-record</goal>
            </goals>
        </execution>
    </executions>
</plugin>

<properties>
    <spring-boot.aot-cache-record>true</spring-boot.aot-cache-record>
</properties>
```

```bash
mvn test spring-boot:build-image
```

**Gradle** — set `aotCacheRecord = true` on the `bootBuildImage` task and run tests together with the image build:

```groovy
bootBuildImage {
    aotCacheRecord = true
}
```

```bash
./gradlew test bootBuildImage
```

## What it does

### Recording the cache from integration tests
When enabled, the plugin injects `-XX:AOTCacheOutput=<path>` into the test JVM arguments, so the JVM records an AOT cache during integration test execution. Recording is gated on the image build being scheduled in the same execution:
- Gradle — `JavaPluginAction` injects the flag into the test JVM args via `whenReady`, only when the project's `bootBuildImage` is in the task graph.
- Maven — `AotCacheRecordMojo` (initialized in the `initialize` phase) injects the flag into the Surefire `argLine`, only when `spring-boot:build-image` is in the execution plan.

The test-only paths do not record a cache; the image build fails closed with actionable guidance when the cache is expected but missing.

### Bundling the cache into the image
The generated `aot-cache/application.aot` is bundled into the OCI image and `BP_JVM_AOTCACHE_ENABLED=true` is set for the Paketo buildpack.

### AOT cache compatibility metadata
AOT caches are JDK-version- and platform-specific. The plugins now write `aot-cache/application.aot.meta` alongside the cache, recording the `java.version` and `os.arch` of the JVM that built the image. The Paketo buildpack compares this against the JRE baked into the image and fails the build on a mismatch, preventing an incompatible cache from being reused.

## Related
- Paketo buildpack consuming the cache at startup: paketo-buildpacks/spring-boot#609
- Spring Framework test listener that produces the cache during integration tests: spring-projects/spring-framework#37124