### PR TITLE
Automatically filter additional configuration metadata from Spring Boot-built archives

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootArchiveSupport.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootArchiveSupport.java
@@ -46,6 +46,7 @@ import org.jspecify.annotations.Nullable;
  * @author Andy Wilkinson
  * @author Phillip Webb
  * @author Scott Frederick
+ * @author Wan bin yu
  * @see BootJar
  * @see BootWar
  */
@@ -81,6 +82,7 @@ class BootArchiveSupport {
 		this.librarySpec = librarySpec;
 		this.compressionResolver = compressionResolver;
 		this.requiresUnpack.include(Specs.satisfyNone());
+		this.exclusions.exclude("**/META-INF/additional-spring-configuration-metadata.json");
 	}
 
 	void configureManifest(Manifest manifest, String mainClass, String classes, String lib,

--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/AbstractBootArchiveTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/AbstractBootArchiveTests.java
@@ -248,6 +248,25 @@ abstract class AbstractBootArchiveTests<T extends Jar & BootArchive> {
 	}
 
 	@Test
+	void additionalConfigurationMetadataIsExcluded() throws IOException {
+		this.task.getMainClass().set("com.example.Main");
+		File classpathDirectory = new File(this.temp, "classes");
+		File additionalMetadata = new File(classpathDirectory,
+				"META-INF/additional-spring-configuration-metadata.json");
+		additionalMetadata.getParentFile().mkdirs();
+		additionalMetadata.createNewFile();
+		File metadata = new File(classpathDirectory, "META-INF/spring-configuration-metadata.json");
+		metadata.createNewFile();
+		this.task.classpath(classpathDirectory);
+		executeTask();
+		try (JarFile jarFile = new JarFile(this.task.getArchiveFile().get().getAsFile())) {
+			assertThat(getEntryNames(jarFile))
+				.noneMatch((name) -> name.endsWith("META-INF/additional-spring-configuration-metadata.json"))
+				.anyMatch((name) -> name.endsWith("META-INF/spring-configuration-metadata.json"));
+		}
+	}
+
+	@Test
 	void loaderIsWrittenToTheRootOfTheJarAfterManifest() throws IOException {
 		this.task.getMainClass().set("com.example.Main");
 		executeTask();

--- a/documentation/spring-boot-docs/src/docs/antora/modules/specification/pages/configuration-metadata/annotation-processor.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/specification/pages/configuration-metadata/annotation-processor.adoc
@@ -192,3 +192,28 @@ The items contained in the "`ignored.properties`" section are removed from the "
 
 The additional properties file is optional.
 If you do not have any additional properties, do not add the file.
+
+The Spring Boot Maven and Gradle plugins exclude `additional-spring-configuration-metadata.json` from the packaged artifact.
+If you do not use either plugin to build your library, you should configure your build to exclude the file.
+With Maven, you can configure the `maven-jar-plugin` as follows:
+
+[source,xml]
+----
+<plugin>
+	<artifactId>maven-jar-plugin</artifactId>
+	<configuration>
+		<excludes>
+			<exclude>META-INF/additional-spring-configuration-metadata.json</exclude>
+		</excludes>
+	</configuration>
+</plugin>
+----
+
+With Gradle, you can configure the `jar` task as follows:
+
+[source,gradle]
+----
+tasks.named('jar') {
+	exclude('META-INF/additional-spring-configuration-metadata.json')
+}
+----

--- a/loader/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Packager.java
+++ b/loader/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/Packager.java
@@ -55,9 +55,12 @@ import org.springframework.util.StringUtils;
  * @author Stephane Nicoll
  * @author Madhura Bhave
  * @author Scott Frederick
+ * @author Wan bin yu
  * @since 2.3.0
  */
 public abstract class Packager {
+
+	private static final String ADDITIONAL_CONFIGURATION_METADATA_PATH = "META-INF/additional-spring-configuration-metadata.json";
 
 	private static final String MAIN_CLASS_ATTRIBUTE = "Main-Class";
 
@@ -205,7 +208,7 @@ public abstract class Packager {
 		}
 		writer.writeManifest(buildManifest(sourceJar));
 		writeLoaderClasses(writer);
-		writer.writeEntries(sourceJar, getEntityTransformer(), libraries.getUnpackHandler(),
+		writer.writeEntries(sourceJar, getEntryTransformer(), libraries.getUnpackHandler(),
 				libraries.getLibraryLookup());
 		Map<String, Library> writtenLibraries = libraries.write(writer);
 		writeNativeImageArgFile(writer, sourceJar, writtenLibraries);
@@ -272,11 +275,14 @@ public abstract class Packager {
 			throws IOException {
 	}
 
-	private EntryTransformer getEntityTransformer() {
+	private EntryTransformer getEntryTransformer() {
+		EntryTransformer transformer = EntryTransformer.NONE;
 		if (getLayout() instanceof RepackagingLayout repackagingLayout) {
-			return new RepackagingEntryTransformer(repackagingLayout);
+			transformer = new RepackagingEntryTransformer(repackagingLayout);
 		}
-		return EntryTransformer.NONE;
+		EntryTransformer delegate = transformer;
+		String additionalMetadataLocation = getLayout().getClassesLocation() + ADDITIONAL_CONFIGURATION_METADATA_PATH;
+		return (entry) -> (entry.getName().equals(additionalMetadataLocation)) ? null : delegate.transform(entry);
 	}
 
 	private boolean isZip(InputStreamSupplier supplier) {

--- a/loader/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/AbstractPackagerTests.java
+++ b/loader/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/AbstractPackagerTests.java
@@ -487,6 +487,32 @@ abstract class AbstractPackagerTests<P extends Packager> {
 	}
 
 	@Test
+	void additionalConfigurationMetadataIsRemovedFromRepackagedJar() throws Exception {
+		this.testJarFile.addClass("A.class", ClassWithMainMethod.class);
+		this.testJarFile.addFile("META-INF/additional-spring-configuration-metadata.json",
+				new ByteArrayInputStream(new byte[0]));
+		this.testJarFile.addFile("META-INF/spring-configuration-metadata.json", new ByteArrayInputStream(new byte[0]));
+		P packager = createPackager();
+		execute(packager, NO_LIBRARIES);
+		assertThat(getPackagedEntry("META-INF/additional-spring-configuration-metadata.json")).isNull();
+		assertThat(getPackagedEntry("META-INF/spring-configuration-metadata.json")).isNotNull();
+	}
+
+	@Test
+	void additionalConfigurationMetadataIsRemovedFromRepackagedWar() throws Exception {
+		this.testJarFile.addClass("WEB-INF/classes/com/example/Application.class", ClassWithMainMethod.class);
+		this.testJarFile.addFile("WEB-INF/classes/META-INF/additional-spring-configuration-metadata.json",
+				new ByteArrayInputStream(new byte[0]));
+		this.testJarFile.addFile("WEB-INF/classes/META-INF/spring-configuration-metadata.json",
+				new ByteArrayInputStream(new byte[0]));
+		P packager = createPackager(this.testJarFile.getFile("war"));
+		packager.setLayout(new Layouts.War());
+		execute(packager, NO_LIBRARIES);
+		assertThat(getPackagedEntry("WEB-INF/classes/META-INF/additional-spring-configuration-metadata.json")).isNull();
+		assertThat(getPackagedEntry("WEB-INF/classes/META-INF/spring-configuration-metadata.json")).isNotNull();
+	}
+
+	@Test
 	void customLayoutFactoryWithoutLayout() throws Exception {
 		this.testJarFile.addClass("a/b/C.class", ClassWithMainMethod.class);
 		P packager = createPackager();


### PR DESCRIPTION
This updates Spring Boot's Maven and Gradle packaging support to exclude `META-INF/additional-spring-configuration-metadata.json` from built archives. The additional metadata has already been merged into `spring-configuration-metadata.json` by the annotation processor.

The loader tools filter the metadata relative to the layout's classes location, covering both jars and wars. Gradle boot archives apply the equivalent default exclusion. The documentation also shows how to configure the exclusion when building a library without either Spring Boot plugin.

Closes #27430