### PR TITLE
runtimeClasspath and testRuntimeClasspath exclusions are not applied to processAotClasspath and processTestAotClasspath

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/SpringBootAotPlugin.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/SpringBootAotPlugin.java
@@ -16,6 +16,8 @@
 
 package org.springframework.boot.gradle.plugin;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -176,6 +178,7 @@ public class SpringBootAotPlugin implements Plugin<Project> {
 			classpath.setDescription("Classpath of the " + taskName + " task.");
 			removeDevelopmentOnly(base.getExtendsFrom(), developmentOnlyConfigurationNames)
 				.forEach(classpath::extendsFrom);
+			classpath.getIncoming().beforeResolve((dependencies) -> copyExcludeRules(base, classpath));
 			classpath.attributes((attributes) -> {
 				ProviderFactory providers = project.getProviders();
 				AttributeContainer baseAttributes = base.getAttributes();
@@ -184,6 +187,21 @@ public class SpringBootAotPlugin implements Plugin<Project> {
 							providers.provider(() -> baseAttributes.getAttribute(attribute)));
 				}
 			});
+		});
+	}
+
+	private void copyExcludeRules(Configuration source, Configuration target) {
+		source.getExcludeRules().forEach((excludeRule) -> {
+			Map<String, String> exclusion = new HashMap<>();
+			String group = excludeRule.getGroup();
+			String module = excludeRule.getModule();
+			if (group != null) {
+				exclusion.put("group", group);
+			}
+			if (module != null) {
+				exclusion.put("module", module);
+			}
+			target.exclude(exclusion);
 		});
 	}
 

--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/SpringBootAotPluginIntegrationTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/SpringBootAotPluginIntegrationTests.java
@@ -95,9 +95,21 @@ class SpringBootAotPluginIntegrationTests {
 	}
 
 	@TestTemplate
+	void processAotHonorsRuntimeClasspathExclusions() {
+		String output = this.gradleBuild.build("processAotClasspath").getOutput();
+		assertThat(output).doesNotContain("org.jboss.logging" + File.separatorChar + "jboss-logging");
+	}
+
+	@TestTemplate
 	void processTestAotHasTransitiveRuntimeDependenciesOnItsClasspath() {
 		String output = this.gradleBuild.build("processTestAotClasspath").getOutput();
 		assertThat(output).contains("org.jboss.logging" + File.separatorChar + "jboss-logging");
+	}
+
+	@TestTemplate
+	void processTestAotHonorsTestRuntimeClasspathExclusions() {
+		String output = this.gradleBuild.build("processTestAotClasspath").getOutput();
+		assertThat(output).doesNotContain("org.jboss.logging" + File.separatorChar + "jboss-logging");
 	}
 
 	@TestTemplate

--- a/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/SpringBootAotPluginIntegrationTests-processAotHonorsRuntimeClasspathExclusions.gradle
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/SpringBootAotPluginIntegrationTests-processAotHonorsRuntimeClasspathExclusions.gradle
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+	id 'org.springframework.boot'
+	id 'org.springframework.boot.aot'
+	id 'java'
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation "org.hibernate.orm:hibernate-core:6.1.1.Final"
+}
+
+configurations.runtimeClasspath {
+	exclude group: "org.jboss.logging", module: "jboss-logging"
+}
+
+task('processAotClasspath') {
+	doFirst {
+		tasks.findByName('processAot').classpath.files.each { println it }
+	}
+}

--- a/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/SpringBootAotPluginIntegrationTests-processTestAotHonorsTestRuntimeClasspathExclusions.gradle
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/resources/org/springframework/boot/gradle/plugin/SpringBootAotPluginIntegrationTests-processTestAotHonorsTestRuntimeClasspathExclusions.gradle
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+	id 'org.springframework.boot'
+	id 'org.springframework.boot.aot'
+	id 'java'
+}
+
+repositories {
+	mavenCentral()
+	maven {
+		url = 'repository'
+	}
+}
+
+configurations.all {
+	resolutionStrategy {
+		eachDependency {
+			if (it.requested.group == 'org.springframework.boot') {
+				it.useVersion project.bootVersion
+			}
+		}
+	}
+}
+
+dependencies {
+	testImplementation "org.hibernate.orm:hibernate-core:6.1.1.Final"
+}
+
+configurations.testRuntimeClasspath {
+	exclude group: "org.jboss.logging", module: "jboss-logging"
+}
+
+task('processTestAotClasspath') {
+	doFirst {
+		tasks.findByName('processTestAot').classpath.files.each { println it }
+	}
+}


### PR DESCRIPTION
`processAotClasspath` and `processTestAotClasspath` are assembled from the parent configurations of their respective runtime classpaths so that development-only dependencies can be omitted. As a result, exclusion rules declared directly on `runtimeClasspath` or `testRuntimeClasspath` are currently lost.

This can make AOT processing evaluate classpath conditions differently from the packaged application. For example, excluding `aspectjweaver` from `runtimeClasspath` still exposes it to AOT processing, which selects `AnnotationAwareAspectJAutoProxyCreator`; the AOT-processed application then fails at runtime because AspectJ is correctly absent.

Copy the direct runtime classpath exclusion rules immediately before resolving the AOT processing classpath. Doing this lazily honors exclusions configured after the AOT plugin is applied. Integration tests cover both application and test AOT classpaths on the supported Gradle versions.

Verified with:

```
./gradlew :build-plugin:spring-boot-gradle-plugin:check
```