### PR TITLE
Caching documentation refers to AutoConfigureCache by its pre-4.0 package

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/io/caching.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/io/caching.adoc
@@ -284,7 +284,7 @@ Doing so makes sure that caching is not required by slice tests.
 For tests that enable a full context, such as javadoc:org.springframework.boot.test.context.SpringBootTest[format=annotation], an explicit configuration overriding the regular configuration is required.
 
 If caching is auto-configured, more options are available.
-Tests can be annotated with javadoc:org.springframework.boot.test.autoconfigure.core.AutoConfigureCache[format=annotation] to replace the auto-configured javadoc:org.springframework.cache.CacheManager[] by a no-op implementation.
+Tests can be annotated with javadoc:org.springframework.boot.cache.test.autoconfigure.AutoConfigureCache[format=annotation] to replace the auto-configured javadoc:org.springframework.cache.CacheManager[] by a no-op implementation.
 
 include-code::MyIntegrationTests[]
 


### PR DESCRIPTION
The caching chapter of the reference guide refers to `AutoConfigureCache` by its pre-4.0 package:

```
javadoc:org.springframework.boot.test.autoconfigure.core.AutoConfigureCache[format=annotation]
```

The annotation moved to `org.springframework.boot.cache.test.autoconfigure` when `spring-boot-test-autoconfigure` was modularized in 5348880b, so on 4.0.x this reference points at a class that no longer exists and the generated link is dead. The sentence originated on 3.4.x in a5b20863, where the package is correct, and the package was not adapted when the change was merged forward; the rewording in 21aedaad kept the stale package.

The compiled sample right below the sentence (`MyIntegrationTests`) already imports `org.springframework.boot.cache.test.autoconfigure.AutoConfigureCache`, and other test-slice references in the guide already use the new module packages, for example `javadoc:org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest[format=annotation]` in `testing/spring-boot-applications.adoc`.

This updates the reference to the new package.

