### PR TITLE
Fix stale type reference for OTLP logging transport metadata

### DIFF
--- a/module/spring-boot-opentelemetry/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/module/spring-boot-opentelemetry/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -76,7 +76,7 @@
     },
     {
       "name": "management.otlp.logging.transport",
-      "type": "org.springframework.boot.opentelemetry.actuate.autoconfigure.logging.Transport",
+      "type": "org.springframework.boot.opentelemetry.autoconfigure.logging.otlp.Transport",
       "description": "Transport used to send the logs.",
       "defaultValue": "http",
       "deprecation": {


### PR DESCRIPTION

The metadata for the deprecated `management.otlp.logging.transport` property declares:

```json
"type": "org.springframework.boot.opentelemetry.actuate.autoconfigure.logging.Transport",
```

That class does not exist. The `Transport` enum lives in `org.springframework.boot.opentelemetry.autoconfigure.logging.otlp`, which is also the package the sibling `management.otlp.logging.compression` entry already uses.

#50375 corrected this reference on 4.0.x, but the fix did not carry over to 4.1.x, so 4.1.x and main still have the stale value.

This updates the type to the actual class, matching what 4.0.x already has.
