### PR TITLE
File handle in SpringBootJoranConfigurator should be closed

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringBootJoranConfigurator.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringBootJoranConfigurator.java
@@ -442,7 +442,10 @@ class SpringBootJoranConfigurator extends JoranConfigurator {
 			if (file.exists()) {
 				InputStreamSource content = file.getContent();
 				Assert.state(content != null, "Unable to get file content");
-				byte[] existingContent = content.getInputStream().readAllBytes();
+				byte[] existingContent;
+				try (InputStream inputStream = content.getInputStream()) {
+					existingContent = inputStream.readAllBytes();
+				}
 				if (!Arrays.equals(this.newContent, existingContent)) {
 					throw new IllegalStateException(
 							"Logging configuration differs from the configuration that has already been written. "

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/SpringBootJoranConfiguratorTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/SpringBootJoranConfiguratorTests.java
@@ -16,10 +16,17 @@
 
 package org.springframework.boot.logging.logback;
 
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import ch.qos.logback.classic.BasicConfigurator;
 import ch.qos.logback.classic.LoggerContext;
@@ -32,7 +39,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.aot.generate.ClassNameGenerator;
+import org.springframework.aot.generate.DefaultGenerationContext;
+import org.springframework.aot.generate.GeneratedFiles;
+import org.springframework.aot.generate.GeneratedFiles.FileHandler;
 import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationCode;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
 import org.springframework.boot.logging.LoggingInitializationContext;
 import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
@@ -40,10 +52,14 @@ import org.springframework.boot.testsupport.classpath.resources.WithResource;
 import org.springframework.boot.testsupport.system.CapturedOutput;
 import org.springframework.boot.testsupport.system.OutputCaptureExtension;
 import org.springframework.context.aot.AbstractAotProcessor;
+import org.springframework.core.io.InputStreamSource;
+import org.springframework.javapoet.ClassName;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.context.support.TestPropertySourceUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link SpringBootJoranConfigurator}.
@@ -283,6 +299,29 @@ class SpringBootJoranConfiguratorTests {
 		});
 	}
 
+	@Test
+	@WithPropertyXmlResource
+	void aotContributionClosesExistingFileContent() throws Exception {
+		withSystemProperty(AbstractAotProcessor.AOT_PROCESSING, "true", () -> {
+			initialize("property.xml");
+			BeanFactoryInitializationAotContribution contribution = (BeanFactoryInitializationAotContribution) this.context
+				.getObject(BeanFactoryInitializationAotContribution.class.getName());
+			assertThat(contribution).isNotNull();
+			List<AtomicBoolean> closed = new ArrayList<>();
+			GeneratedFiles generatedFiles = (kind, path, handler) -> {
+				AtomicBoolean fileClosed = new AtomicBoolean();
+				closed.add(fileClosed);
+				handler.accept(new ClosableContentFileHandler(fileClosed));
+			};
+			DefaultGenerationContext generationContext = new DefaultGenerationContext(
+					new ClassNameGenerator(ClassName.get(Object.class)), generatedFiles);
+			assertThatIllegalStateException()
+				.isThrownBy(() -> contribution.applyTo(generationContext, mock(BeanFactoryInitializationCode.class)))
+				.withMessageContaining("Logging configuration differs");
+			assertThat(closed).isNotEmpty().allMatch(AtomicBoolean::get);
+		});
+	}
+
 	private void withSystemProperty(String name, String value, Action action) throws Exception {
 		System.setProperty(name, value);
 		try {
@@ -315,6 +354,30 @@ class SpringBootJoranConfiguratorTests {
 	private interface Action {
 
 		void perform() throws Exception;
+
+	}
+
+	/**
+	 * {@link FileHandler} whose existing content records when its stream is closed.
+	 */
+	private static final class ClosableContentFileHandler extends FileHandler {
+
+		private ClosableContentFileHandler(AtomicBoolean closed) {
+			super(true, () -> (InputStreamSource) () -> new FilterInputStream(
+					new ByteArrayInputStream("existing".getBytes(StandardCharsets.UTF_8))) {
+
+				@Override
+				public void close() throws IOException {
+					closed.set(true);
+					super.close();
+				}
+
+			});
+		}
+
+		@Override
+		protected void copy(InputStreamSource content, boolean override) {
+		}
 
 	}
 


### PR DESCRIPTION
## What Problem This Solves

`SpringBootJoranConfigurator.RequireNewOrMatchingContentFileHandler` compares
the logging resources it is about to write against what is already there:

```java
InputStreamSource content = file.getContent();
Assert.state(content != null, "Unable to get file content");
byte[] existingContent = content.getInputStream().readAllBytes();
```

`InputStream.readAllBytes()` is documented as "This method does not close the
input stream", and the stream is never assigned to anything, so nothing can
close it afterwards.

During AOT processing the handler is a `FileSystemGeneratedFiles.FileSystemFileHandler`,
whose content supplier returns `new FileSystemResource(path)`, so this is a real
file handle rather than an in-memory resource. The handler is used for both
generated files (`MODEL_RESOURCE_LOCATION` and `RESOURCE_LOCATION`), and
`file.exists()` is true whenever more than one application context contributes
the same resource.

`FileSystemGeneratedFiles` itself already uses try-with-resources when it
consumes an `InputStreamSource`, so this is inconsistent with the code on the
other side of the same interface.

## Evidence

Red — fix reverted, test present:

```text
./gradlew :core:spring-boot:test --tests '*SpringBootJoranConfiguratorTests'

SpringBootJoranConfiguratorTests > aotContributionClosesExistingFileContent() FAILED
23 tests completed, 1 failed

java.lang.AssertionError:
Expecting all elements of:
  [AtomicBoolean(false)]
to match given predicate but this element did not:
  AtomicBoolean(false)
```

The failure is on the close assertion only. The `IllegalStateException` and
non-empty assertions before it pass, so the handler was invoked and the
comparison ran; only the stream was left open.

Green — same command with the fix applied:

```text
BUILD SUCCESSFUL
```

## Summary

Read the existing content inside a try-with-resources block. `InputStream` was
already imported, so the production change is three lines.

The test supplies its own `GeneratedFiles` and a `FileHandler` whose content
records when its stream is closed, then drives the AOT contribution through
`applyTo`.

## Related

Same leak class as prior cleanups, all merged:

- #50949 `JarFile is not closed when finding main class from archive`
- #50639 `Close FileOutputStream delegate in InspectingOutputStream`
- #50626 `Close URLClassLoader in ArchitectureCheck`

No open PR touches `SpringBootJoranConfigurator`, no closed PR in the last 200
has, and I found no existing issue for this. The only commits to this file are
the Spring Framework 7.0.6 snapshot upgrade, the nullability annotations and
the directory restructure, none of which touched this method.

## Test plan

- [x] Red: `aotContributionClosesExistingFileContent` fails without the
  production change
- [x] Green: it passes with the fix
- [x] `:core:spring-boot:test` — 3829 tests, 0 failures, 0 errors, 14 skipped
- [x] `checkFormatMain`, `checkFormatTest`, `checkstyleMain`, `checkstyleTest`

---

Contributed on behalf of [Goatshave](https://github.com/Goatshave).
