### PR TITLE
Correct exception type documented by resolveConfigLocation

### DIFF
--- a/module/spring-boot-hazelcast/src/main/java/org/springframework/boot/hazelcast/autoconfigure/HazelcastProperties.java
+++ b/module/spring-boot-hazelcast/src/main/java/org/springframework/boot/hazelcast/autoconfigure/HazelcastProperties.java
@@ -47,7 +47,6 @@ public class HazelcastProperties {
 	/**
 	 * Resolve the config location if set.
 	 * @return the location or {@code null} if it is not set
-	 * @throws IllegalStateException if the config attribute is set to an unknown location
 	 */
 	public @Nullable Resource resolveConfigLocation() {
 		Resource config = this.config;

--- a/module/spring-boot-hazelcast/src/main/java/org/springframework/boot/hazelcast/autoconfigure/HazelcastProperties.java
+++ b/module/spring-boot-hazelcast/src/main/java/org/springframework/boot/hazelcast/autoconfigure/HazelcastProperties.java
@@ -47,8 +47,7 @@ public class HazelcastProperties {
 	/**
 	 * Resolve the config location if set.
 	 * @return the location or {@code null} if it is not set
-	 * @throws IllegalArgumentException if the config attribute is set to an unknown
-	 * location
+	 * @throws IllegalStateException if the config attribute is set to an unknown location
 	 */
 	public @Nullable Resource resolveConfigLocation() {
 		Resource config = this.config;


### PR DESCRIPTION
`HazelcastProperties.resolveConfigLocation` documents `@throws IllegalArgumentException`, but it asserts with `Assert.state`, which throws `IllegalStateException`. Spring Framework's own javadoc on `Assert.state` says as much, and points at `isTrue` for the `IllegalArgumentException` case.
