### PR TITLE
fix: close BufferedWriter/PrintWriter in finally blocks and extract magic number

### DIFF
--- a/loader/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/AbstractJarWriter.java
+++ b/loader/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/AbstractJarWriter.java
@@ -173,11 +173,16 @@ public abstract class AbstractJarWriter implements LoaderClassesWriter {
 			writeEntry(entry, (outputStream) -> {
 				BufferedWriter writer = new BufferedWriter(
 						new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
-				for (String line : lines) {
-					writer.write(line);
-					writer.write("\n");
+				try {
+					for (String line : lines) {
+						writer.write(line);
+						writer.write("\n");
+					}
+					writer.flush();
 				}
-				writer.flush();
+				finally {
+					writer.close();
+				}
 			});
 		}
 	}

--- a/loader/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/LayersIndex.java
+++ b/loader/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/LayersIndex.java
@@ -95,16 +95,21 @@ public class LayersIndex {
 		this.root.buildIndex("", index);
 		index.values().forEach(Collections::sort);
 		BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
-		for (Layer layer : this.layers) {
-			List<String> names = index.get(layer);
-			writer.write("- \"" + layer + "\":\n");
-			if (names != null) {
-				for (String name : names) {
-					writer.write("  - \"" + name + "\"\n");
+		try {
+			for (Layer layer : this.layers) {
+				List<String> names = index.get(layer);
+				writer.write("- \"" + layer + "\":\n");
+				if (names != null) {
+					for (String name : names) {
+						writer.write("  - \"" + name + "\"\n");
+					}
 				}
 			}
+			writer.flush();
 		}
-		writer.flush();
+		finally {
+			writer.close();
+		}
 	}
 
 	/**

--- a/loader/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/RunProcess.java
+++ b/loader/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/RunProcess.java
@@ -39,6 +39,8 @@ public class RunProcess {
 
 	private static final long JUST_ENDED_LIMIT = 500;
 
+	private static final int EXIT_CODE_RUNNING = 5;
+
 	private final @Nullable File workingDirectory;
 
 	private final String[] command;
@@ -92,7 +94,7 @@ public class RunProcess {
 					return 1;
 				}
 			}
-			return 5;
+			return EXIT_CODE_RUNNING;
 		}
 		finally {
 			if (waitForProcess) {

--- a/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/error/DefaultErrorAttributes.java
+++ b/module/spring-boot-webmvc/src/main/java/org/springframework/boot/webmvc/error/DefaultErrorAttributes.java
@@ -215,8 +215,9 @@ public class DefaultErrorAttributes implements ErrorAttributes, HandlerException
 
 	private void addStackTrace(Map<String, @Nullable Object> errorAttributes, Throwable error) {
 		StringWriter stackTrace = new StringWriter();
-		error.printStackTrace(new PrintWriter(stackTrace));
-		stackTrace.flush();
+		try (PrintWriter printWriter = new PrintWriter(stackTrace)) {
+			error.printStackTrace(printWriter);
+		}
 		errorAttributes.put("trace", stackTrace.toString());
 	}
 


### PR DESCRIPTION
## Summary

This PR addresses minor code quality issues found during a code review:

### Changes

1. **`LayersIndex.writeTo()`** - Wrap `BufferedWriter` in `try-finally` to ensure `close()` is called after `flush()`
2. **`AbstractJarWriter.writeIndexFile()`** - Same pattern as above
3. **`DefaultErrorAttributes.addStackTrace()`** - Use `try-with-resources` for `PrintWriter` wrapping `StringWriter`
4. **`RunProcess`** - Extract magic number `5` to `EXIT_CODE_RUNNING` constant

### Files Changed
- `loader/spring-boot-loader-tools/.../LayersIndex.java`
- `loader/spring-boot-loader-tools/.../AbstractJarWriter.java`
- `module/spring-boot-webmvc/.../DefaultErrorAttributes.java`
- `loader/spring-boot-loader-tools/.../RunProcess.java`