### PR TITLE
Source is not closed when a JSON tester read fails

### DIFF
--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/json/AbstractJsonMarshalTester.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/json/AbstractJsonMarshalTester.java
@@ -297,9 +297,13 @@ public abstract class AbstractJsonMarshalTester<T> {
 		verify();
 		Assert.notNull(resource, "'resource' must not be null");
 		InputStream inputStream = resource.getInputStream();
-		T object = readObject(inputStream, getTypeNotNull());
-		closeQuietly(inputStream);
-		return new ObjectContent<>(this.type, object);
+		try {
+			T object = readObject(inputStream, getTypeNotNull());
+			return new ObjectContent<>(this.type, object);
+		}
+		finally {
+			closeQuietly(inputStream);
+		}
 	}
 
 	/**
@@ -322,9 +326,13 @@ public abstract class AbstractJsonMarshalTester<T> {
 	public ObjectContent<T> read(Reader reader) throws IOException {
 		verify();
 		Assert.notNull(reader, "'reader' must not be null");
-		T object = readObject(reader, getTypeNotNull());
-		closeQuietly(reader);
-		return new ObjectContent<>(this.type, object);
+		try {
+			T object = readObject(reader, getTypeNotNull());
+			return new ObjectContent<>(this.type, object);
+		}
+		finally {
+			closeQuietly(reader);
+		}
 	}
 
 	private void closeQuietly(Closeable closeable) {

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/json/AbstractJsonMarshalTesterTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/json/AbstractJsonMarshalTesterTests.java
@@ -18,6 +18,9 @@ package org.springframework.boot.test.json;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FilterInputStream;
+import java.io.FilterReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
@@ -27,6 +30,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.jspecify.annotations.Nullable;
@@ -40,6 +44,7 @@ import org.springframework.util.FileCopyUtils;
 import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
@@ -54,6 +59,8 @@ abstract class AbstractJsonMarshalTesterTests {
 	private static final String MAP_JSON = "{\"a\":" + JSON + "}";
 
 	private static final String ARRAY_JSON = "[" + JSON + "]";
+
+	private static final String TRUNCATED_JSON = "{\"name\":\"Spring\",";
 
 	private static final ExampleObject OBJECT = createExampleObject("Spring", 123);
 
@@ -146,10 +153,51 @@ abstract class AbstractJsonMarshalTesterTests {
 	}
 
 	@Test
+	void readResourceWhenReadFailsShouldCloseInputStream() {
+		AtomicBoolean closed = new AtomicBoolean();
+		Resource resource = new ByteArrayResource(TRUNCATED_JSON.getBytes()) {
+
+			@Override
+			public InputStream getInputStream() throws IOException {
+				return new FilterInputStream(super.getInputStream()) {
+
+					@Override
+					public void close() throws IOException {
+						closed.set(true);
+						super.close();
+					}
+
+				};
+			}
+
+		};
+		AbstractJsonMarshalTester<Object> tester = createTester(TYPE);
+		assertThatException().isThrownBy(() -> tester.read(resource));
+		assertThat(closed).isTrue();
+	}
+
+	@Test
 	void readReaderShouldReturnObject() throws Exception {
 		Reader reader = new StringReader(JSON);
 		AbstractJsonMarshalTester<Object> tester = createTester(TYPE);
 		assertThat(tester.read(reader)).isEqualTo(OBJECT);
+	}
+
+	@Test
+	void readReaderWhenReadFailsShouldCloseReader() {
+		AtomicBoolean closed = new AtomicBoolean();
+		Reader reader = new FilterReader(new StringReader(TRUNCATED_JSON)) {
+
+			@Override
+			public void close() throws IOException {
+				closed.set(true);
+				super.close();
+			}
+
+		};
+		AbstractJsonMarshalTester<Object> tester = createTester(TYPE);
+		assertThatException().isThrownBy(() -> tester.read(reader));
+		assertThat(closed).isTrue();
 	}
 
 	@Test

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/json/AbstractJsonMarshalTesterTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/json/AbstractJsonMarshalTesterTests.java
@@ -18,8 +18,6 @@ package org.springframework.boot.test.json;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FilterInputStream;
-import java.io.FilterReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -30,7 +28,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.jspecify.annotations.Nullable;
@@ -46,6 +43,11 @@ import org.springframework.util.ReflectionUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 /**
  * Tests for {@link AbstractJsonMarshalTester}.
@@ -153,27 +155,13 @@ abstract class AbstractJsonMarshalTesterTests {
 	}
 
 	@Test
-	void readResourceWhenReadFailsShouldCloseInputStream() {
-		AtomicBoolean closed = new AtomicBoolean();
-		Resource resource = new ByteArrayResource(TRUNCATED_JSON.getBytes()) {
-
-			@Override
-			public InputStream getInputStream() throws IOException {
-				return new FilterInputStream(super.getInputStream()) {
-
-					@Override
-					public void close() throws IOException {
-						closed.set(true);
-						super.close();
-					}
-
-				};
-			}
-
-		};
+	void readResourceWhenReadFailsShouldCloseInputStream() throws IOException {
+		Resource resource = mock();
+		InputStream inputStream = spy(new ByteArrayInputStream(TRUNCATED_JSON.getBytes()));
+		given(resource.getInputStream()).willReturn(inputStream);
 		AbstractJsonMarshalTester<Object> tester = createTester(TYPE);
 		assertThatException().isThrownBy(() -> tester.read(resource));
-		assertThat(closed).isTrue();
+		then(inputStream).should(atLeastOnce()).close();
 	}
 
 	@Test
@@ -184,20 +172,11 @@ abstract class AbstractJsonMarshalTesterTests {
 	}
 
 	@Test
-	void readReaderWhenReadFailsShouldCloseReader() {
-		AtomicBoolean closed = new AtomicBoolean();
-		Reader reader = new FilterReader(new StringReader(TRUNCATED_JSON)) {
-
-			@Override
-			public void close() throws IOException {
-				closed.set(true);
-				super.close();
-			}
-
-		};
+	void readReaderWhenReadFailsShouldCloseReader() throws IOException {
+		Reader reader = spy(new StringReader(TRUNCATED_JSON));
 		AbstractJsonMarshalTester<Object> tester = createTester(TYPE);
 		assertThatException().isThrownBy(() -> tester.read(reader));
-		assertThat(closed).isTrue();
+		then(reader).should(atLeastOnce()).close();
 	}
 
 	@Test


### PR DESCRIPTION
## What Problem This Solves

`AbstractJsonMarshalTester.read(Resource)` and `read(Reader)` open or take
ownership of a source, hand it to `readObject(...)`, and then close it:

```java
InputStream inputStream = resource.getInputStream();
T object = readObject(inputStream, getTypeNotNull());
closeQuietly(inputStream);
return new ObjectContent<>(this.type, object);
```

`closeQuietly` is only reached when `readObject` returns normally. When it
throws — most commonly on malformed JSON, but also on any binding failure —
the source is left open.

Whether that actually leaks depends on whether the delegate closes the source
itself, which the base class cannot control. I measured this per tester with
the tests below rather than assuming it:

| Tester | Closes the source on failure? |
| --- | --- |
| `JacksonTester` / `Jackson2Tester` | yes (Jackson `AUTO_CLOSE_SOURCE`) |
| `JsonbTester` | yes |
| `GsonTester` | **no** |

So `GsonTester.read(...)` leaks a file handle on every failed read. It
reaches `read(Resource)` through four public entry points, three of which
open a real file: `read(String resourcePath)` via `ClassPathResource`,
`read(File)` via `FileSystemResource`, and `read(Resource)` itself.

Negative-path assertions are ordinary in test suites, so this accumulates
over a run rather than happening once.

## Evidence

Red — the fix reverted, the tests present:

```text
./gradlew :core:spring-boot-test:test --tests '*JacksonTesterTests' \
  --tests '*Jackson2TesterTests' --tests '*GsonTesterTests' --tests '*JsonbTesterTests'

GsonTesterTests > readResourceWhenReadFailsShouldCloseInputStream() FAILED
    org.mockito.exceptions.verification.WantedButNotInvoked

GsonTesterTests > readReaderWhenReadFailsShouldCloseReader() FAILED
    org.mockito.exceptions.verification.WantedButNotInvoked

84 tests completed, 2 failed
```

Only `GsonTesterTests` fails, which is what makes the point: the other three
pass by accident, because their delegate happens to close the source. The
tester should not depend on that.

Green — same command with the fix applied:

```text
BUILD SUCCESSFUL
```

## Summary

Close the source in a `finally` block in both methods, so the tester honours
its own contract regardless of the delegate.

For the three delegates that already close the source, `close()` now runs a
second time. That is a no-op by contract — `Closeable` specifies that closing
an already closed stream has no effect, and `Reader` repeats it — so the tests
verify `close()` with `atLeastOnce()` rather than pinning the count. What the
tester owes its caller is that the source ends up closed, not how many times
`close()` was invoked. `ObjectContent` is still constructed before the close,
and `closeQuietly` still swallows `IOException` from `close`.

`JsonLoader`, used by `BasicJsonTester`, is not affected — it delegates to
`FileCopyUtils.copyToString`, which already closes in a `finally` block.

## Related

Same leak class as prior cleanups, all merged:

- #50949 `JarFile is not closed when finding main class from archive`
- #50639 `Close FileOutputStream delegate in InspectingOutputStream`
- #50626 `Close URLClassLoader in ArchitectureCheck`

No open PR touches `AbstractJsonMarshalTester`, and I found no existing issue
for this.

## Test plan

- [x] Red: `readResourceWhenReadFailsShouldCloseInputStream` and
  `readReaderWhenReadFailsShouldCloseReader` fail for `GsonTesterTests`
  without the fix
- [x] Green: both pass with the fix, across all four testers
- [x] `:core:spring-boot-test:test` — 755 tests, 0 failures, 1 skipped
- [x] `:core:spring-boot-test-autoconfigure:test` — 22 tests, 0 failures
- [x] `checkFormatMain`, `checkFormatTest`, `checkstyleMain`, `checkstyleTest`

The tests were added to `AbstractJsonMarshalTesterTests`, so they run for
`JacksonTester`, `Jackson2Tester`, `GsonTester` and `JsonbTester`.

---

Contributed on behalf of [Goatshave](https://github.com/Goatshave).

