### PR TITLE
Make @AutoConfigureTestGrpcTransport participate in MergedContextConfiguration

### DIFF
--- a/module/spring-boot-grpc-test/src/main/java/org/springframework/boot/grpc/test/autoconfigure/TestGrpcTransportAutoConfiguration.java
+++ b/module/spring-boot-grpc-test/src/main/java/org/springframework/boot/grpc/test/autoconfigure/TestGrpcTransportAutoConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
 import org.springframework.grpc.client.ClientInterceptorsConfigurer;
 import org.springframework.grpc.client.GrpcChannelFactory;
 import org.springframework.grpc.server.GrpcServerFactory;
@@ -42,6 +43,7 @@ import org.springframework.grpc.server.ServerServiceDefinitionFilter;
 import org.springframework.grpc.server.lifecycle.GrpcServerLifecycle;
 import org.springframework.grpc.server.service.GrpcServiceConfigurer;
 import org.springframework.grpc.server.service.GrpcServiceDiscoverer;
+import org.springframework.util.StringUtils;
 
 /**
  * Auto-configuration for an in-process test gRPC transport.
@@ -50,14 +52,34 @@ import org.springframework.grpc.server.service.GrpcServiceDiscoverer;
  * @author Dave Syer
  * @author Andrey Litvitski
  * @author Phillip Webb
+ * @author xing
  * @since 4.1.0
  * @see AutoConfigureTestGrpcTransport
+ * @see TestGrpcTransportContextCustomizer
  */
 @AutoConfiguration(before = { GrpcServerAutoConfiguration.class, GrpcClientAutoConfiguration.class })
 @ConditionalOnClass({ InProcessServerBuilder.class, InProcessGrpcServerFactory.class })
 public final class TestGrpcTransportAutoConfiguration {
 
-	private static final String address = InProcessServerBuilder.generateName();
+	/**
+	 * In-process address shared by the test server and channel factories within a single
+	 * application context.
+	 * <p>
+	 * Prefer the test-only property written by {@link TestGrpcTransportContextCustomizer};
+	 * otherwise generate a name for this context. Intentionally does not read
+	 * {@code spring.grpc.server.inprocess.name}.
+	 */
+	record TestGrpcTransportAddress(String value) {
+	}
+
+	@Bean
+	TestGrpcTransportAddress testGrpcTransportAddress(Environment environment) {
+		String configured = environment.getProperty(TestGrpcTransportContextCustomizer.INPROCESS_NAME_PROPERTY);
+		if (StringUtils.hasText(configured)) {
+			return new TestGrpcTransportAddress(configured);
+		}
+		return new TestGrpcTransportAddress(InProcessServerBuilder.generateName());
+	}
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(GrpcServerFactory.class)
@@ -66,9 +88,10 @@ public final class TestGrpcTransportAutoConfiguration {
 
 		@Bean
 		@Order(Ordered.HIGHEST_PRECEDENCE)
-		TestGrpcServerFactory testGrpcServerFactory(GrpcServiceDiscoverer serviceDiscoverer,
-				GrpcServiceConfigurer serviceConfigurer, ObjectProvider<ServerServiceDefinitionFilter> serviceFilter) {
-			TestGrpcServerFactory factory = new TestGrpcServerFactory(address);
+		TestGrpcServerFactory testGrpcServerFactory(TestGrpcTransportAddress address,
+				GrpcServiceDiscoverer serviceDiscoverer, GrpcServiceConfigurer serviceConfigurer,
+				ObjectProvider<ServerServiceDefinitionFilter> serviceFilter) {
+			TestGrpcServerFactory factory = new TestGrpcServerFactory(address.value());
 			serviceFilter.ifAvailable(factory::setServiceFilter);
 			serviceDiscoverer.findServices()
 				.stream()
@@ -99,8 +122,9 @@ public final class TestGrpcTransportAutoConfiguration {
 
 		@Bean
 		@Order(Ordered.HIGHEST_PRECEDENCE)
-		TestGrpcChannelFactory testGrpcChannelFactory(ClientInterceptorsConfigurer interceptorsConfigurer) {
-			return new TestGrpcChannelFactory(address, interceptorsConfigurer);
+		TestGrpcChannelFactory testGrpcChannelFactory(TestGrpcTransportAddress address,
+				ClientInterceptorsConfigurer interceptorsConfigurer) {
+			return new TestGrpcChannelFactory(address.value(), interceptorsConfigurer);
 		}
 
 	}

--- a/module/spring-boot-grpc-test/src/main/java/org/springframework/boot/grpc/test/autoconfigure/TestGrpcTransportContextCustomizer.java
+++ b/module/spring-boot-grpc-test/src/main/java/org/springframework/boot/grpc/test/autoconfigure/TestGrpcTransportContextCustomizer.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.grpc.test.autoconfigure;
+
+import java.util.Objects;
+
+import io.grpc.inprocess.InProcessServerBuilder;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.MergedContextConfiguration;
+
+/**
+ * {@link ContextCustomizer} for {@link AutoConfigureTestGrpcTransport}.
+ * <p>
+ * Equality is based on annotation attributes so the annotation participates in
+ * {@link MergedContextConfiguration}. The in-process name is generated once per
+ * context creation inside {@link #customizeContext} (not as a JVM-wide static), so
+ * cached contexts keep a single name while distinct contexts get distinct names.
+ *
+ * @author xing
+ * @since 4.1.0
+ */
+class TestGrpcTransportContextCustomizer implements ContextCustomizer {
+
+	/**
+	 * Test-only property used by {@link TestGrpcTransportAutoConfiguration} to bind the
+	 * in-process transport name for the current application context.
+	 */
+	static final String INPROCESS_NAME_PROPERTY = "spring.grpc.test.transport.inprocess-name";
+
+	private final boolean enableServlet;
+
+	private final boolean enableServerFactory;
+
+	private final boolean enableChannelFactory;
+
+	TestGrpcTransportContextCustomizer(AutoConfigureTestGrpcTransport annotation) {
+		this.enableServlet = annotation.enableServlet();
+		this.enableServerFactory = annotation.enableServerFactory();
+		this.enableChannelFactory = annotation.enableChannelFactory();
+	}
+
+	@Override
+	public void customizeContext(ConfigurableApplicationContext context,
+			MergedContextConfiguration mergedContextConfiguration) {
+		// Generate per context creation. Spring Test does not re-run this for a cached
+		// context, so reuse keeps the same name; a new MergedContextConfiguration gets a
+		// new name without relying on a static field in auto-configuration.
+		String name = InProcessServerBuilder.generateName();
+		TestPropertyValues.of(INPROCESS_NAME_PROPERTY + "=" + name).applyTo(context);
+	}
+
+	@Override
+	public boolean equals(@Nullable Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null || getClass() != obj.getClass()) {
+			return false;
+		}
+		TestGrpcTransportContextCustomizer other = (TestGrpcTransportContextCustomizer) obj;
+		return this.enableServlet == other.enableServlet && this.enableServerFactory == other.enableServerFactory
+				&& this.enableChannelFactory == other.enableChannelFactory;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.enableServlet, this.enableServerFactory, this.enableChannelFactory);
+	}
+
+}

--- a/module/spring-boot-grpc-test/src/main/java/org/springframework/boot/grpc/test/autoconfigure/TestGrpcTransportContextCustomizerFactory.java
+++ b/module/spring-boot-grpc-test/src/main/java/org/springframework/boot/grpc/test/autoconfigure/TestGrpcTransportContextCustomizerFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.grpc.test.autoconfigure;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.ContextCustomizerFactory;
+import org.springframework.test.context.TestContextAnnotationUtils;
+
+/**
+ * {@link ContextCustomizerFactory} that integrates
+ * {@link AutoConfigureTestGrpcTransport} with the Spring Test context cache key and
+ * assigns a per-context in-process transport name.
+ * <p>
+ * The generated name is written as a test-only property
+ * ({@value TestGrpcTransportContextCustomizer#INPROCESS_NAME_PROPERTY}) rather than
+ * {@code spring.grpc.server.inprocess.name}, which is reserved for application-level
+ * in-process servers.
+ *
+ * @author xing
+ * @since 4.1.0
+ * @see AutoConfigureTestGrpcTransport
+ * @see TestGrpcTransportContextCustomizer
+ */
+class TestGrpcTransportContextCustomizerFactory implements ContextCustomizerFactory {
+
+	@Override
+	public @Nullable ContextCustomizer createContextCustomizer(Class<?> testClass,
+			List<ContextConfigurationAttributes> configAttributes) {
+		AutoConfigureTestGrpcTransport annotation = TestContextAnnotationUtils.findMergedAnnotation(testClass,
+				AutoConfigureTestGrpcTransport.class);
+		if (annotation == null) {
+			return null;
+		}
+		return new TestGrpcTransportContextCustomizer(annotation);
+	}
+
+}

--- a/module/spring-boot-grpc-test/src/main/resources/META-INF/spring.factories
+++ b/module/spring-boot-grpc-test/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,7 @@
 # Application Context Initializers
 org.springframework.context.ApplicationContextInitializer=\
 org.springframework.boot.grpc.test.autoconfigure.GrpcPortInfoApplicationContextInitializer
+
+# Spring Test Context Customizer Factories
+org.springframework.test.context.ContextCustomizerFactory=\
+org.springframework.boot.grpc.test.autoconfigure.TestGrpcTransportContextCustomizerFactory

--- a/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/AutoConfigureTestGrpcTransportNestedTests.java
+++ b/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/AutoConfigureTestGrpcTransportNestedTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.boot.grpc.test.autoconfigure;
 
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
@@ -49,7 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestMethodOrder(OrderAnnotation.class)
 class AutoConfigureTestGrpcTransportNestedTests {
 
-	private static String topLevelName;
+	private static final AtomicReference<String> topLevelName = new AtomicReference<>();
 
 	@Autowired
 	private Environment environment;
@@ -57,8 +60,9 @@ class AutoConfigureTestGrpcTransportNestedTests {
 	@Test
 	@Order(1)
 	void topLevelContextReceivesTestOnlyInProcessName() {
-		topLevelName = this.environment.getProperty(TestGrpcTransportContextCustomizer.INPROCESS_NAME_PROPERTY);
-		assertThat(topLevelName).isNotBlank();
+		String name = this.environment.getProperty(TestGrpcTransportContextCustomizer.INPROCESS_NAME_PROPERTY);
+		assertThat(name).isNotBlank();
+		topLevelName.set(Objects.requireNonNull(name));
 		assertThat(this.environment.getProperty("spring.grpc.server.inprocess.name")).isNull();
 	}
 
@@ -78,8 +82,8 @@ class AutoConfigureTestGrpcTransportNestedTests {
 				.getProperty(TestGrpcTransportContextCustomizer.INPROCESS_NAME_PROPERTY);
 			assertThat(nestedName).isNotBlank();
 			assertThat(this.environment.getProperty("spring.grpc.server.inprocess.name")).isNull();
-			assertThat(topLevelName).as("top-level name should already have been captured").isNotBlank();
-			assertThat(nestedName).isNotEqualTo(topLevelName);
+			assertThat(topLevelName.get()).as("top-level name should already have been captured").isNotBlank();
+			assertThat(nestedName).isNotEqualTo(topLevelName.get());
 		}
 
 	}

--- a/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/AutoConfigureTestGrpcTransportNestedTests.java
+++ b/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/AutoConfigureTestGrpcTransportNestedTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.grpc.test.autoconfigure;
+
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression-oriented tests for nested Spring Test contexts using
+ * {@link AutoConfigureTestGrpcTransport}.
+ * <p>
+ * Models the multi-context scenario reported in spring-boot#50860: a top-level
+ * test and a {@code @Nested} class with a different active profile must each
+ * receive a distinct test-only in-process transport name instead of sharing a
+ * JVM-wide static name.
+ *
+ * @author xing
+ */
+@ExtendWith(SpringExtension.class)
+@AutoConfigureTestGrpcTransport
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+@TestMethodOrder(OrderAnnotation.class)
+class AutoConfigureTestGrpcTransportNestedTests {
+
+	private static String topLevelName;
+
+	@Autowired
+	private Environment environment;
+
+	@Test
+	@Order(1)
+	void topLevelContextReceivesTestOnlyInProcessName() {
+		topLevelName = this.environment.getProperty(TestGrpcTransportContextCustomizer.INPROCESS_NAME_PROPERTY);
+		assertThat(topLevelName).isNotBlank();
+		assertThat(this.environment.getProperty("spring.grpc.server.inprocess.name")).isNull();
+	}
+
+	@Nested
+	@Order(2)
+	@ActiveProfiles("oauth2-disabled")
+	@TestMethodOrder(OrderAnnotation.class)
+	class NestedProfileContext {
+
+		@Autowired
+		private Environment environment;
+
+		@Test
+		@Order(1)
+		void nestedContextReceivesDistinctTestOnlyInProcessName() {
+			String nestedName = this.environment
+				.getProperty(TestGrpcTransportContextCustomizer.INPROCESS_NAME_PROPERTY);
+			assertThat(nestedName).isNotBlank();
+			assertThat(this.environment.getProperty("spring.grpc.server.inprocess.name")).isNull();
+			assertThat(topLevelName).as("top-level name should already have been captured").isNotBlank();
+			assertThat(nestedName).isNotEqualTo(topLevelName);
+		}
+
+	}
+
+}

--- a/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/AutoConfigureTestGrpcTransportTests.java
+++ b/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/AutoConfigureTestGrpcTransportTests.java
@@ -41,4 +41,11 @@ class AutoConfigureTestGrpcTransportTests {
 		assertThat(environment.getProperty("spring.grpc.client.channelfactory.enabled", Boolean.class)).isFalse();
 	}
 
+	@Test
+	void assignsTestOnlyInProcessName(@Autowired Environment environment) {
+		assertThat(environment.getProperty(TestGrpcTransportContextCustomizer.INPROCESS_NAME_PROPERTY)).isNotBlank();
+		assertThat(environment.getProperty("spring.grpc.server.inprocess.name")).isNull();
+	}
+
 }
+

--- a/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/TestGrpcTransportAutoConfigurationTests.java
+++ b/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/TestGrpcTransportAutoConfigurationTests.java
@@ -104,4 +104,41 @@ class TestGrpcTransportAutoConfigurationTests {
 			.run((context) -> assertThat(context).doesNotHaveBean(TestGrpcChannelFactory.class));
 	}
 
+	@Test
+	void usesTestOnlyInProcessNameWhenConfigured() {
+		String expected = "test-context-name-one";
+		this.contextRunner
+			.withPropertyValues(TestGrpcTransportContextCustomizer.INPROCESS_NAME_PROPERTY + "=" + expected)
+			.run((context) -> {
+				assertThat(context).hasNotFailed();
+				assertThat(context).hasSingleBean(TestGrpcServerFactory.class);
+				assertThat(context.getBean(TestGrpcTransportAutoConfiguration.TestGrpcTransportAddress.class)
+					.value()).isEqualTo(expected);
+			});
+	}
+
+	@Test
+	void createsDistinctInProcessServersForConcurrentApplicationContexts() {
+		// Regression for #50860: nested / multi-context tests must not share a static
+		// in-process name and fail with "name already registered".
+		this.contextRunner
+			.withPropertyValues(TestGrpcTransportContextCustomizer.INPROCESS_NAME_PROPERTY + "=nested-a")
+			.run((firstContext) -> {
+				assertThat(firstContext).hasNotFailed();
+				this.contextRunner
+					.withPropertyValues(TestGrpcTransportContextCustomizer.INPROCESS_NAME_PROPERTY + "=nested-b")
+					.run((secondContext) -> {
+						assertThat(secondContext).hasNotFailed();
+						String first = firstContext
+							.getBean(TestGrpcTransportAutoConfiguration.TestGrpcTransportAddress.class)
+							.value();
+						String second = secondContext
+							.getBean(TestGrpcTransportAutoConfiguration.TestGrpcTransportAddress.class)
+							.value();
+						assertThat(first).isEqualTo("nested-a");
+						assertThat(second).isEqualTo("nested-b");
+					});
+			});
+	}
+
 }

--- a/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/TestGrpcTransportContextCustomizerFactoryTests.java
+++ b/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/TestGrpcTransportContextCustomizerFactoryTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.grpc.test.autoconfigure;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.ContextLoader;
+import org.springframework.test.context.MergedContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link TestGrpcTransportContextCustomizerFactory} and
+ * {@link TestGrpcTransportContextCustomizer}.
+ *
+ * @author xing
+ */
+class TestGrpcTransportContextCustomizerFactoryTests {
+
+	private final TestGrpcTransportContextCustomizerFactory factory = new TestGrpcTransportContextCustomizerFactory();
+
+	@Test
+	void whenNotAnnotatedDoesNotCreateCustomizer() {
+		assertThat(this.factory.createContextCustomizer(NoAnnotation.class, Collections.emptyList())).isNull();
+	}
+
+	@Test
+	void whenAnnotatedCreatesCustomizerAndSetsTestOnlyInProcessName() {
+		ContextCustomizer customizer = createContextCustomizer(WithAnnotation.class);
+		ConfigurableApplicationContext context = new GenericApplicationContext();
+		applyCustomizerToContext(customizer, context);
+		String name = context.getEnvironment()
+			.getProperty(TestGrpcTransportContextCustomizer.INPROCESS_NAME_PROPERTY);
+		assertThat(name).isNotBlank();
+		assertThat(context.getEnvironment().getProperty("spring.grpc.server.inprocess.name")).isNull();
+	}
+
+	@Test
+	void customizeContextGeneratesDifferentNamesForDifferentContexts() {
+		ContextCustomizer customizer = createContextCustomizer(WithAnnotation.class);
+		ConfigurableApplicationContext first = new GenericApplicationContext();
+		ConfigurableApplicationContext second = new GenericApplicationContext();
+		applyCustomizerToContext(customizer, first);
+		applyCustomizerToContext(customizer, second);
+		assertThat(first.getEnvironment().getProperty(TestGrpcTransportContextCustomizer.INPROCESS_NAME_PROPERTY))
+			.isNotEqualTo(
+					second.getEnvironment().getProperty(TestGrpcTransportContextCustomizer.INPROCESS_NAME_PROPERTY));
+	}
+
+	@Test
+	void equalsWhenAnnotationAttributesMatch() {
+		ContextCustomizer first = createContextCustomizer(WithAnnotation.class);
+		ContextCustomizer second = createContextCustomizer(WithAnnotation.class);
+		assertThat(first).isEqualTo(second);
+		assertThat(first).hasSameHashCodeAs(second);
+	}
+
+	@Test
+	void notEqualsWhenAnnotationAttributesDiffer() {
+		ContextCustomizer defaults = createContextCustomizer(WithAnnotation.class);
+		ContextCustomizer overrides = createContextCustomizer(WithOverrides.class);
+		assertThat(defaults).isNotEqualTo(overrides);
+	}
+
+	private void applyCustomizerToContext(ContextCustomizer customizer, ConfigurableApplicationContext context) {
+		customizer.customizeContext(context,
+				new MergedContextConfiguration(getClass(), null, null, null, mock(ContextLoader.class)));
+	}
+
+	private ContextCustomizer createContextCustomizer(Class<?> testClass) {
+		ContextCustomizer customizer = this.factory.createContextCustomizer(testClass, Collections.emptyList());
+		assertThat(customizer).as("contextCustomizer").isNotNull();
+		return customizer;
+	}
+
+	static class NoAnnotation {
+
+	}
+
+	@AutoConfigureTestGrpcTransport
+	static class WithAnnotation {
+
+	}
+
+	@AutoConfigureTestGrpcTransport(enableServlet = true, enableServerFactory = true, enableChannelFactory = true)
+	static class WithOverrides {
+
+	}
+
+}


### PR DESCRIPTION
## Issue

Fixes #50860

## Summary

`TestGrpcTransportAutoConfiguration` used a JVM-wide `static final` in-process name from `InProcessServerBuilder.generateName()`. Nested Spring Test contexts (for example `@Nested` + different `@ActiveProfiles`) then tried to register the same in-process server name and failed with `name already registered`.

Following the guidance on #50860 / #50865, this change integrates the test transport slice with Spring Test instead of only generating a new random name:

1. Add `TestGrpcTransportContextCustomizerFactory` / `TestGrpcTransportContextCustomizer`
2. Register the factory in `META-INF/spring.factories`
3. Use annotation attributes in customizer `equals` / `hashCode` so `@AutoConfigureTestGrpcTransport` participates in `MergedContextConfiguration`
4. Assign a **test-only** property per context creation: `spring.grpc.test.transport.inprocess-name`
5. Remove the static address and share one resolved name between test server and channel factories via `TestGrpcTransportAddress`
6. Do **not** read `spring.grpc.server.inprocess.name` (application-level in-process server property)

## Why this differs from #50865

#50865 generated a per-context name bean only. Maintainers rejected that approach because the auto-configuration / slice still did not integrate with the test context properly, and could create a new server irrespective of whether it was needed.

This PR targets the integration point called out in the issue discussion: participation in the context key, plus a per-context test transport name assigned at context creation time.

## Test plan

- [x] Unit tests for customizer equals/hashCode and test-only property assignment
- [x] Auto-configuration regression for concurrent contexts with distinct names
- [x] Nested SpringExtension test with `@ActiveProfiles`
- [ ] Local `./gradlew :module:spring-boot-grpc-test:test` could not be completed on the contributor machine (Gradle worker `ClassNotFoundException: GradleWorkerMain` in buildSrc); CI verification requested

Suggested CI check:

```bash
./gradlew :module:spring-boot-grpc-test:test   --tests 'org.springframework.boot.grpc.test.autoconfigure.TestGrpcTransport*'   --tests 'org.springframework.boot.grpc.test.autoconfigure.AutoConfigureTestGrpcTransport*'
```

## Notes / open questions

1. Property name `spring.grpc.test.transport.inprocess-name` is a proposal; happy to rename if maintainers prefer a different test-only key.
2. If a different Boot-internal pattern is preferred over `ContextCustomizer` for slice integration, I can adjust.