### PR TITLE
Add an @XmlTest test slice similar to @JsonTest

### DIFF
--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/AutoConfigureXml.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/AutoConfigureXml.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.xml;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+
+/**
+ * {@link ImportAutoConfiguration Auto-configuration imports} for typical XML tests. Most
+ * tests should consider using {@link XmlTest @XmlTest} rather than using this annotation
+ * directly.
+ *
+ * @author Tiziano Basile
+ * @since 4.2.0
+ * @see XmlTest
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ImportAutoConfiguration
+public @interface AutoConfigureXml {
+
+}

--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/AutoConfigureXmlTesters.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/AutoConfigureXmlTesters.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.xml;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.PropertyMapping;
+import org.springframework.boot.test.xml.JacksonXmlTester;
+
+/**
+ * Annotation that can be applied to a test class to enable and configure
+ * auto-configuration of XML testers.
+ *
+ * @author Tiziano Basile
+ * @since 4.2.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@AutoConfigureXml
+@ImportAutoConfiguration
+@PropertyMapping("spring.test.xmltesters")
+public @interface AutoConfigureXmlTesters {
+
+	/**
+	 * If {@link JacksonXmlTester} beans should be registered. Defaults to {@code true}.
+	 * @return if tester support is enabled
+	 */
+	boolean enabled() default true;
+
+}

--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/ConditionalOnXmlTesters.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/ConditionalOnXmlTesters.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.xml;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Conditional;
+
+/**
+ * {@link Conditional @Conditional} that checks if XML testers are enabled.
+ *
+ * @author Tiziano Basile
+ * @since 4.2.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Documented
+@ConditionalOnBooleanProperty("spring.test.xmltesters.enabled")
+@ConditionalOnClass(name = "org.assertj.core.api.Assert")
+public @interface ConditionalOnXmlTesters {
+
+}

--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/XmlMarshalTesterRuntimeHints.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/XmlMarshalTesterRuntimeHints.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.xml;
+
+import java.lang.reflect.Method;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.aot.hint.ExecutableMode;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.ReflectionHints;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.boot.test.xml.AbstractXmlMarshalTester;
+import org.springframework.core.ResolvableType;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Base class for {@link AbstractXmlMarshalTester} runtime hints.
+ *
+ * @author Tiziano Basile
+ * @since 4.2.0
+ */
+@SuppressWarnings("rawtypes")
+public abstract class XmlMarshalTesterRuntimeHints implements RuntimeHintsRegistrar {
+
+	private final Class<? extends AbstractXmlMarshalTester> tester;
+
+	protected XmlMarshalTesterRuntimeHints(Class<? extends AbstractXmlMarshalTester> tester) {
+		this.tester = tester;
+	}
+
+	@Override
+	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+		ReflectionHints reflection = hints.reflection();
+		reflection.registerType(this.tester, MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
+		Method method = ReflectionUtils.findMethod(this.tester, "initialize", Class.class, ResolvableType.class);
+		Assert.state(method != null, "'method' must not be null");
+		reflection.registerMethod(method, ExecutableMode.INVOKE);
+	}
+
+}

--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/XmlTest.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/XmlTest.java
@@ -39,6 +39,11 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 /**
  * Annotation for an XML test that focuses <strong>only</strong> on XML serialization.
  * <p>
+ * This slice supports <strong>Jackson XML only</strong>. It auto-configures Jackson's
+ * {@code XmlMapper} and initializes {@link JacksonXmlTester} fields. Neither JAXB nor the
+ * deprecated Jackson 2 XML support ({@code com.fasterxml.jackson.dataformat.xml}) is
+ * auto-configured, and no tester is provided for either of them.
+ * <p>
  * Using this annotation only enables auto-configuration that is relevant to XML tests.
  * Similarly, component scanning is limited to beans annotated with:
  * <ul>

--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/XmlTest.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/XmlTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.xml;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
+import org.springframework.boot.test.context.filter.annotation.TypeExcludeFilters;
+import org.springframework.boot.test.xml.JacksonXmlTester;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Annotation for an XML test that focuses <strong>only</strong> on XML serialization.
+ * <p>
+ * Using this annotation only enables auto-configuration that is relevant to XML tests.
+ * Similarly, component scanning is limited to beans annotated with:
+ * <ul>
+ * <li>{@code @JacksonComponent}</li>
+ * </ul>
+ * <p>
+ * as well as beans that implement:
+ * <ul>
+ * <li>{@code JacksonModule}, if Jackson is available</li>
+ * </ul>
+ * <p>
+ * By default, tests annotated with {@code XmlTest} will also initialize
+ * {@link JacksonXmlTester} fields. More fine-grained control can be provided through the
+ * {@link AutoConfigureXmlTesters @AutoConfigureXmlTesters} annotation.
+ *
+ * @author Tiziano Basile
+ * @since 4.2.0
+ * @see AutoConfigureXml
+ * @see AutoConfigureXmlTesters
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@BootstrapWith(XmlTestContextBootstrapper.class)
+@ExtendWith(SpringExtension.class)
+@OverrideAutoConfiguration(enabled = false)
+@TypeExcludeFilters(XmlTypeExcludeFilter.class)
+@AutoConfigureXmlTesters
+@ImportAutoConfiguration
+public @interface XmlTest {
+
+	/**
+	 * Properties in form {@literal key=value} that should be added to the Spring
+	 * {@link Environment} before the test runs.
+	 * @return the properties to add
+	 */
+	String[] properties() default {};
+
+	/**
+	 * Determines if default filtering should be used with
+	 * {@link SpringBootApplication @SpringBootApplication}. By default, only
+	 * {@code @JacksonComponent} and {@code JacksonModule} beans are included.
+	 * @return if default filters should be used
+	 * @see #includeFilters()
+	 * @see #excludeFilters()
+	 */
+	boolean useDefaultFilters() default true;
+
+	/**
+	 * A set of include filters which can be used to add otherwise filtered beans to the
+	 * application context.
+	 * @return include filters to apply
+	 */
+	Filter[] includeFilters() default {};
+
+	/**
+	 * A set of exclude filters which can be used to filter beans that would otherwise be
+	 * added to the application context.
+	 * @return exclude filters to apply
+	 */
+	Filter[] excludeFilters() default {};
+
+	/**
+	 * Auto-configuration exclusions that should be applied for this test.
+	 * @return auto-configuration exclusions to apply
+	 */
+	@AliasFor(annotation = ImportAutoConfiguration.class, attribute = "exclude")
+	Class<?>[] excludeAutoConfiguration() default {};
+
+}

--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/XmlTestContextBootstrapper.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/XmlTestContextBootstrapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.xml;
+
+import org.springframework.boot.test.autoconfigure.TestSliceTestContextBootstrapper;
+import org.springframework.test.context.TestContextBootstrapper;
+
+/**
+ * {@link TestContextBootstrapper} for {@link XmlTest @XmlTest} support.
+ *
+ * @author Tiziano Basile
+ */
+class XmlTestContextBootstrapper extends TestSliceTestContextBootstrapper<XmlTest> {
+
+}

--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/XmlTestersAutoConfiguration.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/XmlTestersAutoConfiguration.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.xml;
+
+import java.lang.reflect.Field;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.beans.factory.config.InstantiationAwareBeanPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.test.xml.AbstractXmlMarshalTester;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.ResolvableType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Auto-configuration for XML testers.
+ *
+ * @author Tiziano Basile
+ * @since 4.2.0
+ * @see AutoConfigureXmlTesters
+ */
+@AutoConfiguration
+@ConditionalOnXmlTesters
+public final class XmlTestersAutoConfiguration {
+
+	@Bean
+	static XmlMarshalTestersBeanPostProcessor xmlMarshalTestersBeanPostProcessor() {
+		return new XmlMarshalTestersBeanPostProcessor();
+	}
+
+	/**
+	 * {@link BeanPostProcessor} used to initialize XML testers.
+	 */
+	static class XmlMarshalTestersBeanPostProcessor implements InstantiationAwareBeanPostProcessor {
+
+		@Override
+		public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+			ReflectionUtils.doWithFields(bean.getClass(), (field) -> processField(bean, field));
+			return bean;
+		}
+
+		private void processField(Object bean, Field field) {
+			if (AbstractXmlMarshalTester.class.isAssignableFrom(field.getType())) {
+				initializeTester(bean, field, bean.getClass(), ResolvableType.forField(field).getGeneric());
+			}
+		}
+
+		private void initializeTester(Object bean, Field field, Object... args) {
+			ReflectionUtils.makeAccessible(field);
+			Object tester = ReflectionUtils.getField(field, bean);
+			if (tester != null) {
+				ReflectionTestUtils.invokeMethod(tester, "initialize", args);
+			}
+		}
+
+	}
+
+}

--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/XmlTestersAutoConfiguration.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/XmlTestersAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.test.xml.AbstractXmlMarshalTester;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.ResolvableType;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
 
 /**
@@ -57,16 +58,22 @@ public final class XmlTestersAutoConfiguration {
 
 		private void processField(Object bean, Field field) {
 			if (AbstractXmlMarshalTester.class.isAssignableFrom(field.getType())) {
-				initializeTester(bean, field, bean.getClass(), ResolvableType.forField(field).getGeneric());
+				ReflectionUtils.makeAccessible(field);
+				Object tester = ReflectionUtils.getField(field, bean);
+				if (tester != null) {
+					ReflectionTestUtils.invokeMethod(tester, "initialize", bean.getClass(), getTypeUnderTest(field));
+				}
 			}
 		}
 
-		private void initializeTester(Object bean, Field field, Object... args) {
-			ReflectionUtils.makeAccessible(field);
-			Object tester = ReflectionUtils.getField(field, bean);
-			if (tester != null) {
-				ReflectionTestUtils.invokeMethod(tester, "initialize", args);
-			}
+		private ResolvableType getTypeUnderTest(Field field) {
+			ResolvableType type = ResolvableType.forField(field).getGeneric();
+			Assert.state(type.resolve() != null,
+					() -> "Unable to determine the type under test for field '" + field.getName() + "' of "
+							+ field.getDeclaringClass().getName() + ". Declare the field with an explicit generic "
+							+ "type, for example '" + field.getType().getSimpleName() + "<MyType> " + field.getName()
+							+ ";'.");
+			return type;
 		}
 
 	}

--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/XmlTypeExcludeFilter.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/XmlTypeExcludeFilter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.xml;
+
+import org.springframework.boot.context.TypeExcludeFilter;
+import org.springframework.boot.test.context.filter.annotation.StandardAnnotationCustomizableTypeExcludeFilter;
+
+/**
+ * {@link TypeExcludeFilter} for {@link XmlTest @XmlTest}.
+ *
+ * @author Tiziano Basile
+ */
+class XmlTypeExcludeFilter extends StandardAnnotationCustomizableTypeExcludeFilter<XmlTest> {
+
+	XmlTypeExcludeFilter(Class<?> testClass) {
+		super(testClass);
+	}
+
+}

--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/package-info.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/xml/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for XML tests.
+ */
+@NullMarked
+package org.springframework.boot.test.autoconfigure.xml;
+
+import org.jspecify.annotations.NullMarked;

--- a/core/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/core/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -19,6 +19,12 @@
       "type": "java.lang.Boolean",
       "description": "Whether the condition evaluation report should be printed when the ApplicationContext fails to start.",
       "defaultValue": true
+    },
+    {
+      "name": "spring.test.xmltesters.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether auto-configuration of XML testers is enabled.",
+      "defaultValue": "true"
     }
   ]
 }

--- a/core/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.xml.AutoConfigureXmlTesters.imports
+++ b/core/spring-boot-test-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.xml.AutoConfigureXmlTesters.imports
@@ -1,0 +1,1 @@
+org.springframework.boot.test.autoconfigure.xml.XmlTestersAutoConfiguration

--- a/core/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/xml/ExampleXmlApplication.java
+++ b/core/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/xml/ExampleXmlApplication.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.xml;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Example {@link SpringBootApplication @SpringBootApplication} for use with
+ * {@link XmlTest @XmlTest} tests.
+ *
+ * @author Tiziano Basile
+ */
+@SpringBootApplication
+public class ExampleXmlApplication {
+
+}

--- a/core/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/xml/ExampleXmlMarshalTester.java
+++ b/core/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/xml/ExampleXmlMarshalTester.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.xml;
+
+import java.io.InputStream;
+import java.io.Reader;
+
+import org.springframework.boot.test.xml.AbstractXmlMarshalTester;
+import org.springframework.core.ResolvableType;
+import org.springframework.util.Assert;
+
+/**
+ * Example {@link AbstractXmlMarshalTester} used to check that XML testers are
+ * initialized. The marshalling methods are never called, only the initialization applied
+ * by {@link XmlTestersAutoConfiguration} is of interest.
+ *
+ * @param <T> the type under test
+ * @author Tiziano Basile
+ */
+class ExampleXmlMarshalTester<T> extends AbstractXmlMarshalTester<T> {
+
+	boolean isInitialized() {
+		return getType() != null;
+	}
+
+	ResolvableType getTypeUnderTest() {
+		ResolvableType type = getType();
+		Assert.state(type != null, "Tester has not been initialized");
+		return type;
+	}
+
+	@Override
+	protected String writeObject(T value, ResolvableType type) {
+		throw new UnsupportedOperationException("Not used by these tests");
+	}
+
+	@Override
+	protected T readObject(InputStream inputStream, ResolvableType type) {
+		throw new UnsupportedOperationException("Not used by these tests");
+	}
+
+	@Override
+	protected T readObject(Reader reader, ResolvableType type) {
+		throw new UnsupportedOperationException("Not used by these tests");
+	}
+
+}

--- a/core/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/xml/SpringBootTestWithAutoConfigureXmlTestersTests.java
+++ b/core/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/xml/SpringBootTestWithAutoConfigureXmlTestersTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.xml;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.xml.XmlTestersAutoConfiguration.XmlMarshalTestersBeanPostProcessor;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link SpringBootTest @SpringBootTest} with
+ * {@link AutoConfigureXmlTesters @AutoConfigureXmlTesters}. Proves that the
+ * {@code spring.test.xmltesters} property mapping is correct, as
+ * {@link XmlTestersAutoConfiguration} would otherwise back off silently.
+ *
+ * @author Tiziano Basile
+ */
+@SpringBootTest
+@AutoConfigureXmlTesters
+@ContextConfiguration(classes = ExampleXmlApplication.class)
+class SpringBootTestWithAutoConfigureXmlTestersTests {
+
+	private final ExampleXmlMarshalTester<String> xml = new ExampleXmlMarshalTester<>();
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Autowired
+	private Environment environment;
+
+	@Test
+	void propertyMappingWhenAutoConfigureXmlTestersThenTestersAreEnabled() {
+		assertThat(this.environment.getProperty("spring.test.xmltesters.enabled")).isEqualTo("true");
+	}
+
+	@Test
+	void contextWhenAutoConfigureXmlTestersThenBeanPostProcessorIsRegistered() {
+		assertThat(this.applicationContext.getBeansOfType(XmlMarshalTestersBeanPostProcessor.class)).hasSize(1);
+	}
+
+	@Test
+	void testerWhenAutoConfigureXmlTestersThenIsInitialized() {
+		assertThat(this.xml.isInitialized()).isTrue();
+		assertThat(this.xml.getTypeUnderTest().resolve()).isEqualTo(String.class);
+	}
+
+}

--- a/core/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/xml/XmlTestPropertiesIntegrationTests.java
+++ b/core/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/xml/XmlTestPropertiesIntegrationTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.xml;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the {@link XmlTest#properties properties} attribute of
+ * {@link XmlTest @XmlTest}.
+ *
+ * @author Tiziano Basile
+ */
+@XmlTest(properties = { "spring.profiles.active=test", "example.property=example-value" })
+class XmlTestPropertiesIntegrationTests {
+
+	@Autowired
+	private Environment environment;
+
+	@Test
+	void environmentWhenPropertiesAreDeclaredThenContainsThem() {
+		assertThat(this.environment.getActiveProfiles()).containsExactly("test");
+		assertThat(this.environment.getProperty("example.property")).isEqualTo("example-value");
+	}
+
+	@Nested
+	class NestedTests {
+
+		@Autowired
+		private Environment innerEnvironment;
+
+		@Test
+		void propertiesFromEnclosingClassAffectNestedTests() {
+			assertThat(XmlTestPropertiesIntegrationTests.this.environment.getActiveProfiles()).containsExactly("test");
+			assertThat(this.innerEnvironment.getActiveProfiles()).containsExactly("test");
+			assertThat(this.innerEnvironment.getProperty("example.property")).isEqualTo("example-value");
+		}
+
+	}
+
+}

--- a/core/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/xml/XmlTestersAutoConfigurationTests.java
+++ b/core/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/xml/XmlTestersAutoConfigurationTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.xml;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.autoconfigure.xml.XmlTestersAutoConfiguration.XmlMarshalTestersBeanPostProcessor;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+/**
+ * Tests for {@link XmlTestersAutoConfiguration}.
+ *
+ * @author Tiziano Basile
+ */
+class XmlTestersAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(XmlTestersAutoConfiguration.class));
+
+	private final XmlMarshalTestersBeanPostProcessor postProcessor = new XmlMarshalTestersBeanPostProcessor();
+
+	@Test
+	void contextWhenTestersAreEnabledThenBeanPostProcessorIsRegistered() {
+		this.contextRunner.withPropertyValues("spring.test.xmltesters.enabled=true")
+			.run((context) -> assertThat(context).hasSingleBean(XmlMarshalTestersBeanPostProcessor.class));
+	}
+
+	@Test
+	void contextWhenTestersAreNotEnabledThenBeanPostProcessorIsNotRegistered() {
+		this.contextRunner
+			.run((context) -> assertThat(context).doesNotHaveBean(XmlMarshalTestersBeanPostProcessor.class));
+	}
+
+	@Test
+	void contextWhenTestersAreDisabledThenBeanPostProcessorIsNotRegistered() {
+		this.contextRunner.withPropertyValues("spring.test.xmltesters.enabled=false")
+			.run((context) -> assertThat(context).doesNotHaveBean(XmlMarshalTestersBeanPostProcessor.class));
+	}
+
+	@Test
+	void postProcessWhenFieldHasGenericTypeThenTesterIsInitialized() {
+		TypedTesterBean bean = new TypedTesterBean();
+		this.postProcessor.postProcessAfterInitialization(bean, "typedTesterBean");
+		assertThat(bean.xml.isInitialized()).isTrue();
+		assertThat(bean.xml.getTypeUnderTest().resolve()).isEqualTo(String.class);
+	}
+
+	@Test
+	void postProcessWhenFieldIsNullThenTesterIsNotInitialized() {
+		NoTesterBean bean = new NoTesterBean();
+		this.postProcessor.postProcessAfterInitialization(bean, "noTesterBean");
+		assertThat(bean.xml).isNull();
+	}
+
+	@Test
+	void postProcessWhenFieldIsRawThenFailsNamingTheField() {
+		RawTesterBean bean = new RawTesterBean();
+		assertThatIllegalStateException()
+			.isThrownBy(() -> this.postProcessor.postProcessAfterInitialization(bean, "rawTesterBean"))
+			.withMessageContaining("Unable to determine the type under test for field 'xml'")
+			.withMessageContaining(RawTesterBean.class.getName())
+			.withMessageContaining("ExampleXmlMarshalTester<MyType> xml;");
+	}
+
+	@Test
+	void postProcessWhenFieldIsWildcardThenFailsNamingTheField() {
+		WildcardTesterBean bean = new WildcardTesterBean();
+		assertThatIllegalStateException()
+			.isThrownBy(() -> this.postProcessor.postProcessAfterInitialization(bean, "wildcardTesterBean"))
+			.withMessageContaining("Unable to determine the type under test for field 'xml'")
+			.withMessageContaining(WildcardTesterBean.class.getName());
+	}
+
+	static class TypedTesterBean {
+
+		private final ExampleXmlMarshalTester<String> xml = new ExampleXmlMarshalTester<>();
+
+	}
+
+	static class NoTesterBean {
+
+		private @Nullable ExampleXmlMarshalTester<String> xml;
+
+	}
+
+	@SuppressWarnings("rawtypes")
+	static class RawTesterBean {
+
+		private final ExampleXmlMarshalTester xml = new ExampleXmlMarshalTester<>();
+
+	}
+
+	static class WildcardTesterBean {
+
+		private final ExampleXmlMarshalTester<?> xml = new ExampleXmlMarshalTester<String>();
+
+	}
+
+}

