### PR TITLE
Metadata for spring.test.mockmvc.htmlunit.url declares the wrong type

### DIFF
--- a/module/spring-boot-webmvc-test/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/module/spring-boot-webmvc-test/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -2,7 +2,7 @@
   "properties": [
     {
       "name": "spring.test.mockmvc.htmlunit.url",
-      "type": "java.lang.Boolean",
+      "type": "java.lang.String",
       "description": "URL to use when HtmlUnit expands relative paths.",
       "defaultValue": "http://localhost"
     },


### PR DESCRIPTION
The manual metadata entry for `spring.test.mockmvc.htmlunit.url` in `spring-boot-webmvc-test` declares `"type": "java.lang.Boolean"`, while its own description ("URL to use when HtmlUnit expands relative paths.") and default value (`"http://localhost"`) describe a string. Both `MockMvcWebClientAutoConfiguration` and `MockMvcWebDriverAutoConfiguration` read it as one:

```java
String url = environment.getProperty("spring.test.mockmvc.htmlunit.url", "http://localhost");
```

The entry was added in 2e79fc01 next to the two Boolean `*.enabled` entries, so the wrong type looks like a copy-paste leftover. As a result, the published metadata declares a boolean and IDE property assistance offers `true`/`false` for this property.

This changes the declared type to `java.lang.String`.
