### PR TITLE
Add application bootstrap mode

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/JavaPluginAction.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/JavaPluginAction.java
@@ -214,6 +214,7 @@ final class JavaPluginAction implements PluginApplicationAction {
 			run.setGroup(ApplicationPlugin.APPLICATION_GROUP);
 			run.classpath(classpath);
 			run.getMainClass().convention(resolveMainClassName.flatMap(ResolveMainClassName::readMainClassName));
+			run.systemProperty("spring.application.mode", "dev");
 			configureToolchainConvention(project, run);
 		});
 	}
@@ -230,6 +231,7 @@ final class JavaPluginAction implements PluginApplicationAction {
 			run.setGroup(ApplicationPlugin.APPLICATION_GROUP);
 			run.classpath(classpath);
 			run.getMainClass().convention(resolveMainClassName.flatMap(ResolveMainClassName::readMainClassName));
+			run.systemProperty("spring.application.mode", "dev");
 			configureToolchainConvention(project, run);
 		});
 	}

--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/run/BootRunIntegrationTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/run/BootRunIntegrationTests.java
@@ -111,7 +111,7 @@ class BootRunIntegrationTests {
 		BuildTask task = result.task(":bootRun");
 		assertThat(task).isNotNull();
 		assertThat(task.getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
-		assertThat(result.getOutput()).contains("-XX:TieredStopAtLevel=1");
+		assertThat(result.getOutput()).contains("-Dspring.application.mode=dev").contains("-XX:TieredStopAtLevel=1");
 	}
 
 	@TestTemplate

--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/run/BootTestRunIntegrationTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/run/BootTestRunIntegrationTests.java
@@ -68,7 +68,7 @@ class BootTestRunIntegrationTests {
 		BuildTask task = result.task(":bootTestRun");
 		assertThat(task).isNotNull();
 		assertThat(task.getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
-		assertThat(result.getOutput()).contains("-XX:TieredStopAtLevel=1");
+		assertThat(result.getOutput()).contains("-Dspring.application.mode=dev").contains("-XX:TieredStopAtLevel=1");
 	}
 
 	@TestTemplate

--- a/build-plugin/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/RunIntegrationTests.java
+++ b/build-plugin/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/RunIntegrationTests.java
@@ -38,7 +38,7 @@ class RunIntegrationTests {
 	@TestTemplate
 	void whenTheRunGoalIsExecutedTheApplicationIsForkedWithOptimizedJvmArguments(MavenBuild mavenBuild) {
 		mavenBuild.project("run").goals("spring-boot:run", "-X").execute((project) -> {
-			String jvmArguments = "JVM argument: -XX:TieredStopAtLevel=1";
+			String jvmArguments = "JVM arguments: -XX:TieredStopAtLevel=1 -Dspring.application.mode=dev";
 			assertThat(buildLog(project)).contains("I haz been run").contains(jvmArguments);
 		});
 	}

--- a/build-plugin/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/TestRunIntegrationTests.java
+++ b/build-plugin/spring-boot-maven-plugin/src/intTest/java/org/springframework/boot/maven/TestRunIntegrationTests.java
@@ -38,6 +38,7 @@ class TestRunIntegrationTests {
 		mavenBuild.project("test-run")
 			.goals("spring-boot:test-run", "-X")
 			.execute((project) -> assertThat(buildLog(project))
+				.contains("JVM arguments: -XX:TieredStopAtLevel=1 -Dspring.application.mode=dev")
 				.contains("Main class name = org.test.TestSampleApplication")
 				.contains("1. " + canonicalPathOf(project, "target/test-classes"))
 				.contains("2. " + canonicalPathOf(project, "target/classes"))

--- a/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractRunMojo.java
+++ b/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/AbstractRunMojo.java
@@ -313,6 +313,7 @@ public abstract class AbstractRunMojo extends AbstractDependencyFilterMojo {
 	 */
 	protected RunArguments resolveJvmArguments() {
 		List<@Nullable String> arguments = new ArrayList<>();
+		arguments.add(SystemPropertyFormatter.format("spring.application.mode", getApplicationMode()));
 		if (this.systemPropertyVariables != null) {
 			for (Entry<String, String> systemProperty : this.systemPropertyVariables.entrySet()) {
 				String argument = SystemPropertyFormatter.format(systemProperty.getKey(), systemProperty.getValue());
@@ -327,6 +328,12 @@ public abstract class AbstractRunMojo extends AbstractDependencyFilterMojo {
 		}
 		return new RunArguments(arguments);
 	}
+
+	/**
+	 * Return the application mode to use.
+	 * @return the application mode
+	 */
+	protected abstract String getApplicationMode();
 
 	private void addJvmArgs(List<String> args) {
 		RunArguments jvmArguments = resolveJvmArguments();

--- a/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunMojo.java
+++ b/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunMojo.java
@@ -67,6 +67,11 @@ public class RunMojo extends AbstractRunMojo {
 	}
 
 	@Override
+	protected String getApplicationMode() {
+		return "dev";
+	}
+
+	@Override
 	protected RunArguments resolveJvmArguments() {
 		RunArguments jvmArguments = super.resolveJvmArguments();
 		if (this.optimizedLaunch) {

--- a/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StartMojo.java
+++ b/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StartMojo.java
@@ -101,6 +101,11 @@ public class StartMojo extends AbstractRunMojo {
 	}
 
 	@Override
+	protected String getApplicationMode() {
+		return "test";
+	}
+
+	@Override
 	protected void run(JavaProcessExecutor processExecutor, File workingDirectory, List<String> args,
 			Map<String, String> environmentVariables) throws MojoExecutionException, MojoFailureException {
 		RunProcess runProcess = processExecutor.runAsync(workingDirectory, args, environmentVariables);

--- a/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/TestRunMojo.java
+++ b/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/TestRunMojo.java
@@ -71,6 +71,11 @@ public class TestRunMojo extends AbstractRunMojo {
 	}
 
 	@Override
+	protected String getApplicationMode() {
+		return "dev";
+	}
+
+	@Override
 	protected List<File> getClassesDirectories() {
 		ArrayList<File> classesDirectories = new ArrayList<>(super.getClassesDirectories());
 		classesDirectories.add(0, this.testClassesDirectory);

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootContextLoader.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootContextLoader.java
@@ -326,6 +326,7 @@ public class SpringBootContextLoader extends AbstractContextLoader implements Ao
 		ArrayList<String> properties = new ArrayList<>();
 		// JMX bean names will clash if the same bean is used in multiple contexts
 		properties.add("spring.jmx.enabled=false");
+		properties.add("spring.application.mode=test");
 		properties.addAll(Arrays.asList(mergedConfig.getPropertySourceProperties()));
 		return StringUtils.toStringArray(properties);
 	}

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootContextLoaderTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootContextLoaderTests.java
@@ -78,6 +78,13 @@ class SpringBootContextLoaderTests {
 	}
 
 	@Test
+	void applicationModeDefaultsToTest() {
+		TestContext context = new ExposedTestContextManager(SimpleConfig.class).getExposedTestContext();
+		assertThat(context.getApplicationContext().getEnvironment().getProperty("spring.application.mode"))
+			.isEqualTo("test");
+	}
+
+	@Test
 	void environmentPropertiesSimple() {
 		Map<String, Object> config = getMergedContextConfigurationProperties(SimpleConfig.class);
 		assertKey(config, "key", "myValue");

--- a/core/spring-boot/src/main/java/org/springframework/boot/ApplicationInfoPropertySource.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/ApplicationInfoPropertySource.java
@@ -54,6 +54,7 @@ class ApplicationInfoPropertySource extends MapPropertySource implements Propert
 
 	private static Map<String, Object> getProperties(@Nullable String applicationVersion) {
 		Map<String, Object> result = new HashMap<>();
+		result.put("spring.application.mode", "prod");
 		if (StringUtils.hasText(applicationVersion)) {
 			result.put("spring.application.version", applicationVersion);
 		}

--- a/core/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/spring-boot/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -406,6 +406,12 @@
       }
     },
     {
+      "name": "spring.application.mode",
+      "type": "java.lang.String",
+      "description": "Application bootstrap mode.",
+      "defaultValue": "prod"
+    },
+    {
       "name": "spring.application.name",
       "type": "java.lang.String",
       "sourceType": "org.springframework.boot.context.ContextIdApplicationContextInitializer",
@@ -699,6 +705,23 @@
     }
   ],
   "hints": [
+    {
+      "name": "spring.application.mode",
+      "values": [
+        {
+          "value": "dev",
+          "description": "Application is running as part of a development workflow."
+        },
+        {
+          "value": "test",
+          "description": "Application is running as part of automated tests."
+        },
+        {
+          "value": "prod",
+          "description": "Application is running in production."
+        }
+      ]
+    },
     {
       "name": "logging.group.values",
       "providers": [

--- a/core/spring-boot/src/test/java/org/springframework/boot/ApplicationInfoPropertySourceTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/ApplicationInfoPropertySourceTests.java
@@ -36,6 +36,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ApplicationInfoPropertySourceTests {
 
 	@Test
+	void shouldAddProductionMode() {
+		MockEnvironment environment = new MockEnvironment();
+		environment.getPropertySources().addLast(new ApplicationInfoPropertySource("1.2.3"));
+		assertThat(environment.getProperty("spring.application.mode")).isEqualTo("prod");
+	}
+
+	@Test
+	void shouldAllowApplicationModeToBeOverridden() {
+		MockEnvironment environment = new MockEnvironment();
+		environment.setProperty("spring.application.mode", "dev");
+		environment.getPropertySources().addLast(new ApplicationInfoPropertySource("1.2.3"));
+		assertThat(environment.getProperty("spring.application.mode")).isEqualTo("dev");
+	}
+
+	@Test
 	void shouldAddVersion() {
 		MockEnvironment environment = new MockEnvironment();
 		environment.getPropertySources().addLast(new ApplicationInfoPropertySource("1.2.3"));


### PR DESCRIPTION
## Summary

Adds `spring.application.mode` to identify an application's bootstrap mode:

- `prod` by default
- `test` for Spring Boot test contexts and Maven `spring-boot:start`
- `dev` for Gradle `bootRun`/`bootTestRun` and Maven `spring-boot:run`/`spring-boot:test-run`

The property is exposed through configuration metadata with supported values of `dev`, `test`, and `prod`.

Fixes #46368

## Testing

- Passed focused core and Maven plugin tests.