--- a/core/spring-boot-test/build.gradle
+++ b/core/spring-boot-test/build.gradle
@@ -45,7 +45,9 @@ dependencies {
 	optional("org.seleniumhq.selenium:selenium-api")
 	optional("org.skyscreamer:jsonassert")
 	optional("org.springframework:spring-web")
+	optional("org.xmlunit:xmlunit-core")
 	optional("tools.jackson.core:jackson-databind")
+	optional("tools.jackson.dataformat:jackson-dataformat-xml")
 
 	testImplementation(project(":test-support:spring-boot-test-support"))
 	testImplementation("ch.qos.logback:logback-classic")

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/AbstractXmlMarshalTester.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/AbstractXmlMarshalTester.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.xml;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.lang.reflect.Field;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.boot.test.json.ObjectContent;
+import org.springframework.boot.test.json.ObjectContentAssert;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Base class for AssertJ based XML marshal testers. Exposes specific Asserts following a
+ * {@code read}, {@code write} or {@code parse} of XML content. Typically used in
+ * combination with an AssertJ {@link org.assertj.core.api.Assertions#assertThat(Object)
+ * assertThat} call. For example:
+ *
+ * <pre class="code">
+ * public class ExampleObjectXmlTests {
+ *
+ *     private AbstractXmlMarshalTester&lt;ExampleObject&gt; xml = //...
+ *
+ *     &#064;Test
+ *     public void testWriteXml() {
+ *         ExampleObject object = //...
+ *         assertThat(xml.write(object)).isSimilarToXml("expected.xml");
+ *         assertThat(xml.read("expected.xml")).isEqualTo(object);
+ *     }
+ *
+ * }
+ * </pre>
+ *
+ * For a complete list of supported assertions see {@link XmlContentAssert} and
+ * {@link ObjectContentAssert}.
+ * <p>
+ * To use this library XMLUnit must be on the test classpath.
+ *
+ * @param <T> the type under test
+ * @author Tiziano Basile
+ * @since 4.2.0
+ * @see XmlContentAssert
+ * @see ObjectContentAssert
+ */
+public abstract class AbstractXmlMarshalTester<T> {
+
+	private @Nullable Class<?> resourceLoadClass;
+
+	private @Nullable ResolvableType type;
+
+	/**
+	 * Create a new uninitialized {@link AbstractXmlMarshalTester} instance.
+	 */
+	protected AbstractXmlMarshalTester() {
+	}
+
+	/**
+	 * Create a new {@link AbstractXmlMarshalTester} instance.
+	 * @param resourceLoadClass the source class used when loading relative classpath
+	 * resources
+	 * @param type the type under test
+	 */
+	public AbstractXmlMarshalTester(Class<?> resourceLoadClass, ResolvableType type) {
+		Assert.notNull(resourceLoadClass, "'resourceLoadClass' must not be null");
+		Assert.notNull(type, "'type' must not be null");
+		initialize(resourceLoadClass, type);
+	}
+
+	/**
+	 * Initialize the marshal tester for use.
+	 * @param resourceLoadClass the source class used when loading relative classpath
+	 * resources
+	 * @param type the type under test
+	 */
+	protected final void initialize(Class<?> resourceLoadClass, ResolvableType type) {
+		if (this.resourceLoadClass == null && this.type == null) {
+			this.resourceLoadClass = resourceLoadClass;
+			this.type = type;
+		}
+	}
+
+	/**
+	 * Return the type under test.
+	 * @return the type under test
+	 */
+	protected final @Nullable ResolvableType getType() {
+		return this.type;
+	}
+
+	private ResolvableType getTypeNotNull() {
+		ResolvableType type = getType();
+		Assert.state(type != null, "Instance has not been initialized");
+		return type;
+	}
+
+	/**
+	 * Return class used to load relative resources.
+	 * @return the resource load class
+	 */
+	protected final @Nullable Class<?> getResourceLoadClass() {
+		return this.resourceLoadClass;
+	}
+
+	private Class<?> getResourceLoadClassNotNull() {
+		Class<?> resourceLoadClass = getResourceLoadClass();
+		Assert.state(resourceLoadClass != null, "Instance has not been initialized");
+		return resourceLoadClass;
+	}
+
+	/**
+	 * Return {@link XmlContent} from writing the specific value.
+	 * @param value the value to write
+	 * @return the {@link XmlContent}
+	 * @throws IOException on write error
+	 */
+	public XmlContent<T> write(T value) throws IOException {
+		verify();
+		Assert.notNull(value, "'value' must not be null");
+		String xml = writeObject(value, getTypeNotNull());
+		return getXmlContent(xml);
+	}
+
+	/**
+	 * Factory method used to get an {@link XmlContent} instance from a source XML string.
+	 * @param xml the source XML
+	 * @return a new {@link XmlContent} instance
+	 */
+	protected XmlContent<T> getXmlContent(String xml) {
+		return new XmlContent<>(getResourceLoadClassNotNull(), getType(), xml);
+	}
+
+	/**
+	 * Return the object created from parsing the specific XML bytes.
+	 * @param xmlBytes the source XML bytes
+	 * @return the resulting object
+	 * @throws IOException on parse error
+	 */
+	public T parseObject(byte[] xmlBytes) throws IOException {
+		verify();
+		return parse(xmlBytes).getObject();
+	}
+
+	/**
+	 * Return {@link ObjectContent} from parsing the specific XML bytes.
+	 * @param xmlBytes the source XML bytes
+	 * @return the {@link ObjectContent}
+	 * @throws IOException on parse error
+	 */
+	public ObjectContent<T> parse(byte[] xmlBytes) throws IOException {
+		verify();
+		Assert.notNull(xmlBytes, "'xmlBytes' must not be null");
+		return read(new ByteArrayResource(xmlBytes));
+	}
+
+	/**
+	 * Return the object created from parsing the specific XML String.
+	 * @param xmlString the source XML string
+	 * @return the resulting object
+	 * @throws IOException on parse error
+	 */
+	public T parseObject(String xmlString) throws IOException {
+		verify();
+		return parse(xmlString).getObject();
+	}
+
+	/**
+	 * Return {@link ObjectContent} from parsing the specific XML String.
+	 * @param xmlString the source XML string
+	 * @return the {@link ObjectContent}
+	 * @throws IOException on parse error
+	 */
+	public ObjectContent<T> parse(String xmlString) throws IOException {
+		verify();
+		Assert.notNull(xmlString, "'xmlString' must not be null");
+		return read(new StringReader(xmlString));
+	}
+
+	/**
+	 * Return the object created from reading from the specified classpath resource.
+	 * @param resourcePath the source resource path. May be a full path or a path relative
+	 * to the {@code resourceLoadClass} passed to the constructor
+	 * @return the resulting object
+	 * @throws IOException on read error
+	 */
+	public T readObject(String resourcePath) throws IOException {
+		verify();
+		return read(resourcePath).getObject();
+	}
+
+	/**
+	 * Return {@link ObjectContent} from reading from the specified classpath resource.
+	 * @param resourcePath the source resource path. May be a full path or a path relative
+	 * to the {@code resourceLoadClass} passed to the constructor
+	 * @return the {@link ObjectContent}
+	 * @throws IOException on read error
+	 */
+	public ObjectContent<T> read(String resourcePath) throws IOException {
+		verify();
+		Assert.notNull(resourcePath, "'resourcePath' must not be null");
+		return read(new ClassPathResource(resourcePath, this.resourceLoadClass));
+	}
+
+	/**
+	 * Return the object created from reading from the specified file.
+	 * @param file the source file
+	 * @return the resulting object
+	 * @throws IOException on read error
+	 */
+	public T readObject(File file) throws IOException {
+		verify();
+		return read(file).getObject();
+	}
+
+	/**
+	 * Return {@link ObjectContent} from reading from the specified file.
+	 * @param file the source file
+	 * @return the {@link ObjectContent}
+	 * @throws IOException on read error
+	 */
+	public ObjectContent<T> read(File file) throws IOException {
+		verify();
+		Assert.notNull(file, "'file' must not be null");
+		return read(new FileSystemResource(file));
+	}
+
+	/**
+	 * Return the object created from reading from the specified input stream.
+	 * @param inputStream the source input stream
+	 * @return the resulting object
+	 * @throws IOException on read error
+	 */
+	public T readObject(InputStream inputStream) throws IOException {
+		verify();
+		return read(inputStream).getObject();
+	}
+
+	/**
+	 * Return {@link ObjectContent} from reading from the specified input stream.
+	 * @param inputStream the source input stream
+	 * @return the {@link ObjectContent}
+	 * @throws IOException on read error
+	 */
+	public ObjectContent<T> read(InputStream inputStream) throws IOException {
+		verify();
+		Assert.notNull(inputStream, "'inputStream' must not be null");
+		return read(new InputStreamResource(inputStream));
+	}
+
+	/**
+	 * Return the object created from reading from the specified resource.
+	 * @param resource the source resource
+	 * @return the resulting object
+	 * @throws IOException on read error
+	 */
+	public T readObject(Resource resource) throws IOException {
+		verify();
+		return read(resource).getObject();
+	}
+
+	/**
+	 * Return {@link ObjectContent} from reading from the specified resource.
+	 * @param resource the source resource
+	 * @return the {@link ObjectContent}
+	 * @throws IOException on read error
+	 */
+	public ObjectContent<T> read(Resource resource) throws IOException {
+		verify();
+		Assert.notNull(resource, "'resource' must not be null");
+		InputStream inputStream = resource.getInputStream();
+		T object = readObject(inputStream, getTypeNotNull());
+		closeQuietly(inputStream);
+		return new ObjectContent<>(this.type, object);
+	}
+
+	/**
+	 * Return the object created from reading from the specified reader.
+	 * @param reader the source reader
+	 * @return the resulting object
+	 * @throws IOException on read error
+	 */
+	public T readObject(Reader reader) throws IOException {
+		verify();
+		return read(reader).getObject();
+	}
+
+	/**
+	 * Return {@link ObjectContent} from reading from the specified reader.
+	 * @param reader the source reader
+	 * @return the {@link ObjectContent}
+	 * @throws IOException on read error
+	 */
+	public ObjectContent<T> read(Reader reader) throws IOException {
+		verify();
+		Assert.notNull(reader, "'reader' must not be null");
+		T object = readObject(reader, getTypeNotNull());
+		closeQuietly(reader);
+		return new ObjectContent<>(this.type, object);
+	}
+
+	private void closeQuietly(Closeable closeable) {
+		try {
+			closeable.close();
+		}
+		catch (IOException ex) {
+			// Ignore
+		}
+	}
+
+	private void verify() {
+		Assert.state(this.resourceLoadClass != null, "Uninitialized XmlMarshalTester (ResourceLoadClass is null)");
+		Assert.state(this.type != null, "Uninitialized XmlMarshalTester (Type is null)");
+	}
+
+	/**
+	 * Write the specified object to an XML string.
+	 * @param value the source value (never {@code null})
+	 * @param type the resulting type (never {@code null})
+	 * @return the XML string
+	 * @throws IOException on write error
+	 */
+	protected abstract String writeObject(T value, ResolvableType type) throws IOException;
+
+	/**
+	 * Read from the specified input stream to create an object of the specified type. The
+	 * default implementation delegates to {@link #readObject(Reader, ResolvableType)}.
+	 * @param inputStream the source input stream (never {@code null})
+	 * @param type the resulting type (never {@code null})
+	 * @return the resulting object
+	 * @throws IOException on read error
+	 */
+	protected T readObject(InputStream inputStream, ResolvableType type) throws IOException {
+		BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+		return readObject(reader, type);
+	}
+
+	/**
+	 * Read from the specified reader to create an object of the specified type.
+	 * @param reader the source reader (never {@code null})
+	 * @param type the resulting type (never {@code null})
+	 * @return the resulting object
+	 * @throws IOException on read error
+	 */
+	protected abstract T readObject(Reader reader, ResolvableType type) throws IOException;
+
+	/**
+	 * Utility class used to support field initialization. Used by subclasses to support
+	 * {@code initFields}.
+	 *
+	 * @param <M> the marshaller type
+	 */
+	protected abstract static class FieldInitializer<M> {
+
+		private final Class<?> testerClass;
+
+		@SuppressWarnings("rawtypes")
+		protected FieldInitializer(Class<? extends AbstractXmlMarshalTester> testerClass) {
+			Assert.notNull(testerClass, "'testerClass' must not be null");
+			this.testerClass = testerClass;
+		}
+
+		public void initFields(Object testInstance, M marshaller) {
+			Assert.notNull(testInstance, "'testInstance' must not be null");
+			Assert.notNull(marshaller, "'marshaller' must not be null");
+			initFields(testInstance, () -> marshaller);
+		}
+
+		public void initFields(Object testInstance, final ObjectFactory<M> marshaller) {
+			Assert.notNull(testInstance, "'testInstance' must not be null");
+			Assert.notNull(marshaller, "'marshaller' must not be null");
+			ReflectionUtils.doWithFields(testInstance.getClass(),
+					(field) -> doWithField(field, testInstance, marshaller));
+		}
+
+		protected void doWithField(Field field, Object test, ObjectFactory<M> marshaller) {
+			if (this.testerClass.isAssignableFrom(field.getType())) {
+				ReflectionUtils.makeAccessible(field);
+				Object existingValue = ReflectionUtils.getField(field, test);
+				if (existingValue == null) {
+					setupField(field, test, marshaller);
+				}
+			}
+		}
+
+		private void setupField(Field field, Object test, ObjectFactory<M> marshaller) {
+			ResolvableType type = ResolvableType.forField(field).getGeneric();
+			ReflectionUtils.setField(field, test, createTester(test.getClass(), type, marshaller.getObject()));
+		}
+
+		protected abstract AbstractXmlMarshalTester<Object> createTester(Class<?> resourceLoadClass,
+				ResolvableType type, M marshaller);
+
+	}
+
+}

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/AbstractXmlMarshalTester.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/AbstractXmlMarshalTester.java
@@ -61,7 +61,7 @@ import org.springframework.util.ReflectionUtils;
  * For a complete list of supported assertions see {@link XmlContentAssert} and
  * {@link ObjectContentAssert}.
  * <p>
- * To use this library XMLUnit must be on the test classpath.
+ * To use this library XMLUnit 2.12.0 or later must be on the test classpath.
  *
  * @param <T> the type under test
  * @author Tiziano Basile

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/AbstractXmlMarshalTester.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/AbstractXmlMarshalTester.java
@@ -16,12 +16,9 @@
 
 package org.springframework.boot.test.xml;
 
-import java.io.BufferedReader;
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.lang.reflect.Field;
@@ -54,7 +51,7 @@ import org.springframework.util.ReflectionUtils;
  *     &#064;Test
  *     public void testWriteXml() {
  *         ExampleObject object = //...
- *         assertThat(xml.write(object)).isSimilarToXml("expected.xml");
+ *         assertThat(xml.write(object)).isEqualToXml("expected.xml");
  *         assertThat(xml.read("expected.xml")).isEqualTo(object);
  *     }
  *
@@ -296,10 +293,10 @@ public abstract class AbstractXmlMarshalTester<T> {
 	public ObjectContent<T> read(Resource resource) throws IOException {
 		verify();
 		Assert.notNull(resource, "'resource' must not be null");
-		InputStream inputStream = resource.getInputStream();
-		T object = readObject(inputStream, getTypeNotNull());
-		closeQuietly(inputStream);
-		return new ObjectContent<>(this.type, object);
+		try (InputStream inputStream = resource.getInputStream()) {
+			T object = readObject(inputStream, getTypeNotNull());
+			return new ObjectContent<>(this.type, object);
+		}
 	}
 
 	/**
@@ -322,17 +319,9 @@ public abstract class AbstractXmlMarshalTester<T> {
 	public ObjectContent<T> read(Reader reader) throws IOException {
 		verify();
 		Assert.notNull(reader, "'reader' must not be null");
-		T object = readObject(reader, getTypeNotNull());
-		closeQuietly(reader);
-		return new ObjectContent<>(this.type, object);
-	}
-
-	private void closeQuietly(Closeable closeable) {
-		try {
-			closeable.close();
-		}
-		catch (IOException ex) {
-			// Ignore
+		try (Reader source = reader) {
+			T object = readObject(source, getTypeNotNull());
+			return new ObjectContent<>(this.type, object);
 		}
 	}
 
@@ -351,17 +340,16 @@ public abstract class AbstractXmlMarshalTester<T> {
 	protected abstract String writeObject(T value, ResolvableType type) throws IOException;
 
 	/**
-	 * Read from the specified input stream to create an object of the specified type. The
-	 * default implementation delegates to {@link #readObject(Reader, ResolvableType)}.
+	 * Read from the specified input stream to create an object of the specified type.
+	 * Implementations must pass the bytes to the XML parser so that any encoding declared
+	 * by the XML prolog is honored, rather than decoding them with a charset of their own
+	 * choosing.
 	 * @param inputStream the source input stream (never {@code null})
 	 * @param type the resulting type (never {@code null})
 	 * @return the resulting object
 	 * @throws IOException on read error
 	 */
-	protected T readObject(InputStream inputStream, ResolvableType type) throws IOException {
-		BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
-		return readObject(reader, type);
-	}
+	protected abstract T readObject(InputStream inputStream, ResolvableType type) throws IOException;
 
 	/**
 	 * Read from the specified reader to create an object of the specified type.
@@ -413,6 +401,11 @@ public abstract class AbstractXmlMarshalTester<T> {
 
 		private void setupField(Field field, Object test, ObjectFactory<M> marshaller) {
 			ResolvableType type = ResolvableType.forField(field).getGeneric();
+			Assert.state(type.resolve() != null,
+					() -> "Unable to determine the type under test for field '" + field.getName() + "' of "
+							+ field.getDeclaringClass().getName() + ". Declare the field with an explicit generic "
+							+ "type, for example '" + field.getType().getSimpleName() + "<MyType> " + field.getName()
+							+ ";'.");
 			ReflectionUtils.setField(field, test, createTester(test.getClass(), type, marshaller.getObject()));
 		}
 

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/JacksonXmlTester.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/JacksonXmlTester.java
@@ -45,7 +45,7 @@ import org.springframework.util.Assert;
  *     &#064;Test
  *     public void testWriteXml() throws IOException {
  *         ExampleObject object = //...
- *         assertThat(xml.write(object)).isSimilarToXml("expected.xml");
+ *         assertThat(xml.write(object)).isEqualToXml("expected.xml");
  *     }
  *
  * }

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/JacksonXmlTester.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/JacksonXmlTester.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.xml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.databind.ObjectWriter;
+import tools.jackson.dataformat.xml.XmlMapper;
+
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.core.ResolvableType;
+import org.springframework.util.Assert;
+
+/**
+ * AssertJ based XML tester backed by Jackson. Usually instantiated via
+ * {@link #initFields(Object, XmlMapper)}, for example: <pre class="code">
+ * public class ExampleObjectXmlTests {
+ *
+ *     private JacksonXmlTester&lt;ExampleObject&gt; xml;
+ *
+ *     &#064;BeforeEach
+ *     public void setup() {
+ *         XmlMapper xmlMapper = new XmlMapper();
+ *         JacksonXmlTester.initFields(this, xmlMapper);
+ *     }
+ *
+ *     &#064;Test
+ *     public void testWriteXml() throws IOException {
+ *         ExampleObject object = //...
+ *         assertThat(xml.write(object)).isSimilarToXml("expected.xml");
+ *     }
+ *
+ * }
+ * </pre>
+ *
+ * See {@link AbstractXmlMarshalTester} for more details.
+ *
+ * @param <T> the type under test
+ * @author Tiziano Basile
+ * @since 4.2.0
+ */
+public class JacksonXmlTester<T> extends AbstractXmlMarshalTester<T> {
+
+	private final XmlMapper xmlMapper;
+
+	/**
+	 * Create a new uninitialized {@link JacksonXmlTester} instance.
+	 * @param xmlMapper the Jackson XML mapper
+	 */
+	protected JacksonXmlTester(XmlMapper xmlMapper) {
+		Assert.notNull(xmlMapper, "'xmlMapper' must not be null");
+		this.xmlMapper = xmlMapper;
+	}
+
+	/**
+	 * Create a new {@link JacksonXmlTester} instance.
+	 * @param resourceLoadClass the source class used to load resources
+	 * @param type the type under test
+	 * @param xmlMapper the Jackson XML mapper
+	 */
+	public JacksonXmlTester(Class<?> resourceLoadClass, ResolvableType type, XmlMapper xmlMapper) {
+		super(resourceLoadClass, type);
+		Assert.notNull(xmlMapper, "'xmlMapper' must not be null");
+		this.xmlMapper = xmlMapper;
+	}
+
+	@Override
+	protected T readObject(InputStream inputStream, ResolvableType type) throws IOException {
+		return getObjectReader(type).readValue(inputStream);
+	}
+
+	@Override
+	protected T readObject(Reader reader, ResolvableType type) throws IOException {
+		return getObjectReader(type).readValue(reader);
+	}
+
+	private ObjectReader getObjectReader(ResolvableType type) {
+		return this.xmlMapper.readerFor(getType(type));
+	}
+
+	@Override
+	protected String writeObject(T value, ResolvableType type) throws IOException {
+		return getObjectWriter(type).writeValueAsString(value);
+	}
+
+	private ObjectWriter getObjectWriter(ResolvableType type) {
+		return this.xmlMapper.writerFor(getType(type));
+	}
+
+	private JavaType getType(ResolvableType type) {
+		return this.xmlMapper.constructType(type.getType());
+	}
+
+	/**
+	 * Utility method to initialize {@link JacksonXmlTester} fields. See
+	 * {@link JacksonXmlTester class-level documentation} for example usage.
+	 * @param testInstance the test instance
+	 * @param xmlMapper the XML mapper
+	 * @see #initFields(Object, ObjectFactory)
+	 */
+	public static void initFields(Object testInstance, XmlMapper xmlMapper) {
+		new JacksonXmlFieldInitializer().initFields(testInstance, xmlMapper);
+	}
+
+	/**
+	 * Utility method to initialize {@link JacksonXmlTester} fields. See
+	 * {@link JacksonXmlTester class-level documentation} for example usage.
+	 * @param testInstance the test instance
+	 * @param xmlMapperFactory a factory to create the XML mapper
+	 * @see #initFields(Object, XmlMapper)
+	 */
+	public static void initFields(Object testInstance, ObjectFactory<XmlMapper> xmlMapperFactory) {
+		new JacksonXmlFieldInitializer().initFields(testInstance, xmlMapperFactory);
+	}
+
+	/**
+	 * {@link FieldInitializer} for Jackson XML.
+	 */
+	private static class JacksonXmlFieldInitializer extends FieldInitializer<XmlMapper> {
+
+		protected JacksonXmlFieldInitializer() {
+			super(JacksonXmlTester.class);
+		}
+
+		@Override
+		protected AbstractXmlMarshalTester<Object> createTester(Class<?> resourceLoadClass, ResolvableType type,
+				XmlMapper marshaller) {
+			return new JacksonXmlTester<>(resourceLoadClass, type, marshaller);
+		}
+
+	}
+
+}

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlContent.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlContent.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.xml;
+
+import org.assertj.core.api.AssertProvider;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.util.Assert;
+
+/**
+ * XML content usually created from an XML tester. Generally used only to
+ * {@link AssertProvider provide} {@link XmlContentAssert} to AssertJ {@code assertThat}
+ * calls.
+ *
+ * @param <T> the source type that created the content
+ * @author Tiziano Basile
+ * @since 4.2.0
+ */
+public final class XmlContent<T> implements AssertProvider<XmlContentAssert> {
+
+	private final Class<?> resourceLoadClass;
+
+	private final @Nullable ResolvableType type;
+
+	private final String xml;
+
+	/**
+	 * Create a new {@link XmlContent} instance.
+	 * @param resourceLoadClass the source class used to load resources
+	 * @param type the type under test (or {@code null} if not known)
+	 * @param xml the actual XML content
+	 */
+	public XmlContent(Class<?> resourceLoadClass, @Nullable ResolvableType type, String xml) {
+		Assert.notNull(resourceLoadClass, "'resourceLoadClass' must not be null");
+		Assert.notNull(xml, "'xml' must not be null");
+		this.resourceLoadClass = resourceLoadClass;
+		this.type = type;
+		this.xml = xml;
+	}
+
+	/**
+	 * Use AssertJ's {@link org.assertj.core.api.Assertions#assertThat assertThat}
+	 * instead.
+	 * @deprecated to prevent accidental use. Prefer standard AssertJ
+	 * {@code assertThat(context)...} calls instead.
+	 */
+	@Override
+	@Deprecated(since = "4.2.0", forRemoval = false)
+	public XmlContentAssert assertThat() {
+		return new XmlContentAssert(this.resourceLoadClass, this.xml);
+	}
+
+	/**
+	 * Return the actual XML content string.
+	 * @return the XML content
+	 */
+	public String getXml() {
+		return this.xml;
+	}
+
+	@Override
+	public String toString() {
+		String createdFrom = (this.type != null) ? " created from " + this.type : "";
+		return "XmlContent " + this.xml + createdFrom;
+	}
+
+}

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlContent.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlContent.java
@@ -54,13 +54,14 @@ public final class XmlContent<T> implements AssertProvider<XmlContentAssert> {
 	}
 
 	/**
-	 * Use AssertJ's {@link org.assertj.core.api.Assertions#assertThat assertThat}
+	 * Return the {@link XmlContentAssert} for this content. This method is the
+	 * {@link AssertProvider} hook used by AssertJ and is not intended to be called
+	 * directly. Use AssertJ's
+	 * {@link org.assertj.core.api.Assertions#assertThat(AssertProvider) assertThat}
 	 * instead.
-	 * @deprecated to prevent accidental use. Prefer standard AssertJ
-	 * {@code assertThat(context)...} calls instead.
+	 * @return the assertion object
 	 */
 	@Override
-	@Deprecated(since = "4.2.0", forRemoval = false)
 	public XmlContentAssert assertThat() {
 		return new XmlContentAssert(this.resourceLoadClass, this.xml);
 	}

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlContentAssert.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlContentAssert.java
@@ -35,6 +35,7 @@ import javax.xml.namespace.NamespaceContext;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
@@ -78,9 +79,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Two flavours of comparison are supported, mirroring
  * {@link org.springframework.boot.test.json.JsonContentAssert JsonContentAssert}. A
  * <em>lenient</em> comparison ({@link #isEqualToXml(CharSequence) isEqualToXml}) ignores
- * insignificant whitespace and comments, whereas a <em>strict</em> comparison
+ * comments and whitespace, whereas a <em>strict</em> comparison
  * ({@link #isStrictlyEqualToXml(CharSequence) isStrictlyEqualToXml}) requires the two
  * documents to be identical.
+ * <p>
+ * A lenient comparison ignores more whitespace than the whitespace between elements. Text
+ * content is compared with its leading and trailing whitespace removed, so
+ * <code>&lt;name&gt;  Honda  &lt;/name&gt;</code> is leniently equal to
+ * <code>&lt;name&gt;Honda&lt;/name&gt;</code>, and text that consists only of whitespace
+ * is ignored altogether, so <code>&lt;name&gt;   &lt;/name&gt;</code> is leniently equal
+ * to <code>&lt;name/&gt;</code>.
  * <p>
  * The ordering of attributes is never significant. For a lenient comparison the ordering
  * of sibling elements that share a name is not significant either, <em>as long as those
@@ -89,22 +97,40 @@ import static org.assertj.core.api.Assertions.assertThat;
  * and siblings that differ only in their attributes are both paired up by name alone and
  * their ordering remains significant.
  * <p>
- * A strict comparison also compares the XML declaration, so an expected document that
- * starts with {@code <?xml version="1.0" encoding="UTF-8"?>} is not identical to one
- * written without a declaration. Marshallers such as
- * {@link tools.jackson.dataformat.xml.XmlMapper XmlMapper} write no declaration by
- * default, so fixtures compared with {@link #isStrictlyEqualToXml(CharSequence)} should
- * omit it too.
+ * A strict comparison compares everything that a lenient comparison ignores, and it also
+ * fails on a difference in any of the following:
+ * <ul>
+ * <li>The XML declaration, including its version, encoding and standalone
+ * pseudo-attributes. A document that starts with
+ * {@code <?xml version="1.0" encoding="UTF-8"?>} is not identical to one written without
+ * a declaration. Marshallers such as {@link tools.jackson.dataformat.xml.XmlMapper
+ * XmlMapper} write no declaration by default, so fixtures compared with
+ * {@link #isStrictlyEqualToXml(CharSequence)} should omit it too.</li>
+ * <li>Namespace prefixes. {@code <p:a xmlns:p="urn:example"/>} is not identical to
+ * {@code <q:a xmlns:q="urn:example"/>} even though both elements are in the same
+ * namespace.</li>
+ * <li>The distinction between a CDATA section and ordinary text.
+ * {@code <a><![CDATA[x]]></a>} is not identical to {@code <a>x</a>}. XPath expressions
+ * make no such distinction, see below.</li>
+ * <li>Comments and processing instructions.</li>
+ * <li>Whitespace, both between elements and within text content.</li>
+ * </ul>
+ * <p>
+ * XML that cannot be parsed always fails the assertion, whichever side of the comparison
+ * it is on and including for {@link #isNotEqualToXml(CharSequence) isNotEqualToXml} and
+ * {@link #isNotStrictlyEqualToXml(CharSequence) isNotStrictlyEqualToXml}.
  * <p>
  * XPath expressions are evaluated with a namespace aware parser. Prefixes used in an
  * expression must first be registered with {@link #withNamespaces(Map)}; an expression
- * with no prefix only matches elements that are in no namespace.
+ * with no prefix only matches elements that are in no namespace. As in the XPath data
+ * model, a CDATA section is not distinguished from the text around it, so
+ * {@code <a>x<![CDATA[y]]>z</a>} has a single text node with the value {@code xyz}.
  * <p>
  * Documents may carry a {@code DOCTYPE} declaration with an internal subset. Entities
  * declared in that internal subset are part of the document and are expanded. External
  * entities are never resolved.
  * <p>
- * To use this class XMLUnit must be on the test classpath.
+ * To use this class XMLUnit 2.12.0 or later must be on the test classpath.
  *
  * @author Tiziano Basile
  * @since 4.2.0
@@ -185,9 +211,11 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 	 * XPath expressions. Prefixes already bound on this instance are retained, with the
 	 * given bindings taking precedence. This instance is left unchanged.
 	 * @param namespaces a map of namespace prefix to namespace URI. XPath 1.0 has no
-	 * default namespace, so the empty prefix cannot be bound
+	 * default namespace, so the empty prefix cannot be bound, and the {@code xml} and
+	 * {@code xmlns} prefixes are reserved, so they cannot be rebound
 	 * @return a new assertion object bound to the given namespaces
 	 */
+	@CheckReturnValue
 	public XmlContentAssert withNamespaces(Map<String, String> namespaces) {
 		Assert.notNull(namespaces, "'namespaces' must not be null");
 		Map<String, String> merged = new LinkedHashMap<>(this.namespaces);
@@ -195,6 +223,8 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 			Assert.isTrue(StringUtils.hasText(prefix),
 					"'namespaces' must not contain an empty prefix as XPath 1.0 has no default namespace, "
 							+ "bind an explicit prefix and use it in the expression instead");
+			Assert.isTrue(!XMLConstants.XML_NS_PREFIX.equals(prefix) && !XMLConstants.XMLNS_ATTRIBUTE.equals(prefix),
+					() -> "'namespaces' must not rebind the reserved prefix '" + prefix + "'");
 			Assert.isTrue(StringUtils.hasText(namespaceUri),
 					() -> "'namespaces' must not map prefix '" + prefix + "' to an empty namespace URI");
 			merged.put(prefix, namespaceUri);
@@ -209,6 +239,7 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 		if (overridingErrorMessage != null) {
 			result.info.overridingErrorMessage(overridingErrorMessage);
 		}
+		result.info.useRepresentation(this.info.representation());
 		return result;
 	}
 
@@ -240,9 +271,9 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 
 	/**
 	 * Verifies that the actual value is leniently equal to the specified XML, ignoring
-	 * insignificant whitespace and comments. The {@code expected} value can contain the
-	 * XML itself or, if it ends with {@code .xml}, the name of a resource to be loaded
-	 * using {@code resourceLoadClass}.
+	 * comments and whitespace, including the leading and trailing whitespace of text
+	 * content. The {@code expected} value can contain the XML itself or, if it ends with
+	 * {@code .xml}, the name of a resource to be loaded using {@code resourceLoadClass}.
 	 * @param expected the expected XML or the name of a resource containing the expected
 	 * XML
 	 * @return {@code this} assertion object
@@ -254,7 +285,8 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 
 	/**
 	 * Verifies that the actual value is leniently equal to the specified XML resource,
-	 * ignoring insignificant whitespace and comments.
+	 * ignoring comments and whitespace, including the leading and trailing whitespace of
+	 * text content.
 	 * @param path the name of a resource containing the expected XML
 	 * @param resourceLoadClass the source class used to load the resource
 	 * @return {@code this} assertion object
@@ -266,7 +298,8 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 
 	/**
 	 * Verifies that the actual value is leniently equal to the specified XML bytes,
-	 * ignoring insignificant whitespace and comments.
+	 * ignoring comments and whitespace, including the leading and trailing whitespace of
+	 * text content.
 	 * @param expected the expected XML bytes
 	 * @return {@code this} assertion object
 	 * @throws AssertionError if the actual XML value is not equal to the given one
@@ -277,7 +310,8 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 
 	/**
 	 * Verifies that the actual value is leniently equal to the specified XML file,
-	 * ignoring insignificant whitespace and comments.
+	 * ignoring comments and whitespace, including the leading and trailing whitespace of
+	 * text content.
 	 * @param expected a file containing the expected XML
 	 * @return {@code this} assertion object
 	 * @throws AssertionError if the actual XML value is not equal to the given one
@@ -288,7 +322,8 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 
 	/**
 	 * Verifies that the actual value is leniently equal to the specified XML input
-	 * stream, ignoring insignificant whitespace and comments.
+	 * stream, ignoring comments and whitespace, including the leading and trailing
+	 * whitespace of text content.
 	 * @param expected an input stream containing the expected XML
 	 * @return {@code this} assertion object
 	 * @throws AssertionError if the actual XML value is not equal to the given one
@@ -299,7 +334,8 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 
 	/**
 	 * Verifies that the actual value is leniently equal to the specified XML resource,
-	 * ignoring insignificant whitespace and comments.
+	 * ignoring comments and whitespace, including the leading and trailing whitespace of
+	 * text content.
 	 * @param expected a resource containing the expected XML
 	 * @return {@code this} assertion object
 	 * @throws AssertionError if the actual XML value is not equal to the given one
@@ -314,11 +350,15 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 	 * the XML itself or, if it ends with {@code .xml}, the name of a resource to be
 	 * loaded using {@code resourceLoadClass}.
 	 * <p>
-	 * The XML declaration is part of a strict comparison. An expected document that
-	 * starts with {@code <?xml version="1.0" encoding="UTF-8"?>} is therefore
-	 * <em>not</em> identical to an actual document written without one, and the
-	 * comparison fails with a message such as
-	 * {@code Expected xml encoding 'UTF-8' but was 'null'}. Marshallers such as
+	 * As well as the comments and whitespace that {@link #isEqualToXml(CharSequence)}
+	 * ignores, a strict comparison fails on a difference in the XML declaration, in
+	 * namespace prefixes, in the distinction between a CDATA section and ordinary text,
+	 * and in processing instructions.
+	 * <p>
+	 * The XML declaration is a common trap. An expected document that starts with
+	 * {@code <?xml version="1.0" encoding="UTF-8"?>} is <em>not</em> identical to an
+	 * actual document written without one, and the comparison fails with a message such
+	 * as {@code Expected xml encoding 'UTF-8' but was 'null'}. Marshallers such as
 	 * {@link tools.jackson.dataformat.xml.XmlMapper XmlMapper} write no declaration by
 	 * default, so omit it from fixtures used for strict comparison, or use
 	 * {@link #isEqualToXml(CharSequence)} instead, which ignores the declaration.
@@ -552,7 +592,8 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 	 * specifiers defined in {@link String#format(String, Object...)}. When no arguments
 	 * are supplied the expression is used verbatim
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if there is no value at the given XPath expression
+	 * @throws AssertionError if there is no value at the given XPath expression or if the
+	 * expression does not select a node set
 	 */
 	public XmlContentAssert hasXPathValue(CharSequence expression, Object... args) {
 		new XPathValue(expression, args).assertHasValue();
@@ -566,7 +607,8 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 	 * specifiers defined in {@link String#format(String, Object...)}. When no arguments
 	 * are supplied the expression is used verbatim
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if there is a value at the given XPath expression
+	 * @throws AssertionError if there is a value at the given XPath expression or if the
+	 * expression does not select a node set
 	 */
 	public XmlContentAssert doesNotHaveXPathValue(CharSequence expression, Object... args) {
 		new XPathValue(expression, args).assertDoesNotHaveValue();
@@ -584,7 +626,7 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 	 * are supplied the expression is used verbatim
 	 * @return {@code this} assertion object
 	 * @throws AssertionError if the expression does not match the expected number of
-	 * nodes
+	 * nodes or if the expression does not select a node set
 	 */
 	public XmlContentAssert hasXPathNodeCount(CharSequence expression, int expectedCount, Object... args) {
 		Assert.isTrue(expectedCount >= 0, "'expectedCount' must not be negative");
@@ -660,7 +702,7 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 	}
 
 	private XmlContentAssert assertMatch(@Nullable String expectedXml, boolean strict) {
-		String difference = compare(expectedXml, strict, true);
+		String difference = compare(expectedXml, strict);
 		if (difference != null) {
 			failWithMessage("XML Comparison failure: %s", difference);
 		}
@@ -668,14 +710,23 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 	}
 
 	private XmlContentAssert assertNoMatch(@Nullable String expectedXml, boolean strict) {
-		String difference = compare(expectedXml, strict, false);
+		String difference = compare(expectedXml, strict);
 		if (difference == null) {
 			failWithMessage("XML Comparison failure: expected a difference but none was found");
 		}
 		return this;
 	}
 
-	private @Nullable String compare(@Nullable String expectedXml, boolean strict, boolean failOnError) {
+	/**
+	 * Compare the actual content with the expected content, returning a description of
+	 * their differences or {@code null} if there are none. XML that cannot be parsed
+	 * always fails rather than being reported as a difference, as content that cannot be
+	 * read is not evidence that the two documents differ.
+	 * @param expectedXml the expected XML
+	 * @param strict whether the comparison is strict
+	 * @return a description of the differences or {@code null}
+	 */
+	private @Nullable String compare(@Nullable String expectedXml, boolean strict) {
 		CharSequence actual = this.actual;
 		if (actual == null) {
 			return (expectedXml != null) ? "Expected null XML" : null;
@@ -687,10 +738,7 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 			return describeDifferences(diff(expectedXml, actual.toString(), strict), strict);
 		}
 		catch (XMLUnitException ex) {
-			if (failOnError) {
-				throw new AssertionError("Unable to compare XML: " + ex.getMessage(), ex);
-			}
-			return "Unable to compare XML: " + ex.getMessage();
+			throw new AssertionError("Unable to compare XML: " + ex.getMessage(), ex);
 		}
 	}
 
@@ -698,7 +746,10 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 		// The document builder factory is honored for the stream sources used here. It is
 		// ignored for DOMSource inputs and, as XMLUnit's own javadoc notes,
 		// ignoreComments
-		// applies an XSLT transform which can reduce its effect.
+		// applies an XSLT transform which can reduce its effect. The factory deliberately
+		// does not coalesce, unlike the one used to evaluate XPath expressions, so that a
+		// strict comparison keeps reporting a CDATA section and the equivalent text as a
+		// difference.
 		DiffBuilder builder = DiffBuilder.compare(Input.fromString(expectedXml))
 			.withTest(Input.fromString(actualXml))
 			.withDocumentBuilderFactory(createDocumentBuilderFactory());
@@ -732,7 +783,15 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 			throw new AssertionError("Expecting actual XML content not to be null");
 		}
 		try {
-			DocumentBuilder documentBuilder = createDocumentBuilderFactory().newDocumentBuilder();
+			DocumentBuilderFactory factory = createDocumentBuilderFactory();
+			// The XPath data model has no CDATA sections, a CDATA section and the text
+			// around it form a single text node. Coalescing makes the parsed document
+			// match that model, so that a selected text node carries the whole of the
+			// text rather than only the part before the first CDATA section. It is set
+			// here and not on the factory used for comparison, where a CDATA section and
+			// the equivalent text must remain a difference for a strict comparison.
+			factory.setCoalescing(true);
+			DocumentBuilder documentBuilder = factory.newDocumentBuilder();
 			return documentBuilder.parse(new InputSource(new StringReader(actual.toString())));
 		}
 		catch (Exception ex) {
@@ -753,6 +812,8 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 		// expansion is turned back on. Only entities the document declares itself are
 		// expanded, as the external entity features remain disabled.
 		factory.setExpandEntityReferences(true);
+		// Entity expansion is bounded by secure processing, which is requested here as
+		// well as on the XPath factory rather than being left to the parser's default.
 		setAttributeQuietly(factory, XMLConstants.ACCESS_EXTERNAL_DTD);
 		setAttributeQuietly(factory, XMLConstants.ACCESS_EXTERNAL_SCHEMA);
 		return factory;
@@ -766,7 +827,7 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 			return String.format(expression, args);
 		}
 		catch (IllegalFormatException ex) {
-			throw new AssertionError("Unable to format XML path \"" + expression + "\" with arguments "
+			throw new AssertionError("Unable to format XPath expression \"" + expression + "\" with arguments "
 					+ Arrays.toString(args) + ": " + ex.getMessage(), ex);
 		}
 	}
@@ -776,6 +837,15 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 			factory.setAttribute(name, "");
 		}
 		catch (IllegalArgumentException ex) {
+			// Not supported by this parser, ignore
+		}
+	}
+
+	private void setFeatureQuietly(DocumentBuilderFactory factory, String name) {
+		try {
+			factory.setFeature(name, true);
+		}
+		catch (ParserConfigurationException ex) {
 			// Not supported by this parser, ignore
 		}
 	}
@@ -805,22 +875,22 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 		void assertHasValue() {
 			NodeList nodeSet = requireNodeSet();
 			if (nodeSet.getLength() == 0) {
-				failWithMessage("No XML path \"%s\" found", this.expression);
+				failWithMessage("No XPath expression \"%s\" found", this.expression);
 			}
 		}
 
 		void assertDoesNotHaveValue() {
 			NodeList nodeSet = requireNodeSet();
 			if (nodeSet.getLength() > 0) {
-				failWithMessage("Expecting no XML path \"%s\"", this.expression);
+				failWithMessage("Expecting no XPath expression \"%s\"", this.expression);
 			}
 		}
 
 		void assertNodeCount(int expectedCount) {
 			NodeList nodeSet = requireNodeSet();
 			if (nodeSet.getLength() != expectedCount) {
-				failWithMessage("Expected %s node(s) at XML path \"%s\" but found %s", expectedCount, this.expression,
-						nodeSet.getLength());
+				failWithMessage("Expected %s node(s) at XPath expression \"%s\" but found %s", expectedCount,
+						this.expression, nodeSet.getLength());
 			}
 		}
 
@@ -843,12 +913,13 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 			if (this.nodeSet != null) {
 				String text = ((String) evaluate(XPathConstants.STRING)).trim();
 				if (!NUMBER_PATTERN.matcher(text).matches()) {
-					failWithMessage("Expected a number at XML path \"%s\" but found: %s", this.expression, text);
+					failWithMessage("Expected a number at XPath expression \"%s\" but found: %s", this.expression,
+							text);
 				}
 			}
 			double value = (Double) evaluate(XPathConstants.NUMBER);
 			if (Double.isNaN(value) || Double.isInfinite(value)) {
-				failWithMessage("Expected a number at XML path \"%s\" but found: %s", this.expression, value);
+				failWithMessage("Expected a number at XPath expression \"%s\" but found: %s", this.expression, value);
 			}
 			return value;
 		}
@@ -863,7 +934,7 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 				return Boolean.TRUE;
 			}
 			if (!"false".equals(text) && !"0".equals(text)) {
-				failWithMessage("Expected a boolean at XML path \"%s\" but found: %s", this.expression, text);
+				failWithMessage("Expected a boolean at XPath expression \"%s\" but found: %s", this.expression, text);
 			}
 			return Boolean.FALSE;
 		}
@@ -871,7 +942,7 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 		private NodeList requireNodeSet() {
 			NodeList nodeSet = this.nodeSet;
 			if (nodeSet == null) {
-				failWithMessage("XML path \"%s\" does not select nodes", this.expression);
+				failWithMessage("XPath expression \"%s\" does not select nodes", this.expression);
 				throw new AssertionError("Unreachable");
 			}
 			return nodeSet;
@@ -888,10 +959,10 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 				return;
 			}
 			if (nodeSet.getLength() == 0) {
-				failWithMessage("No value at XML path \"%s\"", this.expression);
+				failWithMessage("No value at XPath expression \"%s\"", this.expression);
 			}
 			else if (nodeSet.getLength() > 1) {
-				failWithMessage("Expected a single node at XML path \"%s\" but found %s nodes", this.expression,
+				failWithMessage("Expected a single node at XPath expression \"%s\" but found %s nodes", this.expression,
 						nodeSet.getLength());
 			}
 		}
@@ -904,8 +975,8 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 				String prefix = matcher.group(1);
 				if (!XMLConstants.XML_NS_PREFIX.equals(prefix)
 						&& !XmlContentAssert.this.namespaces.containsKey(prefix)) {
-					failWithMessage("Namespace prefix \"%s\" used in XML path \"%s\" has not been registered", prefix,
-							this.expression);
+					failWithMessage("Namespace prefix \"%s\" used in XPath expression \"%s\" has not been registered",
+							prefix, this.expression);
 				}
 			}
 		}
@@ -924,8 +995,8 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 				return xpath.compile(this.expression);
 			}
 			catch (XPathExpressionException ex) {
-				throw new AssertionError("Unable to compile XML path \"" + this.expression + "\": " + ex.getMessage(),
-						ex);
+				throw new AssertionError(
+						"Unable to compile XPath expression \"" + this.expression + "\": " + ex.getMessage(), ex);
 			}
 		}
 
@@ -944,8 +1015,8 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 				return this.compiled.evaluate(this.document, returnType);
 			}
 			catch (XPathExpressionException ex) {
-				throw new AssertionError("Unable to evaluate XML path \"" + this.expression + "\": " + ex.getMessage(),
-						ex);
+				throw new AssertionError(
+						"Unable to evaluate XPath expression \"" + this.expression + "\": " + ex.getMessage(), ex);
 			}
 		}
 

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlContentAssert.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlContentAssert.java
@@ -1,0 +1,600 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.xml;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.charset.Charset;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractBooleanAssert;
+import org.assertj.core.api.AbstractCharSequenceAssert;
+import org.assertj.core.api.AbstractObjectAssert;
+import org.jspecify.annotations.Nullable;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+import org.xmlunit.XMLUnitException;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.Diff;
+import org.xmlunit.diff.ElementSelectors;
+
+import org.springframework.core.io.Resource;
+import org.springframework.lang.CheckReturnValue;
+import org.springframework.util.Assert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * AssertJ {@link org.assertj.core.api.Assert Assert} for {@link XmlContent}.
+ * <p>
+ * Two flavours of comparison are supported. An <em>identical</em> comparison
+ * ({@link #isEqualToXml(CharSequence) isEqualToXml}) requires the documents to match
+ * exactly, whereas a <em>similar</em> comparison ({@link #isSimilarToXml(CharSequence)
+ * isSimilarToXml}) ignores insignificant whitespace, comments and the ordering of
+ * elements and attributes.
+ * <p>
+ * To use this class XMLUnit must be on the test classpath.
+ *
+ * @author Tiziano Basile
+ * @since 4.2.0
+ */
+public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSequence> {
+
+	private final XmlLoader loader;
+
+	/**
+	 * Create a new {@link XmlContentAssert} instance that will load resources as UTF-8.
+	 * @param resourceLoadClass the source class used to load resources
+	 * @param xml the actual XML content
+	 */
+	public XmlContentAssert(Class<?> resourceLoadClass, @Nullable CharSequence xml) {
+		this(resourceLoadClass, null, xml);
+	}
+
+	/**
+	 * Create a new {@link XmlContentAssert} instance that will load resources in the
+	 * given {@code charset}.
+	 * @param resourceLoadClass the source class used to load resources
+	 * @param charset the charset of the XML resources
+	 * @param xml the actual XML content
+	 */
+	public XmlContentAssert(Class<?> resourceLoadClass, @Nullable Charset charset, @Nullable CharSequence xml) {
+		super(xml, XmlContentAssert.class);
+		Assert.notNull(resourceLoadClass, "'resourceLoadClass' must not be null");
+		this.loader = new XmlLoader(resourceLoadClass, charset);
+	}
+
+	/**
+	 * Verifies that the actual value is identical to the specified XML. The
+	 * {@code expected} value can contain the XML itself or, if it ends with {@code .xml},
+	 * the name of a resource to be loaded using {@code resourceLoadClass}.
+	 * @param expected the expected XML or the name of a resource containing the expected
+	 * XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not identical to the given one
+	 */
+	public XmlContentAssert isEqualToXml(@Nullable CharSequence expected) {
+		return assertMatch(this.loader.getXml(expected), false);
+	}
+
+	/**
+	 * Verifies that the actual value is identical to the specified XML resource.
+	 * @param path the name of a resource containing the expected XML
+	 * @param resourceLoadClass the source class used to load the resource
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not identical to the given one
+	 */
+	public XmlContentAssert isEqualToXml(String path, Class<?> resourceLoadClass) {
+		return assertMatch(this.loader.getXml(path, resourceLoadClass), false);
+	}
+
+	/**
+	 * Verifies that the actual value is identical to the specified XML bytes.
+	 * @param expected the expected XML bytes
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not identical to the given one
+	 */
+	public XmlContentAssert isEqualToXml(byte[] expected) {
+		return assertMatch(this.loader.getXml(expected), false);
+	}
+
+	/**
+	 * Verifies that the actual value is identical to the specified XML file.
+	 * @param expected a file containing the expected XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not identical to the given one
+	 */
+	public XmlContentAssert isEqualToXml(File expected) {
+		return assertMatch(this.loader.getXml(expected), false);
+	}
+
+	/**
+	 * Verifies that the actual value is identical to the specified XML input stream.
+	 * @param expected an input stream containing the expected XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not identical to the given one
+	 */
+	public XmlContentAssert isEqualToXml(InputStream expected) {
+		return assertMatch(this.loader.getXml(expected), false);
+	}
+
+	/**
+	 * Verifies that the actual value is identical to the specified XML resource.
+	 * @param expected a resource containing the expected XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not identical to the given one
+	 */
+	public XmlContentAssert isEqualToXml(Resource expected) {
+		return assertMatch(this.loader.getXml(expected), false);
+	}
+
+	/**
+	 * Verifies that the actual value is not identical to the specified XML. The
+	 * {@code expected} value can contain the XML itself or, if it ends with {@code .xml},
+	 * the name of a resource to be loaded using {@code resourceLoadClass}.
+	 * @param expected the expected XML or the name of a resource containing the expected
+	 * XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is identical to the given one
+	 */
+	public XmlContentAssert isNotEqualToXml(@Nullable CharSequence expected) {
+		return assertNoMatch(this.loader.getXml(expected), false);
+	}
+
+	/**
+	 * Verifies that the actual value is not identical to the specified XML resource.
+	 * @param path the name of a resource containing the expected XML
+	 * @param resourceLoadClass the source class used to load the resource
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is identical to the given one
+	 */
+	public XmlContentAssert isNotEqualToXml(String path, Class<?> resourceLoadClass) {
+		return assertNoMatch(this.loader.getXml(path, resourceLoadClass), false);
+	}
+
+	/**
+	 * Verifies that the actual value is not identical to the specified XML bytes.
+	 * @param expected the expected XML bytes
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is identical to the given one
+	 */
+	public XmlContentAssert isNotEqualToXml(byte[] expected) {
+		return assertNoMatch(this.loader.getXml(expected), false);
+	}
+
+	/**
+	 * Verifies that the actual value is not identical to the specified XML file.
+	 * @param expected a file containing the expected XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is identical to the given one
+	 */
+	public XmlContentAssert isNotEqualToXml(File expected) {
+		return assertNoMatch(this.loader.getXml(expected), false);
+	}
+
+	/**
+	 * Verifies that the actual value is not identical to the specified XML input stream.
+	 * @param expected an input stream containing the expected XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is identical to the given one
+	 */
+	public XmlContentAssert isNotEqualToXml(InputStream expected) {
+		return assertNoMatch(this.loader.getXml(expected), false);
+	}
+
+	/**
+	 * Verifies that the actual value is not identical to the specified XML resource.
+	 * @param expected a resource containing the expected XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is identical to the given one
+	 */
+	public XmlContentAssert isNotEqualToXml(Resource expected) {
+		return assertNoMatch(this.loader.getXml(expected), false);
+	}
+
+	/**
+	 * Verifies that the actual value is similar to the specified XML, ignoring
+	 * insignificant whitespace, comments and the ordering of elements and attributes. The
+	 * {@code expected} value can contain the XML itself or, if it ends with {@code .xml},
+	 * the name of a resource to be loaded using {@code resourceLoadClass}.
+	 * @param expected the expected XML or the name of a resource containing the expected
+	 * XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not similar to the given one
+	 */
+	public XmlContentAssert isSimilarToXml(@Nullable CharSequence expected) {
+		return assertMatch(this.loader.getXml(expected), true);
+	}
+
+	/**
+	 * Verifies that the actual value is similar to the specified XML resource, ignoring
+	 * insignificant whitespace, comments and the ordering of elements and attributes.
+	 * @param path the name of a resource containing the expected XML
+	 * @param resourceLoadClass the source class used to load the resource
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not similar to the given one
+	 */
+	public XmlContentAssert isSimilarToXml(String path, Class<?> resourceLoadClass) {
+		return assertMatch(this.loader.getXml(path, resourceLoadClass), true);
+	}
+
+	/**
+	 * Verifies that the actual value is similar to the specified XML bytes, ignoring
+	 * insignificant whitespace, comments and the ordering of elements and attributes.
+	 * @param expected the expected XML bytes
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not similar to the given one
+	 */
+	public XmlContentAssert isSimilarToXml(byte[] expected) {
+		return assertMatch(this.loader.getXml(expected), true);
+	}
+
+	/**
+	 * Verifies that the actual value is similar to the specified XML file, ignoring
+	 * insignificant whitespace, comments and the ordering of elements and attributes.
+	 * @param expected a file containing the expected XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not similar to the given one
+	 */
+	public XmlContentAssert isSimilarToXml(File expected) {
+		return assertMatch(this.loader.getXml(expected), true);
+	}
+
+	/**
+	 * Verifies that the actual value is similar to the specified XML input stream,
+	 * ignoring insignificant whitespace, comments and the ordering of elements and
+	 * attributes.
+	 * @param expected an input stream containing the expected XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not similar to the given one
+	 */
+	public XmlContentAssert isSimilarToXml(InputStream expected) {
+		return assertMatch(this.loader.getXml(expected), true);
+	}
+
+	/**
+	 * Verifies that the actual value is similar to the specified XML resource, ignoring
+	 * insignificant whitespace, comments and the ordering of elements and attributes.
+	 * @param expected a resource containing the expected XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not similar to the given one
+	 */
+	public XmlContentAssert isSimilarToXml(Resource expected) {
+		return assertMatch(this.loader.getXml(expected), true);
+	}
+
+	/**
+	 * Verifies that the actual value is not similar to the specified XML. The
+	 * {@code expected} value can contain the XML itself or, if it ends with {@code .xml},
+	 * the name of a resource to be loaded using {@code resourceLoadClass}.
+	 * @param expected the expected XML or the name of a resource containing the expected
+	 * XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is similar to the given one
+	 */
+	public XmlContentAssert isNotSimilarToXml(@Nullable CharSequence expected) {
+		return assertNoMatch(this.loader.getXml(expected), true);
+	}
+
+	/**
+	 * Verifies that the actual value is not similar to the specified XML resource.
+	 * @param path the name of a resource containing the expected XML
+	 * @param resourceLoadClass the source class used to load the resource
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is similar to the given one
+	 */
+	public XmlContentAssert isNotSimilarToXml(String path, Class<?> resourceLoadClass) {
+		return assertNoMatch(this.loader.getXml(path, resourceLoadClass), true);
+	}
+
+	/**
+	 * Verifies that the actual value is not similar to the specified XML bytes.
+	 * @param expected the expected XML bytes
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is similar to the given one
+	 */
+	public XmlContentAssert isNotSimilarToXml(byte[] expected) {
+		return assertNoMatch(this.loader.getXml(expected), true);
+	}
+
+	/**
+	 * Verifies that the actual value is not similar to the specified XML file.
+	 * @param expected a file containing the expected XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is similar to the given one
+	 */
+	public XmlContentAssert isNotSimilarToXml(File expected) {
+		return assertNoMatch(this.loader.getXml(expected), true);
+	}
+
+	/**
+	 * Verifies that the actual value is not similar to the specified XML input stream.
+	 * @param expected an input stream containing the expected XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is similar to the given one
+	 */
+	public XmlContentAssert isNotSimilarToXml(InputStream expected) {
+		return assertNoMatch(this.loader.getXml(expected), true);
+	}
+
+	/**
+	 * Verifies that the actual value is not similar to the specified XML resource.
+	 * @param expected a resource containing the expected XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is similar to the given one
+	 */
+	public XmlContentAssert isNotSimilarToXml(Resource expected) {
+		return assertNoMatch(this.loader.getXml(expected), true);
+	}
+
+	/**
+	 * Verify that the actual value at the given XPath expression produces a result.
+	 * @param expression the XPath expression
+	 * @param args arguments to parameterize the XPath expression with, using formatting
+	 * specifiers defined in {@link String#format(String, Object...)}
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if there is no value at the given XPath expression
+	 */
+	public XmlContentAssert hasXPathValue(CharSequence expression, Object... args) {
+		new XPathValue(expression, args).assertHasValue();
+		return this;
+	}
+
+	/**
+	 * Verify that the actual value at the given XPath expression produces no result.
+	 * @param expression the XPath expression
+	 * @param args arguments to parameterize the XPath expression with, using formatting
+	 * specifiers defined in {@link String#format(String, Object...)}
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if there is a value at the given XPath expression
+	 */
+	public XmlContentAssert doesNotHaveXPathValue(CharSequence expression, Object... args) {
+		new XPathValue(expression, args).assertDoesNotHaveValue();
+		return this;
+	}
+
+	/**
+	 * Extract the value at the given XPath expression for further object assertions.
+	 * @param expression the XPath expression
+	 * @param args arguments to parameterize the XPath expression with, using formatting
+	 * specifiers defined in {@link String#format(String, Object...)}
+	 * @return a new assertion object whose object under test is the extracted item
+	 * @throws AssertionError if the expression is not valid
+	 */
+	@CheckReturnValue
+	public AbstractObjectAssert<?, Object> extractingXPathValue(CharSequence expression, Object... args) {
+		return assertThat(new XPathValue(expression, args).getValue());
+	}
+
+	/**
+	 * Extract the string value at the given XPath expression for further object
+	 * assertions.
+	 * @param expression the XPath expression
+	 * @param args arguments to parameterize the XPath expression with, using formatting
+	 * specifiers defined in {@link String#format(String, Object...)}
+	 * @return a new assertion object whose object under test is the extracted item
+	 * @throws AssertionError if the expression is not valid
+	 */
+	@CheckReturnValue
+	public AbstractCharSequenceAssert<?, String> extractingXPathStringValue(CharSequence expression, Object... args) {
+		return assertThat(new XPathValue(expression, args).getStringValue());
+	}
+
+	/**
+	 * Extract the number value at the given XPath expression for further object
+	 * assertions.
+	 * @param expression the XPath expression
+	 * @param args arguments to parameterize the XPath expression with, using formatting
+	 * specifiers defined in {@link String#format(String, Object...)}
+	 * @return a new assertion object whose object under test is the extracted item
+	 * @throws AssertionError if the expression is not valid or does not result in a
+	 * number
+	 */
+	@CheckReturnValue
+	public AbstractObjectAssert<?, Number> extractingXPathNumberValue(CharSequence expression, Object... args) {
+		return assertThat(new XPathValue(expression, args).getNumberValue());
+	}
+
+	/**
+	 * Extract the boolean value at the given XPath expression for further object
+	 * assertions.
+	 * @param expression the XPath expression
+	 * @param args arguments to parameterize the XPath expression with, using formatting
+	 * specifiers defined in {@link String#format(String, Object...)}
+	 * @return a new assertion object whose object under test is the extracted item
+	 * @throws AssertionError if the expression is not valid or does not result in a
+	 * boolean
+	 */
+	@CheckReturnValue
+	public AbstractBooleanAssert<?> extractingXPathBooleanValue(CharSequence expression, Object... args) {
+		return assertThat(new XPathValue(expression, args).getBooleanValue());
+	}
+
+	private XmlContentAssert assertMatch(@Nullable String expectedXml, boolean similar) {
+		String difference = compare(expectedXml, similar);
+		if (difference != null) {
+			failWithMessage("XML Comparison failure: %s", difference);
+		}
+		return this;
+	}
+
+	private XmlContentAssert assertNoMatch(@Nullable String expectedXml, boolean similar) {
+		String difference = compare(expectedXml, similar);
+		if (difference == null) {
+			failWithMessage("XML Comparison failure: expected a difference but none was found");
+		}
+		return this;
+	}
+
+	private @Nullable String compare(@Nullable String expectedXml, boolean similar) {
+		CharSequence actual = this.actual;
+		if (actual == null) {
+			return (expectedXml != null) ? "Expected null XML" : null;
+		}
+		if (expectedXml == null) {
+			return "Expected XML but got null";
+		}
+		Diff diff = diff(expectedXml, actual.toString(), similar);
+		return (diff.hasDifferences()) ? diff.toString() : null;
+	}
+
+	private Diff diff(String expectedXml, String actualXml, boolean similar) {
+		DiffBuilder builder = DiffBuilder.compare(Input.fromString(expectedXml)).withTest(Input.fromString(actualXml));
+		if (similar) {
+			builder = builder.ignoreWhitespace()
+				.ignoreComments()
+				.withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byName))
+				.checkForSimilar();
+		}
+		else {
+			builder = builder.checkForIdentical();
+		}
+		try {
+			return builder.build();
+		}
+		catch (XMLUnitException ex) {
+			throw new AssertionError("Unable to compare XML: " + ex.getMessage(), ex);
+		}
+	}
+
+	private Document parseActual() {
+		CharSequence actual = this.actual;
+		if (actual == null) {
+			throw new AssertionError("Expecting actual XML content not to be null");
+		}
+		try {
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+			factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			DocumentBuilder documentBuilder = factory.newDocumentBuilder();
+			return documentBuilder.parse(new InputSource(new StringReader(actual.toString())));
+		}
+		catch (Exception ex) {
+			throw new AssertionError("Unable to parse XML content: " + ex.getMessage(), ex);
+		}
+	}
+
+	/**
+	 * A value resolved from an XPath expression.
+	 */
+	private final class XPathValue {
+
+		private final String expression;
+
+		XPathValue(CharSequence expression, Object... args) {
+			Assert.hasText((expression != null) ? expression.toString() : null, "'expression' must not be empty");
+			this.expression = String.format(expression.toString(), args);
+		}
+
+		void assertHasValue() {
+			if (getNode() == null) {
+				failWithMessage("No value at XPath \"%s\"", this.expression);
+			}
+		}
+
+		void assertDoesNotHaveValue() {
+			Node node = getNode();
+			if (node != null) {
+				failWithMessage("Expected no value at XPath \"%s\" but found: %s", this.expression,
+						node.getTextContent());
+			}
+		}
+
+		@Nullable Object getValue() {
+			return getStringValue();
+		}
+
+		@Nullable String getStringValue() {
+			Node node = getNode();
+			return (node != null) ? node.getTextContent() : null;
+		}
+
+		@Nullable Number getNumberValue() {
+			String value = getStringValue();
+			if (value == null) {
+				return null;
+			}
+			Number number = parseNumber(value.trim());
+			if (number == null) {
+				failWithMessage("Expected a number at XPath \"%s\" but found: %s", this.expression, value);
+			}
+			return number;
+		}
+
+		@Nullable Boolean getBooleanValue() {
+			String value = getStringValue();
+			if (value == null) {
+				return null;
+			}
+			String trimmed = value.trim();
+			if ("true".equalsIgnoreCase(trimmed)) {
+				return Boolean.TRUE;
+			}
+			if ("false".equalsIgnoreCase(trimmed)) {
+				return Boolean.FALSE;
+			}
+			failWithMessage("Expected a boolean at XPath \"%s\" but found: %s", this.expression, value);
+			return null;
+		}
+
+		private @Nullable Number parseNumber(String value) {
+			try {
+				return Integer.valueOf(value);
+			}
+			catch (NumberFormatException ex) {
+				// Not an int, continue
+			}
+			try {
+				return Long.valueOf(value);
+			}
+			catch (NumberFormatException ex) {
+				// Not a long, continue
+			}
+			try {
+				return Double.valueOf(value);
+			}
+			catch (NumberFormatException ex) {
+				return null;
+			}
+		}
+
+		private @Nullable Node getNode() {
+			Document document = parseActual();
+			try {
+				XPath xPath = XPathFactory.newInstance().newXPath();
+				return (Node) xPath.evaluate(this.expression, document, XPathConstants.NODE);
+			}
+			catch (Exception ex) {
+				throw new AssertionError("Unable to evaluate XPath \"" + this.expression + "\": " + ex.getMessage(),
+						ex);
+			}
+		}
+
+	}
+
+}

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlContentAssert.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlContentAssert.java
@@ -20,43 +20,89 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.IllegalFormatException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.xml.XMLConstants;
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathFactoryConfigurationException;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.description.Description;
 import org.jspecify.annotations.Nullable;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xmlunit.XMLUnitException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.builder.Input;
+import org.xmlunit.diff.ComparisonResult;
 import org.xmlunit.diff.DefaultNodeMatcher;
 import org.xmlunit.diff.Diff;
+import org.xmlunit.diff.Difference;
 import org.xmlunit.diff.ElementSelectors;
+import org.xmlunit.util.DocumentBuilderFactoryConfigurer;
 
 import org.springframework.core.io.Resource;
 import org.springframework.lang.CheckReturnValue;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.util.xml.SimpleNamespaceContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * AssertJ {@link org.assertj.core.api.Assert Assert} for {@link XmlContent}.
  * <p>
- * Two flavours of comparison are supported. An <em>identical</em> comparison
- * ({@link #isEqualToXml(CharSequence) isEqualToXml}) requires the documents to match
- * exactly, whereas a <em>similar</em> comparison ({@link #isSimilarToXml(CharSequence)
- * isSimilarToXml}) ignores insignificant whitespace, comments and the ordering of
- * elements and attributes.
+ * Two flavours of comparison are supported, mirroring
+ * {@link org.springframework.boot.test.json.JsonContentAssert JsonContentAssert}. A
+ * <em>lenient</em> comparison ({@link #isEqualToXml(CharSequence) isEqualToXml}) ignores
+ * insignificant whitespace and comments, whereas a <em>strict</em> comparison
+ * ({@link #isStrictlyEqualToXml(CharSequence) isStrictlyEqualToXml}) requires the two
+ * documents to be identical.
+ * <p>
+ * The ordering of attributes is never significant. For a lenient comparison the ordering
+ * of sibling elements that share a name is not significant either, <em>as long as those
+ * elements can be told apart by their own text content alone</em>. Siblings are paired up
+ * on name and text content, and nothing else, so siblings that have element-only content
+ * and siblings that differ only in their attributes are both paired up by name alone and
+ * their ordering remains significant.
+ * <p>
+ * A strict comparison also compares the XML declaration, so an expected document that
+ * starts with {@code <?xml version="1.0" encoding="UTF-8"?>} is not identical to one
+ * written without a declaration. Marshallers such as
+ * {@link tools.jackson.dataformat.xml.XmlMapper XmlMapper} write no declaration by
+ * default, so fixtures compared with {@link #isStrictlyEqualToXml(CharSequence)} should
+ * omit it too.
+ * <p>
+ * XPath expressions are evaluated with a namespace aware parser. Prefixes used in an
+ * expression must first be registered with {@link #withNamespaces(Map)}; an expression
+ * with no prefix only matches elements that are in no namespace.
+ * <p>
+ * Documents may carry a {@code DOCTYPE} declaration with an internal subset. Entities
+ * declared in that internal subset are part of the document and are expanded. External
+ * entities are never resolved.
  * <p>
  * To use this class XMLUnit must be on the test classpath.
  *
@@ -65,10 +111,43 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSequence> {
 
-	private final XmlLoader loader;
+	/**
+	 * The lexical space accepted by XPath 1.0 for a number. Deliberately narrow so that
+	 * {@code 10d}, {@code NaN}, {@code Infinity} and hex floats are rejected rather than
+	 * silently coerced.
+	 */
+	private static final Pattern NUMBER_PATTERN = Pattern.compile("-?(\\d+(\\.\\d*)?|\\.\\d+)");
 
 	/**
-	 * Create a new {@link XmlContentAssert} instance that will load resources as UTF-8.
+	 * Matches a namespace prefix, in other words a name followed by a single colon.
+	 */
+	private static final Pattern PREFIX_PATTERN = Pattern.compile("(?<![-\\w:])([A-Za-z_][\\w.-]*):(?!:)");
+
+	/**
+	 * Matches a quoted XPath string literal.
+	 */
+	private static final Pattern STRING_LITERAL_PATTERN = Pattern.compile("'[^']*'|\"[^\"]*\"");
+
+	/**
+	 * Matches an explicit axis, in other words an axis name followed by {@code ::}. An
+	 * axis is not a prefix and, unless it is removed first, it hides the prefix that
+	 * follows it from {@link #PREFIX_PATTERN}.
+	 */
+	private static final Pattern AXIS_PATTERN = Pattern.compile("[A-Za-z][A-Za-z-]*\\s*::");
+
+	private final Class<?> resourceLoadClass;
+
+	private final @Nullable Charset charset;
+
+	private final XmlLoader loader;
+
+	private final Map<String, String> namespaces;
+
+	private final NamespaceContext namespaceContext;
+
+	/**
+	 * Create a new {@link XmlContentAssert} instance that will load resources using the
+	 * encoding they declare, defaulting to UTF-8 when they declare none.
 	 * @param resourceLoadClass the source class used to load resources
 	 * @param xml the actual XML content
 	 */
@@ -80,275 +159,389 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 	 * Create a new {@link XmlContentAssert} instance that will load resources in the
 	 * given {@code charset}.
 	 * @param resourceLoadClass the source class used to load resources
-	 * @param charset the charset of the XML resources
+	 * @param charset the charset of the XML resources, or {@code null} to use the
+	 * encoding that each resource declares
 	 * @param xml the actual XML content
 	 */
 	public XmlContentAssert(Class<?> resourceLoadClass, @Nullable Charset charset, @Nullable CharSequence xml) {
+		this(resourceLoadClass, charset, xml, Collections.emptyMap());
+	}
+
+	private XmlContentAssert(Class<?> resourceLoadClass, @Nullable Charset charset, @Nullable CharSequence xml,
+			Map<String, String> namespaces) {
 		super(xml, XmlContentAssert.class);
 		Assert.notNull(resourceLoadClass, "'resourceLoadClass' must not be null");
+		this.resourceLoadClass = resourceLoadClass;
+		this.charset = charset;
 		this.loader = new XmlLoader(resourceLoadClass, charset);
+		this.namespaces = namespaces;
+		SimpleNamespaceContext namespaceContext = new SimpleNamespaceContext();
+		namespaceContext.setBindings(namespaces);
+		this.namespaceContext = namespaceContext;
 	}
 
 	/**
-	 * Verifies that the actual value is identical to the specified XML. The
-	 * {@code expected} value can contain the XML itself or, if it ends with {@code .xml},
-	 * the name of a resource to be loaded using {@code resourceLoadClass}.
+	 * Return a new instance that resolves the given namespace prefixes when evaluating
+	 * XPath expressions. Prefixes already bound on this instance are retained, with the
+	 * given bindings taking precedence. This instance is left unchanged.
+	 * @param namespaces a map of namespace prefix to namespace URI. XPath 1.0 has no
+	 * default namespace, so the empty prefix cannot be bound
+	 * @return a new assertion object bound to the given namespaces
+	 */
+	public XmlContentAssert withNamespaces(Map<String, String> namespaces) {
+		Assert.notNull(namespaces, "'namespaces' must not be null");
+		Map<String, String> merged = new LinkedHashMap<>(this.namespaces);
+		namespaces.forEach((prefix, namespaceUri) -> {
+			Assert.isTrue(StringUtils.hasText(prefix),
+					"'namespaces' must not contain an empty prefix as XPath 1.0 has no default namespace, "
+							+ "bind an explicit prefix and use it in the expression instead");
+			Assert.isTrue(StringUtils.hasText(namespaceUri),
+					() -> "'namespaces' must not map prefix '" + prefix + "' to an empty namespace URI");
+			merged.put(prefix, namespaceUri);
+		});
+		XmlContentAssert result = new XmlContentAssert(this.resourceLoadClass, this.charset, this.actual,
+				Collections.unmodifiableMap(merged));
+		Description description = this.info.description();
+		if (description != null) {
+			result.info.description(description);
+		}
+		String overridingErrorMessage = this.info.overridingErrorMessage();
+		if (overridingErrorMessage != null) {
+			result.info.overridingErrorMessage(overridingErrorMessage);
+		}
+		return result;
+	}
+
+	/**
+	 * Overridden version of {@code isEqualTo} to perform XML tests based on the object
+	 * type.
+	 * @see org.assertj.core.api.AbstractAssert#isEqualTo(java.lang.Object)
+	 */
+	@Override
+	public XmlContentAssert isEqualTo(@Nullable Object expected) {
+		if (expected == null || expected instanceof CharSequence) {
+			return isEqualToXml((CharSequence) expected);
+		}
+		if (expected instanceof byte[] bytes) {
+			return isEqualToXml(bytes);
+		}
+		if (expected instanceof File file) {
+			return isEqualToXml(file);
+		}
+		if (expected instanceof InputStream inputStream) {
+			return isEqualToXml(inputStream);
+		}
+		if (expected instanceof Resource resource) {
+			return isEqualToXml(resource);
+		}
+		failWithMessage("Unsupported type for XML assert %s", expected.getClass());
+		return this;
+	}
+
+	/**
+	 * Verifies that the actual value is leniently equal to the specified XML, ignoring
+	 * insignificant whitespace and comments. The {@code expected} value can contain the
+	 * XML itself or, if it ends with {@code .xml}, the name of a resource to be loaded
+	 * using {@code resourceLoadClass}.
 	 * @param expected the expected XML or the name of a resource containing the expected
 	 * XML
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is not identical to the given one
+	 * @throws AssertionError if the actual XML value is not equal to the given one
 	 */
 	public XmlContentAssert isEqualToXml(@Nullable CharSequence expected) {
 		return assertMatch(this.loader.getXml(expected), false);
 	}
 
 	/**
-	 * Verifies that the actual value is identical to the specified XML resource.
+	 * Verifies that the actual value is leniently equal to the specified XML resource,
+	 * ignoring insignificant whitespace and comments.
 	 * @param path the name of a resource containing the expected XML
 	 * @param resourceLoadClass the source class used to load the resource
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is not identical to the given one
+	 * @throws AssertionError if the actual XML value is not equal to the given one
 	 */
 	public XmlContentAssert isEqualToXml(String path, Class<?> resourceLoadClass) {
 		return assertMatch(this.loader.getXml(path, resourceLoadClass), false);
 	}
 
 	/**
-	 * Verifies that the actual value is identical to the specified XML bytes.
+	 * Verifies that the actual value is leniently equal to the specified XML bytes,
+	 * ignoring insignificant whitespace and comments.
 	 * @param expected the expected XML bytes
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is not identical to the given one
+	 * @throws AssertionError if the actual XML value is not equal to the given one
 	 */
 	public XmlContentAssert isEqualToXml(byte[] expected) {
 		return assertMatch(this.loader.getXml(expected), false);
 	}
 
 	/**
-	 * Verifies that the actual value is identical to the specified XML file.
+	 * Verifies that the actual value is leniently equal to the specified XML file,
+	 * ignoring insignificant whitespace and comments.
 	 * @param expected a file containing the expected XML
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is not identical to the given one
+	 * @throws AssertionError if the actual XML value is not equal to the given one
 	 */
 	public XmlContentAssert isEqualToXml(File expected) {
 		return assertMatch(this.loader.getXml(expected), false);
 	}
 
 	/**
-	 * Verifies that the actual value is identical to the specified XML input stream.
+	 * Verifies that the actual value is leniently equal to the specified XML input
+	 * stream, ignoring insignificant whitespace and comments.
 	 * @param expected an input stream containing the expected XML
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is not identical to the given one
+	 * @throws AssertionError if the actual XML value is not equal to the given one
 	 */
 	public XmlContentAssert isEqualToXml(InputStream expected) {
 		return assertMatch(this.loader.getXml(expected), false);
 	}
 
 	/**
-	 * Verifies that the actual value is identical to the specified XML resource.
+	 * Verifies that the actual value is leniently equal to the specified XML resource,
+	 * ignoring insignificant whitespace and comments.
 	 * @param expected a resource containing the expected XML
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is not identical to the given one
+	 * @throws AssertionError if the actual XML value is not equal to the given one
 	 */
 	public XmlContentAssert isEqualToXml(Resource expected) {
 		return assertMatch(this.loader.getXml(expected), false);
 	}
 
 	/**
-	 * Verifies that the actual value is not identical to the specified XML. The
+	 * Verifies that the actual value is strictly equal to the specified XML, in other
+	 * words that the two documents are identical. The {@code expected} value can contain
+	 * the XML itself or, if it ends with {@code .xml}, the name of a resource to be
+	 * loaded using {@code resourceLoadClass}.
+	 * <p>
+	 * The XML declaration is part of a strict comparison. An expected document that
+	 * starts with {@code <?xml version="1.0" encoding="UTF-8"?>} is therefore
+	 * <em>not</em> identical to an actual document written without one, and the
+	 * comparison fails with a message such as
+	 * {@code Expected xml encoding 'UTF-8' but was 'null'}. Marshallers such as
+	 * {@link tools.jackson.dataformat.xml.XmlMapper XmlMapper} write no declaration by
+	 * default, so omit it from fixtures used for strict comparison, or use
+	 * {@link #isEqualToXml(CharSequence)} instead, which ignores the declaration.
+	 * @param expected the expected XML or the name of a resource containing the expected
+	 * XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not equal to the given one
+	 */
+	public XmlContentAssert isStrictlyEqualToXml(CharSequence expected) {
+		return assertMatch(this.loader.getXml(expected), true);
+	}
+
+	/**
+	 * Verifies that the actual value is strictly equal to the specified XML resource, in
+	 * other words that the two documents are identical.
+	 * @param path the name of a resource containing the expected XML
+	 * @param resourceLoadClass the source class used to load the resource
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not equal to the given one
+	 */
+	public XmlContentAssert isStrictlyEqualToXml(String path, Class<?> resourceLoadClass) {
+		return assertMatch(this.loader.getXml(path, resourceLoadClass), true);
+	}
+
+	/**
+	 * Verifies that the actual value is strictly equal to the specified XML bytes, in
+	 * other words that the two documents are identical.
+	 * @param expected the expected XML bytes
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not equal to the given one
+	 */
+	public XmlContentAssert isStrictlyEqualToXml(byte[] expected) {
+		return assertMatch(this.loader.getXml(expected), true);
+	}
+
+	/**
+	 * Verifies that the actual value is strictly equal to the specified XML file, in
+	 * other words that the two documents are identical.
+	 * @param expected a file containing the expected XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not equal to the given one
+	 */
+	public XmlContentAssert isStrictlyEqualToXml(File expected) {
+		return assertMatch(this.loader.getXml(expected), true);
+	}
+
+	/**
+	 * Verifies that the actual value is strictly equal to the specified XML input stream,
+	 * in other words that the two documents are identical.
+	 * @param expected an input stream containing the expected XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not equal to the given one
+	 */
+	public XmlContentAssert isStrictlyEqualToXml(InputStream expected) {
+		return assertMatch(this.loader.getXml(expected), true);
+	}
+
+	/**
+	 * Verifies that the actual value is strictly equal to the specified XML resource, in
+	 * other words that the two documents are identical.
+	 * @param expected a resource containing the expected XML
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the actual XML value is not equal to the given one
+	 */
+	public XmlContentAssert isStrictlyEqualToXml(Resource expected) {
+		return assertMatch(this.loader.getXml(expected), true);
+	}
+
+	/**
+	 * Overridden version of {@code isNotEqualTo} to perform XML tests based on the object
+	 * type.
+	 * @see org.assertj.core.api.AbstractAssert#isEqualTo(java.lang.Object)
+	 */
+	@Override
+	public XmlContentAssert isNotEqualTo(@Nullable Object expected) {
+		if (expected == null || expected instanceof CharSequence) {
+			return isNotEqualToXml((CharSequence) expected);
+		}
+		if (expected instanceof byte[] bytes) {
+			return isNotEqualToXml(bytes);
+		}
+		if (expected instanceof File file) {
+			return isNotEqualToXml(file);
+		}
+		if (expected instanceof InputStream inputStream) {
+			return isNotEqualToXml(inputStream);
+		}
+		if (expected instanceof Resource resource) {
+			return isNotEqualToXml(resource);
+		}
+		failWithMessage("Unsupported type for XML assert %s", expected.getClass());
+		return this;
+	}
+
+	/**
+	 * Verifies that the actual value is not leniently equal to the specified XML. The
 	 * {@code expected} value can contain the XML itself or, if it ends with {@code .xml},
 	 * the name of a resource to be loaded using {@code resourceLoadClass}.
 	 * @param expected the expected XML or the name of a resource containing the expected
 	 * XML
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is identical to the given one
+	 * @throws AssertionError if the actual XML value is equal to the given one
 	 */
 	public XmlContentAssert isNotEqualToXml(@Nullable CharSequence expected) {
 		return assertNoMatch(this.loader.getXml(expected), false);
 	}
 
 	/**
-	 * Verifies that the actual value is not identical to the specified XML resource.
+	 * Verifies that the actual value is not leniently equal to the specified XML
+	 * resource.
 	 * @param path the name of a resource containing the expected XML
 	 * @param resourceLoadClass the source class used to load the resource
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is identical to the given one
+	 * @throws AssertionError if the actual XML value is equal to the given one
 	 */
 	public XmlContentAssert isNotEqualToXml(String path, Class<?> resourceLoadClass) {
 		return assertNoMatch(this.loader.getXml(path, resourceLoadClass), false);
 	}
 
 	/**
-	 * Verifies that the actual value is not identical to the specified XML bytes.
+	 * Verifies that the actual value is not leniently equal to the specified XML bytes.
 	 * @param expected the expected XML bytes
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is identical to the given one
+	 * @throws AssertionError if the actual XML value is equal to the given one
 	 */
 	public XmlContentAssert isNotEqualToXml(byte[] expected) {
 		return assertNoMatch(this.loader.getXml(expected), false);
 	}
 
 	/**
-	 * Verifies that the actual value is not identical to the specified XML file.
+	 * Verifies that the actual value is not leniently equal to the specified XML file.
 	 * @param expected a file containing the expected XML
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is identical to the given one
+	 * @throws AssertionError if the actual XML value is equal to the given one
 	 */
 	public XmlContentAssert isNotEqualToXml(File expected) {
 		return assertNoMatch(this.loader.getXml(expected), false);
 	}
 
 	/**
-	 * Verifies that the actual value is not identical to the specified XML input stream.
+	 * Verifies that the actual value is not leniently equal to the specified XML input
+	 * stream.
 	 * @param expected an input stream containing the expected XML
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is identical to the given one
+	 * @throws AssertionError if the actual XML value is equal to the given one
 	 */
 	public XmlContentAssert isNotEqualToXml(InputStream expected) {
 		return assertNoMatch(this.loader.getXml(expected), false);
 	}
 
 	/**
-	 * Verifies that the actual value is not identical to the specified XML resource.
+	 * Verifies that the actual value is not leniently equal to the specified XML
+	 * resource.
 	 * @param expected a resource containing the expected XML
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is identical to the given one
+	 * @throws AssertionError if the actual XML value is equal to the given one
 	 */
 	public XmlContentAssert isNotEqualToXml(Resource expected) {
 		return assertNoMatch(this.loader.getXml(expected), false);
 	}
 
 	/**
-	 * Verifies that the actual value is similar to the specified XML, ignoring
-	 * insignificant whitespace, comments and the ordering of elements and attributes. The
+	 * Verifies that the actual value is not strictly equal to the specified XML. The
 	 * {@code expected} value can contain the XML itself or, if it ends with {@code .xml},
 	 * the name of a resource to be loaded using {@code resourceLoadClass}.
 	 * @param expected the expected XML or the name of a resource containing the expected
 	 * XML
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is not similar to the given one
+	 * @throws AssertionError if the actual XML value is equal to the given one
 	 */
-	public XmlContentAssert isSimilarToXml(@Nullable CharSequence expected) {
-		return assertMatch(this.loader.getXml(expected), true);
-	}
-
-	/**
-	 * Verifies that the actual value is similar to the specified XML resource, ignoring
-	 * insignificant whitespace, comments and the ordering of elements and attributes.
-	 * @param path the name of a resource containing the expected XML
-	 * @param resourceLoadClass the source class used to load the resource
-	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is not similar to the given one
-	 */
-	public XmlContentAssert isSimilarToXml(String path, Class<?> resourceLoadClass) {
-		return assertMatch(this.loader.getXml(path, resourceLoadClass), true);
-	}
-
-	/**
-	 * Verifies that the actual value is similar to the specified XML bytes, ignoring
-	 * insignificant whitespace, comments and the ordering of elements and attributes.
-	 * @param expected the expected XML bytes
-	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is not similar to the given one
-	 */
-	public XmlContentAssert isSimilarToXml(byte[] expected) {
-		return assertMatch(this.loader.getXml(expected), true);
-	}
-
-	/**
-	 * Verifies that the actual value is similar to the specified XML file, ignoring
-	 * insignificant whitespace, comments and the ordering of elements and attributes.
-	 * @param expected a file containing the expected XML
-	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is not similar to the given one
-	 */
-	public XmlContentAssert isSimilarToXml(File expected) {
-		return assertMatch(this.loader.getXml(expected), true);
-	}
-
-	/**
-	 * Verifies that the actual value is similar to the specified XML input stream,
-	 * ignoring insignificant whitespace, comments and the ordering of elements and
-	 * attributes.
-	 * @param expected an input stream containing the expected XML
-	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is not similar to the given one
-	 */
-	public XmlContentAssert isSimilarToXml(InputStream expected) {
-		return assertMatch(this.loader.getXml(expected), true);
-	}
-
-	/**
-	 * Verifies that the actual value is similar to the specified XML resource, ignoring
-	 * insignificant whitespace, comments and the ordering of elements and attributes.
-	 * @param expected a resource containing the expected XML
-	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is not similar to the given one
-	 */
-	public XmlContentAssert isSimilarToXml(Resource expected) {
-		return assertMatch(this.loader.getXml(expected), true);
-	}
-
-	/**
-	 * Verifies that the actual value is not similar to the specified XML. The
-	 * {@code expected} value can contain the XML itself or, if it ends with {@code .xml},
-	 * the name of a resource to be loaded using {@code resourceLoadClass}.
-	 * @param expected the expected XML or the name of a resource containing the expected
-	 * XML
-	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is similar to the given one
-	 */
-	public XmlContentAssert isNotSimilarToXml(@Nullable CharSequence expected) {
+	public XmlContentAssert isNotStrictlyEqualToXml(CharSequence expected) {
 		return assertNoMatch(this.loader.getXml(expected), true);
 	}
 
 	/**
-	 * Verifies that the actual value is not similar to the specified XML resource.
+	 * Verifies that the actual value is not strictly equal to the specified XML resource.
 	 * @param path the name of a resource containing the expected XML
 	 * @param resourceLoadClass the source class used to load the resource
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is similar to the given one
+	 * @throws AssertionError if the actual XML value is equal to the given one
 	 */
-	public XmlContentAssert isNotSimilarToXml(String path, Class<?> resourceLoadClass) {
+	public XmlContentAssert isNotStrictlyEqualToXml(String path, Class<?> resourceLoadClass) {
 		return assertNoMatch(this.loader.getXml(path, resourceLoadClass), true);
 	}
 
 	/**
-	 * Verifies that the actual value is not similar to the specified XML bytes.
+	 * Verifies that the actual value is not strictly equal to the specified XML bytes.
 	 * @param expected the expected XML bytes
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is similar to the given one
+	 * @throws AssertionError if the actual XML value is equal to the given one
 	 */
-	public XmlContentAssert isNotSimilarToXml(byte[] expected) {
+	public XmlContentAssert isNotStrictlyEqualToXml(byte[] expected) {
 		return assertNoMatch(this.loader.getXml(expected), true);
 	}
 
 	/**
-	 * Verifies that the actual value is not similar to the specified XML file.
+	 * Verifies that the actual value is not strictly equal to the specified XML file.
 	 * @param expected a file containing the expected XML
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is similar to the given one
+	 * @throws AssertionError if the actual XML value is equal to the given one
 	 */
-	public XmlContentAssert isNotSimilarToXml(File expected) {
+	public XmlContentAssert isNotStrictlyEqualToXml(File expected) {
 		return assertNoMatch(this.loader.getXml(expected), true);
 	}
 
 	/**
-	 * Verifies that the actual value is not similar to the specified XML input stream.
+	 * Verifies that the actual value is not strictly equal to the specified XML input
+	 * stream.
 	 * @param expected an input stream containing the expected XML
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is similar to the given one
+	 * @throws AssertionError if the actual XML value is equal to the given one
 	 */
-	public XmlContentAssert isNotSimilarToXml(InputStream expected) {
+	public XmlContentAssert isNotStrictlyEqualToXml(InputStream expected) {
 		return assertNoMatch(this.loader.getXml(expected), true);
 	}
 
 	/**
-	 * Verifies that the actual value is not similar to the specified XML resource.
+	 * Verifies that the actual value is not strictly equal to the specified XML resource.
 	 * @param expected a resource containing the expected XML
 	 * @return {@code this} assertion object
-	 * @throws AssertionError if the actual XML value is similar to the given one
+	 * @throws AssertionError if the actual XML value is equal to the given one
 	 */
-	public XmlContentAssert isNotSimilarToXml(Resource expected) {
+	public XmlContentAssert isNotStrictlyEqualToXml(Resource expected) {
 		return assertNoMatch(this.loader.getXml(expected), true);
 	}
 
@@ -356,7 +549,8 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 	 * Verify that the actual value at the given XPath expression produces a result.
 	 * @param expression the XPath expression
 	 * @param args arguments to parameterize the XPath expression with, using formatting
-	 * specifiers defined in {@link String#format(String, Object...)}
+	 * specifiers defined in {@link String#format(String, Object...)}. When no arguments
+	 * are supplied the expression is used verbatim
 	 * @return {@code this} assertion object
 	 * @throws AssertionError if there is no value at the given XPath expression
 	 */
@@ -369,7 +563,8 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 	 * Verify that the actual value at the given XPath expression produces no result.
 	 * @param expression the XPath expression
 	 * @param args arguments to parameterize the XPath expression with, using formatting
-	 * specifiers defined in {@link String#format(String, Object...)}
+	 * specifiers defined in {@link String#format(String, Object...)}. When no arguments
+	 * are supplied the expression is used verbatim
 	 * @return {@code this} assertion object
 	 * @throws AssertionError if there is a value at the given XPath expression
 	 */
@@ -379,16 +574,38 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 	}
 
 	/**
-	 * Extract the value at the given XPath expression for further object assertions.
+	 * Verify that the given XPath expression matches exactly the expected number of
+	 * nodes.
+	 * @param expression the XPath expression
+	 * @param expectedCount the expected number of matching nodes, which must not be
+	 * negative
+	 * @param args arguments to parameterize the XPath expression with, using formatting
+	 * specifiers defined in {@link String#format(String, Object...)}. When no arguments
+	 * are supplied the expression is used verbatim
+	 * @return {@code this} assertion object
+	 * @throws AssertionError if the expression does not match the expected number of
+	 * nodes
+	 */
+	public XmlContentAssert hasXPathNodeCount(CharSequence expression, int expectedCount, Object... args) {
+		Assert.isTrue(expectedCount >= 0, "'expectedCount' must not be negative");
+		new XPathValue(expression, args).assertNodeCount(expectedCount);
+		return this;
+	}
+
+	/**
+	 * Extract the nodes matched by the given XPath expression for further list
+	 * assertions.
 	 * @param expression the XPath expression
 	 * @param args arguments to parameterize the XPath expression with, using formatting
-	 * specifiers defined in {@link String#format(String, Object...)}
-	 * @return a new assertion object whose object under test is the extracted item
-	 * @throws AssertionError if the expression is not valid
+	 * specifiers defined in {@link String#format(String, Object...)}. When no arguments
+	 * are supplied the expression is used verbatim
+	 * @return a new assertion object whose object under test is the list of matched nodes
+	 * @throws AssertionError if the expression is not valid or does not result in a node
+	 * set
 	 */
 	@CheckReturnValue
-	public AbstractObjectAssert<?, Object> extractingXPathValue(CharSequence expression, Object... args) {
-		return assertThat(new XPathValue(expression, args).getValue());
+	public ListAssert<Node> extractingXPathNodeList(CharSequence expression, Object... args) {
+		return assertThat(new XPathValue(expression, args).getNodeList());
 	}
 
 	/**
@@ -396,9 +613,11 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 	 * assertions.
 	 * @param expression the XPath expression
 	 * @param args arguments to parameterize the XPath expression with, using formatting
-	 * specifiers defined in {@link String#format(String, Object...)}
+	 * specifiers defined in {@link String#format(String, Object...)}. When no arguments
+	 * are supplied the expression is used verbatim
 	 * @return a new assertion object whose object under test is the extracted item
-	 * @throws AssertionError if the expression is not valid
+	 * @throws AssertionError if the expression is not valid, matches no node or matches
+	 * more than one node
 	 */
 	@CheckReturnValue
 	public AbstractCharSequenceAssert<?, String> extractingXPathStringValue(CharSequence expression, Object... args) {
@@ -407,13 +626,16 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 
 	/**
 	 * Extract the number value at the given XPath expression for further object
-	 * assertions.
+	 * assertions. The extracted value is always a {@link Double}, matching the way XPath
+	 * itself converts to a number. Text that is not in the XPath number lexical space,
+	 * such as {@code 10d}, {@code NaN} or {@code 0x1p3}, is rejected rather than coerced.
 	 * @param expression the XPath expression
 	 * @param args arguments to parameterize the XPath expression with, using formatting
-	 * specifiers defined in {@link String#format(String, Object...)}
+	 * specifiers defined in {@link String#format(String, Object...)}. When no arguments
+	 * are supplied the expression is used verbatim
 	 * @return a new assertion object whose object under test is the extracted item
-	 * @throws AssertionError if the expression is not valid or does not result in a
-	 * number
+	 * @throws AssertionError if the expression is not valid, matches no node, matches
+	 * more than one node or does not result in a number
 	 */
 	@CheckReturnValue
 	public AbstractObjectAssert<?, Number> extractingXPathNumberValue(CharSequence expression, Object... args) {
@@ -422,36 +644,38 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 
 	/**
 	 * Extract the boolean value at the given XPath expression for further object
-	 * assertions.
+	 * assertions. The full {@code xs:boolean} lexical space is accepted, in other words
+	 * {@code true}, {@code false}, {@code 1} and {@code 0}.
 	 * @param expression the XPath expression
 	 * @param args arguments to parameterize the XPath expression with, using formatting
-	 * specifiers defined in {@link String#format(String, Object...)}
+	 * specifiers defined in {@link String#format(String, Object...)}. When no arguments
+	 * are supplied the expression is used verbatim
 	 * @return a new assertion object whose object under test is the extracted item
-	 * @throws AssertionError if the expression is not valid or does not result in a
-	 * boolean
+	 * @throws AssertionError if the expression is not valid, matches no node, matches
+	 * more than one node or does not result in a boolean
 	 */
 	@CheckReturnValue
 	public AbstractBooleanAssert<?> extractingXPathBooleanValue(CharSequence expression, Object... args) {
 		return assertThat(new XPathValue(expression, args).getBooleanValue());
 	}
 
-	private XmlContentAssert assertMatch(@Nullable String expectedXml, boolean similar) {
-		String difference = compare(expectedXml, similar);
+	private XmlContentAssert assertMatch(@Nullable String expectedXml, boolean strict) {
+		String difference = compare(expectedXml, strict, true);
 		if (difference != null) {
 			failWithMessage("XML Comparison failure: %s", difference);
 		}
 		return this;
 	}
 
-	private XmlContentAssert assertNoMatch(@Nullable String expectedXml, boolean similar) {
-		String difference = compare(expectedXml, similar);
+	private XmlContentAssert assertNoMatch(@Nullable String expectedXml, boolean strict) {
+		String difference = compare(expectedXml, strict, false);
 		if (difference == null) {
 			failWithMessage("XML Comparison failure: expected a difference but none was found");
 		}
 		return this;
 	}
 
-	private @Nullable String compare(@Nullable String expectedXml, boolean similar) {
+	private @Nullable String compare(@Nullable String expectedXml, boolean strict, boolean failOnError) {
 		CharSequence actual = this.actual;
 		if (actual == null) {
 			return (expectedXml != null) ? "Expected null XML" : null;
@@ -459,27 +683,47 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 		if (expectedXml == null) {
 			return "Expected XML but got null";
 		}
-		Diff diff = diff(expectedXml, actual.toString(), similar);
-		return (diff.hasDifferences()) ? diff.toString() : null;
-	}
-
-	private Diff diff(String expectedXml, String actualXml, boolean similar) {
-		DiffBuilder builder = DiffBuilder.compare(Input.fromString(expectedXml)).withTest(Input.fromString(actualXml));
-		if (similar) {
-			builder = builder.ignoreWhitespace()
-				.ignoreComments()
-				.withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byName))
-				.checkForSimilar();
-		}
-		else {
-			builder = builder.checkForIdentical();
-		}
 		try {
-			return builder.build();
+			return describeDifferences(diff(expectedXml, actual.toString(), strict), strict);
 		}
 		catch (XMLUnitException ex) {
-			throw new AssertionError("Unable to compare XML: " + ex.getMessage(), ex);
+			if (failOnError) {
+				throw new AssertionError("Unable to compare XML: " + ex.getMessage(), ex);
+			}
+			return "Unable to compare XML: " + ex.getMessage();
 		}
+	}
+
+	private Diff diff(String expectedXml, String actualXml, boolean strict) {
+		// The document builder factory is honored for the stream sources used here. It is
+		// ignored for DOMSource inputs and, as XMLUnit's own javadoc notes,
+		// ignoreComments
+		// applies an XSLT transform which can reduce its effect.
+		DiffBuilder builder = DiffBuilder.compare(Input.fromString(expectedXml))
+			.withTest(Input.fromString(actualXml))
+			.withDocumentBuilderFactory(createDocumentBuilderFactory());
+		if (strict) {
+			builder = builder.checkForIdentical();
+		}
+		else {
+			// The selectors are applied in separate passes. ElementSelectors.or(...) must
+			// not be used here as it degenerates to positional matching.
+			builder = builder.ignoreWhitespace()
+				.ignoreComments()
+				.withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndText, ElementSelectors.byName))
+				.checkForSimilar();
+		}
+		return builder.build();
+	}
+
+	private @Nullable String describeDifferences(Diff diff, boolean strict) {
+		List<String> messages = new ArrayList<>();
+		for (Difference difference : diff.getDifferences()) {
+			if (strict || difference.getResult() == ComparisonResult.DIFFERENT) {
+				messages.add(difference.toString());
+			}
+		}
+		return (!messages.isEmpty()) ? String.join(", ", messages) : null;
 	}
 
 	private Document parseActual() {
@@ -488,14 +732,51 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 			throw new AssertionError("Expecting actual XML content not to be null");
 		}
 		try {
-			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-			factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-			DocumentBuilder documentBuilder = factory.newDocumentBuilder();
+			DocumentBuilder documentBuilder = createDocumentBuilderFactory().newDocumentBuilder();
 			return documentBuilder.parse(new InputSource(new StringReader(actual.toString())));
 		}
 		catch (Exception ex) {
 			throw new AssertionError("Unable to parse XML content: " + ex.getMessage(), ex);
+		}
+	}
+
+	private DocumentBuilderFactory createDocumentBuilderFactory() {
+		// DefaultWithDTDParsing allows a DOCTYPE with an internal subset while keeping
+		// every external entity feature disabled, so external entities are not resolved.
+		DocumentBuilderFactory factory = DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+			.configure(DocumentBuilderFactory.newInstance());
+		// The configurer does not touch namespace awareness.
+		factory.setNamespaceAware(true);
+		// The configurer turns entity reference expansion off, which leaves an empty
+		// EntityReference node in the tree for an entity declared in the internal subset.
+		// That node has no text and makes every XPath evaluation on the document fail, so
+		// expansion is turned back on. Only entities the document declares itself are
+		// expanded, as the external entity features remain disabled.
+		factory.setExpandEntityReferences(true);
+		setAttributeQuietly(factory, XMLConstants.ACCESS_EXTERNAL_DTD);
+		setAttributeQuietly(factory, XMLConstants.ACCESS_EXTERNAL_SCHEMA);
+		return factory;
+	}
+
+	private static String formatExpression(String expression, Object... args) {
+		if (ObjectUtils.isEmpty(args)) {
+			return expression;
+		}
+		try {
+			return String.format(expression, args);
+		}
+		catch (IllegalFormatException ex) {
+			throw new AssertionError("Unable to format XML path \"" + expression + "\" with arguments "
+					+ Arrays.toString(args) + ": " + ex.getMessage(), ex);
+		}
+	}
+
+	private void setAttributeQuietly(DocumentBuilderFactory factory, String name) {
+		try {
+			factory.setAttribute(name, "");
+		}
+		catch (IllegalArgumentException ex) {
+			// Not supported by this parser, ignore
 		}
 	}
 
@@ -506,91 +787,164 @@ public class XmlContentAssert extends AbstractAssert<XmlContentAssert, CharSeque
 
 		private final String expression;
 
+		private final Document document;
+
+		private final XPathExpression compiled;
+
+		private final @Nullable NodeList nodeSet;
+
 		XPathValue(CharSequence expression, Object... args) {
 			Assert.hasText((expression != null) ? expression.toString() : null, "'expression' must not be empty");
-			this.expression = String.format(expression.toString(), args);
+			this.expression = formatExpression(expression.toString(), args);
+			assertPrefixesAreRegistered();
+			this.document = parseActual();
+			this.compiled = compile();
+			this.nodeSet = evaluateNodeSet();
 		}
 
 		void assertHasValue() {
-			if (getNode() == null) {
-				failWithMessage("No value at XPath \"%s\"", this.expression);
+			NodeList nodeSet = requireNodeSet();
+			if (nodeSet.getLength() == 0) {
+				failWithMessage("No XML path \"%s\" found", this.expression);
 			}
 		}
 
 		void assertDoesNotHaveValue() {
-			Node node = getNode();
-			if (node != null) {
-				failWithMessage("Expected no value at XPath \"%s\" but found: %s", this.expression,
-						node.getTextContent());
+			NodeList nodeSet = requireNodeSet();
+			if (nodeSet.getLength() > 0) {
+				failWithMessage("Expecting no XML path \"%s\"", this.expression);
 			}
 		}
 
-		@Nullable Object getValue() {
-			return getStringValue();
+		void assertNodeCount(int expectedCount) {
+			NodeList nodeSet = requireNodeSet();
+			if (nodeSet.getLength() != expectedCount) {
+				failWithMessage("Expected %s node(s) at XML path \"%s\" but found %s", expectedCount, this.expression,
+						nodeSet.getLength());
+			}
 		}
 
-		@Nullable String getStringValue() {
-			Node node = getNode();
-			return (node != null) ? node.getTextContent() : null;
+		List<Node> getNodeList() {
+			NodeList nodeSet = requireNodeSet();
+			List<Node> nodes = new ArrayList<>(nodeSet.getLength());
+			for (int i = 0; i < nodeSet.getLength(); i++) {
+				nodes.add(nodeSet.item(i));
+			}
+			return nodes;
 		}
 
-		@Nullable Number getNumberValue() {
-			String value = getStringValue();
-			if (value == null) {
-				return null;
-			}
-			Number number = parseNumber(value.trim());
-			if (number == null) {
-				failWithMessage("Expected a number at XPath \"%s\" but found: %s", this.expression, value);
-			}
-			return number;
+		String getStringValue() {
+			assertHasSingleValue();
+			return (String) evaluate(XPathConstants.STRING);
 		}
 
-		@Nullable Boolean getBooleanValue() {
-			String value = getStringValue();
-			if (value == null) {
-				return null;
+		Number getNumberValue() {
+			assertHasSingleValue();
+			if (this.nodeSet != null) {
+				String text = ((String) evaluate(XPathConstants.STRING)).trim();
+				if (!NUMBER_PATTERN.matcher(text).matches()) {
+					failWithMessage("Expected a number at XML path \"%s\" but found: %s", this.expression, text);
+				}
 			}
-			String trimmed = value.trim();
-			if ("true".equalsIgnoreCase(trimmed)) {
+			double value = (Double) evaluate(XPathConstants.NUMBER);
+			if (Double.isNaN(value) || Double.isInfinite(value)) {
+				failWithMessage("Expected a number at XML path \"%s\" but found: %s", this.expression, value);
+			}
+			return value;
+		}
+
+		Boolean getBooleanValue() {
+			assertHasSingleValue();
+			if (this.nodeSet == null) {
+				return (Boolean) evaluate(XPathConstants.BOOLEAN);
+			}
+			String text = ((String) evaluate(XPathConstants.STRING)).trim();
+			if ("true".equals(text) || "1".equals(text)) {
 				return Boolean.TRUE;
 			}
-			if ("false".equalsIgnoreCase(trimmed)) {
-				return Boolean.FALSE;
+			if (!"false".equals(text) && !"0".equals(text)) {
+				failWithMessage("Expected a boolean at XML path \"%s\" but found: %s", this.expression, text);
 			}
-			failWithMessage("Expected a boolean at XPath \"%s\" but found: %s", this.expression, value);
-			return null;
+			return Boolean.FALSE;
 		}
 
-		private @Nullable Number parseNumber(String value) {
+		private NodeList requireNodeSet() {
+			NodeList nodeSet = this.nodeSet;
+			if (nodeSet == null) {
+				failWithMessage("XML path \"%s\" does not select nodes", this.expression);
+				throw new AssertionError("Unreachable");
+			}
+			return nodeSet;
+		}
+
+		/**
+		 * An empty node set evaluates to {@code NaN}, {@code false} or an empty string
+		 * rather than {@code null}, so the node set is probed first to tell a missing
+		 * value from a value that is legitimately empty.
+		 */
+		private void assertHasSingleValue() {
+			NodeList nodeSet = this.nodeSet;
+			if (nodeSet == null) {
+				return;
+			}
+			if (nodeSet.getLength() == 0) {
+				failWithMessage("No value at XML path \"%s\"", this.expression);
+			}
+			else if (nodeSet.getLength() > 1) {
+				failWithMessage("Expected a single node at XML path \"%s\" but found %s nodes", this.expression,
+						nodeSet.getLength());
+			}
+		}
+
+		private void assertPrefixesAreRegistered() {
+			String withoutLiterals = STRING_LITERAL_PATTERN.matcher(this.expression).replaceAll("''");
+			String withoutAxes = AXIS_PATTERN.matcher(withoutLiterals).replaceAll(" ");
+			Matcher matcher = PREFIX_PATTERN.matcher(withoutAxes);
+			while (matcher.find()) {
+				String prefix = matcher.group(1);
+				if (!XMLConstants.XML_NS_PREFIX.equals(prefix)
+						&& !XmlContentAssert.this.namespaces.containsKey(prefix)) {
+					failWithMessage("Namespace prefix \"%s\" used in XML path \"%s\" has not been registered", prefix,
+							this.expression);
+				}
+			}
+		}
+
+		private XPathExpression compile() {
 			try {
-				return Integer.valueOf(value);
+				XPathFactory xpathFactory = XPathFactory.newInstance();
+				try {
+					xpathFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+				}
+				catch (XPathFactoryConfigurationException ex) {
+					// Not supported by this implementation, ignore
+				}
+				XPath xpath = xpathFactory.newXPath();
+				xpath.setNamespaceContext(XmlContentAssert.this.namespaceContext);
+				return xpath.compile(this.expression);
 			}
-			catch (NumberFormatException ex) {
-				// Not an int, continue
+			catch (XPathExpressionException ex) {
+				throw new AssertionError("Unable to compile XML path \"" + this.expression + "\": " + ex.getMessage(),
+						ex);
 			}
+		}
+
+		private @Nullable NodeList evaluateNodeSet() {
 			try {
-				return Long.valueOf(value);
+				return (NodeList) this.compiled.evaluate(this.document, XPathConstants.NODESET);
 			}
-			catch (NumberFormatException ex) {
-				// Not a long, continue
-			}
-			try {
-				return Double.valueOf(value);
-			}
-			catch (NumberFormatException ex) {
+			catch (XPathExpressionException ex) {
+				// Not a node set expression, for example count(...)
 				return null;
 			}
 		}
 
-		private @Nullable Node getNode() {
-			Document document = parseActual();
+		private Object evaluate(QName returnType) {
 			try {
-				XPath xPath = XPathFactory.newInstance().newXPath();
-				return (Node) xPath.evaluate(this.expression, document, XPathConstants.NODE);
+				return this.compiled.evaluate(this.document, returnType);
 			}
-			catch (Exception ex) {
-				throw new AssertionError("Unable to evaluate XPath \"" + this.expression + "\": " + ex.getMessage(),
+			catch (XPathExpressionException ex) {
+				throw new AssertionError("Unable to evaluate XML path \"" + this.expression + "\": " + ex.getMessage(),
 						ex);
 			}
 		}

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlLoader.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlLoader.java
@@ -21,7 +21,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -36,12 +40,21 @@ import org.springframework.util.FileCopyUtils;
 /**
  * Internal helper used to load XML from various sources. When no charset has been
  * supplied the bytes are decoded using the encoding that the document itself declares,
- * either through a byte order mark or through its XML declaration, so that the expected
- * side of a comparison is read the same way a parser would read it.
+ * either through a byte order mark, through the way the first character is padded with
+ * NUL bytes or through its XML declaration, so that the expected side of a comparison is
+ * read the same way a parser would read it. A byte order mark is never part of the
+ * document, so it is removed whether or not a charset was supplied. Bytes that are
+ * malformed for the charset in use are rejected rather than being replaced.
  *
  * @author Tiziano Basile
  */
 class XmlLoader {
+
+	private static final Charset UTF_32BE = Charset.forName("UTF-32BE");
+
+	private static final Charset UTF_32LE = Charset.forName("UTF-32LE");
+
+	private static final char BYTE_ORDER_MARK = '\uFEFF';
 
 	private static final byte[] UTF_8_BOM = { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
 
@@ -49,15 +62,36 @@ class XmlLoader {
 
 	private static final byte[] UTF_16_LE_BOM = { (byte) 0xFF, (byte) 0xFE };
 
-	private static final byte[] UTF_16_BE_DECLARATION = { 0x00, 0x3C, 0x00, 0x3F };
+	private static final byte[] UTF_32_BE_BOM = { 0x00, 0x00, (byte) 0xFE, (byte) 0xFF };
 
-	private static final byte[] UTF_16_LE_DECLARATION = { 0x3C, 0x00, 0x3F, 0x00 };
+	private static final byte[] UTF_32_LE_BOM = { (byte) 0xFF, (byte) 0xFE, 0x00, 0x00 };
+
+	private static final byte[] UTF_16_BE_START = { 0x00, 0x3C };
+
+	private static final byte[] UTF_16_LE_START = { 0x3C, 0x00 };
+
+	private static final byte[] UTF_32_BE_START = { 0x00, 0x00, 0x00, 0x3C };
+
+	private static final byte[] UTF_32_LE_START = { 0x3C, 0x00, 0x00, 0x00 };
 
 	/**
-	 * Matches the {@code encoding} pseudo-attribute of an XML declaration.
+	 * The number of bytes that an XML declaration is expected to fit into.
 	 */
-	private static final Pattern ENCODING_PATTERN = Pattern
-		.compile("^<\\?xml\\s[^>]*?encoding\\s*=\\s*[\"']([^\"']+)[\"']");
+	private static final int DECLARATION_LIMIT = 256;
+
+	/**
+	 * Matches the start of an XML declaration. The trailing whitespace is required so
+	 * that a processing instruction such as {@code <?xml-stylesheet ... ?>} is not
+	 * mistaken for one.
+	 */
+	private static final Pattern DECLARATION_START_PATTERN = Pattern.compile("^<\\?xml\\s");
+
+	/**
+	 * Matches the {@code encoding} pseudo-attribute of an XML declaration. The quoted
+	 * value is deliberately allowed to be empty so that an empty encoding is reported
+	 * rather than silently ignored.
+	 */
+	private static final Pattern ENCODING_PATTERN = Pattern.compile("encoding\\s*=\\s*([\"'])(.*?)\\1");
 
 	private final Class<?> resourceLoadClass;
 
@@ -115,50 +149,135 @@ class XmlLoader {
 	}
 
 	private String decode(byte[] bytes) {
-		Charset charset = this.charset;
-		if (charset != null) {
-			return new String(bytes, charset);
-		}
-		if (startsWith(bytes, UTF_8_BOM)) {
-			return new String(bytes, UTF_8_BOM.length, bytes.length - UTF_8_BOM.length, StandardCharsets.UTF_8);
-		}
-		if (startsWith(bytes, UTF_16_BE_BOM)) {
-			return new String(bytes, UTF_16_BE_BOM.length, bytes.length - UTF_16_BE_BOM.length,
-					StandardCharsets.UTF_16BE);
-		}
-		if (startsWith(bytes, UTF_16_LE_BOM)) {
-			return new String(bytes, UTF_16_LE_BOM.length, bytes.length - UTF_16_LE_BOM.length,
-					StandardCharsets.UTF_16LE);
-		}
-		if (startsWith(bytes, UTF_16_BE_DECLARATION)) {
-			return new String(bytes, StandardCharsets.UTF_16BE);
-		}
-		if (startsWith(bytes, UTF_16_LE_DECLARATION)) {
-			return new String(bytes, StandardCharsets.UTF_16LE);
-		}
-		return new String(bytes, getDeclaredCharset(bytes));
+		Charset charset = (this.charset != null) ? this.charset : detectCharset(bytes);
+		return removeByteOrderMark(decode(bytes, charset));
 	}
 
 	/**
-	 * Return the charset named by the XML declaration, if any. The declaration itself is
-	 * restricted to ASCII characters, so it can safely be read using ISO-8859-1 whatever
-	 * the actual encoding of the remainder of the document turns out to be.
+	 * Decode the given bytes, rejecting any byte sequence that the charset cannot
+	 * represent rather than replacing it with the replacement character, which would turn
+	 * a mis-encoded document into a comparison failure that says nothing about the cause.
 	 * @param bytes the source bytes
-	 * @return the declared charset or UTF-8 if none is declared or it is not supported
+	 * @param charset the charset to decode with
+	 * @return the decoded content
+	 */
+	private String decode(byte[] bytes, Charset charset) {
+		CharsetDecoder decoder = charset.newDecoder()
+			.onMalformedInput(CodingErrorAction.REPORT)
+			.onUnmappableCharacter(CodingErrorAction.REPORT);
+		try {
+			return decoder.decode(ByteBuffer.wrap(bytes)).toString();
+		}
+		catch (CharacterCodingException ex) {
+			throw new AssertionError(
+					"Unable to load XML as it cannot be decoded using " + charset.name() + ": " + ex.getMessage(), ex);
+		}
+	}
+
+	/**
+	 * Remove a leading byte order mark. The mark identifies the encoding, it is not part
+	 * of the document, and a parser rejects it if it is left in place.
+	 * @param xml the decoded content
+	 * @return the content without its byte order mark
+	 */
+	private String removeByteOrderMark(String xml) {
+		return (!xml.isEmpty() && xml.charAt(0) == BYTE_ORDER_MARK) ? xml.substring(1) : xml;
+	}
+
+	private Charset detectCharset(byte[] bytes) {
+		Charset charset = getByteOrderMarkCharset(bytes);
+		if (charset == null) {
+			charset = getSniffedCharset(bytes);
+		}
+		return (charset != null) ? charset : getDeclaredCharset(bytes);
+	}
+
+	/**
+	 * Return the charset identified by a byte order mark, if there is one. The UTF-32
+	 * marks are tested first as the little-endian UTF-32 mark starts with the
+	 * little-endian UTF-16 mark.
+	 * @param bytes the source bytes
+	 * @return the charset or {@code null} if there is no byte order mark
+	 */
+	private @Nullable Charset getByteOrderMarkCharset(byte[] bytes) {
+		if (startsWith(bytes, UTF_32_LE_BOM)) {
+			return UTF_32LE;
+		}
+		if (startsWith(bytes, UTF_32_BE_BOM)) {
+			return UTF_32BE;
+		}
+		if (startsWith(bytes, UTF_8_BOM)) {
+			return StandardCharsets.UTF_8;
+		}
+		if (startsWith(bytes, UTF_16_LE_BOM)) {
+			return StandardCharsets.UTF_16LE;
+		}
+		if (startsWith(bytes, UTF_16_BE_BOM)) {
+			return StandardCharsets.UTF_16BE;
+		}
+		return null;
+	}
+
+	/**
+	 * Return the charset of a document that carries neither a byte order mark nor,
+	 * necessarily, an XML declaration. A document always starts with {@code <}, so the
+	 * NUL bytes that pad that first character reveal a UTF-16 or UTF-32 encoding. Without
+	 * this the bytes would be read as UTF-8, which turns a UTF-16 document into text that
+	 * is interleaved with NUL characters.
+	 * @param bytes the source bytes
+	 * @return the charset or {@code null} if the document is not padded
+	 */
+	private @Nullable Charset getSniffedCharset(byte[] bytes) {
+		if (startsWith(bytes, UTF_32_LE_START)) {
+			return UTF_32LE;
+		}
+		if (startsWith(bytes, UTF_32_BE_START)) {
+			return UTF_32BE;
+		}
+		if (startsWith(bytes, UTF_16_LE_START)) {
+			return StandardCharsets.UTF_16LE;
+		}
+		if (startsWith(bytes, UTF_16_BE_START)) {
+			return StandardCharsets.UTF_16BE;
+		}
+		return null;
+	}
+
+	/**
+	 * Return the charset named by the XML declaration. The declaration itself is
+	 * restricted to ASCII characters, so it can safely be read using ISO-8859-1 whatever
+	 * the actual encoding of the remainder of the document turns out to be. A declaration
+	 * whose encoding cannot be read is an error, as guessing UTF-8 instead would leave
+	 * the document to fail later in a way that does not point at the encoding.
+	 * @param bytes the source bytes
+	 * @return the declared charset, or UTF-8 if the document has no declaration or its
+	 * declaration names no encoding
 	 */
 	private Charset getDeclaredCharset(byte[] bytes) {
-		String declaration = new String(bytes, 0, Math.min(bytes.length, 256), StandardCharsets.ISO_8859_1);
-		Matcher matcher = ENCODING_PATTERN.matcher(declaration);
-		if (matcher.find()) {
-			String name = matcher.group(1);
-			try {
-				return Charset.forName(name);
-			}
-			catch (RuntimeException ex) {
-				throw new AssertionError("Unable to load XML declaring unsupported encoding '" + name + "'", ex);
-			}
+		String start = new String(bytes, 0, Math.min(bytes.length, DECLARATION_LIMIT), StandardCharsets.ISO_8859_1);
+		if (!DECLARATION_START_PATTERN.matcher(start).find()) {
+			return StandardCharsets.UTF_8;
 		}
-		return StandardCharsets.UTF_8;
+		int end = start.indexOf("?>");
+		if (end == -1) {
+			throw new AssertionError("Unable to load XML with an XML declaration that does not end within the first "
+					+ DECLARATION_LIMIT + " bytes");
+		}
+		String declaration = start.substring(0, end);
+		Matcher matcher = ENCODING_PATTERN.matcher(declaration);
+		if (!matcher.find()) {
+			return StandardCharsets.UTF_8;
+		}
+		String name = matcher.group(2);
+		if (name.isBlank()) {
+			throw new AssertionError("Unable to load XML declaring an empty encoding");
+		}
+		try {
+			return Charset.forName(name);
+		}
+		catch (RuntimeException ex) {
+			throw new AssertionError("Unable to load XML declaring unsupported encoding '" + name + "'", ex);
+		}
 	}
 
 	private boolean startsWith(byte[] bytes, byte[] prefix) {

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlLoader.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlLoader.java
@@ -21,9 +21,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.jspecify.annotations.Nullable;
 
@@ -33,23 +34,38 @@ import org.springframework.lang.Contract;
 import org.springframework.util.FileCopyUtils;
 
 /**
- * Internal helper used to load XML from various sources.
+ * Internal helper used to load XML from various sources. When no charset has been
+ * supplied the bytes are decoded using the encoding that the document itself declares,
+ * either through a byte order mark or through its XML declaration, so that the expected
+ * side of a comparison is read the same way a parser would read it.
  *
  * @author Tiziano Basile
  */
 class XmlLoader {
 
+	private static final byte[] UTF_8_BOM = { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+
+	private static final byte[] UTF_16_BE_BOM = { (byte) 0xFE, (byte) 0xFF };
+
+	private static final byte[] UTF_16_LE_BOM = { (byte) 0xFF, (byte) 0xFE };
+
+	private static final byte[] UTF_16_BE_DECLARATION = { 0x00, 0x3C, 0x00, 0x3F };
+
+	private static final byte[] UTF_16_LE_DECLARATION = { 0x3C, 0x00, 0x3F, 0x00 };
+
+	/**
+	 * Matches the {@code encoding} pseudo-attribute of an XML declaration.
+	 */
+	private static final Pattern ENCODING_PATTERN = Pattern
+		.compile("^<\\?xml\\s[^>]*?encoding\\s*=\\s*[\"']([^\"']+)[\"']");
+
 	private final Class<?> resourceLoadClass;
 
-	private final Charset charset;
+	private final @Nullable Charset charset;
 
 	XmlLoader(Class<?> resourceLoadClass, @Nullable Charset charset) {
 		this.resourceLoadClass = resourceLoadClass;
-		this.charset = (charset != null) ? charset : StandardCharsets.UTF_8;
-	}
-
-	Class<?> getResourceLoadClass() {
-		return this.resourceLoadClass;
+		this.charset = charset;
 	}
 
 	@Contract("!null -> !null")
@@ -76,7 +92,7 @@ class XmlLoader {
 			return getXml(new FileInputStream(source));
 		}
 		catch (IOException ex) {
-			throw new IllegalStateException("Unable to load XML from " + source, ex);
+			throw new AssertionError("Unable to load XML from " + source + ": " + ex.getMessage(), ex);
 		}
 	}
 
@@ -85,17 +101,76 @@ class XmlLoader {
 			return getXml(source.getInputStream());
 		}
 		catch (IOException ex) {
-			throw new IllegalStateException("Unable to load XML from " + source, ex);
+			throw new AssertionError("Unable to load XML from " + source + ": " + ex.getMessage(), ex);
 		}
 	}
 
 	String getXml(InputStream source) {
 		try {
-			return FileCopyUtils.copyToString(new InputStreamReader(source, this.charset));
+			return decode(FileCopyUtils.copyToByteArray(source));
 		}
 		catch (IOException ex) {
-			throw new IllegalStateException("Unable to load XML from InputStream", ex);
+			throw new AssertionError("Unable to load XML from InputStream: " + ex.getMessage(), ex);
 		}
+	}
+
+	private String decode(byte[] bytes) {
+		Charset charset = this.charset;
+		if (charset != null) {
+			return new String(bytes, charset);
+		}
+		if (startsWith(bytes, UTF_8_BOM)) {
+			return new String(bytes, UTF_8_BOM.length, bytes.length - UTF_8_BOM.length, StandardCharsets.UTF_8);
+		}
+		if (startsWith(bytes, UTF_16_BE_BOM)) {
+			return new String(bytes, UTF_16_BE_BOM.length, bytes.length - UTF_16_BE_BOM.length,
+					StandardCharsets.UTF_16BE);
+		}
+		if (startsWith(bytes, UTF_16_LE_BOM)) {
+			return new String(bytes, UTF_16_LE_BOM.length, bytes.length - UTF_16_LE_BOM.length,
+					StandardCharsets.UTF_16LE);
+		}
+		if (startsWith(bytes, UTF_16_BE_DECLARATION)) {
+			return new String(bytes, StandardCharsets.UTF_16BE);
+		}
+		if (startsWith(bytes, UTF_16_LE_DECLARATION)) {
+			return new String(bytes, StandardCharsets.UTF_16LE);
+		}
+		return new String(bytes, getDeclaredCharset(bytes));
+	}
+
+	/**
+	 * Return the charset named by the XML declaration, if any. The declaration itself is
+	 * restricted to ASCII characters, so it can safely be read using ISO-8859-1 whatever
+	 * the actual encoding of the remainder of the document turns out to be.
+	 * @param bytes the source bytes
+	 * @return the declared charset or UTF-8 if none is declared or it is not supported
+	 */
+	private Charset getDeclaredCharset(byte[] bytes) {
+		String declaration = new String(bytes, 0, Math.min(bytes.length, 256), StandardCharsets.ISO_8859_1);
+		Matcher matcher = ENCODING_PATTERN.matcher(declaration);
+		if (matcher.find()) {
+			String name = matcher.group(1);
+			try {
+				return Charset.forName(name);
+			}
+			catch (RuntimeException ex) {
+				throw new AssertionError("Unable to load XML declaring unsupported encoding '" + name + "'", ex);
+			}
+		}
+		return StandardCharsets.UTF_8;
+	}
+
+	private boolean startsWith(byte[] bytes, byte[] prefix) {
+		if (bytes.length < prefix.length) {
+			return false;
+		}
+		for (int i = 0; i < prefix.length; i++) {
+			if (bytes[i] != prefix[i]) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 }

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlLoader.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/XmlLoader.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.xml;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.lang.Contract;
+import org.springframework.util.FileCopyUtils;
+
+/**
+ * Internal helper used to load XML from various sources.
+ *
+ * @author Tiziano Basile
+ */
+class XmlLoader {
+
+	private final Class<?> resourceLoadClass;
+
+	private final Charset charset;
+
+	XmlLoader(Class<?> resourceLoadClass, @Nullable Charset charset) {
+		this.resourceLoadClass = resourceLoadClass;
+		this.charset = (charset != null) ? charset : StandardCharsets.UTF_8;
+	}
+
+	Class<?> getResourceLoadClass() {
+		return this.resourceLoadClass;
+	}
+
+	@Contract("!null -> !null")
+	@Nullable String getXml(@Nullable CharSequence source) {
+		if (source == null) {
+			return null;
+		}
+		if (source.toString().endsWith(".xml")) {
+			return getXml(new ClassPathResource(source.toString(), this.resourceLoadClass));
+		}
+		return source.toString();
+	}
+
+	String getXml(String path, Class<?> resourceLoadClass) {
+		return getXml(new ClassPathResource(path, resourceLoadClass));
+	}
+
+	String getXml(byte[] source) {
+		return getXml(new ByteArrayInputStream(source));
+	}
+
+	String getXml(File source) {
+		try {
+			return getXml(new FileInputStream(source));
+		}
+		catch (IOException ex) {
+			throw new IllegalStateException("Unable to load XML from " + source, ex);
+		}
+	}
+
+	String getXml(Resource source) {
+		try {
+			return getXml(source.getInputStream());
+		}
+		catch (IOException ex) {
+			throw new IllegalStateException("Unable to load XML from " + source, ex);
+		}
+	}
+
+	String getXml(InputStream source) {
+		try {
+			return FileCopyUtils.copyToString(new InputStreamReader(source, this.charset));
+		}
+		catch (IOException ex) {
+			throw new IllegalStateException("Unable to load XML from InputStream", ex);
+		}
+	}
+
+}

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/package-info.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/xml/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * XML testing support.
+ */
+@NullMarked
+package org.springframework.boot.test.xml;
+
+import org.jspecify.annotations.NullMarked;

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/xml/JacksonXmlTesterTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/xml/JacksonXmlTesterTests.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.xml;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tools.jackson.dataformat.xml.XmlMapper;
+
+import org.springframework.boot.test.json.ExampleObject;
+import org.springframework.core.ResolvableType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+/**
+ * Tests for {@link JacksonXmlTester}.
+ *
+ * @author Tiziano Basile
+ */
+class JacksonXmlTesterTests {
+
+	private static final String EXAMPLE_XML = "<ExampleObject><name>Spring</name><age>100</age></ExampleObject>";
+
+	@SuppressWarnings("NullAway.Init")
+	private JacksonXmlTester<ExampleObject> xml;
+
+	@BeforeEach
+	void setup() {
+		this.xml = new JacksonXmlTester<>(JacksonXmlTesterTests.class, ResolvableType.forClass(ExampleObject.class),
+				new XmlMapper());
+	}
+
+	@Test
+	void writeWhenObjectIsGivenShouldReturnSimilarXml() throws Exception {
+		assertThat(this.xml.write(createExampleObject())).isSimilarToXml(EXAMPLE_XML);
+	}
+
+	@Test
+	void writeWhenObjectIsGivenShouldMatchResource() throws Exception {
+		assertThat(this.xml.write(createExampleObject())).isSimilarToXml("example-object.xml");
+	}
+
+	@Test
+	void writeWhenObjectIsGivenShouldHaveXPathValues() throws Exception {
+		XmlContent<ExampleObject> content = this.xml.write(createExampleObject());
+		assertThat(content).extractingXPathStringValue("/ExampleObject/name").isEqualTo("Spring");
+		assertThat(content).extractingXPathNumberValue("/ExampleObject/age").isEqualTo(100);
+	}
+
+	@Test
+	void writeWhenObjectIsGivenShouldReturnContentWithXml() throws Exception {
+		XmlContent<ExampleObject> content = this.xml.write(createExampleObject());
+		assertThat(content.getXml()).contains("<name>Spring</name>");
+		assertThat(content.toString()).startsWith("XmlContent ");
+	}
+
+	@Test
+	void readWhenResourceIsGivenShouldReturnObject() throws Exception {
+		assertThat(this.xml.read("example-object.xml")).isEqualTo(createExampleObject());
+	}
+
+	@Test
+	void readObjectWhenResourceIsGivenShouldReturnObject() throws Exception {
+		assertThat(this.xml.readObject("example-object.xml")).isEqualTo(createExampleObject());
+	}
+
+	@Test
+	void parseWhenStringIsGivenShouldReturnObject() throws Exception {
+		assertThat(this.xml.parse(EXAMPLE_XML)).isEqualTo(createExampleObject());
+	}
+
+	@Test
+	void parseObjectWhenBytesAreGivenShouldReturnObject() throws Exception {
+		assertThat(this.xml.parseObject(EXAMPLE_XML.getBytes())).isEqualTo(createExampleObject());
+	}
+
+	@Test
+	void writeWhenTesterIsUninitializedShouldThrowException() {
+		JacksonXmlTester<ExampleObject> uninitialized = new UninitializedTester(new XmlMapper());
+		assertThatIllegalStateException().isThrownBy(() -> uninitialized.write(createExampleObject()))
+			.withMessageContaining("Uninitialized XmlMarshalTester");
+	}
+
+	@Test
+	@SuppressWarnings("NullAway") // Test null check
+	void initFieldsWhenTestIsNullShouldThrowException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> JacksonXmlTester.initFields(null, new XmlMapper()))
+			.withMessageContaining("'testInstance' must not be null");
+	}
+
+	@Test
+	@SuppressWarnings("NullAway") // Test null check
+	void initFieldsWhenMarshallerIsNullShouldThrowException() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> JacksonXmlTester.initFields(new InitFieldsTestClass(), (XmlMapper) null))
+			.withMessageContaining("'marshaller' must not be null");
+	}
+
+	@Test
+	void initFieldsShouldSetNullFields() {
+		InitFieldsTestClass test = new InitFieldsTestClass();
+		assertThat(test.test).isNull();
+		assertThat(test.base).isNull();
+		JacksonXmlTester.initFields(test, new XmlMapper());
+		assertThat(test.test).isNotNull();
+		assertThat(test.base).isNotNull();
+		ResolvableType type = test.test.getType();
+		assertThat(type).isNotNull();
+		assertThat(type.resolve()).isEqualTo(List.class);
+		assertThat(type.resolveGeneric()).isEqualTo(ExampleObject.class);
+	}
+
+	private ExampleObject createExampleObject() {
+		ExampleObject exampleObject = new ExampleObject();
+		exampleObject.setName("Spring");
+		exampleObject.setAge(100);
+		return exampleObject;
+	}
+
+	static class UninitializedTester extends JacksonXmlTester<ExampleObject> {
+
+		UninitializedTester(XmlMapper xmlMapper) {
+			super(xmlMapper);
+		}
+
+	}
+
+	abstract static class InitFieldsBaseClass {
+
+		public @Nullable JacksonXmlTester<ExampleObject> base;
+
+		public JacksonXmlTester<ExampleObject> baseSet = new JacksonXmlTester<>(InitFieldsBaseClass.class,
+				ResolvableType.forClass(ExampleObject.class), new XmlMapper());
+
+	}
+
+	static class InitFieldsTestClass extends InitFieldsBaseClass {
+
+		public @Nullable JacksonXmlTester<List<ExampleObject>> test;
+
+		public JacksonXmlTester<ExampleObject> testSet = new JacksonXmlTester<>(InitFieldsBaseClass.class,
+				ResolvableType.forClass(ExampleObject.class), new XmlMapper());
+
+	}
+
+}

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/xml/JacksonXmlTesterTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/xml/JacksonXmlTesterTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.test.xml;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.jspecify.annotations.Nullable;
@@ -49,20 +51,20 @@ class JacksonXmlTesterTests {
 	}
 
 	@Test
-	void writeWhenObjectIsGivenShouldReturnSimilarXml() throws Exception {
-		assertThat(this.xml.write(createExampleObject())).isSimilarToXml(EXAMPLE_XML);
+	void writeWhenObjectIsGivenShouldReturnEqualXml() throws Exception {
+		assertThat(this.xml.write(createExampleObject())).isEqualToXml(EXAMPLE_XML);
 	}
 
 	@Test
 	void writeWhenObjectIsGivenShouldMatchResource() throws Exception {
-		assertThat(this.xml.write(createExampleObject())).isSimilarToXml("example-object.xml");
+		assertThat(this.xml.write(createExampleObject())).isEqualToXml("example-object.xml");
 	}
 
 	@Test
 	void writeWhenObjectIsGivenShouldHaveXPathValues() throws Exception {
 		XmlContent<ExampleObject> content = this.xml.write(createExampleObject());
 		assertThat(content).extractingXPathStringValue("/ExampleObject/name").isEqualTo("Spring");
-		assertThat(content).extractingXPathNumberValue("/ExampleObject/age").isEqualTo(100);
+		assertThat(content).extractingXPathNumberValue("/ExampleObject/age").isEqualTo(100.0);
 	}
 
 	@Test
@@ -89,7 +91,29 @@ class JacksonXmlTesterTests {
 
 	@Test
 	void parseObjectWhenBytesAreGivenShouldReturnObject() throws Exception {
-		assertThat(this.xml.parseObject(EXAMPLE_XML.getBytes())).isEqualTo(createExampleObject());
+		assertThat(this.xml.parseObject(EXAMPLE_XML.getBytes(StandardCharsets.UTF_8))).isEqualTo(createExampleObject());
+	}
+
+	@Test
+	void readWhenInputStreamDeclaresEncodingShouldUseDeclaredEncoding() throws Exception {
+		String xml = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>"
+				+ "<ExampleObject><name>Sprüng</name><age>100</age></ExampleObject>";
+		ByteArrayInputStream inputStream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.ISO_8859_1));
+		assertThat(this.xml.readObject(inputStream).getName()).isEqualTo("Sprüng");
+	}
+
+	@Test
+	void initFieldsWhenFieldIsRawShouldThrowException() {
+		RawFieldTestClass test = new RawFieldTestClass();
+		assertThatIllegalStateException().isThrownBy(() -> JacksonXmlTester.initFields(test, new XmlMapper()))
+			.withMessageContaining("field 'raw'");
+	}
+
+	@Test
+	void initFieldsWhenFieldIsWildcardShouldThrowException() {
+		WildcardFieldTestClass test = new WildcardFieldTestClass();
+		assertThatIllegalStateException().isThrownBy(() -> JacksonXmlTester.initFields(test, new XmlMapper()))
+			.withMessageContaining("field 'wildcard'");
 	}
 
 	@Test
@@ -149,6 +173,19 @@ class JacksonXmlTesterTests {
 
 		public JacksonXmlTester<ExampleObject> baseSet = new JacksonXmlTester<>(InitFieldsBaseClass.class,
 				ResolvableType.forClass(ExampleObject.class), new XmlMapper());
+
+	}
+
+	static class RawFieldTestClass {
+
+		@SuppressWarnings("rawtypes")
+		public @Nullable JacksonXmlTester raw;
+
+	}
+
+	static class WildcardFieldTestClass {
+
+		public @Nullable JacksonXmlTester<?> wildcard;
 
 	}
 

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/xml/XmlContentAssertTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/xml/XmlContentAssertTests.java
@@ -20,13 +20,16 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Map;
 
 import org.assertj.core.api.AssertProvider;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Node;
 
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.ClassPathResource;
@@ -52,6 +55,33 @@ class XmlContentAssertTests {
 
 	private static final String MALFORMED = loadXml("malformed.xml");
 
+	private static final String NAMESPACED = loadXml("namespaced.xml");
+
+	private static final String DOCTYPE = loadXml("doctype.xml");
+
+	private static final String REPEATED = "<example><item>a</item><item>b</item></example>";
+
+	private static final String REPEATED_REORDERED = "<example><item>b</item><item>a</item></example>";
+
+	private static final String NESTED = "<example><item><id>1</id></item><item><id>2</id></item></example>";
+
+	private static final String NESTED_REORDERED = "<example><item><id>2</id></item><item><id>1</id></item></example>";
+
+	private static final String ATTRIBUTED = "<example><item key=\"1\">x</item><item key=\"2\">x</item></example>";
+
+	private static final String ATTRIBUTED_REORDERED = "<example><item key=\"2\">x</item><item key=\"1\">x</item></example>";
+
+	private static final String MULTI_NAMESPACED = """
+			<a:example xmlns:a="urn:one"><b:name xmlns:b="urn:two">Spring</b:name></a:example>""";
+
+	private static final String PERCENT = "<example><value>100%</value></example>";
+
+	private static final String EXTERNAL_ENTITY = """
+			<!DOCTYPE example [<!ENTITY xxe SYSTEM "file:///does/not/exist">]>\
+			<example><name>&xxe;</name></example>""";
+
+	private static final Map<String, String> NAMESPACES = Map.of("ns", "urn:example");
+
 	@TempDir
 	@SuppressWarnings("NullAway.Init")
 	public Path tempDir;
@@ -64,315 +94,731 @@ class XmlContentAssertTests {
 	}
 
 	@Test
-	void isEqualToXmlWhenStringIsIdenticalShouldPass() {
+	void isEqualToXmlWhenStringIsIdenticalThenPasses() {
 		assertThat(forXml(SOURCE)).isEqualToXml(SOURCE);
 	}
 
 	@Test
-	void isEqualToXmlWhenOnlyWhitespaceAndOrderDifferShouldFail() {
+	void isEqualToXmlWhenOnlyWhitespaceCommentsAndOrderDifferThenPasses() {
+		assertThat(forXml(SOURCE)).isEqualToXml(SIMILAR_SAME);
+	}
+
+	@Test
+	void isEqualToXmlWhenOnlyAttributeOrderDiffersThenPasses() {
+		assertThat(forXml("<example a=\"1\" b=\"2\"/>")).isEqualToXml("<example b=\"2\" a=\"1\"/>");
+	}
+
+	@Test
+	void isEqualToXmlWhenRepeatedElementsAreReorderedThenPasses() {
+		assertThat(forXml(REPEATED)).isEqualToXml(REPEATED_REORDERED);
+	}
+
+	@Test
+	void isEqualToXmlWhenRepeatedElementOnlyChildrenAreReorderedThenFails() {
+		// Documented limit: byNameAndText cannot tell element-only siblings apart
 		assertThatExceptionOfType(AssertionError.class)
-			.isThrownBy(() -> assertThat(forXml(SOURCE)).isEqualToXml(SIMILAR_SAME))
+			.isThrownBy(() -> assertThat(forXml(NESTED)).isEqualToXml(NESTED_REORDERED))
 			.withMessageContaining("XML Comparison failure");
 	}
 
 	@Test
-	void isEqualToXmlWhenResourcePathIsIdenticalShouldPass() {
-		assertThat(forXml(SOURCE)).isEqualToXml("source.xml");
+	void isEqualToXmlWhenRepeatedElementsDifferOnlyByAttributesAndAreReorderedThenFails() {
+		// Documented limit: byNameAndText pairs siblings up on text content only
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(ATTRIBUTED)).isEqualToXml(ATTRIBUTED_REORDERED))
+			.withMessageContaining("XML Comparison failure");
 	}
 
 	@Test
-	void isEqualToXmlWhenResourcePathIsNotMatchingShouldFail() {
+	void isEqualToXmlWhenResourcePathIsSimilarThenPasses() {
+		assertThat(forXml(SOURCE)).isEqualToXml("similar-same.xml");
+	}
+
+	@Test
+	void isEqualToXmlWhenResourcePathIsNotMatchingThenFails() {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forXml(SOURCE)).isEqualToXml("different.xml"));
 	}
 
 	@Test
-	void isEqualToXmlWhenPathAndClassAreIdenticalShouldPass() {
-		assertThat(forXml(SOURCE)).isEqualToXml("source.xml", XmlContentAssertTests.class);
+	void isEqualToXmlWhenResourcePathIsMissingThenFailsWithAssertionError() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isEqualToXml("does-not-exist.xml"))
+			.withMessageContaining("does-not-exist.xml");
 	}
 
 	@Test
-	void isEqualToXmlWhenBytesAreIdenticalShouldPass() {
-		assertThat(forXml(SOURCE)).isEqualToXml(SOURCE.getBytes());
+	void isEqualToXmlWhenPathAndClassAreSimilarThenPasses() {
+		assertThat(forXml(SOURCE)).isEqualToXml("similar-same.xml", XmlContentAssertTests.class);
 	}
 
 	@Test
-	void isEqualToXmlWhenFileIsIdenticalShouldPass() throws Exception {
-		assertThat(forXml(SOURCE)).isEqualToXml(createFile(SOURCE));
+	void isEqualToXmlWhenBytesAreSimilarThenPasses() {
+		assertThat(forXml(SOURCE)).isEqualToXml(SIMILAR_SAME.getBytes(StandardCharsets.UTF_8));
 	}
 
 	@Test
-	void isEqualToXmlWhenInputStreamIsIdenticalShouldPass() {
-		assertThat(forXml(SOURCE)).isEqualToXml(createInputStream(SOURCE));
+	void isEqualToXmlWhenFileIsSimilarThenPasses() throws Exception {
+		assertThat(forXml(SOURCE)).isEqualToXml(createFile(SIMILAR_SAME));
 	}
 
 	@Test
-	void isEqualToXmlWhenResourceIsIdenticalShouldPass() {
-		assertThat(forXml(SOURCE)).isEqualToXml(createResource(SOURCE));
+	void isEqualToXmlWhenInputStreamIsSimilarThenPasses() {
+		assertThat(forXml(SOURCE)).isEqualToXml(createInputStream(SIMILAR_SAME));
 	}
 
 	@Test
-	void isEqualToXmlWhenActualIsNullAndExpectedIsNotShouldFail() {
+	void isEqualToXmlWhenResourceIsSimilarThenPasses() {
+		assertThat(forXml(SOURCE)).isEqualToXml(createResource(SIMILAR_SAME));
+	}
+
+	@Test
+	void isEqualToXmlWhenContentIsDifferentThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isEqualToXml(DIFFERENT))
+			.withMessageContaining("XML Comparison failure");
+	}
+
+	@Test
+	void isEqualToXmlWhenNamespaceUriDiffersThenFails() {
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(
+				() -> assertThat(forXml("<example xmlns=\"urn:one\"/>")).isEqualToXml("<example xmlns=\"urn:two\"/>"))
+			.withMessageContaining("XML Comparison failure");
+	}
+
+	@Test
+	void isEqualToXmlWhenOnlyNamespacePrefixDiffersThenPasses() {
+		assertThat(forXml("<a:example xmlns:a=\"urn:one\"/>")).isEqualToXml("<b:example xmlns:b=\"urn:one\"/>");
+	}
+
+	@Test
+	void isEqualToXmlWhenActualIsNullAndExpectedIsNotThenFails() {
 		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(forXml(null)).isEqualToXml(SOURCE))
 			.withMessageContaining("Expected null XML");
 	}
 
 	@Test
-	void isEqualToXmlWhenExpectedIsNullAndActualIsNotShouldFail() {
+	void isEqualToXmlWhenExpectedIsNullAndActualIsNotThenFails() {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forXml(SOURCE)).isEqualToXml((CharSequence) null))
 			.withMessageContaining("Expected XML but got null");
 	}
 
 	@Test
-	void isNotEqualToXmlWhenStringIsDifferentShouldPass() {
-		assertThat(forXml(SOURCE)).isNotEqualToXml(DIFFERENT);
-	}
-
-	@Test
-	void isNotEqualToXmlWhenOnlyWhitespaceAndOrderDifferShouldPass() {
-		assertThat(forXml(SOURCE)).isNotEqualToXml(SIMILAR_SAME);
-	}
-
-	@Test
-	void isNotEqualToXmlWhenStringIsIdenticalShouldFail() {
-		assertThatExceptionOfType(AssertionError.class)
-			.isThrownBy(() -> assertThat(forXml(SOURCE)).isNotEqualToXml(SOURCE))
-			.withMessageContaining("expected a difference");
-	}
-
-	@Test
-	void isNotEqualToXmlWhenResourcePathIsDifferentShouldPass() {
-		assertThat(forXml(SOURCE)).isNotEqualToXml("different.xml");
-	}
-
-	@Test
-	void isNotEqualToXmlWhenPathAndClassAreDifferentShouldPass() {
-		assertThat(forXml(SOURCE)).isNotEqualToXml("different.xml", XmlContentAssertTests.class);
-	}
-
-	@Test
-	void isNotEqualToXmlWhenBytesAreDifferentShouldPass() {
-		assertThat(forXml(SOURCE)).isNotEqualToXml(DIFFERENT.getBytes());
-	}
-
-	@Test
-	void isNotEqualToXmlWhenFileIsDifferentShouldPass() throws Exception {
-		assertThat(forXml(SOURCE)).isNotEqualToXml(createFile(DIFFERENT));
-	}
-
-	@Test
-	void isNotEqualToXmlWhenInputStreamIsDifferentShouldPass() {
-		assertThat(forXml(SOURCE)).isNotEqualToXml(createInputStream(DIFFERENT));
-	}
-
-	@Test
-	void isNotEqualToXmlWhenResourceIsDifferentShouldPass() {
-		assertThat(forXml(SOURCE)).isNotEqualToXml(createResource(DIFFERENT));
-	}
-
-	@Test
-	void isSimilarToXmlWhenOnlyWhitespaceAndOrderDifferShouldPass() {
-		assertThat(forXml(SOURCE)).isSimilarToXml(SIMILAR_SAME);
-	}
-
-	@Test
-	void isSimilarToXmlWhenOnlyAttributeOrderDiffersShouldPass() {
-		assertThat(forXml("<example a=\"1\" b=\"2\"/>")).isSimilarToXml("<example b=\"2\" a=\"1\"/>");
-	}
-
-	@Test
-	void isSimilarToXmlWhenResourcePathIsSimilarShouldPass() {
-		assertThat(forXml(SOURCE)).isSimilarToXml("similar-same.xml");
-	}
-
-	@Test
-	void isSimilarToXmlWhenPathAndClassAreSimilarShouldPass() {
-		assertThat(forXml(SOURCE)).isSimilarToXml("similar-same.xml", XmlContentAssertTests.class);
-	}
-
-	@Test
-	void isSimilarToXmlWhenBytesAreSimilarShouldPass() {
-		assertThat(forXml(SOURCE)).isSimilarToXml(SIMILAR_SAME.getBytes());
-	}
-
-	@Test
-	void isSimilarToXmlWhenFileIsSimilarShouldPass() throws Exception {
-		assertThat(forXml(SOURCE)).isSimilarToXml(createFile(SIMILAR_SAME));
-	}
-
-	@Test
-	void isSimilarToXmlWhenInputStreamIsSimilarShouldPass() {
-		assertThat(forXml(SOURCE)).isSimilarToXml(createInputStream(SIMILAR_SAME));
-	}
-
-	@Test
-	void isSimilarToXmlWhenResourceIsSimilarShouldPass() {
-		assertThat(forXml(SOURCE)).isSimilarToXml(createResource(SIMILAR_SAME));
-	}
-
-	@Test
-	void isSimilarToXmlWhenContentIsDifferentShouldFail() {
-		assertThatExceptionOfType(AssertionError.class)
-			.isThrownBy(() -> assertThat(forXml(SOURCE)).isSimilarToXml(DIFFERENT))
-			.withMessageContaining("XML Comparison failure");
-	}
-
-	@Test
-	void isNotSimilarToXmlWhenContentIsDifferentShouldPass() {
-		assertThat(forXml(SOURCE)).isNotSimilarToXml(DIFFERENT);
-	}
-
-	@Test
-	void isNotSimilarToXmlWhenOnlyWhitespaceAndOrderDifferShouldFail() {
-		assertThatExceptionOfType(AssertionError.class)
-			.isThrownBy(() -> assertThat(forXml(SOURCE)).isNotSimilarToXml(SIMILAR_SAME))
-			.withMessageContaining("expected a difference");
-	}
-
-	@Test
-	void isNotSimilarToXmlWhenResourcePathIsDifferentShouldPass() {
-		assertThat(forXml(SOURCE)).isNotSimilarToXml("different.xml");
-	}
-
-	@Test
-	void isNotSimilarToXmlWhenPathAndClassAreDifferentShouldPass() {
-		assertThat(forXml(SOURCE)).isNotSimilarToXml("different.xml", XmlContentAssertTests.class);
-	}
-
-	@Test
-	void isNotSimilarToXmlWhenBytesAreDifferentShouldPass() {
-		assertThat(forXml(SOURCE)).isNotSimilarToXml(DIFFERENT.getBytes());
-	}
-
-	@Test
-	void isNotSimilarToXmlWhenFileIsDifferentShouldPass() throws Exception {
-		assertThat(forXml(SOURCE)).isNotSimilarToXml(createFile(DIFFERENT));
-	}
-
-	@Test
-	void isNotSimilarToXmlWhenInputStreamIsDifferentShouldPass() {
-		assertThat(forXml(SOURCE)).isNotSimilarToXml(createInputStream(DIFFERENT));
-	}
-
-	@Test
-	void isNotSimilarToXmlWhenResourceIsDifferentShouldPass() {
-		assertThat(forXml(SOURCE)).isNotSimilarToXml(createResource(DIFFERENT));
-	}
-
-	@Test
-	void isEqualToXmlWhenActualIsMalformedShouldFailWithAssertionError() {
+	void isEqualToXmlWhenActualIsMalformedThenFailsWithAssertionError() {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forXml(MALFORMED)).isEqualToXml(SOURCE))
 			.withMessageContaining("Unable to compare XML");
 	}
 
 	@Test
-	void isSimilarToXmlWhenExpectedIsMalformedShouldFailWithAssertionError() {
+	void isEqualToXmlWhenExpectedIsMalformedThenFailsWithAssertionError() {
 		assertThatExceptionOfType(AssertionError.class)
-			.isThrownBy(() -> assertThat(forXml(SOURCE)).isSimilarToXml(MALFORMED))
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isEqualToXml(MALFORMED))
 			.withMessageContaining("Unable to compare XML");
 	}
 
 	@Test
-	void hasXPathValueWhenPathIsPresentShouldPass() {
+	void isEqualToXmlWhenDocumentHasDoctypeThenPasses() {
+		assertThat(forXml(DOCTYPE)).isEqualToXml(SOURCE);
+	}
+
+	@Test
+	void isEqualToXmlWhenExpectedHasXmlDeclarationThenPasses() {
+		assertThat(forXml(SOURCE)).isEqualToXml("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + SOURCE);
+	}
+
+	@Test
+	void isEqualToXmlWhenFileDeclaresNonUtf8EncodingThenUsesDeclaredEncoding() throws Exception {
+		String expected = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><example><name>Sprüng</name></example>";
+		File file = createFile(expected.getBytes(StandardCharsets.ISO_8859_1));
+		assertThat(forXml("<example><name>Sprüng</name></example>")).isEqualToXml(file);
+	}
+
+	@Test
+	void isEqualToXmlWhenBytesDeclareNonUtf8EncodingThenUsesDeclaredEncoding() {
+		String expected = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><example><name>Sprüng</name></example>";
+		assertThat(forXml("<example><name>Sprüng</name></example>"))
+			.isEqualToXml(expected.getBytes(StandardCharsets.ISO_8859_1));
+	}
+
+	@Test
+	void isStrictlyEqualToXmlWhenStringIsIdenticalThenPasses() {
+		assertThat(forXml(SOURCE)).isStrictlyEqualToXml(SOURCE);
+	}
+
+	@Test
+	void isStrictlyEqualToXmlWhenOnlyWhitespaceAndCommentsDifferThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isStrictlyEqualToXml(SIMILAR_SAME))
+			.withMessageContaining("XML Comparison failure");
+	}
+
+	@Test
+	void isStrictlyEqualToXmlWhenExpectedHasXmlDeclarationThenFails() {
+		// Documented trap: the XML declaration is part of a strict comparison
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE))
+				.isStrictlyEqualToXml("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + SOURCE))
+			.withMessageContaining("Expected xml encoding 'UTF-8' but was 'null'");
+	}
+
+	@Test
+	void isStrictlyEqualToXmlWhenResourcePathIsIdenticalThenPasses() {
+		assertThat(forXml(SOURCE)).isStrictlyEqualToXml("source.xml");
+	}
+
+	@Test
+	void isStrictlyEqualToXmlWhenPathAndClassAreIdenticalThenPasses() {
+		assertThat(forXml(SOURCE)).isStrictlyEqualToXml("source.xml", XmlContentAssertTests.class);
+	}
+
+	@Test
+	void isStrictlyEqualToXmlWhenBytesAreIdenticalThenPasses() {
+		assertThat(forXml(SOURCE)).isStrictlyEqualToXml(SOURCE.getBytes(StandardCharsets.UTF_8));
+	}
+
+	@Test
+	void isStrictlyEqualToXmlWhenFileIsIdenticalThenPasses() throws Exception {
+		assertThat(forXml(SOURCE)).isStrictlyEqualToXml(createFile(SOURCE));
+	}
+
+	@Test
+	void isStrictlyEqualToXmlWhenInputStreamIsIdenticalThenPasses() {
+		assertThat(forXml(SOURCE)).isStrictlyEqualToXml(createInputStream(SOURCE));
+	}
+
+	@Test
+	void isStrictlyEqualToXmlWhenResourceIsIdenticalThenPasses() {
+		assertThat(forXml(SOURCE)).isStrictlyEqualToXml(createResource(SOURCE));
+	}
+
+	@Test
+	void isNotEqualToXmlWhenStringIsDifferentThenPasses() {
+		assertThat(forXml(SOURCE)).isNotEqualToXml(DIFFERENT);
+	}
+
+	@Test
+	void isNotEqualToXmlWhenOnlyWhitespaceAndCommentsDifferThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isNotEqualToXml(SIMILAR_SAME))
+			.withMessageContaining("expected a difference");
+	}
+
+	@Test
+	void isNotEqualToXmlWhenResourcePathIsDifferentThenPasses() {
+		assertThat(forXml(SOURCE)).isNotEqualToXml("different.xml");
+	}
+
+	@Test
+	void isNotEqualToXmlWhenPathAndClassAreDifferentThenPasses() {
+		assertThat(forXml(SOURCE)).isNotEqualToXml("different.xml", XmlContentAssertTests.class);
+	}
+
+	@Test
+	void isNotEqualToXmlWhenBytesAreDifferentThenPasses() {
+		assertThat(forXml(SOURCE)).isNotEqualToXml(DIFFERENT.getBytes(StandardCharsets.UTF_8));
+	}
+
+	@Test
+	void isNotEqualToXmlWhenFileIsDifferentThenPasses() throws Exception {
+		assertThat(forXml(SOURCE)).isNotEqualToXml(createFile(DIFFERENT));
+	}
+
+	@Test
+	void isNotEqualToXmlWhenInputStreamIsDifferentThenPasses() {
+		assertThat(forXml(SOURCE)).isNotEqualToXml(createInputStream(DIFFERENT));
+	}
+
+	@Test
+	void isNotEqualToXmlWhenResourceIsDifferentThenPasses() {
+		assertThat(forXml(SOURCE)).isNotEqualToXml(createResource(DIFFERENT));
+	}
+
+	@Test
+	void isNotEqualToXmlWhenActualIsMalformedThenPasses() {
+		assertThat(forXml(MALFORMED)).isNotEqualToXml(SOURCE);
+	}
+
+	@Test
+	void isNotEqualToXmlWhenExpectedIsMalformedThenPasses() {
+		assertThat(forXml(SOURCE)).isNotEqualToXml(MALFORMED);
+	}
+
+	@Test
+	void isNotStrictlyEqualToXmlWhenOnlyWhitespaceAndCommentsDifferThenPasses() {
+		assertThat(forXml(SOURCE)).isNotStrictlyEqualToXml(SIMILAR_SAME);
+	}
+
+	@Test
+	void isNotStrictlyEqualToXmlWhenStringIsIdenticalThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isNotStrictlyEqualToXml(SOURCE))
+			.withMessageContaining("expected a difference");
+	}
+
+	@Test
+	void isNotStrictlyEqualToXmlWhenResourcePathIsDifferentThenPasses() {
+		assertThat(forXml(SOURCE)).isNotStrictlyEqualToXml("different.xml");
+	}
+
+	@Test
+	void isNotStrictlyEqualToXmlWhenPathAndClassAreDifferentThenPasses() {
+		assertThat(forXml(SOURCE)).isNotStrictlyEqualToXml("different.xml", XmlContentAssertTests.class);
+	}
+
+	@Test
+	void isNotStrictlyEqualToXmlWhenBytesAreDifferentThenPasses() {
+		assertThat(forXml(SOURCE)).isNotStrictlyEqualToXml(DIFFERENT.getBytes(StandardCharsets.UTF_8));
+	}
+
+	@Test
+	void isNotStrictlyEqualToXmlWhenFileIsDifferentThenPasses() throws Exception {
+		assertThat(forXml(SOURCE)).isNotStrictlyEqualToXml(createFile(DIFFERENT));
+	}
+
+	@Test
+	void isNotStrictlyEqualToXmlWhenInputStreamIsDifferentThenPasses() {
+		assertThat(forXml(SOURCE)).isNotStrictlyEqualToXml(createInputStream(DIFFERENT));
+	}
+
+	@Test
+	void isNotStrictlyEqualToXmlWhenResourceIsDifferentThenPasses() {
+		assertThat(forXml(SOURCE)).isNotStrictlyEqualToXml(createResource(DIFFERENT));
+	}
+
+	@Test
+	void isNotStrictlyEqualToXmlWhenExpectedIsMalformedThenPasses() {
+		assertThat(forXml(SOURCE)).isNotStrictlyEqualToXml(MALFORMED);
+	}
+
+	@Test
+	void isEqualToWhenCharSequenceThenComparesXml() {
+		assertThat(forXml(SOURCE)).isEqualTo(SIMILAR_SAME);
+	}
+
+	@Test
+	void isEqualToWhenBytesThenComparesXml() {
+		assertThat(forXml(SOURCE)).isEqualTo(SIMILAR_SAME.getBytes(StandardCharsets.UTF_8));
+	}
+
+	@Test
+	void isEqualToWhenFileThenComparesXml() throws Exception {
+		assertThat(forXml(SOURCE)).isEqualTo(createFile(SIMILAR_SAME));
+	}
+
+	@Test
+	void isEqualToWhenInputStreamThenComparesXml() {
+		assertThat(forXml(SOURCE)).isEqualTo(createInputStream(SIMILAR_SAME));
+	}
+
+	@Test
+	void isEqualToWhenResourceThenComparesXml() {
+		assertThat(forXml(SOURCE)).isEqualTo(createResource(SIMILAR_SAME));
+	}
+
+	@Test
+	void isEqualToWhenContentIsDifferentThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isEqualTo(DIFFERENT))
+			.withMessageContaining("XML Comparison failure");
+	}
+
+	@Test
+	void isEqualToWhenTypeIsUnsupportedThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isEqualTo(Integer.valueOf(123)))
+			.withMessageContaining("Unsupported type for XML assert");
+	}
+
+	@Test
+	void isNotEqualToWhenCharSequenceThenComparesXml() {
+		assertThat(forXml(SOURCE)).isNotEqualTo(DIFFERENT);
+	}
+
+	@Test
+	void isNotEqualToWhenBytesThenComparesXml() {
+		assertThat(forXml(SOURCE)).isNotEqualTo(DIFFERENT.getBytes(StandardCharsets.UTF_8));
+	}
+
+	@Test
+	void isNotEqualToWhenFileThenComparesXml() throws Exception {
+		assertThat(forXml(SOURCE)).isNotEqualTo(createFile(DIFFERENT));
+	}
+
+	@Test
+	void isNotEqualToWhenInputStreamThenComparesXml() {
+		assertThat(forXml(SOURCE)).isNotEqualTo(createInputStream(DIFFERENT));
+	}
+
+	@Test
+	void isNotEqualToWhenResourceThenComparesXml() {
+		assertThat(forXml(SOURCE)).isNotEqualTo(createResource(DIFFERENT));
+	}
+
+	@Test
+	void isNotEqualToWhenContentIsSimilarThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isNotEqualTo(SIMILAR_SAME))
+			.withMessageContaining("expected a difference");
+	}
+
+	@Test
+	void isNotEqualToWhenTypeIsUnsupportedThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isNotEqualTo(Integer.valueOf(123)))
+			.withMessageContaining("Unsupported type for XML assert");
+	}
+
+	@Test
+	void hasXPathValueWhenPathIsPresentThenPasses() {
 		assertThat(forXml(SOURCE)).hasXPathValue("/example/name");
 	}
 
 	@Test
-	void hasXPathValueWhenPathIsParameterizedShouldPass() {
+	void hasXPathValueWhenPathIsParameterizedThenPasses() {
 		assertThat(forXml(SOURCE)).hasXPathValue("/example/%s", "name");
 	}
 
 	@Test
-	void hasXPathValueWhenPathIsMissingShouldFail() {
-		assertThatExceptionOfType(AssertionError.class)
-			.isThrownBy(() -> assertThat(forXml(SOURCE)).hasXPathValue("/example/nope"))
-			.withMessageContaining("/example/nope");
+	void hasXPathValueWhenExpressionContainsLiteralPercentAndNoArgsThenPasses() {
+		assertThat(forXml(PERCENT)).hasXPathValue("/example/value[text()='100%']");
 	}
 
 	@Test
-	void hasXPathValueWhenActualIsMalformedShouldFailWithAssertionError() {
+	void hasXPathValueWhenExpressionHasLiteralPercentAndArgsThenFailsWithAssertionError() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(PERCENT)).hasXPathValue("/example/value[text()='100%']", "unused"))
+			.withMessageContaining("Unable to format XML path \"/example/value[text()='100%']\"");
+	}
+
+	@Test
+	void hasXPathValueWhenExpressionDoesNotSelectNodesThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).hasXPathValue("count(/example/item)"))
+			.withMessageContaining("XML path \"count(/example/item)\" does not select nodes");
+	}
+
+	@Test
+	void hasXPathValueWhenExpressionIsAComparisonThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).hasXPathValue("/example/name = 'WRONG'"))
+			.withMessageContaining("does not select nodes");
+	}
+
+	@Test
+	void doesNotHaveXPathValueWhenExpressionDoesNotSelectNodesThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).doesNotHaveXPathValue("count(/example/item)"))
+			.withMessageContaining("XML path \"count(/example/item)\" does not select nodes");
+	}
+
+	@Test
+	void hasXPathValueWhenPathIsMissingThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).hasXPathValue("/example/nope"))
+			.withMessageContaining("No XML path \"/example/nope\" found");
+	}
+
+	@Test
+	void hasXPathValueWhenActualIsMalformedThenFailsWithAssertionError() {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forXml(MALFORMED)).hasXPathValue("/example/name"))
 			.withMessageContaining("Unable to parse XML content");
 	}
 
 	@Test
-	void doesNotHaveXPathValueWhenPathIsMissingShouldPass() {
+	void hasXPathValueWhenDocumentHasDoctypeThenPasses() {
+		assertThat(forXml(DOCTYPE)).hasXPathValue("/example/name");
+	}
+
+	@Test
+	void hasXPathValueWhenDocumentHasInternalEntityThenEntityIsResolved() {
+		assertThat(forXml(DOCTYPE)).extractingXPathStringValue("/example/name").isEqualTo("Spring");
+	}
+
+	@Test
+	void hasXPathValueWhenDocumentHasExternalEntityThenEntityIsNotResolved() {
+		assertThat(forXml(EXTERNAL_ENTITY)).hasXPathValue("/example/name");
+		assertThat(forXml(EXTERNAL_ENTITY)).extractingXPathStringValue("/example/name").isEmpty();
+	}
+
+	@Test
+	void hasXPathValueWhenExpressionIsEmptyThenThrowsException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> assertThat(forXml(SOURCE)).hasXPathValue(""))
+			.withMessageContaining("'expression' must not be empty");
+	}
+
+	@Test
+	void hasXPathValueWhenPrefixIsRegisteredThenPasses() {
+		assertThat(forXml(NAMESPACED)).withNamespaces(NAMESPACES).hasXPathValue("/ns:example/ns:name");
+	}
+
+	@Test
+	void hasXPathValueWhenPrefixIsNotRegisteredThenFailsNamingThePrefix() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(NAMESPACED)).hasXPathValue("/ns:example/ns:name"))
+			.withMessageContaining("Namespace prefix \"ns\"");
+	}
+
+	@Test
+	void hasXPathValueWhenAxisPrefixedPrefixIsNotRegisteredThenFailsNamingThePrefix() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(NAMESPACED)).hasXPathValue("/child::ns:example"))
+			.withMessageContaining("Namespace prefix \"ns\"");
+	}
+
+	@Test
+	void hasXPathValueWhenAttributeAxisPrefixIsNotRegisteredThenFailsNamingThePrefix() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(NAMESPACED)).hasXPathValue("//attribute::ns:x"))
+			.withMessageContaining("Namespace prefix \"ns\"");
+	}
+
+	@Test
+	void hasXPathValueWhenExpressionUsesAnAxisWithNoPrefixThenPasses() {
+		assertThat(forXml(SOURCE)).hasXPathValue("/child::example/child::name");
+		assertThat(forXml(SOURCE)).hasXPathValue("/descendant-or-self::node()");
+	}
+
+	@Test
+	void hasXPathValueWhenExpressionHasAColonInsideALiteralThenIsNotTreatedAsAPrefix() {
+		assertThat(forXml(SOURCE)).doesNotHaveXPathValue("//*[name()='a:b']");
+		assertThat(forXml(SOURCE)).doesNotHaveXPathValue("/a[@t=\"5:30\"]/b");
+	}
+
+	@Test
+	void hasXPathValueWhenExpressionUsesTheReservedXmlPrefixThenPasses() {
+		assertThat(forXml(SOURCE)).doesNotHaveXPathValue("//@xml:lang");
+	}
+
+	@Test
+	void hasXPathValueWhenExpressionIsUnprefixedAndDocumentIsNamespacedThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(NAMESPACED)).hasXPathValue("/example/name"))
+			.withMessageContaining("No XML path");
+	}
+
+	@Test
+	void withNamespacesWhenCalledThenLeavesOriginalUnchanged() {
+		XmlContentAssert original = new XmlContentAssert(XmlContentAssertTests.class, NAMESPACED);
+		original.withNamespaces(NAMESPACES).hasXPathValue("/ns:example/ns:name");
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> original.hasXPathValue("/ns:example/ns:name"))
+			.withMessageContaining("Namespace prefix \"ns\"");
+	}
+
+	@Test
+	void withNamespacesWhenCalledTwiceThenMergesBindings() {
+		assertThat(forXml(MULTI_NAMESPACED)).withNamespaces(Map.of("a", "urn:one"))
+			.withNamespaces(Map.of("b", "urn:two"))
+			.hasXPathValue("/a:example/b:name");
+	}
+
+	@Test
+	void withNamespacesWhenPrefixIsReboundThenLaterBindingWins() {
+		assertThat(forXml(NAMESPACED)).withNamespaces(Map.of("ns", "urn:wrong"))
+			.withNamespaces(NAMESPACES)
+			.hasXPathValue("/ns:example/ns:name");
+	}
+
+	@Test
+	void withNamespacesWhenDescribedThenDescriptionIsRetained() {
+		XmlContentAssert assertion = new XmlContentAssert(XmlContentAssertTests.class, NAMESPACED).as("my description");
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertion.withNamespaces(NAMESPACES).hasXPathValue("/ns:example/ns:nope"))
+			.withMessageContaining("[my description]");
+	}
+
+	@Test
+	void withNamespacesWhenPrefixIsEmptyThenThrowsException() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> assertThat(forXml(NAMESPACED)).withNamespaces(Map.of("", "urn:example")))
+			.withMessageContaining("XPath 1.0 has no default namespace");
+	}
+
+	@Test
+	void withNamespacesWhenNamespaceUriIsEmptyThenThrowsException() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> assertThat(forXml(NAMESPACED)).withNamespaces(Map.of("ns", " ")))
+			.withMessageContaining("must not map prefix 'ns' to an empty namespace URI");
+	}
+
+	@Test
+	@SuppressWarnings("NullAway") // Test null check
+	void withNamespacesWhenNamespacesAreNullThenThrowsException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> assertThat(forXml(NAMESPACED)).withNamespaces(null))
+			.withMessageContaining("'namespaces' must not be null");
+	}
+
+	@Test
+	void doesNotHaveXPathValueWhenPathIsMissingThenPasses() {
 		assertThat(forXml(SOURCE)).doesNotHaveXPathValue("/example/nope");
 	}
 
 	@Test
