### PR TITLE
Document alternatives to HttpMessageConverters

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/spring-mvc.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/spring-mvc.adoc
@@ -119,8 +119,7 @@ When defining an javadoc:tools.jackson.databind.json.JsonMapper[] bean, marking 
 Note that, in either case, doing so disables all auto-configuration of the javadoc:tools.jackson.databind.json.JsonMapper[].
 
 If you provide any javadoc:org.springframework.context.annotation.Bean[format=annotation]s of type javadoc:org.springframework.http.converter.json.JacksonJsonHttpMessageConverter[], they replace the default value in the MVC configuration.
-Also, a convenience bean of type javadoc:org.springframework.boot.http.converter.autoconfigure.HttpMessageConverters[] is provided (and is always available if you use the default MVC configuration).
-It has some useful methods to access the default and user-enhanced message converters.
+You can also declare javadoc:org.springframework.boot.http.converter.autoconfigure.ServerHttpMessageConvertersCustomizer[] beans to add converters or to override a specific default converter, as described in xref:reference:web/servlet.adoc#web.servlet.spring-mvc.message-converters[].
 
 See the xref:spring-mvc.adoc#howto.spring-mvc.customize-responsebody-rendering[] section and the {code-spring-boot-webmvc-src}/autoconfigure/WebMvcAutoConfiguration.java[`WebMvcAutoConfiguration`] source code for more details.
 
@@ -129,11 +128,11 @@ See the xref:spring-mvc.adoc#howto.spring-mvc.customize-responsebody-rendering[]
 [[howto.spring-mvc.customize-responsebody-rendering]]
 == Customize the @ResponseBody Rendering
 
-Spring uses javadoc:org.springframework.boot.http.converter.autoconfigure.HttpMessageConverters[] to render javadoc:org.springframework.web.bind.annotation.ResponseBody[format=annotation] (or responses from javadoc:org.springframework.web.bind.annotation.RestController[format=annotation]).
+Spring uses javadoc:org.springframework.http.converter.HttpMessageConverters[] to render javadoc:org.springframework.web.bind.annotation.ResponseBody[format=annotation] (or responses from javadoc:org.springframework.web.bind.annotation.RestController[format=annotation]).
 You can contribute additional converters by adding beans of the appropriate type in a Spring Boot context.
 If a bean you add is of a type that would have been included by default anyway (such as javadoc:org.springframework.http.converter.json.JacksonJsonHttpMessageConverter[] for JSON conversions), it replaces the default value.
-A convenience bean of type javadoc:org.springframework.boot.http.converter.autoconfigure.HttpMessageConverters[] is provided and is always available if you use the default MVC configuration.
-It has some useful methods to access the default and user-enhanced message converters (For example, it can be useful if you want to manually inject them into a custom javadoc:org.springframework.web.client.RestTemplate[]).
+For more control, declare javadoc:org.springframework.boot.http.converter.autoconfigure.ServerHttpMessageConvertersCustomizer[] beans, which let you choose whether a converter is added before the default ones or overrides a specific default converter.
+The converters used by clients are configured separately, using javadoc:org.springframework.boot.http.converter.autoconfigure.ClientHttpMessageConvertersCustomizer[] beans.
 
 As in normal MVC usage, any javadoc:org.springframework.web.servlet.config.annotation.WebMvcConfigurer[] beans that you provide can also contribute converters by overriding the `configureMessageConverters` method.
 However, unlike with normal MVC, you can supply only additional converters that you need (because Spring Boot uses the same mechanism to contribute its defaults).

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/io/rest-client.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/io/rest-client.adoc
@@ -116,7 +116,7 @@ The javadoc:org.springframework.web.client.RestClient[] interface provides a fun
 
 Spring Boot creates and pre-configures a prototype javadoc:org.springframework.web.client.RestClient$Builder[] bean for you.
 It is strongly advised to inject it in your components and use it to create javadoc:org.springframework.web.client.RestClient[] instances.
-Spring Boot is configuring that builder with javadoc:org.springframework.boot.http.converter.autoconfigure.HttpMessageConverters[] and an appropriate javadoc:org.springframework.http.client.ClientHttpRequestFactory[].
+Spring Boot is configuring that builder with javadoc:org.springframework.http.converter.HttpMessageConverters[] and an appropriate javadoc:org.springframework.http.client.ClientHttpRequestFactory[].
 
 The following code shows a typical example:
 

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/web/servlet.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/web/servlet.adoc
@@ -40,7 +40,7 @@ In addition to Spring MVC's defaults, the auto-configuration provides the follow
 * Inclusion of javadoc:org.springframework.web.servlet.view.ContentNegotiatingViewResolver[] and javadoc:org.springframework.web.servlet.view.BeanNameViewResolver[] beans.
 * Support for serving static resources, including support for WebJars (covered xref:web/servlet.adoc#web.servlet.spring-mvc.static-content[later in this document]).
 * Automatic registration of javadoc:org.springframework.core.convert.converter.Converter[], javadoc:org.springframework.core.convert.converter.GenericConverter[], and javadoc:org.springframework.format.Formatter[] beans.
-* Support for javadoc:org.springframework.boot.http.converter.autoconfigure.HttpMessageConverters[] (covered xref:web/servlet.adoc#web.servlet.spring-mvc.message-converters[later in this document]).
+* Support for javadoc:org.springframework.http.converter.HttpMessageConverters[] (covered xref:web/servlet.adoc#web.servlet.spring-mvc.message-converters[later in this document]).
 * Automatic registration of javadoc:org.springframework.validation.MessageCodesResolver[] (covered xref:web/servlet.adoc#web.servlet.spring-mvc.message-codes[later in this document]).
 * Static `index.html` support.
 * Automatic use of a javadoc:org.springframework.web.bind.support.ConfigurableWebBindingInitializer[] bean (covered xref:web/servlet.adoc#web.servlet.spring-mvc.binding-initializer[later in this document]).


### PR DESCRIPTION
Spring Boot's HttpMessageConverters was removed in 07f8034 (gh-50955), but a few pages in the reference docs still refer to it.

In web/servlet.adoc and io/rest-client.adoc it's just a reference swap to Spring Framework's HttpMessageConverters. In how-to/spring-mvc.adoc that wasn't quite enough — the text there described the convenience bean and its methods for accessing the default and user-enhanced converters, which no longer exist, so I reworded those parts around ServerHttpMessageConvertersCustomizer and ClientHttpMessageConvertersCustomizer. I tried to follow the wording already used in the HttpMessageConverters section of web/servlet.adoc.