### PR TITLE
Temporary file is not deleted when ExportedImageTar construction fails

### DIFF
--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/ExportedImageTar.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/ExportedImageTar.java
@@ -64,8 +64,19 @@ class ExportedImageTar implements Closeable {
 
 	ExportedImageTar(ImageReference reference, InputStream inputStream) throws IOException {
 		this.tarFile = Files.createTempFile("docker-layers-", null);
-		Files.copy(inputStream, this.tarFile, StandardCopyOption.REPLACE_EXISTING);
-		this.layerArchiveFactory = LayerArchiveFactory.create(reference, this.tarFile);
+		try {
+			Files.copy(inputStream, this.tarFile, StandardCopyOption.REPLACE_EXISTING);
+			this.layerArchiveFactory = LayerArchiveFactory.create(reference, this.tarFile);
+		}
+		catch (IOException | RuntimeException ex) {
+			try {
+				Files.deleteIfExists(this.tarFile);
+			}
+			catch (IOException suppressed) {
+				ex.addSuppressed(suppressed);
+			}
+			throw ex;
+		}
 	}
 
 	void exportLayers(IOBiConsumer<String, TarArchive> exports) throws IOException {

--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/ExportedImageTar.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/docker/ExportedImageTar.java
@@ -63,8 +63,8 @@ class ExportedImageTar implements Closeable {
 	private final LayerArchiveFactory layerArchiveFactory;
 
 	ExportedImageTar(ImageReference reference, InputStream inputStream) throws IOException {
-		this.tarFile = Files.createTempFile("docker-layers-", null);
-		try {
+		this.tarFile = Files.createTempFile("docker-layers-", ".tar");
+		try (inputStream) {
 			Files.copy(inputStream, this.tarFile, StandardCopyOption.REPLACE_EXISTING);
 			this.layerArchiveFactory = LayerArchiveFactory.create(reference, this.tarFile);
 		}

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ExportedImageTarTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ExportedImageTarTests.java
@@ -16,9 +16,19 @@
 
 package org.springframework.boot.buildpack.platform.docker;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -26,6 +36,7 @@ import org.springframework.boot.buildpack.platform.docker.type.ImageReference;
 import org.springframework.boot.buildpack.platform.io.TarArchive.Compression;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
  * Tests for {@link ExportedImageTar}.
@@ -54,6 +65,42 @@ class ExportedImageTarTests {
 			});
 			assertThat(names).filteredOn((name) -> name.contains(expectedName)).isNotEmpty();
 		}
+	}
+
+	@Test
+	void constructorWhenTarHasNoIndexOrManifestDeletesTempFile() throws Exception {
+		File tempDir = new File(System.getProperty("java.io.tmpdir"));
+		Set<String> tempsBefore = listTempFileNames(tempDir);
+		ImageReference reference = ImageReference.of("test:latest");
+		assertThatIllegalStateException().isThrownBy(() -> new ExportedImageTar(reference, tarWithoutIndexOrManifest()))
+			.withMessageContaining("does not contain 'index.json' or 'manifest.json'");
+		Set<String> leaked = new HashSet<>(listTempFileNames(tempDir));
+		leaked.removeAll(tempsBefore);
+		assertThat(leaked).as("temp file must be deleted when the constructor fails").isEmpty();
+	}
+
+	private InputStream tarWithoutIndexOrManifest() throws Exception {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		try (TarArchiveOutputStream tar = new TarArchiveOutputStream(out)) {
+			byte[] data = "test".getBytes(StandardCharsets.UTF_8);
+			TarArchiveEntry entry = new TarArchiveEntry("some-file.txt");
+			entry.setSize(data.length);
+			tar.putArchiveEntry(entry);
+			tar.write(data);
+			tar.closeArchiveEntry();
+		}
+		return new ByteArrayInputStream(out.toByteArray());
+	}
+
+	private Set<String> listTempFileNames(File tempDir) {
+		File[] files = tempDir.listFiles((dir, name) -> name.startsWith("docker-layers-"));
+		Set<String> names = new HashSet<>();
+		if (files != null) {
+			for (File file : files) {
+				names.add(file.getName());
+			}
+		}
+		return names;
 	}
 
 }

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ExportedImageTarTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/ExportedImageTarTests.java
@@ -17,17 +17,17 @@
 package org.springframework.boot.buildpack.platform.docker;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -37,6 +37,8 @@ import org.springframework.boot.buildpack.platform.io.TarArchive.Compression;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.spy;
 
 /**
  * Tests for {@link ExportedImageTar}.
@@ -51,9 +53,15 @@ class ExportedImageTarTests {
 			"export-docker-desktop-containerd-manifest-list.tar", "export-docker-engine.tar", "export-podman.tar",
 			"export-docker-desktop-nested-index.tar", "export-docker-desktop-containerd-alt-mediatype.tar" })
 	void test(String tarFile) throws Exception {
+		List<Path> temporaryDockerLayersTarFilesBefore = scanTemporaryDockerLayersTarFiles();
 		ImageReference reference = ImageReference.of("test:latest");
-		try (ExportedImageTar exportedImageTar = new ExportedImageTar(reference,
-				getClass().getResourceAsStream(tarFile))) {
+		Path temporaryDockerFile;
+		InputStream inputStream = spy(Objects.requireNonNull(getClass().getResourceAsStream(tarFile)));
+		try (ExportedImageTar exportedImageTar = new ExportedImageTar(reference, inputStream)) {
+			List<Path> temporaryDockerLayersTarFilesCurrent = scanTemporaryDockerLayersTarFiles();
+			temporaryDockerLayersTarFilesCurrent.removeAll(temporaryDockerLayersTarFilesBefore);
+			assertThat(temporaryDockerLayersTarFilesCurrent).hasSize(1);
+			temporaryDockerFile = temporaryDockerLayersTarFilesCurrent.get(0);
 			Compression expectedCompression = (!tarFile.contains("containerd")) ? Compression.NONE : Compression.GZIP;
 			String expectedName = (expectedCompression != Compression.GZIP)
 					? "5caae51697b248b905dca1a4160864b0e1a15c300981736555cdce6567e8d477"
@@ -65,42 +73,30 @@ class ExportedImageTarTests {
 			});
 			assertThat(names).filteredOn((name) -> name.contains(expectedName)).isNotEmpty();
 		}
+		then(inputStream).should().close();
+		assertThat(temporaryDockerFile).doesNotExist();
 	}
 
 	@Test
-	void constructorWhenTarHasNoIndexOrManifestDeletesTempFile() throws Exception {
-		File tempDir = new File(System.getProperty("java.io.tmpdir"));
-		Set<String> tempsBefore = listTempFileNames(tempDir);
+	void constructorWhenTarHasNoIndexOrManifestDeletesTempFile() throws IOException {
+		List<Path> temporaryDockerLayersTarFilesBefore = scanTemporaryDockerLayersTarFiles();
 		ImageReference reference = ImageReference.of("test:latest");
-		assertThatIllegalStateException().isThrownBy(() -> new ExportedImageTar(reference, tarWithoutIndexOrManifest()))
+		InputStream notATarFile = spy(new ByteArrayInputStream("not-a-tar-file".getBytes(StandardCharsets.UTF_8)));
+		assertThatIllegalStateException().isThrownBy(() -> new ExportedImageTar(reference, notATarFile))
 			.withMessageContaining("does not contain 'index.json' or 'manifest.json'");
-		Set<String> leaked = new HashSet<>(listTempFileNames(tempDir));
-		leaked.removeAll(tempsBefore);
-		assertThat(leaked).as("temp file must be deleted when the constructor fails").isEmpty();
+		then(notATarFile).should().close();
+		assertThat(scanTemporaryDockerLayersTarFiles()).containsOnlyOnceElementsOf(temporaryDockerLayersTarFilesBefore)
+			.hasSize(temporaryDockerLayersTarFilesBefore.size());
 	}
 
-	private InputStream tarWithoutIndexOrManifest() throws Exception {
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		try (TarArchiveOutputStream tar = new TarArchiveOutputStream(out)) {
-			byte[] data = "test".getBytes(StandardCharsets.UTF_8);
-			TarArchiveEntry entry = new TarArchiveEntry("some-file.txt");
-			entry.setSize(data.length);
-			tar.putArchiveEntry(entry);
-			tar.write(data);
-			tar.closeArchiveEntry();
+	private static List<Path> scanTemporaryDockerLayersTarFiles() throws IOException {
+		Path tempDir = Path.of(System.getProperty("java.io.tmpdir"));
+		try (Stream<Path> stream = Files.list(tempDir)) {
+			return stream.filter(Files::isRegularFile).filter((candidate) -> {
+				String filename = candidate.getFileName().toString();
+				return filename.startsWith("docker-layers") && filename.endsWith(".tar");
+			}).collect(Collectors.toCollection(ArrayList::new));
 		}
-		return new ByteArrayInputStream(out.toByteArray());
-	}
-
-	private Set<String> listTempFileNames(File tempDir) {
-		File[] files = tempDir.listFiles((dir, name) -> name.startsWith("docker-layers-"));
-		Set<String> names = new HashSet<>();
-		if (files != null) {
-			for (File file : files) {
-				names.add(file.getName());
-			}
-		}
-		return names;
 	}
 
 }


### PR DESCRIPTION

`ExportedImageTar` creates a temporary file in its constructor, copies the exported image into it, and then builds the layer factory from it:

```java
ExportedImageTar(ImageReference reference, InputStream inputStream) throws IOException {
	this.tarFile = Files.createTempFile("docker-layers-", null);
	Files.copy(inputStream, this.tarFile, StandardCopyOption.REPLACE_EXISTING);
	this.layerArchiveFactory = LayerArchiveFactory.create(reference, this.tarFile);
}
```

The only caller relies on try-with-resources to clean the file up:

```java
try (ExportedImageTar exportedImageTar = new ExportedImageTar(reference, response.getContent())) {
	exportedImageTar.exportLayers(exports);
}
```

If `Files.copy` or `LayerArchiveFactory.create` throws, the constructor fails after the temporary file has been created, so the instance is never assigned and `close()` never runs. `LayerArchiveFactory.create` does throw on a tar that has neither `index.json` nor `manifest.json` (`Assert.state(...)`), which can happen for a malformed or unexpected image export, and the `docker-layers-` file is then left behind in the temp directory.

This wraps the constructor body so the temporary file is deleted if either step fails, matching the cleanup already done in `close()`.

This mirrors #50919, which fixed the same kind of leak in the buildpack platform and included a temp-file test; the new test in `ExportedImageTarTests` uses the same approach.