-	void doesNotHaveXPathValueWhenPathIsPresentShouldFail() {
+	void doesNotHaveXPathValueWhenPathIsPresentThenFails() {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forXml(SOURCE)).doesNotHaveXPathValue("/example/name"))
 			.withMessageContaining("/example/name");
 	}
 
 	@Test
-	void extractingXPathValueWhenPathIsPresentShouldReturnValue() {
-		assertThat(forXml(SOURCE)).extractingXPathValue("/example/name").isEqualTo("Spring");
+	void hasXPathNodeCountWhenCountMatchesThenPasses() {
+		assertThat(forXml(REPEATED)).hasXPathNodeCount("/example/item", 2);
 	}
 
 	@Test
-	void extractingXPathValueWhenPathIsMissingShouldReturnNull() {
-		assertThat(forXml(SOURCE)).extractingXPathValue("/example/nope").isNull();
+	void hasXPathNodeCountWhenCountDoesNotMatchThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(REPEATED)).hasXPathNodeCount("/example/item", 3))
+			.withMessageContaining("Expected 3 node(s)");
 	}
 
 	@Test
-	void extractingXPathStringValueWhenPathIsPresentShouldReturnValue() {
+	void hasXPathNodeCountWhenCountIsNegativeThenThrowsException() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> assertThat(forXml(REPEATED)).hasXPathNodeCount("/example/item", -1))
+			.withMessageContaining("'expectedCount' must not be negative");
+	}
+
+	@Test
+	void extractingXPathNodeListWhenPathMatchesThenReturnsNodes() {
+		assertThat(forXml(REPEATED)).extractingXPathNodeList("/example/item")
+			.extracting(Node::getTextContent)
+			.containsExactly("a", "b");
+	}
+
+	@Test
+	void extractingXPathNodeListWhenPathIsMissingThenReturnsEmptyList() {
+		assertThat(forXml(REPEATED)).extractingXPathNodeList("/example/nope").isEmpty();
+	}
+
+	@Test
+	void extractingXPathStringValueWhenPathIsPresentThenReturnsValue() {
 		assertThat(forXml(SOURCE)).extractingXPathStringValue("/example/name").isEqualTo("Spring");
 	}
 
 	@Test
