### PR TITLE
Use String keys in UrlJarFiles cache to avoid HashMap.getNode type profile pollution

### DIFF
--- a/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/JarFileUrlKey.java
+++ b/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/JarFileUrlKey.java
@@ -44,6 +44,21 @@ final class JarFileUrlKey {
 		this.runtimeRef = "runtime".equals(url.getRef());
 	}
 
+	/**
+	 * Return a string representation of this key suitable for use as a
+	 * {@code HashMap<String, ...>} key. Unlike {@code URL.toString()}, this
+	 * method does not trigger DNS lookups.
+	 * @return a unique string key for this URL
+	 */
+	String toKeyString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(this.protocol).append("://").append(this.host).append(':').append(this.port).append(this.file);
+		if (this.runtimeRef) {
+			sb.append("#runtime");
+		}
+		return sb.toString();
+	}
+
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) {

--- a/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/UrlJarFiles.java
+++ b/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/UrlJarFiles.java
@@ -140,11 +140,13 @@ class UrlJarFiles {
 	}
 
 	/**
-	 * Internal cache.
+	 * Internal cache. Uses {@code String} keys in the underlying map to avoid
+	 * polluting the JVM's shared {@code HashMap.getNode} type profile with a
+	 * custom key type. See gh-51141.
 	 */
 	private static final class Cache {
 
-		private final Map<JarFileUrlKey, JarFile> jarFileUrlToJarFile = new HashMap<>();
+		private final Map<String, JarFile> jarFileUrlToJarFile = new HashMap<>();
 
 		private final Map<JarFile, URL> jarFileToJarFileUrl = new HashMap<>();
 
@@ -154,9 +156,8 @@ class UrlJarFiles {
 		 * @return the cached {@link JarFile} or {@code null}
 		 */
 		JarFile get(URL jarFileUrl) {
-			JarFileUrlKey urlKey = new JarFileUrlKey(jarFileUrl);
 			synchronized (this) {
-				return this.jarFileUrlToJarFile.get(urlKey);
+				return this.jarFileUrlToJarFile.get(new JarFileUrlKey(jarFileUrl).toKeyString());
 			}
 		}
 
@@ -180,11 +181,11 @@ class UrlJarFiles {
 		 * they were already there
 		 */
 		boolean putIfAbsent(URL jarFileUrl, JarFile jarFile) {
-			JarFileUrlKey urlKey = new JarFileUrlKey(jarFileUrl);
 			synchronized (this) {
-				JarFile cached = this.jarFileUrlToJarFile.get(urlKey);
+				String key = new JarFileUrlKey(jarFileUrl).toKeyString();
+				JarFile cached = this.jarFileUrlToJarFile.get(key);
 				if (cached == null) {
-					this.jarFileUrlToJarFile.put(urlKey, jarFile);
+					this.jarFileUrlToJarFile.put(key, jarFile);
 					this.jarFileToJarFileUrl.put(jarFile, jarFileUrl);
 					return true;
 				}
@@ -200,7 +201,7 @@ class UrlJarFiles {
 			synchronized (this) {
 				URL removedUrl = this.jarFileToJarFileUrl.remove(jarFile);
 				if (removedUrl != null) {
-					this.jarFileUrlToJarFile.remove(new JarFileUrlKey(removedUrl));
+					this.jarFileUrlToJarFile.remove(new JarFileUrlKey(removedUrl).toKeyString());
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

This commit fixes the performance regression described in #51141.

### Problem

Commit 08cc62a changed the loader cache from `Map<String, JarFile>` to `Map<JarFileUrlKey, JarFile>`. A new `JarFileUrlKey` value object is allocated on every cache lookup, polluting the JVM-wide shared `HashMap.getNode` C2 type profile. This causes the method to go **megamorphic**, so C2 stops devirtualizing/inlining `equals()` / `hashCode()` — degrading unrelated application `HashMap<String,...>` / `HashMap<Integer,...>` lookups on hot code paths.

Before the commit the cache key was a `String` (the same type applications commonly use), so the shared profile stayed mono/bimorphic.

### Fix

1. Added `JarFileUrlKey.toKeyString()` — produces a unique string representation without triggering DNS lookups (preserves the original DNS-avoidance behavior)
2. Changed the internal `Cache` map from `Map<JarFileUrlKey, JarFile>` to `Map<String, JarFile>`
3. Cache operations use `new JarFileUrlKey(url).toKeyString()` as the key

Since `HashMap.getNode` is now called with `String` keys, the shared type profile is no longer polluted by the custom key type, and application `HashMap.get()` calls remain optimized.

### Verification

The `JarFileUrlKeyTests` test class covers the key equality semantics. Cache behavior is unchanged — the same `JarFileUrlKey` fields are used to derive the key string, so cache hit/miss semantics are identical.

Closes #51141