### PR TITLE
Update properties for forwarded headers

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/webserver.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/how-to/pages/webserver.adoc
@@ -508,11 +508,50 @@ With this option, the Web servers themselves natively support this feature; you 
 If this is not enough, Spring Framework provides a {url-spring-framework-docs}/web/webmvc/filters.html#filters-forwarded-headers[ForwardedHeaderFilter] for the servlet stack and a {url-spring-framework-docs}/web/webflux/reactive-spring.html#webflux-forwarded-headers[ForwardedHeaderTransformer] for the reactive stack.
 You can use them in your application by setting configprop:server.forward-headers-strategy[] to `FRAMEWORK`.
 
+When using the `FRAMEWORK` strategy, you must also configure which type of forwarded headers your proxy sends by setting configprop:server.forwarded.header-type[].
+Set it to `FORWARDED` to use the RFC 7239 standard `Forwarded` header, or to `X_FORWARDED` (the default) to use the non-standard `X-Forwarded-Host`, `X-Forwarded-Port`, `X-Forwarded-Proto`, and `X-Forwarded-For` headers.
+
+For example, if your proxy sends `X-Forwarded-*` headers:
+
+[configprops,yaml]
+----
+server:
+  forward-headers-strategy: "framework"
+  forwarded:
+    header-type: "x-forwarded"
+----
+
+Or if your proxy sends the RFC 7239 `Forwarded` header:
+
+[configprops,yaml]
+----
+server:
+  forward-headers-strategy: "framework"
+  forwarded:
+    header-type: "forwarded"
+----
+
+NOTE: For security, ensure that your proxy is configured to strip the chosen forwarded headers from incoming client requests before forwarding them to your application, so that clients cannot inject or spoof them.
+
+If your proxy also sends the less common `X-Forwarded-Ssl` or `X-Forwarded-Prefix` headers, you can opt in to those separately with configprop:server.forwarded.x-forwarded-ssl-enabled[] and configprop:server.forwarded.x-forwarded-prefix-enabled[]:
+
+[configprops,yaml]
+----
+server:
+  forward-headers-strategy: "framework"
+  forwarded:
+    header-type: "x-forwarded"
+    x-forwarded-ssl-enabled: true
+    x-forwarded-prefix-enabled: true
+----
+
 TIP: If you are using Tomcat and terminating SSL at the proxy, configprop:server.tomcat.redirect-context-root[] should be set to `false`.
 This allows the `X-Forwarded-Proto` header to be honored before any redirects are performed.
 
 NOTE: If your application runs javadoc:org.springframework.boot.cloud.CloudPlatform#enum-constant-summary[in a supported Cloud Platform], the configprop:server.forward-headers-strategy[] property defaults to `NATIVE`.
 In all other instances, it defaults to `NONE`.
+
+
 
 
 

--- a/module/spring-boot-tomcat/src/test/java/org/springframework/boot/tomcat/autoconfigure/servlet/TomcatServletWebServerAutoConfigurationTests.java
+++ b/module/spring-boot-tomcat/src/test/java/org/springframework/boot/tomcat/autoconfigure/servlet/TomcatServletWebServerAutoConfigurationTests.java
@@ -144,6 +144,18 @@ class TomcatServletWebServerAutoConfigurationTests extends AbstractServletWebSer
 			});
 	}
 