-	void extractingXPathNumberValueWhenPathIsPresentShouldReturnValue() {
-		assertThat(forXml(SOURCE)).extractingXPathNumberValue("/example/age").isEqualTo(100);
+	void extractingXPathStringValueWhenPathIsMissingThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).extractingXPathStringValue("/example/nope"))
+			.withMessageContaining("No value at XML path \"/example/nope\"");
 	}
 
 	@Test
-	void extractingXPathNumberValueWhenValueIsNotANumberShouldFail() {
+	void extractingXPathStringValueWhenMultipleNodesMatchThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(REPEATED)).extractingXPathStringValue("/example/item"))
+			.withMessageContaining("found 2 nodes");
+	}
+
+	@Test
+	void extractingXPathNumberValueWhenPathIsPresentThenReturnsValue() {
+		assertThat(forXml(SOURCE)).extractingXPathNumberValue("/example/age").isEqualTo(100.0);
+	}
+
+	@Test
+	void extractingXPathNumberValueWhenExpressionIsCountThenReturnsCount() {
+		assertThat(forXml(REPEATED)).extractingXPathNumberValue("count(/example/item)").isEqualTo(2.0);
+	}
+
+	@Test
+	void extractingXPathNumberValueWhenValueIsNotANumberThenFails() {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forXml(SOURCE)).extractingXPathNumberValue("/example/name"))
 			.withMessageContaining("Expected a number");
 	}
 
 	@Test
