### PR TITLE
Support Podman for the Docker Compose feature

### DIFF
--- a/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DockerCli.java
+++ b/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DockerCli.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -36,7 +37,8 @@ import org.springframework.core.log.LogMessage;
 import org.springframework.util.CollectionUtils;
 
 /**
- * Wrapper around {@code docker} and {@code docker-compose} command line tools.
+ * Wrapper around {@code docker} and {@code docker-compose} command line tools. Podman is
+ * supported as an alternative to Docker, see {@link ContainerEngine}.
  *
  * @author Moritz Halbritter
  * @author Andy Wilkinson
@@ -131,59 +133,72 @@ class DockerCli {
 	/**
 	 * Holds details of the actual CLI commands to invoke.
 	 */
-	private static class DockerCommands {
+	static class DockerCommands {
 
 		private final DockerCommand dockerCommand;
 
 		private final DockerCommand dockerComposeCommand;
 
 		DockerCommands(ProcessRunner processRunner) {
-			this.dockerCommand = getDockerCommand(processRunner);
-			this.dockerComposeCommand = getDockerComposeCommand(processRunner);
+			DetectedContainerEngine detected = getContainerEngine(processRunner);
+			this.dockerCommand = new DockerCommand(detected.version(), List.of(detected.engine().command()));
+			this.dockerComposeCommand = getDockerComposeCommand(processRunner, detected.engine());
 		}
 
-		private DockerCommand getDockerCommand(ProcessRunner processRunner) {
-			try {
-				String version = processRunner.run("docker", "version", "--format", "{{.Client.Version}}");
-				logger.trace(LogMessage.format("Using docker %s", version));
-				return new DockerCommand(version, List.of("docker"));
-			}
-			catch (ProcessStartException ex) {
-				throw new DockerProcessStartException("Unable to start docker process. Is docker correctly installed?",
-						ex);
-			}
-			catch (ProcessExitException ex) {
-				if (ex.getStdErr().contains("docker daemon is not running")
-						|| ex.getStdErr().contains("Cannot connect to the Docker daemon")) {
-					throw new DockerNotRunningException(ex.getStdErr(), ex);
+		private static DetectedContainerEngine getContainerEngine(ProcessRunner processRunner) {
+			List<RuntimeException> failures = new ArrayList<>();
+			for (ContainerEngine candidate : ContainerEngine.values()) {
+				try {
+					String version = processRunner.run(candidate.command(), "version", "--format",
+							"{{.Client.Version}}");
+					logger.trace(LogMessage.format("Using %s %s", candidate.command(), version));
+					return new DetectedContainerEngine(candidate, version);
 				}
-				throw ex;
+				catch (ProcessStartException ex) {
+					// Ignore and try the next candidate
+					failures.add(ex);
+				}
+				catch (ProcessExitException ex) {
+					if (candidate.isNotRunning(ex.getStdErr())) {
+						throw new DockerNotRunningException(ex.getStdErr(), ex);
+					}
+					throw ex;
+				}
 			}
+			throw startException("Unable to start docker or podman process. Is docker or podman correctly installed?",
+					failures);
 		}
 
-		private DockerCommand getDockerComposeCommand(ProcessRunner processRunner) {
-			try {
-				DockerCliComposeVersionResponse response = DockerJson.deserialize(
-						processRunner.run("docker", "compose", "version", "--format", "json"),
-						DockerCliComposeVersionResponse.class);
-				logger.trace(LogMessage.format("Using Docker Compose %s", response.version()));
-				return new DockerCommand(response.version(), List.of("docker", "compose"));
+		private static DockerCommand getDockerComposeCommand(ProcessRunner processRunner,
+				ContainerEngine containerEngine) {
+			List<RuntimeException> failures = new ArrayList<>();
+			for (List<String> command : containerEngine.composeCommands()) {
+				try {
+					DockerCliComposeVersionResponse response = DockerJson.deserialize(
+							processRunner.run(join(command, List.of("version", "--format", "json"))),
+							DockerCliComposeVersionResponse.class);
+					logger.trace(LogMessage.format("Using %s %s", String.join(" ", command), response.version()));
+					return new DockerCommand(response.version(), command);
+				}
+				catch (ProcessStartException | ProcessExitException | DockerOutputParseException ex) {
+					// Ignore and try the next candidate
+					failures.add(ex);
+				}
 			}
-			catch (ProcessExitException ex) {
-				// Ignore and try docker-compose
-			}
-			try {
-				DockerCliComposeVersionResponse response = DockerJson.deserialize(
-						processRunner.run("docker-compose", "version", "--format", "json"),
-						DockerCliComposeVersionResponse.class);
-				logger.trace(LogMessage.format("Using docker-compose %s", response.version()));
-				return new DockerCommand(response.version(), List.of("docker-compose"));
-			}
-			catch (ProcessStartException ex) {
-				throw new DockerProcessStartException(
-						"Unable to start 'docker-compose' process or use 'docker compose'. Is docker correctly installed?",
-						ex);
-			}
+			throw startException("Unable to use %s. Is %s correctly installed?"
+				.formatted(containerEngine.describeComposeCommands(), containerEngine.command()), failures);
+		}
+
+		private static String[] join(List<String> command, List<String> arguments) {
+			List<String> result = new ArrayList<>(command);
+			result.addAll(arguments);
+			return result.toArray(String[]::new);
+		}
+
+		private static DockerProcessStartException startException(String message, List<RuntimeException> failures) {
+			DockerProcessStartException result = new DockerProcessStartException(message, failures.get(0));
+			failures.subList(1, failures.size()).forEach(result::addSuppressed);
+			return result;
 		}
 
 		DockerCommand get(Type type) {
@@ -193,9 +208,87 @@ class DockerCli {
 			};
 		}
 
+		/**
+		 * A {@link ContainerEngine} that has been found on the local machine.
+		 *
+		 * @param engine the container engine
+		 * @param version the reported client version
+		 */
+		private record DetectedContainerEngine(ContainerEngine engine, String version) {
+
+		}
+
 	}
 
-	private record DockerCommand(String version, List<String> command) {
+	/**
+	 * Container engines that can be used to run the commands, in the order that they are
+	 * tried.
+	 */
+	enum ContainerEngine {
+
+		/**
+		 * Docker, using either the {@code docker compose} plugin or the standalone
+		 * {@code docker-compose} binary.
+		 */
+		DOCKER("docker", List.of(List.of("docker", "compose"), List.of("docker-compose"))) {
+
+			@Override
+			boolean isNotRunning(String stdErr) {
+				return stdErr.contains("docker daemon is not running")
+						|| stdErr.contains("Cannot connect to the Docker daemon");
+			}
+
+		},
+
+		/**
+		 * Podman. Only {@code podman compose} is used since it delegates to an external
+		 * Docker Compose compatible provider. The {@code podman-compose} binary is not
+		 * supported as its command line arguments and output are not compatible with
+		 * Docker Compose.
+		 */
+		PODMAN("podman", List.of(List.of("podman", "compose"))) {
+
+			@Override
+			boolean isNotRunning(String stdErr) {
+				return stdErr.contains("Cannot connect to Podman");
+			}
+
+		};
+
+		private final String command;
+
+		private final List<List<String>> composeCommands;
+
+		ContainerEngine(String command, List<List<String>> composeCommands) {
+			this.command = command;
+			this.composeCommands = composeCommands;
+		}
+
+		String command() {
+			return this.command;
+		}
+
+		List<List<String>> composeCommands() {
+			return this.composeCommands;
+		}
+
+		String describeComposeCommands() {
+			return this.composeCommands.stream()
+				.map((command) -> "'%s'".formatted(String.join(" ", command)))
+				.collect(Collectors.joining(" or "));
+		}
+
+		/**
+		 * Return if the given standard error output indicates that the engine is
+		 * installed, but not running.
+		 * @param stdErr the standard error output
+		 * @return {@code true} if the engine is not running
+		 */
+		abstract boolean isNotRunning(String stdErr);
+
+	}
+
+	record DockerCommand(String version, List<String> command) {
 
 	}
 

--- a/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DockerJson.java
+++ b/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DockerJson.java
@@ -19,6 +19,7 @@ package org.springframework.boot.docker.compose.core;
 import java.util.List;
 import java.util.Locale;
 
+import tools.jackson.core.JacksonException;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.MapperFeature;
@@ -71,7 +72,12 @@ final class DockerJson {
 	}
 
 	private static <T> T deserialize(String json, JavaType type) {
-		return jsonMapper.readValue(json.trim(), type);
+		try {
+			return jsonMapper.readValue(json.trim(), type);
+		}
+		catch (JacksonException ex) {
+			throw new DockerOutputParseException(json, ex);
+		}
 	}
 
 }

--- a/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DockerCliTests.java
+++ b/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DockerCliTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docker.compose.core;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.docker.compose.core.DockerCli.DockerCommands;
+import org.springframework.boot.docker.compose.core.DockerCliCommand.Type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link DockerCli}.
+ *
+ * @author Martin Imobersteg
+ */
+class DockerCliTests {
+
+	private static final String[] DOCKER_VERSION = { "docker", "version", "--format", "{{.Client.Version}}" };
+
+	private static final String[] PODMAN_VERSION = { "podman", "version", "--format", "{{.Client.Version}}" };
+
+	private static final String[] DOCKER_COMPOSE_VERSION = { "docker", "compose", "version", "--format", "json" };
+
+	private static final String[] DOCKER_COMPOSE_BINARY_VERSION = { "docker-compose", "version", "--format", "json" };
+
+	private static final String[] PODMAN_COMPOSE_VERSION = { "podman", "compose", "version", "--format", "json" };
+
+	private final ProcessRunner processRunner = mock(ProcessRunner.class);
+
+	@Test
+	void usesDockerWhenDockerIsInstalled() {
+		given(this.processRunner.run(DOCKER_VERSION)).willReturn("27.3.1");
+		given(this.processRunner.run(DOCKER_COMPOSE_VERSION)).willReturn("{\"version\":\"v2.30.3\"}");
+		DockerCommands commands = new DockerCommands(this.processRunner);
+		assertThat(commands.get(Type.DOCKER).command()).containsExactly("docker");
+		assertThat(commands.get(Type.DOCKER_COMPOSE).command()).containsExactly("docker", "compose");
+		assertThat(commands.get(Type.DOCKER_COMPOSE).version()).isEqualTo("v2.30.3");
+	}
+
+	@Test
+	void fallsBackToDockerComposeBinaryWhenDockerComposePluginIsNotInstalled() {
+		given(this.processRunner.run(DOCKER_VERSION)).willReturn("27.3.1");
+		willThrow(processExit(DOCKER_COMPOSE_VERSION)).given(this.processRunner).run(DOCKER_COMPOSE_VERSION);
+		given(this.processRunner.run(DOCKER_COMPOSE_BINARY_VERSION)).willReturn("{\"version\":\"v2.30.3\"}");
+		DockerCommands commands = new DockerCommands(this.processRunner);
+		assertThat(commands.get(Type.DOCKER_COMPOSE).command()).containsExactly("docker-compose");
+	}
+
+	@Test
+	void fallsBackToDockerComposeBinaryWhenDockerComposePluginDoesNotReturnJson() {
+		// gh-43440: 'docker' aliased to 'podman' can return non-JSON output here
+		given(this.processRunner.run(DOCKER_VERSION)).willReturn("27.3.1");
+		given(this.processRunner.run(DOCKER_COMPOSE_VERSION)).willReturn("");
+		given(this.processRunner.run(DOCKER_COMPOSE_BINARY_VERSION)).willReturn("{\"version\":\"v2.30.3\"}");
+		DockerCommands commands = new DockerCommands(this.processRunner);
+		assertThat(commands.get(Type.DOCKER_COMPOSE).command()).containsExactly("docker-compose");
+	}
+
+	@Test
+	void usesPodmanWhenDockerIsNotInstalled() {
+		willThrow(processStart(DOCKER_VERSION)).given(this.processRunner).run(DOCKER_VERSION);
+		given(this.processRunner.run(PODMAN_VERSION)).willReturn("5.8.1");
+		given(this.processRunner.run(PODMAN_COMPOSE_VERSION)).willReturn("{\"version\":\"v2.30.3\"}");
+		DockerCommands commands = new DockerCommands(this.processRunner);
+		assertThat(commands.get(Type.DOCKER).command()).containsExactly("podman");
+		assertThat(commands.get(Type.DOCKER).version()).isEqualTo("5.8.1");
+		assertThat(commands.get(Type.DOCKER_COMPOSE).command()).containsExactly("podman", "compose");
+		assertThat(commands.get(Type.DOCKER_COMPOSE).version()).isEqualTo("v2.30.3");
+	}
+
+	@Test
+	void doesNotUsePodmanComposeBinaryWhenPodmanComposeIsNotUsable() {
+		willThrow(processStart(DOCKER_VERSION)).given(this.processRunner).run(DOCKER_VERSION);
+		given(this.processRunner.run(PODMAN_VERSION)).willReturn("5.8.1");
+		willThrow(processExit(PODMAN_COMPOSE_VERSION)).given(this.processRunner).run(PODMAN_COMPOSE_VERSION);
+		assertThatExceptionOfType(DockerProcessStartException.class)
+			.isThrownBy(() -> new DockerCommands(this.processRunner))
+			.withMessageContaining("Unable to use 'podman compose'")
+			.withMessageContaining("Is podman correctly installed?");
+	}
+
+	@Test
+	void failsWhenNeitherDockerNorPodmanIsInstalled() {
+		willThrow(processStart(DOCKER_VERSION)).given(this.processRunner).run(DOCKER_VERSION);
+		willThrow(processStart(PODMAN_VERSION)).given(this.processRunner).run(PODMAN_VERSION);
+		assertThatExceptionOfType(DockerProcessStartException.class)
+			.isThrownBy(() -> new DockerCommands(this.processRunner))
+			.withMessageContaining("Unable to start docker or podman process")
+			.satisfies((ex) -> assertThat(ex.getSuppressed()).hasSize(1));
+	}
+
+	@Test
+	void failsWithDockerNotRunningWhenDockerDaemonIsNotRunning() {
+		willThrow(processExit(DOCKER_VERSION, "Cannot connect to the Docker daemon at unix:///var/run/docker.sock."))
+			.given(this.processRunner)
+			.run(DOCKER_VERSION);
+		assertThatExceptionOfType(DockerNotRunningException.class)
+			.isThrownBy(() -> new DockerCommands(this.processRunner))
+			.satisfies((ex) -> assertThat(ex.getErrorOutput()).contains("Cannot connect to the Docker daemon"));
+	}
+
+	@Test
+	void failsWithDockerNotRunningWhenPodmanMachineIsNotRunning() {
+		willThrow(processStart(DOCKER_VERSION)).given(this.processRunner).run(DOCKER_VERSION);
+		willThrow(processExit(PODMAN_VERSION,
+				"Cannot connect to Podman. Please verify your connection to the Linux "
+						+ "system using `podman system connection list`"))
+			.given(this.processRunner)
+			.run(PODMAN_VERSION);
+		assertThatExceptionOfType(DockerNotRunningException.class)
+			.isThrownBy(() -> new DockerCommands(this.processRunner))
+			.satisfies((ex) -> assertThat(ex.getErrorOutput()).contains("Cannot connect to Podman"));
+	}
+
+	private ProcessStartException processStart(String[] command) {
+		return new ProcessStartException(command, new IOException("Cannot run program \"%s\"".formatted(command[0])));
+	}
+
+	private ProcessExitException processExit(String[] command) {
+		return processExit(command, "");
+	}
+
+	private ProcessExitException processExit(String[] command, String stdErr) {
+		return new ProcessExitException(1, command, "", stdErr);
+	}
+
+}

--- a/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DockerJsonTests.java
+++ b/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DockerJsonTests.java
@@ -22,6 +22,7 @@ import java.util.Locale;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * Tests for {@link DockerJson}.
@@ -67,6 +68,20 @@ class DockerJsonTests {
 				""";
 		List<TestResponse> response = DockerJson.deserializeToList(json, TestResponse.class);
 		assertThat(response).containsExactly(new TestResponse(1), new TestResponse(2));
+	}
+
+	@Test
+	void deserializeWhenNotJsonThrowsException() {
+		assertThatExceptionOfType(DockerOutputParseException.class)
+			.isThrownBy(() -> DockerJson.deserialize("podman-compose version 1.3.0", TestResponse.class))
+			.withMessageContaining("Failed to parse docker JSON");
+	}
+
+	@Test
+	void deserializeWhenEmptyThrowsException() {
+		assertThatExceptionOfType(DockerOutputParseException.class)
+			.isThrownBy(() -> DockerJson.deserialize("", TestResponse.class))
+			.withMessageContaining("Failed to parse docker JSON");
 	}
 
 	@Test

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/dev-services.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/dev-services.adoc
@@ -61,6 +61,11 @@ When using the Gradle plugin, xref:gradle-plugin:packaging.adoc#packaging-execut
 You need to have the `docker` and `docker compose` (or `docker-compose`) CLI applications on your path.
 The minimum supported Docker Compose version is 2.2.0.
 
+Podman can be used instead of Docker.
+If the `docker` CLI application is not on your path, the `podman` and `podman compose` CLI applications are used instead.
+Note that `podman compose` delegates to an external Docker Compose compatible provider which must also be installed.
+The `podman-compose` application is not supported, since its command line arguments and output are not compatible with Docker Compose.
+
 
 
 [[features.dev-services.docker-compose.service-connections]]


### PR DESCRIPTION
Update DockerCli to fall back to podman and podman compose when the
docker CLI application is not available. Podman's CLI is compatible
with Docker for the version, context ls and inspect commands that are
used, and podman compose is a thin wrapper that delegates to an
external Docker Compose compatible provider. As a result, no changes
to the generated command lines are needed.

podman-compose is deliberately not supported as its command line
arguments and output are not compatible with Docker Compose. When it
is the provider in use, version --format json exits with a non-zero
code and a DockerProcessStartException naming the commands that were
tried is thrown instead.

Compose command detection now also moves on to the next candidate when
the output cannot be parsed, rather than only when the process exits
with a non-zero code. This fixes the originally reported failure where
docker was aliased to podman and 'docker compose version --format
json' returned no JSON. Parse failures are once again wrapped in
DockerOutputParseException, which the fallback relies on; the wrapping
was inadvertently dropped during the Jackson 3 migration.

Fixes #43440

Authored-By: Claude Opus 5 <noreply@anthropic.com>