### PR TITLE
Restore default JUL root handler on Logback cleanup [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -114,6 +114,9 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 
 	private boolean bridgeHandlerInstalled;
 
+	@Nullable
+	private java.util.logging.Handler defaultRootHandler;
+
 	public LogbackLoggingSystem(ClassLoader classLoader) {
 		super(classLoader);
 	}
@@ -181,6 +184,7 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 			java.util.logging.Logger rootLogger = LogManager.getLogManager().getLogger("");
 			Handler[] handlers = rootLogger.getHandlers();
 			if (handlers.length == 1 && handlers[0] instanceof ConsoleHandler) {
+				this.defaultRootHandler = handlers[0];
 				rootLogger.removeHandler(handlers[0]);
 			}
 		}
@@ -342,8 +346,17 @@ public class LogbackLoggingSystem extends AbstractLoggingSystem implements BeanF
 			removeJdkLoggingBridgeHandler();
 			this.bridgeHandlerInstalled = false;
 		}
+		restoreDefaultRootHandler();
 		context.getStatusManager().clear();
 		context.getTurboFilterList().remove(SUPPRESS_ALL_FILTER);
+	}
+
+	private void restoreDefaultRootHandler() {
+		if (this.defaultRootHandler != null) {
+			java.util.logging.Logger rootLogger = LogManager.getLogManager().getLogger("");
+			rootLogger.addHandler(this.defaultRootHandler);
+			this.defaultRootHandler = null;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
### Motivation

When the JUL-to-SLF4J bridge is installed, the default java.util.logging root ConsoleHandler is removed. When the logging system is cleaned up (for example when an ApplicationFailedEvent is published), the bridge is uninstalled but the ConsoleHandler was not restored, leaving the JUL root logger with no handlers. Anything subsequently logged through JUL, such as a startup failure reported via a JUL-backed commons-logging Log, was then silently discarded.

Fixes #50969. See also #50404.

### Modification

- Add a `defaultRootHandler` field to save the ConsoleHandler reference before it is removed.
- In `removeDefaultRootHandler()`, save the ConsoleHandler before removing it from the root logger.
- In `cleanUp()`, after uninstalling the bridge, call `restoreDefaultRootHandler()` to add the saved ConsoleHandler back to the root logger.

### Result

After the logging system is cleaned up, the JUL root logger still has its ConsoleHandler, so JUL logging continues to work.