### PR TITLE
Support Gradle's isolated projects

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/ResolvedDependencies.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/ResolvedDependencies.java
@@ -18,10 +18,8 @@ package org.springframework.boot.gradle.tasks.bundling;
 
 import java.io.File;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ResolvedConfiguration;
@@ -30,6 +28,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Classpath;
@@ -47,31 +46,26 @@ import org.springframework.boot.loader.tools.LibraryCoordinates;
  * @author Phillip Webb
  * @author Paddy Drury
  * @author Andy Wilkinson
+ * @author Greg Taube
  */
 class ResolvedDependencies {
-
-	private final Map<String, LibraryCoordinates> projectCoordinatesByPath;
 
 	private final ListProperty<ComponentArtifactIdentifier> artifactIds;
 
 	private final ListProperty<File> artifactFiles;
 
+	private final ListProperty<String> artifactProjectGroups;
+
+	private final ListProperty<String> artifactProjectNames;
+
+	private final ListProperty<String> artifactProjectVersions;
+
 	ResolvedDependencies(Project project) {
 		this.artifactIds = project.getObjects().listProperty(ComponentArtifactIdentifier.class);
 		this.artifactFiles = project.getObjects().listProperty(File.class);
-		this.projectCoordinatesByPath = projectCoordinatesByPath(project);
-	}
-
-	private static Map<String, LibraryCoordinates> projectCoordinatesByPath(Project project) {
-		return project.getRootProject()
-			.getAllprojects()
-			.stream()
-			.collect(Collectors.toMap(Project::getPath, ResolvedDependencies::libraryCoordinates));
-	}
-
-	private static LibraryCoordinates libraryCoordinates(Project project) {
-		return LibraryCoordinates.of(Objects.toString(project.getGroup()), project.getName(),
-				Objects.toString(project.getVersion()));
+		this.artifactProjectGroups = project.getObjects().listProperty(String.class);
+		this.artifactProjectNames = project.getObjects().listProperty(String.class);
+		this.artifactProjectVersions = project.getObjects().listProperty(String.class);
 	}
 
 	@Input
@@ -84,42 +78,93 @@ class ResolvedDependencies {
 		return this.artifactFiles;
 	}
 
+	@Input
+	ListProperty<String> getArtifactProjectGroups() {
+		return this.artifactProjectGroups;
+	}
+
+	@Input
+	ListProperty<String> getArtifactProjectNames() {
+		return this.artifactProjectNames;
+	}
+
+	@Input
+	ListProperty<String> getArtifactProjectVersions() {
+		return this.artifactProjectVersions;
+	}
+
 	void resolvedArtifacts(Provider<Set<ResolvedArtifactResult>> resolvedArtifacts) {
 		this.artifactFiles.addAll(
 				resolvedArtifacts.map((artifacts) -> artifacts.stream().map(ResolvedArtifactResult::getFile).toList()));
 		this.artifactIds.addAll(
 				resolvedArtifacts.map((artifacts) -> artifacts.stream().map(ResolvedArtifactResult::getId).toList()));
+		this.artifactProjectGroups.addAll(resolvedArtifacts
+			.map((artifacts) -> artifacts.stream().map(ResolvedDependencies::projectGroup).toList()));
+		this.artifactProjectNames.addAll(resolvedArtifacts
+			.map((artifacts) -> artifacts.stream().map(ResolvedDependencies::projectName).toList()));
+		this.artifactProjectVersions.addAll(resolvedArtifacts
+			.map((artifacts) -> artifacts.stream().map(ResolvedDependencies::projectVersion).toList()));
+	}
+
+	private static String projectGroup(ResolvedArtifactResult artifact) {
+		Capability capability = projectCapability(artifact);
+		return (capability != null) ? capability.getGroup() : "";
+	}
+
+	private static String projectName(ResolvedArtifactResult artifact) {
+		Capability capability = projectCapability(artifact);
+		return (capability != null) ? capability.getName() : "";
+	}
+
+	private static String projectVersion(ResolvedArtifactResult artifact) {
+		Capability capability = projectCapability(artifact);
+		return (capability != null) ? Objects.toString(capability.getVersion(), "") : "";
+	}
+
+	private static @Nullable Capability projectCapability(ResolvedArtifactResult artifact) {
+		ComponentIdentifier componentIdentifier = artifact.getId().getComponentIdentifier();
+		if (!(componentIdentifier instanceof ProjectComponentIdentifier projectComponentIdentifier)) {
+			return null;
+		}
+		List<? extends Capability> capabilities = artifact.getVariant().getCapabilities();
+		for (Capability candidate : capabilities) {
+			if (candidate.getName().equals(projectComponentIdentifier.getProjectName())) {
+				return candidate;
+			}
+		}
+		return capabilities.get(0);
 	}
 
 	@Nullable DependencyDescriptor find(File file) {
-		ComponentArtifactIdentifier id = findArtifactIdentifier(file);
-		if (id == null) {
+		int artifactIndex = findArtifactIndex(file);
+		if (artifactIndex < 0) {
 			return null;
 		}
+		ComponentArtifactIdentifier id = this.artifactIds.get().get(artifactIndex);
 		if (id instanceof ModuleComponentArtifactIdentifier moduleComponentId) {
 			ModuleComponentIdentifier moduleId = moduleComponentId.getComponentIdentifier();
 			return new DependencyDescriptor(
 					LibraryCoordinates.of(moduleId.getGroup(), moduleId.getModule(), moduleId.getVersion()), false);
 		}
 		ComponentIdentifier componentIdentifier = id.getComponentIdentifier();
-		if (componentIdentifier instanceof ProjectComponentIdentifier projectComponentId) {
-			String projectPath = projectComponentId.getProjectPath();
-			LibraryCoordinates projectCoordinates = this.projectCoordinatesByPath.get(projectPath);
-			if (projectCoordinates != null) {
-				return new DependencyDescriptor(projectCoordinates, true);
-			}
+		if (componentIdentifier instanceof ProjectComponentIdentifier) {
+			LibraryCoordinates projectCoordinates = LibraryCoordinates.of(
+					this.artifactProjectGroups.get().get(artifactIndex),
+					this.artifactProjectNames.get().get(artifactIndex),
+					this.artifactProjectVersions.get().get(artifactIndex));
+			return new DependencyDescriptor(projectCoordinates, true);
 		}
 		return null;
 	}
 
-	private @Nullable ComponentArtifactIdentifier findArtifactIdentifier(File file) {
+	private int findArtifactIndex(File file) {
 		List<File> files = this.artifactFiles.get();
 		for (int i = 0; i < files.size(); i++) {
 			if (file.equals(files.get(i))) {
-				return this.artifactIds.get().get(i);
+				return i;
 			}
 		}
-		return null;
+		return -1;
 	}
 
 	/**

--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/IsolatedProjectsIntegrationTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/IsolatedProjectsIntegrationTests.java
@@ -76,6 +76,8 @@ class IsolatedProjectsIntegrationTests {
 				}
 				group = 'org.example.projects'
 				version = '1.2.3'
+				configurations.runtimeElements.outgoing.capability('org.example.projects:library-alternative:1.2.3')
+				configurations.runtimeElements.outgoing.capability('org.example.projects:library:1.2.3')
 				""");
 	}
 

--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/IsolatedProjectsIntegrationTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/IsolatedProjectsIntegrationTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.gradle.tasks.bundling;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.jar.JarFile;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.TestTemplate;
+
+import org.springframework.boot.gradle.junit.GradleCompatibility;
+import org.springframework.boot.testsupport.gradle.testkit.GradleBuild;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for Gradle's isolated projects feature.
+ *
+ * @author Greg Taube
+ */
+@GradleCompatibility(minimumVersion = "9.6")
+class IsolatedProjectsIntegrationTests {
+
+	@SuppressWarnings("NullAway.Init")
+	GradleBuild gradleBuild;
+
+	@TestTemplate
+	void bootJarUsesProjectDependencyCoordinates() throws IOException {
+		writeProjectFiles();
+		this.gradleBuild.configurationCache();
+		BuildResult result = this.gradleBuild.build("bootJar", "-Dorg.gradle.unsafe.isolated-projects=true");
+		BuildTask task = result.task(":bootJar");
+		assertThat(task).isNotNull();
+		assertThat(task.getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+		File archive = new File(this.gradleBuild.getProjectDir(), "build/libs").listFiles()[0];
+		try (JarFile jarFile = new JarFile(archive)) {
+			String layersIndex = new String(
+					jarFile.getInputStream(jarFile.getEntry("BOOT-INF/layers.idx")).readAllBytes(),
+					StandardCharsets.UTF_8);
+			assertThat(layersIndex).contains("- \"project-dependencies\":\n  - \"BOOT-INF/lib/library-1.2.3.jar\"");
+		}
+		result = this.gradleBuild.build("bootJar", "-Dorg.gradle.unsafe.isolated-projects=true");
+		assertThat(result.getOutput()).contains("Reusing configuration cache.");
+		task = result.task(":bootJar");
+		assertThat(task).isNotNull();
+		assertThat(task.getOutcome()).isEqualTo(TaskOutcome.UP_TO_DATE);
+	}
+
+	private void writeProjectFiles() throws IOException {
+		Files.writeString(new File(this.gradleBuild.getProjectDir(), "settings.gradle").toPath(),
+				"include 'library'\n");
+		File library = new File(this.gradleBuild.getProjectDir(), "library");
+		library.mkdirs();
+		Files.writeString(new File(library, "build.gradle").toPath(), """
+				plugins {
+					id 'java'
+				}
+				group = 'org.example.projects'
+				version = '1.2.3'
+				""");
+	}
+
+}

--- a/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/IsolatedProjectsIntegrationTests.gradle
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/tasks/bundling/IsolatedProjectsIntegrationTests.gradle
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+	id 'java'
+	id 'org.springframework.boot' version '{version}'
+}
+
+dependencies {
+	implementation(project(':library'))
+}
+
+bootJar {
+	mainClass = 'com.example.Application'
+	layered {
+		application {
+			intoLayer('application')
+		}
+		dependencies {
+			intoLayer('project-dependencies') {
+				include 'org.example.projects:library:1.2.3'
+			}
+			intoLayer('dependencies')
+		}
+		layerOrder = [ 'dependencies', 'project-dependencies', 'application' ]
+	}
+}


### PR DESCRIPTION
Closes gh-43755

Spring Boot currently resolves project dependency coordinates by iterating over every project and reading its mutable group and version during task construction. Gradle isolated projects mode rejects that cross-project access. It also prevents Tooling API IdeaProject model import because model creation realizes bootBuildImage and BootJar.

This reads coordinates lazily from the selected project artifact variant instead. It follows the Gradle guidance in https://github.com/gradle/gradle/issues/31973#issuecomment-2580976721 to expose the coordinates through a Provider task input and realize them only after project configuration. Gradle exposes component GAV as an implicit capability, so the implementation selects the capability whose name matches the ProjectComponentIdentifier project name. This preserves project-dependency classification and GAV-based layer matching without accessing another Project. The capability model is documented at https://docs.gradle.org/current/userguide/component_capabilities.html#sec:declaring-component-capabilities.

Tests:
- isolated projects with configuration cache store and reuse on Gradle 9.6.1
- project GAV matching in a custom BootJar layer
- correct GAV selection when the project publishes an additional capability
- existing BootJar and BootWar multi-module layering tests
- BootJarTests and BootWarTests
- Checkstyle and plugin validation