-	void extractingXPathBooleanValueWhenPathIsPresentShouldReturnValue() {
+	void extractingXPathNumberValueWhenValueHasJavaLiteralSuffixThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(
+					() -> assertThat(forXml("<example><v>10d</v></example>")).extractingXPathNumberValue("/example/v"))
+			.withMessageContaining("Expected a number");
+	}
+
+	@Test
+	void extractingXPathNumberValueWhenValueIsNotANumberLiteralThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(
+					() -> assertThat(forXml("<example><v>NaN</v></example>")).extractingXPathNumberValue("/example/v"))
+			.withMessageContaining("Expected a number");
+	}
+
+	@Test
+	void extractingXPathNumberValueWhenValueIsHexFloatThenFails() {
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(
+				() -> assertThat(forXml("<example><v>0x1p3</v></example>")).extractingXPathNumberValue("/example/v"))
+			.withMessageContaining("Expected a number");
+	}
+
+	@Test
+	void extractingXPathNumberValueWhenValueIsInfinityThenFails() {
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(
+				() -> assertThat(forXml("<example><v>Infinity</v></example>")).extractingXPathNumberValue("/example/v"))
+			.withMessageContaining("Expected a number");
+	}
+
+	@Test
+	void extractingXPathNumberValueWhenPathIsMissingThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).extractingXPathNumberValue("/example/nope"))
+			.withMessageContaining("No value at XML path");
+	}
+
+	@Test
+	void extractingXPathBooleanValueWhenPathIsPresentThenReturnsValue() {
 		assertThat(forXml(SOURCE)).extractingXPathBooleanValue("/example/active").isTrue();
 	}
 
 	@Test