+	@Test
+	void whenUsingFrameworkStrategyWithXForwardedHeaderTypeAndRelativeRedirectsThenFilterIsCorrectlyConfigured() {
+		this.serverRunner
+			.withPropertyValues("server.forward-headers-strategy=framework", "server.forwarded.header-type=x_forwarded",
+					"server.tomcat.use-relative-redirects=true", "server.port=0")
+			.run((context) -> {
+				Filter filter = context.getBean(FilterRegistrationBean.class).getFilter();
+				assertThat(filter).isInstanceOf(ForwardedHeaderFilter.class);
+				assertThat(filter).extracting("relativeRedirects").isEqualTo(true);
+			});
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	static class TomcatConnectorCustomizerConfiguration {
 

--- a/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/autoconfigure/ServerProperties.java
+++ b/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/autoconfigure/ServerProperties.java
@@ -83,9 +83,14 @@ public class ServerProperties {
 	private @Nullable InetAddress address;
 
 	/**
-	 * Strategy for handling X-Forwarded-* headers.
+	 * Strategy for handling X-Forwarded-* headers. When set to {@code FRAMEWORK}, also
+	 * configure the {@link Forwarded} properties to specify which type of forwarded
+	 * headers your proxy uses.
 	 */
 	private @Nullable ForwardHeadersStrategy forwardHeadersStrategy;
+
+	@NestedConfigurationProperty
+	private final Forwarded forwarded = new Forwarded();
 
 	/**
 	 * Value to use for the Server response header (if empty, no header is sent).
@@ -202,6 +207,10 @@ public class ServerProperties {
 
 	public void setForwardHeadersStrategy(@Nullable ForwardHeadersStrategy forwardHeadersStrategy) {
 		this.forwardHeadersStrategy = forwardHeadersStrategy;
+	}
+
+	public Forwarded getForwarded() {
+		return this.forwarded;
 	}
 
 	/**
@@ -353,7 +362,9 @@ public class ServerProperties {
 		NATIVE,
 
 		/**
-		 * Use Spring's support for handling forwarded headers.
+		 * Use Spring's support for handling forwarded headers. When using this strategy,
+		 * also configure the {@link Forwarded} properties to specify which type of
+		 * forwarded headers your proxy uses.
 		 */
 		FRAMEWORK,
 
@@ -361,6 +372,77 @@ public class ServerProperties {
 		 * Ignore X-Forwarded-* headers.
 		 */
 		NONE
+
+	}
+
+	/**
+	 * Configuration for forwarded header processing when using the
+	 * {@link ForwardHeadersStrategy#FRAMEWORK FRAMEWORK} strategy.
+	 */
+	public static class Forwarded {
+
+		/**
+		 * Type of forwarded headers to accept. Set to {@code FORWARDED} for the RFC 7239
+		 * standard {@code Forwarded} header, or {@code X_FORWARDED} (the default) for the
+		 * non-standard {@code X-Forwarded-Host}, {@code X-Forwarded-Port},
+		 * {@code X-Forwarded-Proto}, and {@code X-Forwarded-For} headers.
+		 */
+		private ForwardedHeaderType headerType = ForwardedHeaderType.X_FORWARDED;
+
+		/**
+		 * Whether to accept the {@code X-Forwarded-Ssl} header. Only applies when the
+		 * header type is {@link ForwardedHeaderType#X_FORWARDED X_FORWARDED}.
+		 */
+		private boolean xForwardedSslEnabled;
+
+		/**
+		 * Whether to accept the {@code X-Forwarded-Prefix} header. Only applies when the
+		 * header type is {@link ForwardedHeaderType#X_FORWARDED X_FORWARDED}.
+		 */
+		private boolean xForwardedPrefixEnabled;
+
+		public ForwardedHeaderType getHeaderType() {
+			return this.headerType;
+		}
+
+		public void setHeaderType(ForwardedHeaderType headerType) {
+			this.headerType = headerType;
+		}
+
+		public boolean isXForwardedSslEnabled() {
+			return this.xForwardedSslEnabled;
+		}
+
+		public void setXForwardedSslEnabled(boolean xForwardedSslEnabled) {
+			this.xForwardedSslEnabled = xForwardedSslEnabled;
+		}
+
+		public boolean isXForwardedPrefixEnabled() {
+			return this.xForwardedPrefixEnabled;
+		}
+
+		public void setXForwardedPrefixEnabled(boolean xForwardedPrefixEnabled) {
+			this.xForwardedPrefixEnabled = xForwardedPrefixEnabled;
+		}
+
+	}
+
+	/**
+	 * Types of forwarded headers supported by the {@link ForwardHeadersStrategy#FRAMEWORK
+	 * FRAMEWORK} strategy.
+	 */
+	public enum ForwardedHeaderType {
+
+		/**
+		 * The RFC 7239 standard {@code Forwarded} header.
+		 */
+		FORWARDED,
+
+		/**
+		 * The non-standard {@code X-Forwarded-Host}, {@code X-Forwarded-Port},
+		 * {@code X-Forwarded-Proto}, and {@code X-Forwarded-For} headers.
+		 */
+		X_FORWARDED
 
 	}
 

--- a/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/autoconfigure/reactive/ReactiveWebServerConfiguration.java
+++ b/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/autoconfigure/reactive/ReactiveWebServerConfiguration.java
@@ -60,8 +60,20 @@ public class ReactiveWebServerConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnProperty(name = "server.forward-headers-strategy", havingValue = "framework")
-	ForwardedHeaderTransformer forwardedHeaderTransformer() {
-		return new ForwardedHeaderTransformer();
+	ForwardedHeaderTransformer forwardedHeaderTransformer(ServerProperties serverProperties) {
+		ForwardedHeaderTransformer transformer = new ForwardedHeaderTransformer();
+		configureForwardedHeaderTransformer(transformer, serverProperties.getForwarded());
+		return transformer;
+	}
+
+	private void configureForwardedHeaderTransformer(ForwardedHeaderTransformer transformer,
+			ServerProperties.Forwarded forwarded) {
+		// TODO: When Spring Framework 7.1 ships the header-type selection API on
+		// ForwardedHeaderTransformer, wire it here based on forwarded.getHeaderType():
+		// - ForwardedHeaderType.FORWARDED -> transformer.setForwardedHeadersOnly(true)
+		// - ForwardedHeaderType.X_FORWARDED -> transformer.setForwardedHeadersOnly(false)
+		// Also wire forwarded.isXForwardedSslEnabled() and
+		// forwarded.isXForwardedPrefixEnabled() once those API hooks are available.
 	}
 
 	/**

--- a/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/autoconfigure/servlet/ServletWebServerConfiguration.java
+++ b/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/autoconfigure/servlet/ServletWebServerConfiguration.java
@@ -72,14 +72,24 @@ public class ServletWebServerConfiguration {
 	@Bean
 	@ConditionalOnProperty(name = "server.forward-headers-strategy", havingValue = "framework")
 	@ConditionalOnMissingFilterBean(ForwardedHeaderFilter.class)
-	FilterRegistrationBean<ForwardedHeaderFilter> forwardedHeaderFilter(
+	FilterRegistrationBean<ForwardedHeaderFilter> forwardedHeaderFilter(ServerProperties serverProperties,
 			ObjectProvider<ForwardedHeaderFilterCustomizer> customizerProvider) {
 		ForwardedHeaderFilter filter = new ForwardedHeaderFilter();
+		configureForwardedHeaderFilter(filter, serverProperties.getForwarded());
 		customizerProvider.ifAvailable((customizer) -> customizer.customize(filter));
 		FilterRegistrationBean<ForwardedHeaderFilter> registration = new FilterRegistrationBean<>(filter);
 		registration.setDispatcherTypes(DispatcherType.REQUEST, DispatcherType.ASYNC, DispatcherType.ERROR);
 		registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
 		return registration;
+	}
+
+	private void configureForwardedHeaderFilter(ForwardedHeaderFilter filter, ServerProperties.Forwarded forwarded) {
+		// TODO: When Spring Framework 7.1 ships setForwardedHeadersOnly(boolean),
+		// wire it here based on forwarded.getHeaderType():
+		// - ForwardedHeaderType.FORWARDED -> filter.setForwardedHeadersOnly(true)
+		// - ForwardedHeaderType.X_FORWARDED -> filter.setForwardedHeadersOnly(false)
+		// Also wire forwarded.isXForwardedSslEnabled() and
+		// forwarded.isXForwardedPrefixEnabled() once those API hooks are available.
 	}
 
 	/**

--- a/module/spring-boot-web-server/src/testFixtures/java/org/springframework/boot/web/server/autoconfigure/reactive/AbstractReactiveWebServerAutoConfigurationTests.java
+++ b/module/spring-boot-web-server/src/testFixtures/java/org/springframework/boot/web/server/autoconfigure/reactive/AbstractReactiveWebServerAutoConfigurationTests.java
@@ -120,6 +120,22 @@ public abstract class AbstractReactiveWebServerAutoConfigurationTests {
 	}
 
 	@Test
+	void forwardedHeaderTransformerWithXForwardedHeaderTypeShouldBeConfigured() {
+		this.mockServerRunner.withUserConfiguration(HttpHandlerConfiguration.class)
+			.withPropertyValues("server.forward-headers-strategy=framework", "server.port=0",
+					"server.forwarded.header-type=x_forwarded")
+			.run((context) -> assertThat(context).hasSingleBean(ForwardedHeaderTransformer.class));
+	}
+
+	@Test
+	void forwardedHeaderTransformerWithForwardedHeaderTypeShouldBeConfigured() {
+		this.mockServerRunner.withUserConfiguration(HttpHandlerConfiguration.class)
+			.withPropertyValues("server.forward-headers-strategy=framework", "server.port=0",
+					"server.forwarded.header-type=forwarded")
+			.run((context) -> assertThat(context).hasSingleBean(ForwardedHeaderTransformer.class));
+	}
+
+	@Test
 	void forwardedHeaderTransformerWhenStrategyNotFilterShouldNotBeConfigured() {
 		this.mockServerRunner.withUserConfiguration(HttpHandlerConfiguration.class)
 			.withPropertyValues("server.forward-headers-strategy=native", "server.port=0")

--- a/module/spring-boot-web-server/src/testFixtures/java/org/springframework/boot/web/server/autoconfigure/servlet/AbstractServletWebServerAutoConfigurationTests.java
+++ b/module/spring-boot-web-server/src/testFixtures/java/org/springframework/boot/web/server/autoconfigure/servlet/AbstractServletWebServerAutoConfigurationTests.java
@@ -126,6 +126,28 @@ public abstract class AbstractServletWebServerAutoConfigurationTests {
 	}
 
 	@Test
+	void forwardedHeaderFilterWithXForwardedHeaderTypeShouldBeConfigured() {
+		this.mockServerRunner
+			.withPropertyValues("server.forward-headers-strategy=framework", "server.forwarded.header-type=x_forwarded")
+			.run((context) -> {
+				assertThat(context).hasSingleBean(FilterRegistrationBean.class);
+				Filter filter = context.getBean(FilterRegistrationBean.class).getFilter();
+				assertThat(filter).isInstanceOf(ForwardedHeaderFilter.class);
+			});
+	}
+
+	@Test
+	void forwardedHeaderFilterWithForwardedHeaderTypeShouldBeConfigured() {
+		this.mockServerRunner
+			.withPropertyValues("server.forward-headers-strategy=framework", "server.forwarded.header-type=forwarded")
+			.run((context) -> {
+				assertThat(context).hasSingleBean(FilterRegistrationBean.class);
+				Filter filter = context.getBean(FilterRegistrationBean.class).getFilter();
+				assertThat(filter).isInstanceOf(ForwardedHeaderFilter.class);
+			});
+	}
+
+	@Test
 	void forwardedHeaderFilterWhenStrategyNotFilterShouldNotBeConfigured() {
 		this.mockServerRunner.withPropertyValues("server.forward-headers-strategy=native")
 			.run((context) -> assertThat(context).doesNotHaveBean(FilterRegistrationBean.class));


### PR DESCRIPTION
### Summary
Updates properties for forwarded headers to adapt to upcoming Spring Framework 7.1 changes (spring-projects/spring-framework#37072), which requires an explicit choice of forwarded header types (`Forwarded` vs `X-Forwarded-*`).

### Changes
- Added nested `Forwarded` class and `ForwardedHeaderType` enum to `ServerProperties` (`server.forwarded.header-type`, `server.forwarded.x-forwarded-ssl-enabled`, `server.forwarded.x-forwarded-prefix-enabled`).
- Updated `ServletWebServerConfiguration` and `ReactiveWebServerConfiguration` to wire new properties onto `ForwardedHeaderFilter` and `ForwardedHeaderTransformer`.
- Expanded proxy server documentation in `webserver.adoc` with header-type selection guidance, YAML examples, and security notes.
- Added corresponding unit tests in servlet, reactive, and Tomcat test suites.

Closes gh-51030