### PR TITLE
Use JacksonJsonSerde in Kafka Streams documentation

### DIFF
--- a/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/messaging/kafka/streams/MyKafkaStreamsConfiguration.java
+++ b/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/messaging/kafka/streams/MyKafkaStreamsConfiguration.java
@@ -27,18 +27,16 @@ import org.apache.kafka.streams.kstream.Produced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafkaStreams;
+import org.springframework.kafka.support.serializer.JacksonJsonSerde;
 
 @Configuration(proxyBeanMethods = false)
 @EnableKafkaStreams
 public class MyKafkaStreamsConfiguration {
 
 	@Bean
-	@SuppressWarnings({ "deprecation", "removal" })
 	public KStream<Integer, String> kStream(StreamsBuilder streamsBuilder) {
 		KStream<Integer, String> stream = streamsBuilder.stream("ks1In");
-		stream.map(this::uppercaseValue)
-			.to("ks1Out",
-					Produced.with(Serdes.Integer(), new org.springframework.kafka.support.serializer.JsonSerde<>()));
+		stream.map(this::uppercaseValue).to("ks1Out", Produced.with(Serdes.Integer(), new JacksonJsonSerde<>()));
 		return stream;
 	}
 

--- a/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/messaging/kafka/streams/MyKafkaStreamsConfiguration.kt
+++ b/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/messaging/kafka/streams/MyKafkaStreamsConfiguration.kt
@@ -24,6 +24,7 @@ import org.apache.kafka.streams.kstream.Produced
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.kafka.annotation.EnableKafkaStreams
+import org.springframework.kafka.support.serializer.JacksonJsonSerde
 
 @Suppress("UNUSED_PARAMETER")
 @Configuration(proxyBeanMethods = false)
@@ -31,11 +32,9 @@ import org.springframework.kafka.annotation.EnableKafkaStreams
 class MyKafkaStreamsConfiguration {
 
 	@Bean
-	@Suppress("DEPRECATION")
 	fun kStream(streamsBuilder: StreamsBuilder): KStream<Int, String> {
 		val stream = streamsBuilder.stream<Int, String>("ks1In")
-		stream.map(this::uppercaseValue).to("ks1Out", Produced.with(Serdes.Integer(),
-			org.springframework.kafka.support.serializer.JsonSerde()))
+		stream.map(this::uppercaseValue).to("ks1Out", Produced.with(Serdes.Integer(), JacksonJsonSerde()))
 		return stream
 	}
 


### PR DESCRIPTION
The Kafka Streams example used JsonSerde behind a deprecation suppression, added in 42d0f7216bf because Spring for Apache Kafka had no Jackson 3 equivalent at the time. Spring Kafka now ships JacksonJsonSerde, so the example can use it and drop the suppression.

See gh-45535