-	void extractingXPathBooleanValueWhenValueIsNotABooleanShouldFail() {
+	void extractingXPathBooleanValueWhenValueIsOneThenReturnsTrue() {
+		assertThat(forXml("<example><active>1</active></example>")).extractingXPathBooleanValue("/example/active")
+			.isTrue();
+	}
+
+	@Test
+	void extractingXPathBooleanValueWhenValueIsZeroThenReturnsFalse() {
+		assertThat(forXml("<example><active>0</active></example>")).extractingXPathBooleanValue("/example/active")
+			.isFalse();
+	}
+
+	@Test
+	void extractingXPathBooleanValueWhenValueIsNotABooleanThenFails() {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forXml(SOURCE)).extractingXPathBooleanValue("/example/name"))
 			.withMessageContaining("Expected a boolean");
 	}
 
 	@Test
-	void hasXPathValueWhenExpressionIsEmptyShouldThrowException() {
-		assertThatIllegalArgumentException().isThrownBy(() -> assertThat(forXml(SOURCE)).hasXPathValue(""))
-			.withMessageContaining("'expression' must not be empty");
+	void extractingXPathBooleanValueWhenPathIsMissingThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).extractingXPathBooleanValue("/example/nope"))
+			.withMessageContaining("No value at XML path");
 	}
 
 	private File createFile(String content) throws IOException {
+		return createFile(content.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private File createFile(byte[] content) throws IOException {
 		File file = this.temp;
-		FileCopyUtils.copy(content.getBytes(), file);
+		FileCopyUtils.copy(content, file);
 		return file;
 	}
 
 	private InputStream createInputStream(String content) {
-		return new ByteArrayInputStream(content.getBytes());
+		return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
 	}
 
 	private Resource createResource(String content) {
-		return new ByteArrayResource(content.getBytes());
+		return new ByteArrayResource(content.getBytes(StandardCharsets.UTF_8));
 	}
 
 	private static String loadXml(String path) {
 		try {
 			ClassPathResource resource = new ClassPathResource(path, XmlContentAssertTests.class);
-			return new String(FileCopyUtils.copyToByteArray(resource.getInputStream()));
+			return new String(FileCopyUtils.copyToByteArray(resource.getInputStream()), StandardCharsets.UTF_8);
 		}
 		catch (Exception ex) {
 			throw new IllegalStateException(ex);

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/xml/XmlContentAssertTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/xml/XmlContentAssertTests.java
@@ -76,6 +76,21 @@ class XmlContentAssertTests {
 
 	private static final String PERCENT = "<example><value>100%</value></example>";
 
+	private static final String CDATA = "<example><name>x<![CDATA[y]]>z</name></example>";
+
+	private static final String CDATA_AS_TEXT = "<example><name>xyz</name></example>";
+
+	private static final String BILLION_LAUGHS = """
+			<!DOCTYPE lolz [<!ENTITY lol "lol">\
+			<!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">\
+			<!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">\
+			<!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">\
+			<!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">\
+			<!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">\
+			<!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">\
+			<!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">\
+			]><lolz>&lol7;</lolz>""";
+
 	private static final String EXTERNAL_ENTITY = """
 			<!DOCTYPE example [<!ENTITY xxe SYSTEM "file:///does/not/exist">]>\
 			<example><name>&xxe;</name></example>""";
@@ -192,6 +207,24 @@ class XmlContentAssertTests {
 	}
 
 	@Test
+	void isEqualToXmlWhenTextHasLeadingAndTrailingWhitespaceThenPasses() {
+		// A lenient comparison trims text content, it does not only ignore the
+		// whitespace between elements
+		assertThat(forXml("<example><name>  Honda  </name></example>"))
+			.isEqualToXml("<example><name>Honda</name></example>");
+	}
+
+	@Test
+	void isEqualToXmlWhenTextIsOnlyWhitespaceThenPasses() {
+		assertThat(forXml("<example><name>   </name></example>")).isEqualToXml("<example><name/></example>");
+	}
+
+	@Test
+	void isEqualToXmlWhenCdataIsUsedInsteadOfTextThenPasses() {
+		assertThat(forXml(CDATA)).isEqualToXml(CDATA_AS_TEXT);
+	}
+
+	@Test
 	void isEqualToXmlWhenActualIsNullAndExpectedIsNotThenFails() {
 		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(forXml(null)).isEqualToXml(SOURCE))
 			.withMessageContaining("Expected null XML");
@@ -261,6 +294,47 @@ class XmlContentAssertTests {
 			.isThrownBy(() -> assertThat(forXml(SOURCE))
 				.isStrictlyEqualToXml("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + SOURCE))
 			.withMessageContaining("Expected xml encoding 'UTF-8' but was 'null'");
+	}
+
+	@Test
+	void isStrictlyEqualToXmlWhenOnlyNamespacePrefixDiffersThenFails() {
+		// Documented trap: namespace prefixes are part of a strict comparison
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml("<q:example xmlns:q=\"urn:one\"/>"))
+				.isStrictlyEqualToXml("<p:example xmlns:p=\"urn:one\"/>"))
+			.withMessageContaining("Expected namespace prefix 'p' but was 'q'");
+	}
+
+	@Test
+	void isStrictlyEqualToXmlWhenCdataIsUsedInsteadOfTextThenFails() {
+		// Documented trap: a CDATA section is not identical to the equivalent text
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml("<example><name><![CDATA[Spring]]></name></example>"))
+				.isStrictlyEqualToXml("<example><name>Spring</name></example>"))
+			.withMessageContaining("Expected node type 'Text' but was 'CDATA Section'");
+	}
+
+	@Test
+	void isStrictlyEqualToXmlWhenOnlyACommentIsAddedThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml("<example/>")).isStrictlyEqualToXml("<example><!-- note --></example>"))
+			.withMessageContaining("XML Comparison failure");
+	}
+
+	@Test
+	void isStrictlyEqualToXmlWhenOnlyAProcessingInstructionIsAddedThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(
+					() -> assertThat(forXml("<example/>")).isStrictlyEqualToXml("<example><?target data?></example>"))
+			.withMessageContaining("XML Comparison failure");
+	}
+
+	@Test
+	void isStrictlyEqualToXmlWhenTextHasLeadingAndTrailingWhitespaceThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml("<example><name>Honda</name></example>"))
+				.isStrictlyEqualToXml("<example><name>  Honda  </name></example>"))
+			.withMessageContaining("Expected text value '  Honda  ' but was 'Honda'");
 	}
 
 	@Test
