### PR TITLE
Description of spring.graphql.websocket.connection-init-timeout does not render correctly in the reference guide

### DIFF
--- a/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/GraphQlProperties.java
+++ b/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/GraphQlProperties.java
@@ -244,8 +244,7 @@ public class GraphQlProperties {
 		private @Nullable String path;
 
 		/**
-		 * Time within which the initial CONNECTION_INIT type message must be
-		 * received.
+		 * Time within which the initial CONNECTION_INIT type message must be received.
 		 */
 		private Duration connectionInitTimeout = Duration.ofSeconds(60);
 

--- a/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/GraphQlProperties.java
+++ b/module/spring-boot-graphql/src/main/java/org/springframework/boot/graphql/autoconfigure/GraphQlProperties.java
@@ -244,7 +244,7 @@ public class GraphQlProperties {
 		private @Nullable String path;
 
 		/**
-		 * Time within which the initial {@code CONNECTION_INIT} type message must be
+		 * Time within which the initial CONNECTION_INIT type message must be
 		 * received.
 		 */
 		private Duration connectionInitTimeout = Duration.ofSeconds(60);


### PR DESCRIPTION

<img width="1215" height="135" alt="image" src="https://github.com/user-attachments/assets/b26e2a00-783d-42ee-b40d-adca13371eab" />



Reference:
https://docs.spring.io/spring-boot/appendix/application-properties/index.html#application-properties.web.spring.graphql.websocket.connection-init-timeout