### PR TITLE
Skip gRPC port initializer when spring-grpc is absent

### DIFF
--- a/module/spring-boot-grpc-test/src/main/java/org/springframework/boot/grpc/test/autoconfigure/GrpcPortInfoApplicationContextInitializer.java
+++ b/module/spring-boot-grpc-test/src/main/java/org/springframework/boot/grpc/test/autoconfigure/GrpcPortInfoApplicationContextInitializer.java
@@ -31,6 +31,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertySource;
+import org.springframework.util.ClassUtils;
 import org.springframework.grpc.server.GrpcServerFactory;
 import org.springframework.grpc.server.InProcessGrpcServerFactory;
 import org.springframework.grpc.server.lifecycle.GrpcServerStartedEvent;
@@ -50,8 +51,13 @@ import org.springframework.grpc.server.lifecycle.GrpcServerStartedEvent;
 class GrpcPortInfoApplicationContextInitializer
 		implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
+	private static final String GRPC_SERVER_STARTED_EVENT = "org.springframework.grpc.server.lifecycle.GrpcServerStartedEvent";
+
 	@Override
 	public void initialize(ConfigurableApplicationContext applicationContext) {
+		if (!ClassUtils.isPresent(GRPC_SERVER_STARTED_EVENT, applicationContext.getClassLoader())) {
+			return;
+		}
 		applicationContext.addApplicationListener(new Listener(applicationContext));
 	}
 

--- a/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/GrpcPortInfoApplicationContextInitializerTests.java
+++ b/module/spring-boot-grpc-test/src/test/java/org/springframework/boot/grpc/test/autoconfigure/GrpcPortInfoApplicationContextInitializerTests.java
@@ -16,10 +16,13 @@
 
 package org.springframework.boot.grpc.test.autoconfigure;
 
+import java.io.IOException;
+
 import io.grpc.Server;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -42,6 +45,29 @@ import static org.mockito.Mockito.mock;
 class GrpcPortInfoApplicationContextInitializerTests {
 
 	private static final String PORT_PROPERTY = "local.grpc.server.port";
+
+	@Test
+	void whenGrpcServerStartedEventIsNotOnTheClasspathRegistersNoListener() throws IOException {
+		// gh-50825: the initializer is registered unconditionally via
+		// spring.factories, so with spring-grpc absent the listener's generic
+		// interface cannot be resolved and Spring throws TypeNotPresentException.
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+				FilteredClassLoader classLoader = new FilteredClassLoader(GrpcServerStartedEvent.class)) {
+			context.setClassLoader(classLoader);
+			int before = context.getApplicationListeners().size();
+			new GrpcPortInfoApplicationContextInitializer().initialize(context);
+			assertThat(context.getApplicationListeners()).hasSize(before);
+		}
+	}
+
+	@Test
+	void whenGrpcServerStartedEventIsOnTheClasspathRegistersListener() {
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+			int before = context.getApplicationListeners().size();
+			new GrpcPortInfoApplicationContextInitializer().initialize(context);
+			assertThat(context.getApplicationListeners()).hasSize(before + 1);
+		}
+	}
 
 	@Test
 	void whenServerHasAddressInitializerSetsPortProperty() {


### PR DESCRIPTION
See gh-50825

## Problem

`GrpcPortInfoApplicationContextInitializer` is registered unconditionally via `META-INF/spring.factories`, and its `initialize()` unconditionally adds a listener declared as `ApplicationListener<GrpcServerStartedEvent>`.

With `spring-boot-grpc-test` on the classpath but `spring-grpc` absent, Spring resolves that listener's generic interface to decide whether to deliver an event, and `Class.getGenericInterfaces()` throws — which is the stack trace in the report:

```
java.lang.TypeNotPresentException: Type org.springframework.grpc.server.lifecycle.GrpcServerStartedEvent not present
	at java.base/java.lang.Class.getGenericInterfaces(Class.java:1278)
	at org.springframework.core.ResolvableType.getInterfaces(ResolvableType.java:544)
```

## Fix

Guard registration on the event type being present:

```java
private static final String GRPC_SERVER_STARTED_EVENT =
    "org.springframework.grpc.server.lifecycle.GrpcServerStartedEvent";

@Override
public void initialize(ConfigurableApplicationContext applicationContext) {
    if (!ClassUtils.isPresent(GRPC_SERVER_STARTED_EVENT, applicationContext.getClassLoader())) {
        return;
    }
    applicationContext.addApplicationListener(new Listener(applicationContext));
}
```

`ClassUtils.isPresent` rather than a try/catch because that's what `LogbackLoggingSystem.isBridgeHandlerAvailable()` already does for the SLF4J bridge handler — same situation, optional class reached through a factories-registered component.

The classloader comes from the context rather than the class, so the guard sees the same classpath the listener resolution will.

## Scope

Deliberately narrow: only the initializer is guarded. I did not touch the `spring.factories` registration itself, since the initializer being constructed is harmless — it's only the listener whose generic type can't resolve. Happy to take a different approach if you'd rather condition the registration.

## Tests

Two added to `GrpcPortInfoApplicationContextInitializerTests`, using the existing `FilteredClassLoader`:

- `whenGrpcServerStartedEventIsNotOnTheClasspathRegistersNoListener` — hides `GrpcServerStartedEvent`, asserts no listener is registered
- `whenGrpcServerStartedEventIsOnTheClasspathRegistersListener` — control, so the guard can't silently disable the feature

With the source change stashed but both tests kept, the first fails:

```
GrpcPortInfoApplicationContextInitializerTests > whenGrpcServerStartedEventIsNotOnTheClasspathRegistersNoListener() FAILED

java.lang.AssertionError:
Expected size: 0 but was: 1 in:
[org.springframework.boot.grpc.test.autoconfigure.GrpcPortInfoApplicationContextInitializer$Listener@2407a36c]
```

## Verification

`./gradlew :module:spring-boot-grpc-test:test`

| | tests | failures | errors |
|---|---|---|---|
| baseline (`main`, unmodified) | 16 | 0 | 0 |
| this branch | 18 | 0 | 0 |
| tests kept, source change stashed | 18 | **1** | 0 |

The third row is what shows the tests pin the reported bug rather than restating the fix.

I ran the affected module's suite rather than the full build. Happy to run anything wider you'd like to see.