@@ -336,13 +410,17 @@ class XmlContentAssertTests {
 	}
 
 	@Test
-	void isNotEqualToXmlWhenActualIsMalformedThenPasses() {
-		assertThat(forXml(MALFORMED)).isNotEqualToXml(SOURCE);
+	void isNotEqualToXmlWhenActualIsMalformedThenFailsWithAssertionError() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(MALFORMED)).isNotEqualToXml(SOURCE))
+			.withMessageContaining("Unable to compare XML");
 	}
 
 	@Test
-	void isNotEqualToXmlWhenExpectedIsMalformedThenPasses() {
-		assertThat(forXml(SOURCE)).isNotEqualToXml(MALFORMED);
+	void isNotEqualToXmlWhenExpectedIsMalformedThenFailsWithAssertionError() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isNotEqualToXml(MALFORMED))
+			.withMessageContaining("Unable to compare XML");
 	}
 
 	@Test
@@ -388,8 +466,17 @@ class XmlContentAssertTests {
 	}
 
 	@Test
-	void isNotStrictlyEqualToXmlWhenExpectedIsMalformedThenPasses() {
-		assertThat(forXml(SOURCE)).isNotStrictlyEqualToXml(MALFORMED);
+	void isNotStrictlyEqualToXmlWhenExpectedIsMalformedThenFailsWithAssertionError() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isNotStrictlyEqualToXml(MALFORMED))
+			.withMessageContaining("Unable to compare XML");
+	}
+
+	@Test
+	void isNotStrictlyEqualToXmlWhenActualIsMalformedThenFailsWithAssertionError() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(MALFORMED)).isNotStrictlyEqualToXml(SOURCE))
+			.withMessageContaining("Unable to compare XML");
 	}
 
 	@Test
@@ -489,14 +576,14 @@ class XmlContentAssertTests {
 	void hasXPathValueWhenExpressionHasLiteralPercentAndArgsThenFailsWithAssertionError() {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forXml(PERCENT)).hasXPathValue("/example/value[text()='100%']", "unused"))
-			.withMessageContaining("Unable to format XML path \"/example/value[text()='100%']\"");
+			.withMessageContaining("Unable to format XPath expression \"/example/value[text()='100%']\"");
 	}
 
 	@Test
 	void hasXPathValueWhenExpressionDoesNotSelectNodesThenFails() {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forXml(SOURCE)).hasXPathValue("count(/example/item)"))
-			.withMessageContaining("XML path \"count(/example/item)\" does not select nodes");
+			.withMessageContaining("XPath expression \"count(/example/item)\" does not select nodes");
 	}
 
 	@Test
@@ -510,14 +597,14 @@ class XmlContentAssertTests {
 	void doesNotHaveXPathValueWhenExpressionDoesNotSelectNodesThenFails() {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forXml(SOURCE)).doesNotHaveXPathValue("count(/example/item)"))
-			.withMessageContaining("XML path \"count(/example/item)\" does not select nodes");
+			.withMessageContaining("XPath expression \"count(/example/item)\" does not select nodes");
 	}
 
 	@Test
 	void hasXPathValueWhenPathIsMissingThenFails() {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forXml(SOURCE)).hasXPathValue("/example/nope"))
-			.withMessageContaining("No XML path \"/example/nope\" found");
+			.withMessageContaining("No XPath expression \"/example/nope\" found");
 	}
 
 	@Test
@@ -541,6 +628,32 @@ class XmlContentAssertTests {
 	void hasXPathValueWhenDocumentHasExternalEntityThenEntityIsNotResolved() {
 		assertThat(forXml(EXTERNAL_ENTITY)).hasXPathValue("/example/name");
 		assertThat(forXml(EXTERNAL_ENTITY)).extractingXPathStringValue("/example/name").isEmpty();
+	}
+
+	@Test
+	void hasXPathValueWhenDocumentExpandsEntitiesRecursivelyThenFails() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(BILLION_LAUGHS)).hasXPathValue("/lolz"))
+			.withMessageContaining("Unable to parse XML content");
+	}
+
+	@Test
+	void extractingXPathNodeListWhenTextContainsCdataThenNodeCarriesAllOfTheText() {
+		// The XPath data model has no CDATA sections, the text either side of one
+		// belongs to the same text node
+		assertThat(forXml(CDATA)).extractingXPathNodeList("/example/name/text()")
+			.extracting(Node::getNodeValue)
+			.containsExactly("xyz");
+	}
+
+	@Test
+	void hasXPathNodeCountWhenTextContainsCdataThenCountsASingleTextNode() {
+		assertThat(forXml(CDATA)).hasXPathNodeCount("/example/name/text()", 1);
+	}
+
+	@Test
+	void extractingXPathStringValueWhenTextContainsCdataThenReturnsAllOfTheText() {
+		assertThat(forXml(CDATA)).extractingXPathStringValue("/example/name/text()").isEqualTo("xyz");
 	}
 
 	@Test
@@ -596,7 +709,7 @@ class XmlContentAssertTests {
 	void hasXPathValueWhenExpressionIsUnprefixedAndDocumentIsNamespacedThenFails() {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forXml(NAMESPACED)).hasXPathValue("/example/name"))
-			.withMessageContaining("No XML path");
+			.withMessageContaining("No XPath expression");
 	}
 
 	@Test
@@ -627,6 +740,24 @@ class XmlContentAssertTests {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertion.withNamespaces(NAMESPACES).hasXPathValue("/ns:example/ns:nope"))
 			.withMessageContaining("[my description]");
+	}
+
+	@Test
+	void withNamespacesWhenRepresentationIsSetThenRepresentationIsRetained() {
+		XmlContentAssert assertion = new XmlContentAssert(XmlContentAssertTests.class, NAMESPACED)
+			.withRepresentation((object) -> "<redacted>");
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertion.withNamespaces(NAMESPACES).isNull())
+			.withMessageContaining("<redacted>");
+	}
+
+	@Test
+	void withNamespacesWhenPrefixIsReservedThenThrowsException() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> assertThat(forXml(NAMESPACED)).withNamespaces(Map.of("xml", "urn:example")))
+			.withMessageContaining("must not rebind the reserved prefix 'xml'");
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> assertThat(forXml(NAMESPACED)).withNamespaces(Map.of("xmlns", "urn:example")))
+			.withMessageContaining("must not rebind the reserved prefix 'xmlns'");
 	}
 
 	@Test
@@ -702,7 +833,7 @@ class XmlContentAssertTests {
 	void extractingXPathStringValueWhenPathIsMissingThenFails() {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forXml(SOURCE)).extractingXPathStringValue("/example/nope"))
-			.withMessageContaining("No value at XML path \"/example/nope\"");
+			.withMessageContaining("No value at XPath expression \"/example/nope\"");
 	}
 
 	@Test
@@ -763,7 +894,7 @@ class XmlContentAssertTests {
 	void extractingXPathNumberValueWhenPathIsMissingThenFails() {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forXml(SOURCE)).extractingXPathNumberValue("/example/nope"))
-			.withMessageContaining("No value at XML path");
+			.withMessageContaining("No value at XPath expression");
 	}
 
 	@Test
@@ -794,7 +925,7 @@ class XmlContentAssertTests {
 	void extractingXPathBooleanValueWhenPathIsMissingThenFails() {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forXml(SOURCE)).extractingXPathBooleanValue("/example/nope"))
-			.withMessageContaining("No value at XML path");
+			.withMessageContaining("No value at XPath expression");
 	}
 
 	private File createFile(String content) throws IOException {

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/xml/XmlContentAssertTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/xml/XmlContentAssertTests.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.xml;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+import org.assertj.core.api.AssertProvider;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.util.FileCopyUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Tests for {@link XmlContentAssert}.
+ *
+ * @author Tiziano Basile
+ */
+class XmlContentAssertTests {
+
+	private static final String SOURCE = loadXml("source.xml");
+
+	private static final String SIMILAR_SAME = loadXml("similar-same.xml");
+
+	private static final String DIFFERENT = loadXml("different.xml");
+
+	private static final String MALFORMED = loadXml("malformed.xml");
+
+	@TempDir
+	@SuppressWarnings("NullAway.Init")
+	public Path tempDir;
+
+	private File temp;
+
+	@BeforeEach
+	void setup() {
+		this.temp = new File(this.tempDir.toFile(), "file.xml");
+	}
+
+	@Test
+	void isEqualToXmlWhenStringIsIdenticalShouldPass() {
+		assertThat(forXml(SOURCE)).isEqualToXml(SOURCE);
+	}
+
+	@Test
+	void isEqualToXmlWhenOnlyWhitespaceAndOrderDifferShouldFail() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isEqualToXml(SIMILAR_SAME))
+			.withMessageContaining("XML Comparison failure");
+	}
+
+	@Test
+	void isEqualToXmlWhenResourcePathIsIdenticalShouldPass() {
+		assertThat(forXml(SOURCE)).isEqualToXml("source.xml");
+	}
+
+	@Test
+	void isEqualToXmlWhenResourcePathIsNotMatchingShouldFail() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isEqualToXml("different.xml"));
+	}
+
+	@Test
+	void isEqualToXmlWhenPathAndClassAreIdenticalShouldPass() {
+		assertThat(forXml(SOURCE)).isEqualToXml("source.xml", XmlContentAssertTests.class);
+	}
+
+	@Test
+	void isEqualToXmlWhenBytesAreIdenticalShouldPass() {
+		assertThat(forXml(SOURCE)).isEqualToXml(SOURCE.getBytes());
+	}
+
+	@Test
+	void isEqualToXmlWhenFileIsIdenticalShouldPass() throws Exception {
+		assertThat(forXml(SOURCE)).isEqualToXml(createFile(SOURCE));
+	}
+
+	@Test
+	void isEqualToXmlWhenInputStreamIsIdenticalShouldPass() {
+		assertThat(forXml(SOURCE)).isEqualToXml(createInputStream(SOURCE));
+	}
+
+	@Test
+	void isEqualToXmlWhenResourceIsIdenticalShouldPass() {
+		assertThat(forXml(SOURCE)).isEqualToXml(createResource(SOURCE));
+	}
+
+	@Test
+	void isEqualToXmlWhenActualIsNullAndExpectedIsNotShouldFail() {
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(forXml(null)).isEqualToXml(SOURCE))
+			.withMessageContaining("Expected null XML");
+	}
+
+	@Test
+	void isEqualToXmlWhenExpectedIsNullAndActualIsNotShouldFail() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isEqualToXml((CharSequence) null))
+			.withMessageContaining("Expected XML but got null");
+	}
+
+	@Test
+	void isNotEqualToXmlWhenStringIsDifferentShouldPass() {
+		assertThat(forXml(SOURCE)).isNotEqualToXml(DIFFERENT);
+	}
+
+	@Test
+	void isNotEqualToXmlWhenOnlyWhitespaceAndOrderDifferShouldPass() {
+		assertThat(forXml(SOURCE)).isNotEqualToXml(SIMILAR_SAME);
+	}
+
+	@Test
+	void isNotEqualToXmlWhenStringIsIdenticalShouldFail() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isNotEqualToXml(SOURCE))
+			.withMessageContaining("expected a difference");
+	}
+
+	@Test
+	void isNotEqualToXmlWhenResourcePathIsDifferentShouldPass() {
+		assertThat(forXml(SOURCE)).isNotEqualToXml("different.xml");
+	}
+
+	@Test
+	void isNotEqualToXmlWhenPathAndClassAreDifferentShouldPass() {
+		assertThat(forXml(SOURCE)).isNotEqualToXml("different.xml", XmlContentAssertTests.class);
+	}
+
+	@Test
+	void isNotEqualToXmlWhenBytesAreDifferentShouldPass() {
+		assertThat(forXml(SOURCE)).isNotEqualToXml(DIFFERENT.getBytes());
+	}
+
+	@Test
+	void isNotEqualToXmlWhenFileIsDifferentShouldPass() throws Exception {
+		assertThat(forXml(SOURCE)).isNotEqualToXml(createFile(DIFFERENT));
+	}
+
+	@Test
+	void isNotEqualToXmlWhenInputStreamIsDifferentShouldPass() {
+		assertThat(forXml(SOURCE)).isNotEqualToXml(createInputStream(DIFFERENT));
+	}
+
+	@Test
+	void isNotEqualToXmlWhenResourceIsDifferentShouldPass() {
+		assertThat(forXml(SOURCE)).isNotEqualToXml(createResource(DIFFERENT));
+	}
+
+	@Test
+	void isSimilarToXmlWhenOnlyWhitespaceAndOrderDifferShouldPass() {
+		assertThat(forXml(SOURCE)).isSimilarToXml(SIMILAR_SAME);
+	}
+
+	@Test
+	void isSimilarToXmlWhenOnlyAttributeOrderDiffersShouldPass() {
+		assertThat(forXml("<example a=\"1\" b=\"2\"/>")).isSimilarToXml("<example b=\"2\" a=\"1\"/>");
+	}
+
+	@Test
+	void isSimilarToXmlWhenResourcePathIsSimilarShouldPass() {
+		assertThat(forXml(SOURCE)).isSimilarToXml("similar-same.xml");
+	}
+
+	@Test
+	void isSimilarToXmlWhenPathAndClassAreSimilarShouldPass() {
+		assertThat(forXml(SOURCE)).isSimilarToXml("similar-same.xml", XmlContentAssertTests.class);
+	}
+
+	@Test
+	void isSimilarToXmlWhenBytesAreSimilarShouldPass() {
+		assertThat(forXml(SOURCE)).isSimilarToXml(SIMILAR_SAME.getBytes());
+	}
+
+	@Test
+	void isSimilarToXmlWhenFileIsSimilarShouldPass() throws Exception {
+		assertThat(forXml(SOURCE)).isSimilarToXml(createFile(SIMILAR_SAME));
+	}
+
+	@Test
+	void isSimilarToXmlWhenInputStreamIsSimilarShouldPass() {
+		assertThat(forXml(SOURCE)).isSimilarToXml(createInputStream(SIMILAR_SAME));
+	}
+
+	@Test
+	void isSimilarToXmlWhenResourceIsSimilarShouldPass() {
+		assertThat(forXml(SOURCE)).isSimilarToXml(createResource(SIMILAR_SAME));
+	}
+
+	@Test
+	void isSimilarToXmlWhenContentIsDifferentShouldFail() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isSimilarToXml(DIFFERENT))
+			.withMessageContaining("XML Comparison failure");
+	}
+
+	@Test
+	void isNotSimilarToXmlWhenContentIsDifferentShouldPass() {
+		assertThat(forXml(SOURCE)).isNotSimilarToXml(DIFFERENT);
+	}
+
+	@Test
+	void isNotSimilarToXmlWhenOnlyWhitespaceAndOrderDifferShouldFail() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isNotSimilarToXml(SIMILAR_SAME))
+			.withMessageContaining("expected a difference");
+	}
+
+	@Test
+	void isNotSimilarToXmlWhenResourcePathIsDifferentShouldPass() {
+		assertThat(forXml(SOURCE)).isNotSimilarToXml("different.xml");
+	}
+
+	@Test
+	void isNotSimilarToXmlWhenPathAndClassAreDifferentShouldPass() {
+		assertThat(forXml(SOURCE)).isNotSimilarToXml("different.xml", XmlContentAssertTests.class);
+	}
+
+	@Test
+	void isNotSimilarToXmlWhenBytesAreDifferentShouldPass() {
+		assertThat(forXml(SOURCE)).isNotSimilarToXml(DIFFERENT.getBytes());
+	}
+
+	@Test
+	void isNotSimilarToXmlWhenFileIsDifferentShouldPass() throws Exception {
+		assertThat(forXml(SOURCE)).isNotSimilarToXml(createFile(DIFFERENT));
+	}
+
+	@Test
+	void isNotSimilarToXmlWhenInputStreamIsDifferentShouldPass() {
+		assertThat(forXml(SOURCE)).isNotSimilarToXml(createInputStream(DIFFERENT));
+	}
+
+	@Test
+	void isNotSimilarToXmlWhenResourceIsDifferentShouldPass() {
+		assertThat(forXml(SOURCE)).isNotSimilarToXml(createResource(DIFFERENT));
+	}
+
+	@Test
+	void isEqualToXmlWhenActualIsMalformedShouldFailWithAssertionError() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(MALFORMED)).isEqualToXml(SOURCE))
+			.withMessageContaining("Unable to compare XML");
+	}
+
+	@Test
+	void isSimilarToXmlWhenExpectedIsMalformedShouldFailWithAssertionError() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).isSimilarToXml(MALFORMED))
+			.withMessageContaining("Unable to compare XML");
+	}
+
+	@Test
+	void hasXPathValueWhenPathIsPresentShouldPass() {
+		assertThat(forXml(SOURCE)).hasXPathValue("/example/name");
+	}
+
+	@Test
+	void hasXPathValueWhenPathIsParameterizedShouldPass() {
+		assertThat(forXml(SOURCE)).hasXPathValue("/example/%s", "name");
+	}
+
+	@Test
+	void hasXPathValueWhenPathIsMissingShouldFail() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).hasXPathValue("/example/nope"))
+			.withMessageContaining("/example/nope");
+	}
+
+	@Test
+	void hasXPathValueWhenActualIsMalformedShouldFailWithAssertionError() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(MALFORMED)).hasXPathValue("/example/name"))
+			.withMessageContaining("Unable to parse XML content");
+	}
+
+	@Test
+	void doesNotHaveXPathValueWhenPathIsMissingShouldPass() {
+		assertThat(forXml(SOURCE)).doesNotHaveXPathValue("/example/nope");
+	}
+
+	@Test
+	void doesNotHaveXPathValueWhenPathIsPresentShouldFail() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).doesNotHaveXPathValue("/example/name"))
+			.withMessageContaining("/example/name");
+	}
+
+	@Test
+	void extractingXPathValueWhenPathIsPresentShouldReturnValue() {
+		assertThat(forXml(SOURCE)).extractingXPathValue("/example/name").isEqualTo("Spring");
+	}
+
+	@Test
+	void extractingXPathValueWhenPathIsMissingShouldReturnNull() {
+		assertThat(forXml(SOURCE)).extractingXPathValue("/example/nope").isNull();
+	}
+
+	@Test
+	void extractingXPathStringValueWhenPathIsPresentShouldReturnValue() {
+		assertThat(forXml(SOURCE)).extractingXPathStringValue("/example/name").isEqualTo("Spring");
+	}
+
+	@Test
+	void extractingXPathNumberValueWhenPathIsPresentShouldReturnValue() {
+		assertThat(forXml(SOURCE)).extractingXPathNumberValue("/example/age").isEqualTo(100);
+	}
+
+	@Test
+	void extractingXPathNumberValueWhenValueIsNotANumberShouldFail() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).extractingXPathNumberValue("/example/name"))
+			.withMessageContaining("Expected a number");
+	}
+
+	@Test
+	void extractingXPathBooleanValueWhenPathIsPresentShouldReturnValue() {
+		assertThat(forXml(SOURCE)).extractingXPathBooleanValue("/example/active").isTrue();
+	}
+
+	@Test
+	void extractingXPathBooleanValueWhenValueIsNotABooleanShouldFail() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forXml(SOURCE)).extractingXPathBooleanValue("/example/name"))
+			.withMessageContaining("Expected a boolean");
+	}
+
+	@Test
+	void hasXPathValueWhenExpressionIsEmptyShouldThrowException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> assertThat(forXml(SOURCE)).hasXPathValue(""))
+			.withMessageContaining("'expression' must not be empty");
+	}
+
+	private File createFile(String content) throws IOException {
+		File file = this.temp;
+		FileCopyUtils.copy(content.getBytes(), file);
+		return file;
+	}
+
+	private InputStream createInputStream(String content) {
+		return new ByteArrayInputStream(content.getBytes());
+	}
+
+	private Resource createResource(String content) {
+		return new ByteArrayResource(content.getBytes());
+	}
+
+	private static String loadXml(String path) {
+		try {
+			ClassPathResource resource = new ClassPathResource(path, XmlContentAssertTests.class);
+			return new String(FileCopyUtils.copyToByteArray(resource.getInputStream()));
+		}
+		catch (Exception ex) {
+			throw new IllegalStateException(ex);
+		}
+	}
+
+	private AssertProvider<XmlContentAssert> forXml(@Nullable String xml) {
+		return () -> new XmlContentAssert(XmlContentAssertTests.class, xml);
+	}
+
+}

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/xml/XmlLoaderTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/xml/XmlLoaderTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.xml;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for {@link XmlLoader}.
+ *
+ * @author Tiziano Basile
+ */
+class XmlLoaderTests {
+
+	private static final Charset UTF_32BE = Charset.forName("UTF-32BE");
+
+	private static final Charset UTF_32LE = Charset.forName("UTF-32LE");
+
+	private static final String XML = "<example><name>Spring</name></example>";
+
+	private final XmlLoader loader = new XmlLoader(XmlLoaderTests.class, null);
+
+	@Test
+	void getXmlWhenContentHasNoDeclarationThenUsesUtf8() {
+		assertThat(this.loader.getXml("<example><name>Sprüng</name></example>".getBytes(StandardCharsets.UTF_8)))
+			.isEqualTo("<example><name>Sprüng</name></example>");
+	}
+
+	@Test
+	void getXmlWhenContentDeclaresEncodingThenUsesDeclaredEncoding() {
+		String xml = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><example><name>Sprüng</name></example>";
+		assertThat(this.loader.getXml(xml.getBytes(StandardCharsets.ISO_8859_1))).isEqualTo(xml);
+	}
+
+	@Test
+	void getXmlWhenContentHasUtf8ByteOrderMarkThenMarkIsRemoved() {
+		assertThat(this.loader.getXml(("\uFEFF" + XML).getBytes(StandardCharsets.UTF_8))).isEqualTo(XML);
+	}
+
+	@Test
+	void getXmlWhenCharsetIsExplicitAndContentHasByteOrderMarkThenMarkIsRemoved() {
+		XmlLoader loader = new XmlLoader(XmlLoaderTests.class, StandardCharsets.UTF_8);
+		assertThat(loader.getXml(("\uFEFF" + XML).getBytes(StandardCharsets.UTF_8))).isEqualTo(XML);
+	}
+
+	@Test
+	void getXmlWhenContentHasUtf16ByteOrderMarkThenUsesUtf16() {
+		assertThat(this.loader.getXml(("\uFEFF" + XML).getBytes(StandardCharsets.UTF_16LE))).isEqualTo(XML);
+		assertThat(this.loader.getXml(("\uFEFF" + XML).getBytes(StandardCharsets.UTF_16BE))).isEqualTo(XML);
+	}
+
+	@Test
+	void getXmlWhenContentHasUtf32ByteOrderMarkThenUsesUtf32() {
+		// The little-endian UTF-32 mark starts with the little-endian UTF-16 mark, so it
+		// must be recognized first
+		assertThat(this.loader.getXml(("\uFEFF" + XML).getBytes(UTF_32LE))).isEqualTo(XML);
+		assertThat(this.loader.getXml(("\uFEFF" + XML).getBytes(UTF_32BE))).isEqualTo(XML);
+	}
+
+	@Test
+	void getXmlWhenContentIsUtf16WithNoByteOrderMarkOrDeclarationThenUsesUtf16() {
+		assertThat(this.loader.getXml(XML.getBytes(StandardCharsets.UTF_16LE))).isEqualTo(XML);
+		assertThat(this.loader.getXml(XML.getBytes(StandardCharsets.UTF_16BE))).isEqualTo(XML);
+	}
+
+	@Test
+	void getXmlWhenContentIsUtf32WithNoByteOrderMarkOrDeclarationThenUsesUtf32() {
+		assertThat(this.loader.getXml(XML.getBytes(UTF_32LE))).isEqualTo(XML);
+		assertThat(this.loader.getXml(XML.getBytes(UTF_32BE))).isEqualTo(XML);
+	}
+
+	@Test
+	void getXmlWhenContentIsMalformedForTheCharsetThenThrowsException() {
+		byte[] bytes = { '<', 'a', '>', (byte) 0xFF, '<', '/', 'a', '>' };
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> this.loader.getXml(bytes))
+			.withMessageContaining("cannot be decoded using UTF-8");
+	}
+
+	@Test
+	void getXmlWhenDeclaredEncodingIsEmptyThenThrowsException() {
+		byte[] bytes = ("<?xml version=\"1.0\" encoding=\"\"?>" + XML).getBytes(StandardCharsets.UTF_8);
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> this.loader.getXml(bytes))
+			.withMessageContaining("declaring an empty encoding");
+	}
+
+	@Test
+	void getXmlWhenDeclarationIsTooLongToReadThenThrowsException() {
+		String declaration = "<?xml version=\"1.0\"" + " ".repeat(256) + "encoding=\"ISO-8859-1\"?>";
+		byte[] bytes = (declaration + XML).getBytes(StandardCharsets.ISO_8859_1);
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> this.loader.getXml(bytes))
+			.withMessageContaining("does not end within the first 256 bytes");
+	}
+
+	@Test
+	void getXmlWhenDeclaredEncodingIsUnsupportedThenThrowsException() {
+		byte[] bytes = ("<?xml version=\"1.0\" encoding=\"NOT-A-CHARSET\"?>" + XML)
+			.getBytes(StandardCharsets.ISO_8859_1);
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> this.loader.getXml(bytes))
+			.withMessageContaining("unsupported encoding 'NOT-A-CHARSET'");
+	}
+
+	@Test
+	void getXmlWhenContentStartsWithAProcessingInstructionThenUsesUtf8() {
+		String xml = "<?xml-stylesheet type=\"text/xsl\" href=\"style.xsl\"?>" + XML;
+		assertThat(this.loader.getXml(xml.getBytes(StandardCharsets.UTF_8))).isEqualTo(xml);
+	}
+
+}

--- a/core/spring-boot-test/src/test/resources/org/springframework/boot/test/xml/different.xml
+++ b/core/spring-boot-test/src/test/resources/org/springframework/boot/test/xml/different.xml
@@ -1,0 +1,1 @@
+<example><name>Boot</name><age>200</age><active>false</active></example>

