### PR TITLE
Add autoconfiguration for Oracle UCP-specific metrics.

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/metrics.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/metrics.adoc
@@ -920,7 +920,7 @@ TIP: By default, Spring Boot provides metadata for all supported data sources.
 You can add additional javadoc:org.springframework.boot.jdbc.metadata.DataSourcePoolMetadataProvider[] beans if your favorite data source is not supported.
 See javadoc:org.springframework.boot.jdbc.autoconfigure.DataSourcePoolMetadataProvidersConfiguration[] for examples.
 
-Also, Hikari-specific metrics are exposed with a `hikaricp` prefix.
+Also, Hikari-specific metrics are exposed with a `hikaricp` prefix and Oracle UCP-specific metrics are exposed with a `oraclucp` prefix.
 Each metric is tagged by the name of the pool (you can control it with `spring.datasource.name`).
 
 

--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/metrics/DataSourcePoolMetricsAutoConfiguration.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/autoconfigure/metrics/DataSourcePoolMetricsAutoConfiguration.java
@@ -16,8 +16,12 @@
 
 package org.springframework.boot.jdbc.autoconfigure.metrics;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +32,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.metrics.micrometer.MicrometerMetricsTrackerFactory;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import oracle.ucp.jdbc.PoolDataSourceImpl;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -42,6 +47,7 @@ import org.springframework.boot.jdbc.DataSourceUnwrapper;
 import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
 import org.springframework.boot.jdbc.metadata.DataSourcePoolMetadataProvider;
 import org.springframework.boot.jdbc.metrics.DataSourcePoolMetrics;
+import org.springframework.boot.jdbc.metrics.OracleUcpStatisticsMeterBinder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.log.LogMessage;
@@ -53,6 +59,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Stephane Nicoll
  * @author Yanming Zhou
