### PR TITLE
Support Docker Compose in AOT-processed tests

### DIFF
--- a/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/lifecycle/DockerComposeLifecycleManager.java
+++ b/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/lifecycle/DockerComposeLifecycleManager.java
@@ -26,7 +26,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.aot.AotDetector;
 import org.springframework.boot.SpringApplicationShutdownHandlers;
 import org.springframework.boot.docker.compose.core.DockerCompose;
 import org.springframework.boot.docker.compose.core.DockerComposeFile;
@@ -53,6 +52,8 @@ import org.springframework.util.CollectionUtils;
  * @see DockerComposeListener
  */
 class DockerComposeLifecycleManager {
+
+	private static final String TEST_AOT_PROCESSING = "spring.test.context.aot.processing";
 
 	private static final Log logger = LogFactory.getLog(DockerComposeLifecycleManager.class);
 
@@ -97,8 +98,8 @@ class DockerComposeLifecycleManager {
 	}
 
 	void start() {
-		if (Boolean.getBoolean(AbstractAotProcessor.AOT_PROCESSING) || AotDetector.useGeneratedArtifacts()) {
-			logger.trace("Docker Compose support disabled with AOT and native images");
+		if (Boolean.getBoolean(AbstractAotProcessor.AOT_PROCESSING) && !Boolean.getBoolean(TEST_AOT_PROCESSING)) {
+			logger.trace("Docker Compose support disabled during AOT processing");
 			return;
 		}
 		if (!this.properties.isEnabled()) {

--- a/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/DockerComposeServiceConnectionsApplicationListener.java
+++ b/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/service/connection/DockerComposeServiceConnectionsApplicationListener.java
@@ -22,7 +22,9 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.aot.BeanRegistrationExcludeFilter;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.RegisteredBean;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.boot.autoconfigure.container.ContainerImageMetadata;
 import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
@@ -45,6 +47,8 @@ import org.springframework.util.StringUtils;
  */
 class DockerComposeServiceConnectionsApplicationListener
 		implements ApplicationListener<DockerComposeServicesReadyEvent> {
+
+	private static final String BEAN_DEFINITION_ATTRIBUTE = DockerComposeConnectionDetailsFactory.class.getName();
 
 	private final ConnectionDetailsFactories factories;
 
@@ -86,6 +90,7 @@ class DockerComposeServiceConnectionsApplicationListener
 		Class<T> beanType = (Class<T>) connectionDetails.getClass();
 		Supplier<T> beanSupplier = () -> (T) connectionDetails;
 		RootBeanDefinition beanDefinition = new RootBeanDefinition(beanType, beanSupplier);
+		beanDefinition.setAttribute(BEAN_DEFINITION_ATTRIBUTE, true);
 		containerMetadata.addTo(beanDefinition);
 		registry.registerBeanDefinition(beanName, beanDefinition);
 	}
@@ -96,6 +101,15 @@ class DockerComposeServiceConnectionsApplicationListener
 		parts.add("for");
 		parts.addAll(Arrays.asList(runningService.name().split("-")));
 		return StringUtils.uncapitalize(parts.stream().map(StringUtils::capitalize).collect(Collectors.joining()));
+	}
+
+	static class DockerComposeConnectionDetailsBeanRegistrationExcludeFilter implements BeanRegistrationExcludeFilter {
+
+		@Override
+		public boolean isExcludedFromAotProcessing(RegisteredBean registeredBean) {
+			return registeredBean.getMergedBeanDefinition().getAttribute(BEAN_DEFINITION_ATTRIBUTE) != null;
+		}
+
 	}
 
 }

--- a/core/spring-boot-docker-compose/src/main/resources/META-INF/spring/aot.factories
+++ b/core/spring-boot-docker-compose/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,2 @@
+org.springframework.beans.factory.aot.BeanRegistrationExcludeFilter=\
+org.springframework.boot.docker.compose.service.connection.DockerComposeServiceConnectionsApplicationListener$DockerComposeConnectionDetailsBeanRegistrationExcludeFilter

--- a/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/lifecycle/DockerComposeLifecycleManagerTests.java
+++ b/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/lifecycle/DockerComposeLifecycleManagerTests.java
@@ -70,6 +70,8 @@ import static org.mockito.Mockito.never;
 @ExtendWith(OutputCaptureExtension.class)
 class DockerComposeLifecycleManagerTests {
 
+	private static final String TEST_AOT_PROCESSING = "spring.test.context.aot.processing";
+
 	@TempDir
 	@SuppressWarnings("NullAway.Init")
 	File temp;
@@ -142,14 +144,27 @@ class DockerComposeLifecycleManagerTests {
 	}
 
 	@Test
-	void startWhenUsingAotArtifactsDoesNotStart() {
+	void startWhenTestAotProcessingStarts() {
+		withSystemProperty(AbstractAotProcessor.AOT_PROCESSING, "true",
+				() -> withSystemProperty(TEST_AOT_PROCESSING, "true", () -> {
+					EventCapturingListener listener = new EventCapturingListener();
+					this.eventListeners.add(listener);
+					setUpRunningServices();
+					this.lifecycleManager.start();
+					assertThat(listener.getEvent()).isNotNull();
+					then(this.dockerCompose).should().hasDefinedServices();
+				}));
+	}
+
+	@Test
+	void startWhenUsingAotArtifactsStarts() {
 		withSystemProperty(AotDetector.AOT_ENABLED, "true", () -> {
 			EventCapturingListener listener = new EventCapturingListener();
 			this.eventListeners.add(listener);
 			setUpRunningServices();
 			this.lifecycleManager.start();
-			assertThat(listener.getEvent()).isNull();
-			then(this.dockerCompose).should(never()).hasDefinedServices();
+			assertThat(listener.getEvent()).isNotNull();
+			then(this.dockerCompose).should().hasDefinedServices();
 		});
 	}
 

--- a/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/DockerComposeConnectionDetailsBeanRegistrationExcludeFilterTests.java
+++ b/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/service/connection/DockerComposeConnectionDetailsBeanRegistrationExcludeFilterTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docker.compose.service.connection;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.support.RegisteredBean;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.boot.docker.compose.service.connection.DockerComposeServiceConnectionsApplicationListener.DockerComposeConnectionDetailsBeanRegistrationExcludeFilter;
+import org.springframework.context.support.GenericApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DockerComposeConnectionDetailsBeanRegistrationExcludeFilter}.
+ */
+class DockerComposeConnectionDetailsBeanRegistrationExcludeFilterTests {
+
+	private final DockerComposeConnectionDetailsBeanRegistrationExcludeFilter filter = new DockerComposeConnectionDetailsBeanRegistrationExcludeFilter();
+
+	@Test
+	void excludesDockerComposeConnectionDetailsBean() {
+		GenericApplicationContext context = new GenericApplicationContext();
+		RootBeanDefinition beanDefinition = new RootBeanDefinition(Object.class);
+		beanDefinition.setAttribute(DockerComposeConnectionDetailsFactory.class.getName(), true);
+		context.registerBeanDefinition("connectionDetails", beanDefinition);
+		assertThat(this.filter
+			.isExcludedFromAotProcessing(RegisteredBean.of(context.getBeanFactory(), "connectionDetails"))).isTrue();
+	}
+
+	@Test
+	void doesNotExcludeOtherBean() {
+		GenericApplicationContext context = new GenericApplicationContext();
+		context.registerBeanDefinition("other", new RootBeanDefinition(Object.class));
+		assertThat(this.filter.isExcludedFromAotProcessing(RegisteredBean.of(context.getBeanFactory(), "other")))
+			.isFalse();
+	}
+
+}

--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestAotProcessor.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/context/SpringBootTestAotProcessor.java
@@ -36,6 +36,8 @@ import org.springframework.util.Assert;
  */
 public class SpringBootTestAotProcessor extends TestAotProcessor {
 
+	static final String AOT_PROCESSING = "spring.test.context.aot.processing";
+
 	/**
 	 * Create a new processor for the specified test classpath roots and general settings.
 	 * @param classpathRoots the classpath roots to scan for test classes
@@ -43,6 +45,23 @@ public class SpringBootTestAotProcessor extends TestAotProcessor {
 	 */
 	public SpringBootTestAotProcessor(Set<Path> classpathRoots, Settings settings) {
 		super(classpathRoots, settings);
+	}
+
+	@Override
+	protected Void doProcess() {
+		String previous = System.getProperty(AOT_PROCESSING);
+		try {
+			System.setProperty(AOT_PROCESSING, Boolean.TRUE.toString());
+			return super.doProcess();
+		}
+		finally {
+			if (previous != null) {
+				System.setProperty(AOT_PROCESSING, previous);
+			}
+			else {
+				System.clearProperty(AOT_PROCESSING);
+			}
+		}
 	}
 
 	public static void main(String[] args) {

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootTestAotProcessorTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/context/SpringBootTestAotProcessorTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.context;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.springframework.context.aot.AbstractAotProcessor.Settings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SpringBootTestAotProcessor}.
+ */
+class SpringBootTestAotProcessorTests {
+
+	@Test
+	void processingSetsAndRestoresTestAotProcessingSystemProperty(@TempDir Path tempDir) {
+		System.setProperty(SpringBootTestAotProcessor.AOT_PROCESSING, "previous");
+		try {
+			TestSpringBootTestAotProcessor processor = new TestSpringBootTestAotProcessor(tempDir);
+			processor.process();
+			assertThat(processor.testAotProcessing).isTrue();
+			assertThat(System.getProperty(SpringBootTestAotProcessor.AOT_PROCESSING)).isEqualTo("previous");
+		}
+		finally {
+			System.clearProperty(SpringBootTestAotProcessor.AOT_PROCESSING);
+		}
+	}
+
+	private static final class TestSpringBootTestAotProcessor extends SpringBootTestAotProcessor {
+
+		private boolean testAotProcessing;
+
+		private TestSpringBootTestAotProcessor(Path tempDir) {
+			super(Set.of(tempDir),
+					Settings.builder()
+						.sourceOutput(tempDir.resolve("source"))
+						.resourceOutput(tempDir.resolve("resource"))
+						.classOutput(tempDir.resolve("class"))
+						.groupId("com.example")
+						.artifactId("example")
+						.build());
+		}
+
+		@Override
+		protected void performAotProcessing() {
+			this.testAotProcessing = Boolean.getBoolean(AOT_PROCESSING);
+		}
+
+	}
+
+}


### PR DESCRIPTION
Docker Compose support currently backs off during both AOT processing and execution using generated artifacts. Removing only the runtime backoff allows Compose connection details to be registered alongside fallback connection details captured in the generated context, resulting in duplicate beans.

This change identifies test AOT processing separately from application AOT processing. Docker Compose participates while test contexts are AOT-processed so that its connection details influence auto-configuration conditions, while application AOT processing continues to back off. Compose connection details created during test AOT processing are excluded from generated bean registrations and are registered again from the running services when the AOT-processed test executes.

Fixes #36273

Tests:
- `./gradlew :core:spring-boot-docker-compose:check :core:spring-boot-test:check --no-build-cache`
- Petclinic `PostgresIntegrationTests` with `spring.aot.enabled=true`