--- a/core/spring-boot-test/src/test/resources/org/springframework/boot/test/xml/doctype.xml
+++ b/core/spring-boot-test/src/test/resources/org/springframework/boot/test/xml/doctype.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE example [<!ELEMENT example (name,age,active)><!ELEMENT name (#PCDATA)><!ELEMENT age (#PCDATA)><!ELEMENT active (#PCDATA)><!ENTITY who "Spring">]>
+<example><name>&who;</name><age>100</age><active>true</active></example>

--- a/core/spring-boot-test/src/test/resources/org/springframework/boot/test/xml/example-object.xml
+++ b/core/spring-boot-test/src/test/resources/org/springframework/boot/test/xml/example-object.xml
@@ -1,0 +1,1 @@
+<ExampleObject><name>Spring</name><age>100</age></ExampleObject>

--- a/core/spring-boot-test/src/test/resources/org/springframework/boot/test/xml/malformed.xml
+++ b/core/spring-boot-test/src/test/resources/org/springframework/boot/test/xml/malformed.xml
@@ -1,0 +1,1 @@
+<example><name>Spring</name><age>100</age><active>true</active>

--- a/core/spring-boot-test/src/test/resources/org/springframework/boot/test/xml/namespaced.xml
+++ b/core/spring-boot-test/src/test/resources/org/springframework/boot/test/xml/namespaced.xml
@@ -1,0 +1,1 @@
+<ns:example xmlns:ns="urn:example"><ns:name>Spring</ns:name><ns:age>100</ns:age></ns:example>

--- a/core/spring-boot-test/src/test/resources/org/springframework/boot/test/xml/similar-same.xml
+++ b/core/spring-boot-test/src/test/resources/org/springframework/boot/test/xml/similar-same.xml
@@ -1,0 +1,6 @@
+<example>
+	<!-- The same content, reordered and indented -->
+	<age>100</age>
+	<name>Spring</name>
+	<active>true</active>
+</example>

--- a/core/spring-boot-test/src/test/resources/org/springframework/boot/test/xml/source.xml
+++ b/core/spring-boot-test/src/test/resources/org/springframework/boot/test/xml/source.xml
@@ -1,0 +1,1 @@
+<example><name>Spring</name><age>100</age><active>true</active></example>

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/spring-boot-applications.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/spring-boot-applications.adoc
@@ -349,15 +349,18 @@ The following example shows a test class for Jackson:
 
 include-code::MyXmlTests[]
 
-NOTE: A lenient comparison (`isEqualToXml`) ignores insignificant whitespace and comments, whereas a strict comparison (`isStrictlyEqualToXml`) requires the two documents to be identical.
+NOTE: A lenient comparison (`isEqualToXml`) ignores comments and whitespace, whereas a strict comparison (`isStrictlyEqualToXml`) requires the two documents to be identical.
+A lenient comparison ignores more whitespace than the whitespace between elements: text content is compared with its leading and trailing whitespace removed, so `<name>  Honda  </name>` is leniently equal to `<name>Honda</name>`, and text that consists only of whitespace is ignored altogether, so `<name>   </name>` is leniently equal to `<name/>`.
 The ordering of attributes is never significant.
 For a lenient comparison, the ordering of sibling elements that share a name is not significant either, but only as long as those elements can be told apart by their own text content alone: `<i>a</i><i>b</i>` matches `<i>b</i><i>a</i>`.
 Siblings are paired up on name and text content, and nothing else.
 Siblings that have element-only content, such as `<item><id>1</id></item>`, and siblings that differ only in their attributes, such as `<item id="1">x</item>`, are therefore paired up by name alone and their ordering remains significant.
 
-WARNING: The XML declaration is part of a strict comparison.
-javadoc:tools.jackson.dataformat.xml.XmlMapper[] writes no declaration by default, so an expected document that starts with `<?xml version="1.0" encoding="UTF-8"?>` is not identical to the written output and `isStrictlyEqualToXml` fails with a message such as `Expected xml encoding 'UTF-8' but was 'null'`.
+WARNING: A strict comparison compares everything that a lenient comparison ignores, and it also fails on a difference in the XML declaration, in namespace prefixes (`<p:a xmlns:p="urn:example"/>` is not identical to `<q:a xmlns:q="urn:example"/>`), in the distinction between a CDATA section and ordinary text (`<a><![CDATA[x]]></a>` is not identical to `<a>x</a>`), and in processing instructions.
+The XML declaration is a common trap: javadoc:tools.jackson.dataformat.xml.XmlMapper[] writes no declaration by default, so an expected document that starts with `<?xml version="1.0" encoding="UTF-8"?>` is not identical to the written output and `isStrictlyEqualToXml` fails with a message such as `Expected xml encoding 'UTF-8' but was 'null'`.
 Omit the declaration from fixtures used for strict comparison, or use `isEqualToXml`, which ignores it.
+
+NOTE: XML that cannot be parsed always fails the assertion, whichever side of the comparison it is on, including for `isNotEqualToXml` and `isNotStrictlyEqualToXml`.
 
 NOTE: XPath expressions are evaluated with a namespace aware parser.
 An expression that uses no prefix matches only elements that are in no namespace, so to assert against a document that declares namespaces, first register the prefixes you want to use with `withNamespaces(Map)`, which returns a new assertion object bound to them.

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/spring-boot-applications.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/spring-boot-applications.adoc
@@ -331,6 +331,30 @@ include-code::MyJsonAssertJTests[tag=*]
 
 
 
+[[testing.spring-boot-applications.xml-tests]]
+== Auto-configured XML Tests
+
+To test that object XML serialization and deserialization is working as expected, you can use the javadoc:org.springframework.boot.test.autoconfigure.xml.XmlTest[format=annotation] annotation from the `spring-boot-test-autoconfigure` module.
+javadoc:org.springframework.boot.test.autoconfigure.xml.XmlTest[format=annotation] auto-configures the Jackson javadoc:tools.jackson.dataformat.xml.XmlMapper[], any javadoc:org.springframework.boot.jackson.JacksonComponent[format=annotation] beans and any Jackson javadoc:tools.jackson.databind.JacksonModule[].
+
+TIP: A list of the auto-configurations that are enabled by javadoc:org.springframework.boot.test.autoconfigure.xml.XmlTest[format=annotation] can be xref:appendix:test-auto-configuration/index.adoc[found in the appendix].
+
+If you need to configure elements of the auto-configuration, you can use the javadoc:org.springframework.boot.test.autoconfigure.xml.AutoConfigureXmlTesters[format=annotation] annotation.
+
+Spring Boot includes AssertJ-based helpers that work with the XMLUnit library to check that XML appears as expected.
+The javadoc:org.springframework.boot.test.xml.JacksonXmlTester[] class can be used for Jackson.
+Any helper fields on the test class can be javadoc:org.springframework.beans.factory.annotation.Autowired[format=annotation] when using javadoc:org.springframework.boot.test.autoconfigure.xml.XmlTest[format=annotation].
+The following example shows a test class for Jackson:
+
+include-code::MyXmlTests[]
+
+NOTE: An identical comparison (`isEqualToXml`) requires the documents to match exactly, whereas a similar comparison (`isSimilarToXml`) ignores insignificant whitespace, comments and the ordering of elements and attributes.
+
+NOTE: XML helper classes can also be used directly in standard unit tests.
+To do so, call the `initFields` method of the helper in your javadoc:org.junit.jupiter.api.BeforeEach[format=annotation] method if you do not use javadoc:org.springframework.boot.test.autoconfigure.xml.XmlTest[format=annotation].
+
+
+
 [[testing.spring-boot-applications.spring-mvc-tests]]
 == Auto-configured Spring MVC Tests
 

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/spring-boot-applications.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/spring-boot-applications.adoc
@@ -337,7 +337,8 @@ include-code::MyJsonAssertJTests[tag=*]
 To test that object XML serialization and deserialization is working as expected, you can use the javadoc:org.springframework.boot.test.autoconfigure.xml.XmlTest[format=annotation] annotation from the `spring-boot-test-autoconfigure` module.
 javadoc:org.springframework.boot.test.autoconfigure.xml.XmlTest[format=annotation] auto-configures the Jackson javadoc:tools.jackson.dataformat.xml.XmlMapper[], any javadoc:org.springframework.boot.jackson.JacksonComponent[format=annotation] beans and any Jackson javadoc:tools.jackson.databind.JacksonModule[].
 
-TIP: A list of the auto-configurations that are enabled by javadoc:org.springframework.boot.test.autoconfigure.xml.XmlTest[format=annotation] can be xref:appendix:test-auto-configuration/index.adoc[found in the appendix].
+NOTE: The slice supports Jackson XML only.
+Neither JAXB nor the deprecated Jackson 2 XML support is auto-configured by javadoc:org.springframework.boot.test.autoconfigure.xml.XmlTest[format=annotation].
 
 If you need to configure elements of the auto-configuration, you can use the javadoc:org.springframework.boot.test.autoconfigure.xml.AutoConfigureXmlTesters[format=annotation] annotation.
 
@@ -348,7 +349,18 @@ The following example shows a test class for Jackson:
 
 include-code::MyXmlTests[]
 
-NOTE: An identical comparison (`isEqualToXml`) requires the documents to match exactly, whereas a similar comparison (`isSimilarToXml`) ignores insignificant whitespace, comments and the ordering of elements and attributes.
+NOTE: A lenient comparison (`isEqualToXml`) ignores insignificant whitespace and comments, whereas a strict comparison (`isStrictlyEqualToXml`) requires the two documents to be identical.
+The ordering of attributes is never significant.
+For a lenient comparison, the ordering of sibling elements that share a name is not significant either, but only as long as those elements can be told apart by their own text content alone: `<i>a</i><i>b</i>` matches `<i>b</i><i>a</i>`.
+Siblings are paired up on name and text content, and nothing else.
+Siblings that have element-only content, such as `<item><id>1</id></item>`, and siblings that differ only in their attributes, such as `<item id="1">x</item>`, are therefore paired up by name alone and their ordering remains significant.
+
+WARNING: The XML declaration is part of a strict comparison.
+javadoc:tools.jackson.dataformat.xml.XmlMapper[] writes no declaration by default, so an expected document that starts with `<?xml version="1.0" encoding="UTF-8"?>` is not identical to the written output and `isStrictlyEqualToXml` fails with a message such as `Expected xml encoding 'UTF-8' but was 'null'`.
+Omit the declaration from fixtures used for strict comparison, or use `isEqualToXml`, which ignores it.
+
+NOTE: XPath expressions are evaluated with a namespace aware parser.
+An expression that uses no prefix matches only elements that are in no namespace, so to assert against a document that declares namespaces, first register the prefixes you want to use with `withNamespaces(Map)`, which returns a new assertion object bound to them.
 
 NOTE: XML helper classes can also be used directly in standard unit tests.
 To do so, call the `initFields` method of the helper in your javadoc:org.junit.jupiter.api.BeforeEach[format=annotation] method if you do not use javadoc:org.springframework.boot.test.autoconfigure.xml.XmlTest[format=annotation].

--- a/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/springbootapplications/xmltests/MyXmlTests.java
+++ b/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/springbootapplications/xmltests/MyXmlTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docs.testing.springbootapplications.xmltests;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.xml.XmlTest;
+import org.springframework.boot.test.xml.JacksonXmlTester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@XmlTest
+class MyXmlTests {
+
+	@Autowired
+	private JacksonXmlTester<VehicleDetails> xml;
+
+	@Test
+	void serialize() throws Exception {
+		VehicleDetails details = new VehicleDetails("Honda", "Civic");
+		// Assert against a `.xml` file in the same package as the test
+		assertThat(this.xml.write(details)).isSimilarToXml("expected.xml");
+		// Or use XPath based assertions
+		assertThat(this.xml.write(details)).hasXPathValue("/VehicleDetails/make");
+		assertThat(this.xml.write(details)).extractingXPathStringValue("/VehicleDetails/make").isEqualTo("Honda");
+	}
+
+	@Test
+	void deserialize() throws Exception {
+		String content = "<VehicleDetails><make>Ford</make><model>Focus</model></VehicleDetails>";
+		assertThat(this.xml.parse(content)).isEqualTo(new VehicleDetails("Ford", "Focus"));
+		assertThat(this.xml.parseObject(content).getMake()).isEqualTo("Ford");
+	}
+
+}

--- a/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/springbootapplications/xmltests/MyXmlTests.java
+++ b/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/springbootapplications/xmltests/MyXmlTests.java
@@ -34,7 +34,7 @@ class MyXmlTests {
 	void serialize() throws Exception {
 		VehicleDetails details = new VehicleDetails("Honda", "Civic");
 		// Assert against a `.xml` file in the same package as the test
-		assertThat(this.xml.write(details)).isSimilarToXml("expected.xml");
+		assertThat(this.xml.write(details)).isEqualToXml("expected.xml");
 		// Or use XPath based assertions
 		assertThat(this.xml.write(details)).hasXPathValue("/VehicleDetails/make");
 		assertThat(this.xml.write(details)).extractingXPathStringValue("/VehicleDetails/make").isEqualTo("Honda");

--- a/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/springbootapplications/xmltests/VehicleDetails.java
+++ b/documentation/spring-boot-docs/src/main/java/org/springframework/boot/docs/testing/springbootapplications/xmltests/VehicleDetails.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docs.testing.springbootapplications.xmltests;
+
+class VehicleDetails {
+
+	private final String make;
+
+	private final String model;
+
+	VehicleDetails(String make, String model) {
+		this.make = make;
+		this.model = model;
+	}
+
+	String getMake() {
+		return this.make;
+	}
+
+	String getModel() {
+		return this.model;
+	}
+
+}

--- a/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/testing/springbootapplications/xmltests/MyXmlTests.kt
+++ b/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/testing/springbootapplications/xmltests/MyXmlTests.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docs.testing.springbootapplications.xmltests
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.xml.XmlTest
+import org.springframework.boot.test.xml.JacksonXmlTester
+
+@XmlTest
+class MyXmlTests(@Autowired val xml: JacksonXmlTester<VehicleDetails>) {
+
+	@Test
+	fun serialize() {
+		val details = VehicleDetails("Honda", "Civic")
+		// Assert against a `.xml` file in the same package as the test
+		assertThat(xml.write(details)).isSimilarToXml("expected.xml")
+		// Or use XPath based assertions
+		assertThat(xml.write(details)).hasXPathValue("/VehicleDetails/make")
+		assertThat(xml.write(details)).extractingXPathStringValue("/VehicleDetails/make").isEqualTo("Honda")
+	}
+
+	@Test
+	fun deserialize() {
+		val content = "<VehicleDetails><make>Ford</make><model>Focus</model></VehicleDetails>"
+		assertThat(xml.parse(content)).isEqualTo(VehicleDetails("Ford", "Focus"))
+		assertThat(xml.parseObject(content).make).isEqualTo("Ford")
+	}
+
+}

--- a/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/testing/springbootapplications/xmltests/MyXmlTests.kt
+++ b/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/testing/springbootapplications/xmltests/MyXmlTests.kt
@@ -29,7 +29,7 @@ class MyXmlTests(@Autowired val xml: JacksonXmlTester<VehicleDetails>) {
 	fun serialize() {
 		val details = VehicleDetails("Honda", "Civic")
 		// Assert against a `.xml` file in the same package as the test
-		assertThat(xml.write(details)).isSimilarToXml("expected.xml")
+		assertThat(xml.write(details)).isEqualToXml("expected.xml")
 		// Or use XPath based assertions
 		assertThat(xml.write(details)).hasXPathValue("/VehicleDetails/make")
 		assertThat(xml.write(details)).extractingXPathStringValue("/VehicleDetails/make").isEqualTo("Honda")

--- a/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/testing/springbootapplications/xmltests/VehicleDetails.kt
+++ b/documentation/spring-boot-docs/src/main/kotlin/org/springframework/boot/docs/testing/springbootapplications/xmltests/VehicleDetails.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docs.testing.springbootapplications.xmltests
+
+data class VehicleDetails(val make: String, val model: String)

--- a/module/spring-boot-jackson/build.gradle
+++ b/module/spring-boot-jackson/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 
 	testImplementation(project(":core:spring-boot-test"))
 	testImplementation(project(":test-support:spring-boot-test-support"))
+	testImplementation("org.xmlunit:xmlunit-core")
 	testImplementation("tools.jackson.module:jackson-module-kotlin")
 	testRuntimeOnly("ch.qos.logback:logback-classic")
 }

--- a/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonXmlTesterTestAutoConfiguration.java
+++ b/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonXmlTesterTestAutoConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jackson.autoconfigure;
+
+import tools.jackson.dataformat.xml.XmlMapper;
+
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.test.autoconfigure.json.JsonTesterFactoryBean;
+import org.springframework.boot.test.autoconfigure.xml.ConditionalOnXmlTesters;
+import org.springframework.boot.test.autoconfigure.xml.XmlMarshalTesterRuntimeHints;
+import org.springframework.boot.test.xml.JacksonXmlTester;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ImportRuntimeHints;
+import org.springframework.context.annotation.Scope;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for {@link JacksonXmlTester}.
+ *
+ * @author Tiziano Basile
+ */
+@AutoConfiguration(after = JacksonAutoConfiguration.class)
+@ConditionalOnXmlTesters
+final class JacksonXmlTesterTestAutoConfiguration {
+
+	@Bean
+	@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+	@ConditionalOnBean(XmlMapper.class)
+	@ImportRuntimeHints(JacksonXmlTesterRuntimeHints.class)
+	FactoryBean<JacksonXmlTester<?>> jacksonXmlTesterFactoryBean(XmlMapper mapper) {
+		return new JsonTesterFactoryBean<>(JacksonXmlTester.class, mapper);
+	}
+
+	static class JacksonXmlTesterRuntimeHints extends XmlMarshalTesterRuntimeHints {
+
+		JacksonXmlTesterRuntimeHints() {
+			super(JacksonXmlTester.class);
+		}
+
+	}
+
+}

--- a/module/spring-boot-jackson/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.xml.AutoConfigureXml.imports
+++ b/module/spring-boot-jackson/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.xml.AutoConfigureXml.imports
@@ -1,0 +1,1 @@
+org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration

--- a/module/spring-boot-jackson/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.xml.AutoConfigureXmlTesters.imports
+++ b/module/spring-boot-jackson/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.xml.AutoConfigureXmlTesters.imports
@@ -1,0 +1,1 @@
+org.springframework.boot.jackson.autoconfigure.JacksonXmlTesterTestAutoConfiguration

--- a/module/spring-boot-jackson/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.xml.XmlTest.includes
+++ b/module/spring-boot-jackson/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.xml.XmlTest.includes
@@ -1,0 +1,2 @@
+org.springframework.boot.jackson.JacksonComponent
+tools.jackson.databind.JacksonModule

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/JacksonXmlTesterAutoConfigurationTests.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/JacksonXmlTesterAutoConfigurationTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jackson.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.dataformat.xml.XmlMapper;
+
+import org.springframework.aot.hint.predicate.ReflectionHintsPredicates;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import org.springframework.aot.test.generate.TestGenerationContext;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.autoconfigure.xml.XmlTestersAutoConfiguration;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.xml.JacksonXmlTester;
+import org.springframework.context.aot.ApplicationContextAotGenerator;
+import org.springframework.context.support.GenericApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link JacksonXmlTesterTestAutoConfiguration}.
+ *
+ * @author Tiziano Basile
+ */
+class JacksonXmlTesterAutoConfigurationTests {
+
+	private final ApplicationContextRunner runner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(XmlTestersAutoConfiguration.class, JacksonAutoConfiguration.class,
+				JacksonXmlTesterTestAutoConfiguration.class));
+
+	@Test
+	void testerIsRegisteredWhenTestersAreEnabled() {
+		this.runner.withPropertyValues("spring.test.xmltesters.enabled=true")
+			.run((context) -> assertThat(context).hasSingleBean(JacksonXmlTester.class));
+	}
+
+	@Test
+	void testerIsNotRegisteredWhenTestersAreDisabled() {
+		this.runner.withPropertyValues("spring.test.xmltesters.enabled=false")
+			.run((context) -> assertThat(context).doesNotHaveBean(JacksonXmlTester.class));
+	}
+
+	@Test
+	void testerIsNotRegisteredWhenXmlMapperIsNotAvailable() {
+		this.runner.withPropertyValues("spring.test.xmltesters.enabled=true")
+			.withClassLoader(new FilteredClassLoader(XmlMapper.class))
+			.run((context) -> {
+				assertThat(context).hasNotFailed();
+				assertThat(context).doesNotHaveBean(JacksonXmlTester.class);
+			});
+	}
+
+	@Test
+	void hintsAreContributed() {
+		this.runner.withPropertyValues("spring.test.xmltesters.enabled=true").prepare((context) -> {
+			TestGenerationContext generationContext = new TestGenerationContext();
+			new ApplicationContextAotGenerator().processAheadOfTime(
+					(GenericApplicationContext) context.getSourceApplicationContext(), generationContext);
+			ReflectionHintsPredicates hints = RuntimeHintsPredicates.reflection();
+			assertThat(hints.onType(JacksonXmlTester.class)).accepts(generationContext.getRuntimeHints());
+		});
+	}
+
+}

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/JacksonAutoConfigureXmlIntegrationTests.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/JacksonAutoConfigureXmlIntegrationTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jackson.autoconfigure.xmltest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tools.jackson.dataformat.xml.XmlMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.xml.AutoConfigureXml;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Integration tests for {@link AutoConfigureXml @AutoConfigureXml} with Jackson.
+ *
+ * @author Tiziano Basile
+ */
+@AutoConfigureXml
+@ExtendWith(SpringExtension.class)
+class JacksonAutoConfigureXmlIntegrationTests {
+
+	@Autowired
+	private ApplicationContext context;
+
+	@Test
+	void xmlMapperIsAvailable() {
+		assertThatNoException().isThrownBy(() -> this.context.getBean(XmlMapper.class));
+	}
+
+}

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/XmlTestIntegrationTests.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/XmlTestIntegrationTests.java
@@ -72,7 +72,7 @@ class XmlTestIntegrationTests {
 	void writeWhenBasicObjectThenMatchesExpectedXml() throws Exception {
 		ExampleBasicObject object = new ExampleBasicObject();
 		object.setValue("spring");
-		assertThat(this.basicXml.write(object)).isSimilarToXml("example.xml");
+		assertThat(this.basicXml.write(object)).isEqualToXml("example.xml");
 	}
 
 	@Test

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/XmlTestIntegrationTests.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/XmlTestIntegrationTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jackson.autoconfigure.xmltest;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.SerializationFeature;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jackson.autoconfigure.XmlMapperBuilderCustomizer;
+import org.springframework.boot.jackson.autoconfigure.xmltest.app.ExampleBasicObject;
+import org.springframework.boot.jackson.autoconfigure.xmltest.app.ExampleCustomObject;
+import org.springframework.boot.jackson.autoconfigure.xmltest.app.ExampleXmlApplication;
+import org.springframework.boot.test.autoconfigure.xml.XmlTest;
+import org.springframework.boot.test.json.BasicJsonTester;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.boot.test.xml.JacksonXmlTester;
+import org.springframework.boot.test.xml.XmlContent;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link XmlTest @XmlTest}.
+ *
+ * @author Tiziano Basile
+ */
+@XmlTest
+@ContextConfiguration(classes = ExampleXmlApplication.class)
+@Import(XmlTestIntegrationTests.XmlMapperCustomizerConfiguration.class)
+class XmlTestIntegrationTests {
+
+	@Autowired
+	private JacksonXmlTester<ExampleBasicObject> basicXml;
+
+	@Autowired
+	private JacksonXmlTester<ExampleCustomObject> customXml;
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Test
+	void contextWhenXmlTestThenJsonTestersAreNotRegistered() {
+		assertThat(this.applicationContext.getBeanNamesForType(JacksonTester.class)).isEmpty();
+		assertThat(this.applicationContext.getBeanNamesForType(BasicJsonTester.class)).isEmpty();
+	}
+
+	@Test
+	void testerWhenContextStartsThenIsInitialized() {
+		assertThat(this.basicXml).isNotNull();
+		assertThat(this.customXml).isNotNull();
+	}
+
+	@Test
+	void writeWhenBasicObjectThenMatchesExpectedXml() throws Exception {
+		ExampleBasicObject object = new ExampleBasicObject();
+		object.setValue("spring");
+		assertThat(this.basicXml.write(object)).isSimilarToXml("example.xml");
+	}
+
+	@Test
+	void readWhenBasicObjectResourceThenReturnsObject() throws Exception {
+		ExampleBasicObject expected = new ExampleBasicObject();
+		expected.setValue("spring");
+		assertThat(this.basicXml.read("example.xml")).isEqualTo(expected);
+	}
+
+	@Test
+	void writeWhenJacksonComponentIsScannedThenUsesCustomSerializer() throws Exception {
+		XmlContent<ExampleCustomObject> content = this.customXml.write(new ExampleCustomObject("spring"));
+		assertThat(content).extractingXPathStringValue("/example/custom").isEqualTo("spring");
+	}
+
+	@Test
+	void writeWhenCustomizerIsDefinedThenCustomizerIsApplied() throws Exception {
+		ExampleBasicObject object = new ExampleBasicObject();
+		object.setValue("spring");
+		assertThat(this.basicXml.write(object).getXml()).contains("\n");
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class XmlMapperCustomizerConfiguration {
+
+		@Bean
+		XmlMapperBuilderCustomizer indentOutputXmlMapperBuilderCustomizer() {
+			return (builder) -> builder.configure(SerializationFeature.INDENT_OUTPUT, true);
+		}
+
+	}
+
+}

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/XmlTestTypeExcludeFilterTests.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/XmlTestTypeExcludeFilterTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jackson.autoconfigure.xmltest;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jackson.autoconfigure.xmltest.app.ExampleXmlApplication;
+import org.springframework.boot.jackson.autoconfigure.xmltest.app.ExampleXmlJacksonComponent;
+import org.springframework.boot.jackson.autoconfigure.xmltest.app.ExampleXmlService;
+import org.springframework.boot.test.autoconfigure.xml.XmlTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the component scanning applied by {@link XmlTest @XmlTest}.
+ *
+ * @author Tiziano Basile
+ */
+@XmlTest
+@ContextConfiguration(classes = ExampleXmlApplication.class)
+class XmlTestTypeExcludeFilterTests {
+
+	@Autowired
+	private ApplicationContext context;
+
+	@Test
+	void componentScanningWhenJacksonComponentThenBeanIsRegistered() {
+		assertThat(this.context.getBeansOfType(ExampleXmlJacksonComponent.class)).hasSize(1);
+	}
+
+	@Test
+	void componentScanningWhenStandardComponentThenBeanIsNotRegistered() {
+		assertThat(this.context.getBeansOfType(ExampleXmlService.class)).isEmpty();
+	}
+
+}

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/XmlTestWithAutoConfigureXmlTestersTests.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/XmlTestWithAutoConfigureXmlTestersTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jackson.autoconfigure.xmltest;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jackson.autoconfigure.xmltest.app.ExampleBasicObject;
+import org.springframework.boot.jackson.autoconfigure.xmltest.app.ExampleXmlApplication;
+import org.springframework.boot.test.autoconfigure.xml.AutoConfigureXmlTesters;
+import org.springframework.boot.test.autoconfigure.xml.XmlTest;
+import org.springframework.boot.test.xml.JacksonXmlTester;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link XmlTest @XmlTest} with
+ * {@link AutoConfigureXmlTesters @AutoConfigureXmlTesters}.
+ *
+ * @author Tiziano Basile
+ */
+@XmlTest
+@AutoConfigureXmlTesters(enabled = false)
+@ContextConfiguration(classes = ExampleXmlApplication.class)
+class XmlTestWithAutoConfigureXmlTestersTests {
+
+	@Autowired(required = false)
+	private JacksonXmlTester<ExampleBasicObject> xmlTester;
+
+	@Test
+	void testerWhenTestersAreDisabledThenIsNotRegistered() {
+		assertThat(this.xmlTester).isNull();
+	}
+
+}

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/app/ExampleBasicObject.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/app/ExampleBasicObject.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jackson.autoconfigure.xmltest.app;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Example object to read/write as XML.
+ *
+ * @author Tiziano Basile
+ */
+@JsonRootName("example")
+public class ExampleBasicObject {
+
+	private @Nullable String value;
+
+	public @Nullable String getValue() {
+		return this.value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj != null && obj.getClass() == getClass()) {
+			return Objects.equals(this.value, ((ExampleBasicObject) obj).value);
+		}
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(this.value);
+	}
+
+	@Override
+	public String toString() {
+		return String.valueOf(this.value);
+	}
+
+}

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/app/ExampleCustomObject.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/app/ExampleCustomObject.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jackson.autoconfigure.xmltest.app;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Example object to read/write as XML through {@link ExampleXmlJacksonComponent}.
+ *
+ * @author Tiziano Basile
+ * @param value the value
+ */
+@JsonRootName("example")
+public record ExampleCustomObject(@Nullable String value) {
+
+}

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/app/ExampleXmlApplication.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/app/ExampleXmlApplication.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jackson.autoconfigure.xmltest.app;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.xml.XmlTest;
+
+/**
+ * Example {@link SpringBootApplication @SpringBootApplication} for use with
+ * {@link XmlTest @XmlTest} tests.
+ *
+ * @author Tiziano Basile
+ */
+@SpringBootApplication
+public class ExampleXmlApplication {
+
+}

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/app/ExampleXmlJacksonComponent.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/app/ExampleXmlJacksonComponent.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jackson.autoconfigure.xmltest.app;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.SerializationContext;
+
+import org.springframework.boot.jackson.JacksonComponent;
+import org.springframework.boot.jackson.ObjectValueDeserializer;
+import org.springframework.boot.jackson.ObjectValueSerializer;
+import org.springframework.boot.test.autoconfigure.xml.XmlTest;
+
+/**
+ * Example {@link JacksonComponent @JacksonComponent} for use with
+ * {@link XmlTest @XmlTest} tests.
+ *
+ * @author Tiziano Basile
+ */
+@JacksonComponent
+public class ExampleXmlJacksonComponent {
+
+	static class Serializer extends ObjectValueSerializer<ExampleCustomObject> {
+
+		@Override
+		protected void serializeObject(ExampleCustomObject value, JsonGenerator jgen, SerializationContext context) {
+			jgen.writeStringProperty("custom", value.value());
+		}
+
+	}
+
+	static class Deserializer extends ObjectValueDeserializer<ExampleCustomObject> {
+
+		@Override
+		protected ExampleCustomObject deserializeObject(JsonParser jsonParser, DeserializationContext context,
+				JsonNode tree) {
+			return new ExampleCustomObject(nullSafeValue(tree.get("custom"), String.class));
+		}
+
+	}
+
+}

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/app/ExampleXmlService.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/app/ExampleXmlService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.jackson.autoconfigure.xmltest.app;
+
+import org.springframework.boot.test.autoconfigure.xml.XmlTest;
+import org.springframework.stereotype.Component;
+
+/**
+ * Example {@link Component @Component} that should not be scanned by
+ * {@link XmlTest @XmlTest} tests.
+ *
+ * @author Tiziano Basile
+ */
+@Component
+public class ExampleXmlService {
+
+}

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/app/package-info.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/app/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.boot.jackson.autoconfigure.xmltest.app;
+
+import org.jspecify.annotations.NullMarked;

--- a/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/package-info.java
+++ b/module/spring-boot-jackson/src/test/java/org/springframework/boot/jackson/autoconfigure/xmltest/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.boot.jackson.autoconfigure.xmltest;
+
+import org.jspecify.annotations.NullMarked;

--- a/module/spring-boot-jackson/src/test/resources/org/springframework/boot/jackson/autoconfigure/xmltest/example.xml
+++ b/module/spring-boot-jackson/src/test/resources/org/springframework/boot/jackson/autoconfigure/xmltest/example.xml
@@ -1,0 +1,3 @@
+<example>
+	<value>spring</value>
+</example>


### PR DESCRIPTION
Adds an `@XmlTest` slice alongside `@JsonTest`, plus a `JacksonXmlTester` and the assertion support it needs, so XML serialization can be tested with the application's own `XmlMapper` configuration.

Closes gh-49872

## What this adds

`@XmlTest` follows the `@JsonTest` file set one for one: the annotation, `@AutoConfigureXml`, `@AutoConfigureXmlTesters`, `@ConditionalOnXmlTesters`, a type exclude filter, a context bootstrapper and an auto-configuration that registers the tester field post processor. Component scanning is limited to `@JacksonComponent` beans and `JacksonModule` implementations, matching the JSON slice.

On the assertion side there is a new `org.springframework.boot.test.xml` package containing `XmlContent`, `XmlContentAssert`, `AbstractXmlMarshalTester` and `JacksonXmlTester`. `module/spring-boot-jackson` contributes `JacksonXmlTesterTestAutoConfiguration` and the three `META-INF/spring` registration files.

## Things worth your opinion

A few decisions here could reasonably have gone the other way, so I have called them out rather than burying them.

**A parallel tester base was unavoidable.** `AbstractJsonMarshalTester.write()` returns `JsonContent<T>`, and `JsonContent` is final, so covariant return cannot produce an XML content type. Generifying the existing base into something like `AbstractMarshalTester<T, C>` would be behaviour preserving and arguably cleaner, but it changes a class that has been public since 1.4.0, so I did not touch it. Happy to go that way if you prefer. The read side reuses `ObjectContent` and `ObjectContentAssert` unchanged, since those turned out to be entirely format agnostic.

**Equality follows the JSON naming rather than XMLUnit's.** XMLUnit talks about identical and similar comparisons. I went with `isEqualToXml` as the lenient one and `isStrictlyEqualToXml` as the exact one, so that `isEqualToJson` and `isEqualToXml` mean the same thing. Someone porting a `@JsonTest` will rename mechanically, and silently getting stricter semantics seemed like the worse failure mode. `isEqualTo(Object)` is overridden to dispatch by source type the same way `JsonContentAssert` does, otherwise it quietly falls through to raw string comparison.

**XPath is namespace aware.** There is a `withNamespaces(Map)` that returns a new assertion bound to those prefixes, shaped on `XpathExpectationsHelper`. Without it no expression can address a namespaced document, and unprefixed expressions must not match namespaced elements, which is the more dangerous half. Each method also evaluates the XPath result type it actually needs rather than always asking for a node, so `count(...)` works and an expression matching several nodes is rejected instead of silently asserting the first one.

**Two pieces of JSON named API are reused rather than duplicated.** The XML testers return `org.springframework.boot.test.json.ObjectContent`, and `JacksonXmlTesterTestAutoConfiguration` uses the existing public `JsonTesterFactoryBean`, which is generic over the marshaller type and already shared by the Gson, Jsonb and Jackson 2 modules. It works, but it does mean a pure XML test imports from a JSON package. If you would rather those moved to a neutral package or type, that is much easier to do now than after 4.2.0 ships.

**Scope.** This binds to Jackson XML only. There is no JAXB support and no Jackson 2 XML tester, and the `@XmlTest` javadoc says so plainly. I also left out a `BasicXmlTester`, so `XmlTestersAutoConfiguration` registers only the bean post processor. Both felt like they should be your call rather than something I assumed, and if you want the name narrowed to something like `@JacksonXmlTest` I am glad to do that.

## Dependencies

No new managed dependencies. `xmlunit-core` is already on every Boot test classpath through `spring-boot-starter-test`, so `core/spring-boot-test` just declares it as optional. `jackson-dataformat-xml` is added as optional there too, mirroring how `module/spring-boot-jackson` already declares it.

One thing to note: the parser configuration uses `DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing`, which is only available from XMLUnit 2.12.0. That matches the version the BOM pins today, but it is an effective floor.

## A note on the assertion semantics

Negative assertions fail loudly when either document is unparseable, rather than treating a
parse failure as a difference and passing. That matches `JsonContentAssert`, and it matters
because the alternative means a typo in a fixture makes the assertion green forever.

`XmlLoader` decides the encoding of an expected document from its byte order mark or its XML
declaration rather than assuming UTF-8, which keeps the expected side consistent with the
read side, where the prolog is normative.

## Documentation

There is a new "Auto-configured XML Tests" section next to the JSON one, with Java and Kotlin samples. I have tried to keep every claim in it true of the code, in particular the limits of the lenient comparison: sibling elements that share a name are matched on name and text content, so ordering stops being insignificant once those siblings differ only in their child elements or only in their attributes.

## Testing

`:core:spring-boot-test:check`, `:core:spring-boot-test-autoconfigure:check` and `:module:spring-boot-jackson:check` all pass, along with the documentation samples. There are tests in `core/spring-boot-test-autoconfigure` covering the slice properties attribute and the `@SpringBootTest` plus `@AutoConfigureXmlTesters` path, which is what actually pins the `spring.test.xmltesters` prefix, and integration tests in `module/spring-boot-jackson` covering the end to end behaviour including the case where `jackson-dataformat-xml` is absent.

I also verified it from outside the build, as a downstream consumer of the published snapshot, covering the happy path, comparison semantics, XPath extraction, namespaces and the slice actually staying narrower than `@JsonTest`.