+ * @author Fabio Grassi
  * @since 4.0.0
  */
 @AutoConfiguration(after = DataSourceAutoConfiguration.class,
@@ -155,6 +162,51 @@ public final class DataSourcePoolMetricsAutoConfiguration {
 					catch (Exception ex) {
 						logger.warn(LogMessage.format("Failed to bind Hikari metrics: %s", ex.getMessage()));
 					}
+				}
+			}
+
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(PoolDataSourceImpl.class)
+	static class OracleUcpPoolDataSourceMetricConfiguration {
+
+		@Bean
+		OracleUcpPoolDataSourceMeterBinder oracleUCPDataSourceMeterBinder(ObjectProvider<DataSource> dataSources) {
+			return new OracleUcpPoolDataSourceMeterBinder(dataSources);
+		}
+
+		static class OracleUcpPoolDataSourceMeterBinder implements MeterBinder, Closeable {
+
+			private final ObjectProvider<DataSource> dataSources;
+
+			private final Collection<OracleUcpStatisticsMeterBinder> statisticsBinders;
+
+			OracleUcpPoolDataSourceMeterBinder(final ObjectProvider<DataSource> dataSources) {
+				this.dataSources = dataSources;
+				this.statisticsBinders = new LinkedList<>();
+			}
+
+			@Override
+			public void bindTo(final MeterRegistry registry) {
+				this.dataSources.stream(ObjectProvider.UNFILTERED, false).forEach((ds) -> {
+					final PoolDataSourceImpl pds = DataSourceUnwrapper.unwrap(ds, PoolDataSourceImpl.class);
+					if (pds != null) {
+						final OracleUcpStatisticsMeterBinder binder = OracleUcpStatisticsMeterBinder.of(pds);
+						binder.bindTo(registry);
+						this.statisticsBinders.add(binder);
+					}
+				});
+			}
+
+			@Override
+			public void close() throws IOException {
+				final Iterator<OracleUcpStatisticsMeterBinder> iterator = this.statisticsBinders.iterator();
+				while (iterator.hasNext()) {
+					iterator.next().close();
+					iterator.remove();
 				}
 			}
 

--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/metrics/OracleUcpStatisticsMeterBinder.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/metrics/OracleUcpStatisticsMeterBinder.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jdbc.metrics;
+
+import java.io.Closeable;
+import java.sql.SQLException;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.function.ToDoubleFunction;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import oracle.ucp.jdbc.JDBCConnectionPoolStatistics;
+import oracle.ucp.jdbc.PoolDataSourceImpl;
+
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+
+import static io.micrometer.core.instrument.binder.BaseUnits.CONNECTIONS;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link MeterBinder} for a {@link oracle.ucp.jdbc.PoolDataSourceImpl}.
+ *
+ * @author Fabio Grassi
+ * @since 4.1.0
+ */
+public final class OracleUcpStatisticsMeterBinder implements MeterBinder, Closeable {
+
+	private static final String SECONDS = ChronoUnit.SECONDS.toString();
+
+	static final String METRIC_PREFIX = "oracleucp.connections.";
+
+	static final MeterInfo[] METER_INFOS = {
+			// Start - Current state
+			new MeterInfo("curr.count", Tags.of("status", "available"),
+					"Total number of available connections in the pool", CONNECTIONS,
+					JDBCConnectionPoolStatistics::getAvailableConnectionsCount, Meter.Type.GAUGE),
+			new MeterInfo("curr.count", Tags.of("status", "borrowed"),
+					"Total number of borrowed connections in the pool", CONNECTIONS,
+					JDBCConnectionPoolStatistics::getBorrowedConnectionsCount, Meter.Type.GAUGE),
+			new MeterInfo("curr.count.open", Tags.empty(), "Total number of connections in the pool", CONNECTIONS,
+					JDBCConnectionPoolStatistics::getTotalConnectionsCount, Meter.Type.GAUGE),
+			new MeterInfo("curr.count.labeled", Tags.empty(), "Total number of labeled connections in the pool",
+					CONNECTIONS, JDBCConnectionPoolStatistics::getLabeledConnectionsCount, Meter.Type.GAUGE),
+			new MeterInfo("curr.count.pending", Tags.empty(), "Total number of pending requests count in the pool",
+					CONNECTIONS, JDBCConnectionPoolStatistics::getPendingRequestsCount, Meter.Type.GAUGE),
+			new MeterInfo("curr.count.remaining", Tags.empty(), "Remaining pool capacity count for the pool",
+					CONNECTIONS, JDBCConnectionPoolStatistics::getRemainingPoolCapacityCount, Meter.Type.GAUGE),
+			// End - Current state
+			// Start - Aggregates since last reset of the pool
+			new MeterInfo("aggr.count.abandoned", Tags.empty(), "Total number of abandoned connections in the pool",
+					CONNECTIONS, JDBCConnectionPoolStatistics::getAbandonedConnectionsCount, Meter.Type.COUNTER),
+			new MeterInfo("aggr.count.closed", Tags.empty(), "Total number of closed connections in the pool",
+					CONNECTIONS, JDBCConnectionPoolStatistics::getConnectionsClosedCount, Meter.Type.COUNTER),
+			new MeterInfo("aggr.count.created", Tags.empty(), "Total number of connections created in the pool",
+					CONNECTIONS, JDBCConnectionPoolStatistics::getConnectionsCreatedCount, Meter.Type.COUNTER),
+			new MeterInfo("aggr.average.borrowed", Tags.empty(), "Average count for borrowed connections in the pool",
+					CONNECTIONS, JDBCConnectionPoolStatistics::getAverageBorrowedConnectionsCount, Meter.Type.GAUGE),
+			new MeterInfo("aggr.average.wait.time", Tags.empty(), "Average connection wait time in the pool", SECONDS,
+					JDBCConnectionPoolStatistics::getAverageConnectionWaitTime, Meter.Type.GAUGE),
+			new MeterInfo("aggr.max.open", Tags.empty(), "Peak connections count in the pool", CONNECTIONS,
+					JDBCConnectionPoolStatistics::getPeakConnectionsCount, Meter.Type.GAUGE),
+			new MeterInfo("aggr.max.wait.time", Tags.empty(), "Peak connection wait time in the pool", SECONDS,
+					JDBCConnectionPoolStatistics::getPeakConnectionWaitTime, Meter.Type.GAUGE),
+			// End - Aggregates since last reset of the pool
+			// Start - History since last restart of the application
+			new MeterInfo("cum.count.borrowed", Tags.empty(), "Cumulative connection borrowed count for the pool",
+					CONNECTIONS, JDBCConnectionPoolStatistics::getCumulativeConnectionBorrowedCount,
+					Meter.Type.COUNTER),
+			new MeterInfo("cum.count.returned", Tags.empty(), "Cumulative connection returned count in the pool",
+					CONNECTIONS, JDBCConnectionPoolStatistics::getCumulativeConnectionReturnedCount,
+					Meter.Type.COUNTER),
+			new MeterInfo("cum.count.wait", Tags.of("status", "failure"),
+					"Cumulative failed connection wait count for the pool", CONNECTIONS,
+					JDBCConnectionPoolStatistics::getCumulativeFailedConnectionWaitCount, Meter.Type.COUNTER),
+			new MeterInfo("cum.count.wait", Tags.of("status", "success"),
+					"Cumulative successful connection wait count for the pool", CONNECTIONS,
+					JDBCConnectionPoolStatistics::getCumulativeSuccessfulConnectionWaitCount, Meter.Type.COUNTER),
+			new MeterInfo("cum.sum.use.time", Tags.empty(), "Cumulative connection use time for the pool", SECONDS,
+					JDBCConnectionPoolStatistics::getCumulativeConnectionUseTime, Meter.Type.COUNTER),
+			new MeterInfo("cum.sum.wait.time", Tags.of("status", "failure"),
+					"Cumulative failed connection wait time for the pool", SECONDS,
+					JDBCConnectionPoolStatistics::getCumulativeFailedConnectionWaitTime, Meter.Type.COUNTER),
+			new MeterInfo("cum.sum.wait.time", Tags.of("status", "success"),
+					"Cumulative successful connection wait time for the pool", SECONDS,
+					JDBCConnectionPoolStatistics::getCumulativeSuccessfulConnectionWaitTime, Meter.Type.COUNTER)
+			// End - History since last restart of the application
+	};
+
+	private final Tags tags;
+
+	// We need to hold a strong reference to the state object
+	private final JDBCConnectionPoolStatistics poolStatistics;
+
+	private final Collection<Meter> meters;
+
+	private MeterRegistry registry;
+
+	public OracleUcpStatisticsMeterBinder(final PoolDataSourceImpl poolDataSource) {
+		ensurePoolIsCreated(requireNonNull(poolDataSource, "'poolDataSource' must not be null"));
+		this.tags = Tags.of("pool", requireNonNull(poolDataSource.getConnectionPoolName(),
+				"'getConnectionPoolName()' must not return null"));
+		this.poolStatistics = requireNonNull(poolDataSource.getStatistics(), "'getStatistics()' must not return null");
+		this.meters = new LinkedList<>();
+	}
+
+	public static OracleUcpStatisticsMeterBinder of(final PoolDataSourceImpl poolDataSource) {
+		return new OracleUcpStatisticsMeterBinder(poolDataSource);
+	}
+
+	@Override
+	public void bindTo(final MeterRegistry registry) {
+		this.registry = registry;
+		for (MeterInfo meterInfo : METER_INFOS) {
+			this.meters.add(registerMeter(meterInfo));
+		}
+	}
+
+	private Meter registerMeter(final MeterInfo meterInfo) {
+		return switch (meterInfo.type) {
+			case GAUGE -> Gauge //
+				.builder(METRIC_PREFIX + meterInfo.name, this.poolStatistics, meterInfo.function) //
+				.tags(this.tags.and(meterInfo.specificTags)) //
+				.description(meterInfo.description) //
+				.baseUnit(meterInfo.baseUnit) //
+				.register(this.registry); //
+			case COUNTER -> FunctionCounter //
+				.builder(METRIC_PREFIX + meterInfo.name, this.poolStatistics, meterInfo.function) //
+				.tags(this.tags.and(meterInfo.specificTags)) //
+				.description(meterInfo.description) //
+				.baseUnit(meterInfo.baseUnit) //
+				.register(this.registry); //
+			default -> throw new IllegalArgumentException("Unexpected meter type: " + meterInfo.type);
+		};
+	}
+
+	@Override
+	public void close() {
+		if (this.registry != null) {
+			final Iterator<Meter> iterator = this.meters.iterator();
+			while (iterator.hasNext()) {
+				this.registry.remove(iterator.next());
+				iterator.remove();
+			}
+		}
+		else if (!this.meters.isEmpty()) {
+			this.meters.clear();
+		}
+		this.registry = null;
+	}
+
+	private static void ensurePoolIsCreated(final PoolDataSourceImpl poolDataSource) {
+		try {
+			poolDataSource.createUniversalConnectionPool();
+		}
+		catch (SQLException e) {
+			throw new InvalidDataAccessApiUsageException("Oracle connection pool creation failed", e);
+		}
+	}
+
+	static record MeterInfo(String name, Tags specificTags, String description, String baseUnit,
+			ToDoubleFunction<JDBCConnectionPoolStatistics> function, Meter.Type type) {
+
+		@Override
+		public String toString() {
+			return "MeterId{" + "name='" + name() + "', specificTags=" + specificTags() + "}";
+		}
+
+	}
+
+}

--- a/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/autoconfigure/metrics/OracleUcpStatisticsAutoConfigurationTests.java
+++ b/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/autoconfigure/metrics/OracleUcpStatisticsAutoConfigurationTests.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jdbc.autoconfigure.metrics;
+
+import java.sql.SQLException;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import oracle.ucp.UniversalConnectionPoolException;
+import oracle.ucp.admin.UniversalConnectionPoolManager;
+import oracle.ucp.admin.UniversalConnectionPoolManagerImpl;
+import oracle.ucp.jdbc.PoolDataSourceImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.LazyInitializationBeanFactoryPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceInitializationAutoConfiguration;
+import org.springframework.boot.jdbc.metadata.DataSourcePoolMetadataProvider;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.core.Ordered;
+import org.springframework.core.PriorityOrdered;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.jdbc.datasource.DelegatingDataSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DataSourcePoolMetricsAutoConfiguration}. Adapts for Oracle UCP the
+ * same tests performed in {#link DataSourcePoolMetricsAutoConfigurationTests} for Hikari.
+ *
+ * @author Fabio Grassi
+ * @since 4.1.0
+ */
+class OracleUcpStatisticsAutoConfigurationTests {
+
+	private static final String ONE_UCP_METER_NAME = "oracleucp.connections.curr.count.open";
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withPropertyValues("spring.datasource.generate-unique-name=true",
+				"management.metrics.use-global-registry=false")
+		.withBean(SimpleMeterRegistry.class)
+		.withConfiguration(
+				AutoConfigurations.of(MetricsAutoConfiguration.class, DataSourcePoolMetricsAutoConfiguration.class));
+
+	@AfterEach
+	void destroyAllOracleConnectionPools() {
+		try {
+			final UniversalConnectionPoolManager mgr = UniversalConnectionPoolManagerImpl
+				.getUniversalConnectionPoolManager();
+			for (String poolName : mgr.getConnectionPoolNames()) {
+				mgr.destroyConnectionPool(poolName);
+			}
+		}
+		catch (UniversalConnectionPoolException e) {
+			throw new InvalidDataAccessApiUsageException("Error while destroying Oracle connection pools", e);
+		}
+	}
+
+	@Test
+	@ClassPathExclusions({ "Hikari*.jar", "tomcat-jdbc*.jar", "commons-dbcp2*.jar" })
+	void autoConfiguredPoolDataSourceIsInstrumented() {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
+			.run((context) -> {
+				context.getBean(DataSource.class).getConnection();
+				MeterRegistry registry = context.getBean(MeterRegistry.class);
+				registry.get(ONE_UCP_METER_NAME).meter();
+			});
+	}
+
+	@Test
+	@ClassPathExclusions({ "Hikari*.jar", "tomcat-jdbc*.jar", "commons-dbcp2*.jar" })
+	void autoConfiguredPoolDataSourceIsInstrumentedWhenUsingDataSourceInitialization() {
+		this.contextRunner.withPropertyValues("spring.sql.init.schema:db/create-custom-schema.sql")
+			.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class,
+					DataSourceInitializationAutoConfiguration.class))
+			.run((context) -> {
+				context.getBean(DataSource.class).getConnection();
+				MeterRegistry registry = context.getBean(MeterRegistry.class);
+				registry.get(ONE_UCP_METER_NAME).meter();
+			});
+	}
+
+	@Test
+	@ClassPathExclusions({ "Hikari*.jar", "tomcat-jdbc*.jar", "commons-dbcp2*.jar" })
+	void poolCanBeInstrumentedAfterThePoolHasBeenSealed() {
+		this.contextRunner.withUserConfiguration(OracleUCPSealingConfiguration.class)
+			.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
+			.run((context) -> {
+				assertThat(context).hasNotFailed();
+				context.getBean(DataSource.class).getConnection();
+				MeterRegistry registry = context.getBean(MeterRegistry.class);
+				assertThat(registry.find(ONE_UCP_METER_NAME).meter()).isNotNull();
+			});
+	}
+
+	@Test
+	@ClassPathExclusions({ "Hikari*.jar", "tomcat-jdbc*.jar", "commons-dbcp2*.jar" })
+	void poolDataSourceInstrumentationCanBeDisabled() {
+		this.contextRunner.withPropertyValues("management.metrics.enable.oracleucp=false")
+			.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
+			.run((context) -> {
+				context.getBean(DataSource.class).getConnection();
+				MeterRegistry registry = context.getBean(MeterRegistry.class);
+				assertThat(registry.find(ONE_UCP_METER_NAME).meter()).isNull();
+			});
+	}
+
+	@Test
+	void allPoolDataSourcesCanBeInstrumented() {
+		this.contextRunner.withUserConfiguration(MultiplePoolDataSourcesConfiguration.class)
+			.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
+			.run((context) -> {
+				context.getBean("standardDataSource", DataSource.class).getConnection();
+				context.getBean("nonDefault", DataSource.class).getConnection();
+				context.getBean("nonAutowire", DataSource.class).getConnection();
+				MeterRegistry registry = context.getBean(MeterRegistry.class);
+				assertThat(registry.find(ONE_UCP_METER_NAME).meters()).map((meter) -> meter.getId().getTag("pool"))
+					.containsOnly("standardDataSource", "nonDefault");
+			});
+	}
+
+	@Test
+	void somePoolDataSourcesCanBeInstrumented() {
+		this.contextRunner.withUserConfiguration(MixedDataSourcesConfiguration.class)
+			.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
+			.run((context) -> {
+				context.getBean("firstDataSource", DataSource.class).getConnection();
+				context.getBean("secondOne", DataSource.class).getConnection();
+				MeterRegistry registry = context.getBean(MeterRegistry.class);
+				assertThat(registry.get(ONE_UCP_METER_NAME).meter().getId().getTags())
+					.containsExactly(Tag.of("pool", "firstDataSource"));
+			});
+	}
+
+	@Test
+	void allPoolDataSourcesCanBeInstrumentedWhenUsingLazyInitialization() {
+		this.contextRunner.withUserConfiguration(MultiplePoolDataSourcesConfiguration.class)
+			.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
+			.withInitializer(
+					(context) -> context.addBeanFactoryPostProcessor(new LazyInitializationBeanFactoryPostProcessor()))
+			.run((context) -> {
+				context.getBean("standardDataSource", DataSource.class).getConnection();
+				context.getBean("nonDefault", DataSource.class).getConnection();
+				context.getBean("nonAutowire", DataSource.class).getConnection();
+				MeterRegistry registry = context.getBean(MeterRegistry.class);
+				assertThat(registry.find(ONE_UCP_METER_NAME).meters()).map((meter) -> meter.getId().getTag("pool"))
+					.containsOnly("standardDataSource", "nonDefault");
+			});
+	}
+
+	@Test
+	void proxiedPoolDataSourceCanBeInstrumented() {
+		this.contextRunner.withUserConfiguration(ProxiedPoolDataSourcesConfiguration.class)
+			.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class))
+			.run((context) -> {
+				context.getBean("proxiedDataSource", DataSource.class).getConnection();
+				context.getBean("delegateDataSource", DataSource.class).getConnection();
+				MeterRegistry registry = context.getBean(MeterRegistry.class);
+				registry.get(ONE_UCP_METER_NAME).tags("pool", "firstDataSource").meter();
+				registry.get(ONE_UCP_METER_NAME).tags("pool", "secondOne").meter();
+			});
+	}
+
+	@Test
+	void poolDataSourceIsInstrumentedWithoutMetadataProvider() {
+		this.contextRunner.withUserConfiguration(OnePoolDataSourceConfiguration.class).run((context) -> {
+			assertThat(context).doesNotHaveBean(DataSourcePoolMetadataProvider.class);
+			context.getBean("poolDataSource", DataSource.class).getConnection();
+			MeterRegistry registry = context.getBean(MeterRegistry.class);
+			assertThat(registry.get(ONE_UCP_METER_NAME).meter().getId().getTags())
+				.containsExactly(Tag.of("pool", "poolDataSource"));
+		});
+	}
+
+	@Test
+	void prototypeDataSourceIsIgnored() {
+		this.contextRunner
+			.withUserConfiguration(OnePoolDataSourceConfiguration.class, PrototypeDataSourceConfiguration.class)
+			.run((context) -> {
+				context.getBean("poolDataSource", DataSource.class).getConnection();
+				((DataSource) context.getBean("prototypeDataSource", "", "")).getConnection();
+				MeterRegistry registry = context.getBean(MeterRegistry.class);
+				assertThat(registry.get(ONE_UCP_METER_NAME).meter().getId().getTags())
+					.contains(Tag.of("pool", "poolDataSource"));
+			});
+	}
+
+	private static PoolDataSourceImpl createPoolDataSource(String poolName) {
+		final PoolDataSourceImpl poolDataSource = DataSourceBuilder.create()
+			.url("jdbc:hsqldb:mem:test-" + UUID.randomUUID())
+			.type(PoolDataSourceImpl.class)
+			.build();
+		try {
+			poolDataSource.setConnectionPoolName(poolName);
+		}
+		catch (SQLException e) {
+			throw new InvalidDataAccessApiUsageException(
+					"Cannot set Oracle UCP connection pool name '" + poolName + "'", e);
+		}
+		return poolDataSource;
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class MultiplePoolDataSourcesConfiguration {
+
+		@Bean
+		DataSource standardDataSource() {
+			return createPoolDataSource("standardDataSource");
+		}
+
+		@Bean(defaultCandidate = false)
+		DataSource nonDefault() {
+			return createPoolDataSource("nonDefault");
+		}
+
+		@Bean(autowireCandidate = false)
+		DataSource nonAutowire() {
+			return createPoolDataSource("nonAutowire");
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ProxiedPoolDataSourcesConfiguration {
+
+		@Bean
+		DataSource proxiedDataSource() {
+			return (DataSource) new ProxyFactory(createPoolDataSource("firstDataSource")).getProxy();
+		}
+
+		@Bean
+		DataSource delegateDataSource() {
+			return new DelegatingDataSource(createPoolDataSource("secondOne"));
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class OnePoolDataSourceConfiguration {
+
+		@Bean
+		DataSource poolDataSource() {
+			return createPoolDataSource("poolDataSource");
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class MixedDataSourcesConfiguration {
+
+		@Bean
+		DataSource firstDataSource() {
+			return createPoolDataSource("firstDataSource");
+		}
+
+		@Bean
+		DataSource secondOne() {
+			return createHikariDataSource("secondOne");
+		}
+
+		private HikariDataSource createHikariDataSource(String poolName) {
+			String url = "jdbc:hsqldb:mem:test-" + UUID.randomUUID();
+			HikariDataSource hikariDataSource = DataSourceBuilder.create()
+				.url(url)
+				.type(HikariDataSource.class)
+				.build();
+			hikariDataSource.setPoolName(poolName);
+			return hikariDataSource;
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class PrototypeDataSourceConfiguration {
+
+		@Bean
+		@Scope(BeanDefinition.SCOPE_PROTOTYPE)
+		DataSource prototypeDataSource(String username, String password) {
+			return createPoolDataSource(username, password);
+		}
+
+		private PoolDataSourceImpl createPoolDataSource(String username, String password) {
+			return DataSourceBuilder.create()
+				.url("jdbc:hsqldb:mem:test-" + UUID.randomUUID())
+				.type(PoolDataSourceImpl.class)
+				.username(username)
+				.password(password)
+				.build();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class OracleUCPSealingConfiguration {
+
+		@Bean
+		static OracleUCPSealer oracleUCPSealer() {
+			return new OracleUCPSealer();
+		}
+
+		static class OracleUCPSealer implements BeanPostProcessor, PriorityOrdered {
+
+			@Override
+			public int getOrder() {
+				return Ordered.HIGHEST_PRECEDENCE;
+			}
+
+			@Override
+			public Object postProcessAfterInitialization(Object bean, String beanName) {
+				if (bean instanceof PoolDataSourceImpl dataSource) {
+					try {
+						dataSource.getConnection().close();
+					}
+					catch (SQLException ex) {
+						throw new IllegalStateException(ex);
+					}
+				}
+				return bean;
+			}
+
+		}
+
+	}
+
+}

--- a/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/metrics/OracleUcpStatisticsMeterBinderTests.java
+++ b/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/metrics/OracleUcpStatisticsMeterBinderTests.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jdbc.metrics;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.UUID;
+import java.util.function.DoubleSupplier;
+
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import oracle.ucp.UniversalConnectionPoolException;
+import oracle.ucp.admin.UniversalConnectionPoolManager;
+import oracle.ucp.admin.UniversalConnectionPoolManagerImpl;
+import oracle.ucp.jdbc.PoolDataSourceImpl;
+import oracle.ucp.util.Strings;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.jdbc.metrics.OracleUcpStatisticsMeterBinder.MeterInfo;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.util.Assert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCollection;
+import static org.assertj.core.api.Assertions.assertThatList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.boot.jdbc.metrics.OracleUcpStatisticsMeterBinder.METRIC_PREFIX;
+
+/**
+ * Tests for {@link oracle.ucp.jdbc.PoolDataSourceImpl}.
+ *
+ * @author Fabio Grassi
+ * @since 4.1.0
+ */
+class OracleUcpStatisticsMeterBinderTests {
+
+	private static final String POOL_NAME = "testPool";
+
+	static final MeterInfo[] METER_INFOS = OracleUcpStatisticsMeterBinder.METER_INFOS;
+
+	@AfterEach
+	void destroyAllOracleConnectionPools() {
+		try {
+			final UniversalConnectionPoolManager mgr = UniversalConnectionPoolManagerImpl
+				.getUniversalConnectionPoolManager();
+			for (String poolName : mgr.getConnectionPoolNames()) {
+				mgr.destroyConnectionPool(poolName);
+			}
+		}
+		catch (UniversalConnectionPoolException e) {
+			throw new InvalidDataAccessApiUsageException("Error while destroying Oracle connection pools", e);
+		}
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = { POOL_NAME })
+	void constructorCreatesInstance(final String poolName) {
+		final PoolDataSourceImpl pds = createPoolDataSource(poolName);
+		try (final OracleUcpStatisticsMeterBinder binder = new OracleUcpStatisticsMeterBinder(pds)) {
+			assertThat(binder).isNotNull();
+		}
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = { POOL_NAME })
+	void staticFactoryMethodCreatesInstance(final String poolName) {
+		final PoolDataSourceImpl pds = createPoolDataSource(poolName);
+		try (final OracleUcpStatisticsMeterBinder binder = OracleUcpStatisticsMeterBinder.of(pds)) {
+			assertThat(binder).isNotNull();
+		}
+	}
+
+	@Test
+	void constructorThrowsExceptionWhenPoolDataSourceIsNull() {
+		assertThatThrownBy(() -> new OracleUcpStatisticsMeterBinder(null))
+			.isExactlyInstanceOf(NullPointerException.class)
+			.hasMessage("'poolDataSource' must not be null");
+	}
+
+	@Test
+	void staticFactoryMethodThrowsExceptionWhenPoolDataSourceIsNull() {
+		assertThatThrownBy(() -> OracleUcpStatisticsMeterBinder.of(null))
+			.isExactlyInstanceOf(NullPointerException.class)
+			.hasMessage("'poolDataSource' must not be null");
+	}
+
+	@Test
+	void bindToRegistersExpectedNumberOfMetersAndCloseRemovesAllMeters() {
+		final MeterRegistry registry = new SimpleMeterRegistry();
+		try {
+			final PoolDataSourceImpl pds = createPoolDataSource(POOL_NAME);
+			try (final OracleUcpStatisticsMeterBinder binder = OracleUcpStatisticsMeterBinder.of(pds)) {
+				assertThatList(registry.getMeters()).isEmpty();
+				binder.bindTo(registry);
+				assertThatList(registry.getMeters()).hasSize(METER_INFOS.length);
+			}
+			assertThatList(registry.getMeters()).isEmpty();
+		}
+		finally {
+			registry.close();
+		}
+	}
+
+	@ParameterizedTest
+	@FieldSource("METER_INFOS")
+	void bindToRegistersMetersWithExpectedProperties(final MeterInfo meterInfo) {
+
+		final String name = METRIC_PREFIX + meterInfo.name();
+		final Tags tags = Tags.of("pool", POOL_NAME).and(meterInfo.specificTags());
+
+		final MeterRegistry registry = new SimpleMeterRegistry();
+		try {
+			final PoolDataSourceImpl pds = createPoolDataSource(POOL_NAME);
+			try (final OracleUcpStatisticsMeterBinder binder = OracleUcpStatisticsMeterBinder.of(pds)) {
+
+				binder.bindTo(registry);
+
+				// Find all registered meters having a the given name and tags
+				final Collection<Meter> meters = registry.find(name).tags(tags).meters();
+
+				// Check that there is one and only one meter with the given key
+				assertThat(meters).isNotNull();
+				assertThatCollection(meters).hasSize(1);
+				final Meter meter = meters.iterator().next();
+				assertThat(meter).isNotNull();
+				final Meter.Id meterId = meter.getId();
+
+				// For the single meter found, check all other relevant properties
+				assertAll("Check all relevant properties of meter " + meterId,
+						() -> assertThat(meterId.getName()).as("Check name").isEqualTo(name),
+						() -> assertThat(Tags.of(meterId.getTags())).as("Check tags").isEqualTo(tags),
+						() -> assertThat(meterId.getDescription()).as("Check description")
+							.isEqualTo(meterInfo.description()),
+						() -> assertThat(meterId.getBaseUnit()).as("Check baseUnit").isEqualTo(meterInfo.baseUnit()),
+						() -> assertThat(meterId.getType()).as("Check type").isEqualTo(meterInfo.type()));
+			}
+		}
+		finally {
+			registry.close();
+		}
+	}
+
+	@ParameterizedTest
+	@FieldSource("METER_INFOS")
+	void registeredMetersReturnSameValuesAsStateObject(final MeterInfo meterInfo) throws SQLException {
+
+		final String name = METRIC_PREFIX + meterInfo.name();
+		final Tags tags = Tags.of("pool", POOL_NAME).and(meterInfo.specificTags());
+
+		final MeterRegistry registry = new SimpleMeterRegistry();
+		try {
+			final int initSize = 1;
+			final int minSize = 2;
+			final int maxSize = 4;
+			final PoolDataSourceImpl pds = createPoolDataSource(POOL_NAME, initSize, minSize, maxSize);
+			try (final OracleUcpStatisticsMeterBinder binder = OracleUcpStatisticsMeterBinder.of(pds)) {
+
+				binder.bindTo(registry);
+
+				final Collection<Meter> meters = registry.find(name).tags(tags).meters();
+				final Meter meter = meters.iterator().next();
+				final Iterator<Measurement> mesures = meter.measure().iterator();
+				final Measurement measure = mesures.next();
+
+				final DoubleSupplier expected = () -> meterInfo.function().applyAsDouble(pds.getStatistics());
+				final DoubleSupplier actual = measure::getValue;
+
+				assertThat(actual.getAsDouble()).as("When pool created but not yet running")
+					.isEqualTo(expected.getAsDouble());
+
+				startPool(pds.getConnectionPoolName());
+
+				assertThat(actual.getAsDouble()).as("When pool running, but no connection borrowed")
+					.isEqualTo(expected.getAsDouble());
+
+				final Connection conn1 = pds.getConnection();
+
+				assertThat(actual.getAsDouble()).as("When number of borrowed connections is equal to 'intialPoolSize'")
+					.isEqualTo(expected.getAsDouble());
+
+				final Connection conn2 = pds.getConnection();
+
+				assertThat(actual.getAsDouble()).as("When number of borrowed connections is equal to 'minPoolSize'")
+					.isEqualTo(expected.getAsDouble());
+
+				final Connection conn3 = pds.getConnection();
+
+				assertThat(actual.getAsDouble())
+					.as("When number of borrowed connections is between 'minPoolSize' and 'maxPoolSize'")
+					.isEqualTo(expected.getAsDouble());
+
+				final Connection conn4 = pds.getConnection();
+
+				assertThat(actual.getAsDouble()).as("When number of borrowed connections is equal to 'maxPoolSize'")
+					.isEqualTo(expected.getAsDouble());
+
+				await()
+					.untilAsserted(() -> assertThatThrownBy(pds::getConnection).isExactlyInstanceOf(SQLException.class)
+						.hasFieldOrPropertyWithValue("errorCode", 29)
+						.hasMessageStartingWith("UCP-29"));
+
+				assertThat(actual.getAsDouble()).as("After a timeout waiting for a connection while pool is exausted")
+					.isEqualTo(expected.getAsDouble());
+
+				conn1.close();
+				conn2.close();
+
+				assertThat(actual.getAsDouble())
+					.as("When number of borrowed connections has returned between 'minPoolSize' and 'maxPoolSize'")
+					.isEqualTo(expected.getAsDouble());
+
+				conn3.close();
+				conn4.close();
+
+				assertThat(actual.getAsDouble())
+					.as("When number of borrowed connections has returned below 'minPoolSize'")
+					.isEqualTo(expected.getAsDouble());
+
+				purgePool(pds.getConnectionPoolName());
+
+				assertThat(actual.getAsDouble()).as("When pool has just been purged").isEqualTo(expected.getAsDouble());
+
+				stopPool(pds.getConnectionPoolName());
+				startPool(pds.getConnectionPoolName());
+
+				assertThat(actual.getAsDouble()).as("When pool has just been restarted")
+					.isEqualTo(expected.getAsDouble());
+
+				destroyPool(pds.getConnectionPoolName());
+
+				assertThat(actual.getAsDouble()).as("When pool has just been destroyed")
+					.isEqualTo(expected.getAsDouble());
+
+			}
+		}
+		finally {
+			registry.close();
+		}
+	}
+
+	private PoolDataSourceImpl createPoolDataSource(final String poolName) {
+		return createPoolDataSource(poolName, 0, 0, 0);
+	}
+
+	private PoolDataSourceImpl createPoolDataSource(final String poolName, final int InitialSize, final int minSize,
+			final int MaxSize) {
+		final PoolDataSourceImpl poolDataSource = DataSourceBuilder.create()
+			.url("jdbc:hsqldb:mem:test-" + UUID.randomUUID())
+			.type(PoolDataSourceImpl.class)
+			.build();
+		try {
+			if (!Strings.isNullOrEmpty(poolName)) {
+				poolDataSource.setConnectionPoolName(poolName);
+			}
+			poolDataSource.setInitialPoolSize(InitialSize);
+			poolDataSource.setMinPoolSize(minSize);
+			poolDataSource.setMaxPoolSize(MaxSize);
+			poolDataSource.setConnectionWaitDurationInMillis(100);
+		}
+		catch (SQLException e) {
+			throw new IllegalStateException("Oracle connection pool initialization failed", e);
+		}
+		return poolDataSource;
+	}
+
+	private static final void destroyPool(final String poolName) {
+		doWithManager(UniversalConnectionPoolManager::destroyConnectionPool, poolName);
+	}
+
+	private static final void purgePool(final String poolName) {
+		doWithManager(UniversalConnectionPoolManager::purgeConnectionPool, poolName);
+	}
+
+	private static final void startPool(final String poolName) {
+		doWithManager(UniversalConnectionPoolManager::startConnectionPool, poolName);
+	}
+
+	private static final void stopPool(final String poolName) {
+		doWithManager(UniversalConnectionPoolManager::stopConnectionPool, poolName);
+	}
+
+	private static void doWithManager(final ConnectionPoolAction action, final String poolName) {
+		Assert.hasText(poolName, "'poolName' must not be null");
+		try {
+			final UniversalConnectionPoolManager mgr = UniversalConnectionPoolManagerImpl
+				.getUniversalConnectionPoolManager();
+			action.accept(mgr, poolName);
+		}
+		catch (UniversalConnectionPoolException e) {
+			throw new IllegalStateException("Oracle connection pool action failed", e);
+		}
+	}
+
+	@FunctionalInterface
+	private interface ConnectionPoolAction {
+
+		void accept(final UniversalConnectionPoolManager mgr, final String poolName)
+				throws UniversalConnectionPoolException;
+
+	}
+
+}


### PR DESCRIPTION
Oracle UCP exposes a far richer set of metrics than exposed by the standard `org.springframework.boot.jdbc.metrics.DataSourcePoolMetrics`.

Similar to what already done for Hikari, this PR proposes to autoconfigure an extended set of metrics for each `oracle.ucp.jdbc.PoolDataSourceImpl` registered as a bean in the application context.
