### PR TITLE
Remove reference to removed InfluxDB auto-configuration

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/context/properties/DocumentConfigurationProperties.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/context/properties/DocumentConfigurationProperties.java
@@ -131,7 +131,6 @@ public abstract class DocumentConfigurationProperties extends DefaultTask {
 		config.accept("spring.cassandra");
 		config.accept("spring.elasticsearch");
 		config.accept("spring.h2");
-		config.accept("spring.influx");
 		config.accept("spring.ldap");
 		config.accept("spring.mongodb");
 		config.accept("spring.neo4j");

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/data/nosql.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/data/nosql.adoc
@@ -17,8 +17,6 @@ Additionally, {url-spring-boot-for-apache-geode-site}[Spring Boot for Apache Geo
 You can make use of the other projects, but you must configure them yourself.
 See the appropriate reference documentation at {url-spring-data-site}.
 
-Spring Boot also provides auto-configuration for the InfluxDB client but it is deprecated in favor of https://github.com/influxdata/influxdb-client-java[the new InfluxDB Java client] that provides its own Spring Boot integration.
-
 
 
 [[data.nosql.redis]]


### PR DESCRIPTION
The auto-configuration for the InfluxDB client was removed in 3.4.0 (375b3b16a02), but the NoSQL section of the reference documentation still described it.