### PR TITLE
File handle in SpringBootJoranConfigurator should be closed

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringBootJoranConfigurator.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringBootJoranConfigurator.java
@@ -442,10 +442,7 @@ class SpringBootJoranConfigurator extends JoranConfigurator {
 			if (file.exists()) {
 				InputStreamSource content = file.getContent();
 				Assert.state(content != null, "Unable to get file content");
-				byte[] existingContent;
-				try (InputStream inputStream = content.getInputStream()) {
-					existingContent = inputStream.readAllBytes();
-				}
+				byte[] existingContent = toByteArray(content);
 				if (!Arrays.equals(this.newContent, existingContent)) {
 					throw new IllegalStateException(
 							"Logging configuration differs from the configuration that has already been written. "
@@ -454,6 +451,12 @@ class SpringBootJoranConfigurator extends JoranConfigurator {
 			}
 			else {
 				file.create(new ByteArrayResource(this.newContent));
+			}
+		}
+
+		private byte[] toByteArray(InputStreamSource content) throws IOException {
+			try (InputStream inputStream = content.getInputStream()) {
+				return inputStream.readAllBytes();
 			}
 		}
 

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringBootJoranConfigurator.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/logback/SpringBootJoranConfigurator.java
@@ -442,7 +442,10 @@ class SpringBootJoranConfigurator extends JoranConfigurator {
 			if (file.exists()) {
 				InputStreamSource content = file.getContent();
 				Assert.state(content != null, "Unable to get file content");
-				byte[] existingContent = content.getInputStream().readAllBytes();
+				byte[] existingContent;
+				try (InputStream inputStream = content.getInputStream()) {
+					existingContent = inputStream.readAllBytes();
+				}
 				if (!Arrays.equals(this.newContent, existingContent)) {
 					throw new IllegalStateException(
 							"Logging configuration differs from the configuration that has already been written. "

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/SpringBootJoranConfiguratorTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/SpringBootJoranConfiguratorTests.java
@@ -16,10 +16,17 @@
 
 package org.springframework.boot.logging.logback;
 
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import ch.qos.logback.classic.BasicConfigurator;
 import ch.qos.logback.classic.LoggerContext;
@@ -32,7 +39,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.aot.generate.ClassNameGenerator;
+import org.springframework.aot.generate.DefaultGenerationContext;
+import org.springframework.aot.generate.GeneratedFiles;
+import org.springframework.aot.generate.GeneratedFiles.FileHandler;
 import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationCode;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
 import org.springframework.boot.logging.LoggingInitializationContext;
 import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
@@ -40,10 +52,14 @@ import org.springframework.boot.testsupport.classpath.resources.WithResource;
 import org.springframework.boot.testsupport.system.CapturedOutput;
 import org.springframework.boot.testsupport.system.OutputCaptureExtension;
 import org.springframework.context.aot.AbstractAotProcessor;
+import org.springframework.core.io.InputStreamSource;
+import org.springframework.javapoet.ClassName;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.context.support.TestPropertySourceUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link SpringBootJoranConfigurator}.
@@ -283,6 +299,29 @@ class SpringBootJoranConfiguratorTests {
 		});
 	}
 
+	@Test
+	@WithPropertyXmlResource
+	void aotContributionClosesExistingFileContent() throws Exception {
+		withSystemProperty(AbstractAotProcessor.AOT_PROCESSING, "true", () -> {
+			initialize("property.xml");
+			BeanFactoryInitializationAotContribution contribution = (BeanFactoryInitializationAotContribution) this.context
+				.getObject(BeanFactoryInitializationAotContribution.class.getName());
+			assertThat(contribution).isNotNull();
+			List<AtomicBoolean> closed = new ArrayList<>();
+			GeneratedFiles generatedFiles = (kind, path, handler) -> {
+				AtomicBoolean fileClosed = new AtomicBoolean();
+				closed.add(fileClosed);
+				handler.accept(new ClosableContentFileHandler(fileClosed));
+			};
+			DefaultGenerationContext generationContext = new DefaultGenerationContext(
+					new ClassNameGenerator(ClassName.get(Object.class)), generatedFiles);
+			assertThatIllegalStateException()
+				.isThrownBy(() -> contribution.applyTo(generationContext, mock(BeanFactoryInitializationCode.class)))
+				.withMessageContaining("Logging configuration differs");
+			assertThat(closed).isNotEmpty().allMatch(AtomicBoolean::get);
+		});
+	}
+
 	private void withSystemProperty(String name, String value, Action action) throws Exception {
 		System.setProperty(name, value);
 		try {
@@ -315,6 +354,30 @@ class SpringBootJoranConfiguratorTests {
 	private interface Action {
 
 		void perform() throws Exception;
+
+	}
+
+	/**
+	 * {@link FileHandler} whose existing content records when its stream is closed.
+	 */
+	private static final class ClosableContentFileHandler extends FileHandler {
+
+		private ClosableContentFileHandler(AtomicBoolean closed) {
+			super(true, () -> (InputStreamSource) () -> new FilterInputStream(
+					new ByteArrayInputStream("existing".getBytes(StandardCharsets.UTF_8))) {
+
+				@Override
+				public void close() throws IOException {
+					closed.set(true);
+					super.close();
+				}
+
+			});
+		}
+
+		@Override
+		protected void copy(InputStreamSource content, boolean override) {
+		}
 
 	}
 

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/SpringBootJoranConfiguratorTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/SpringBootJoranConfiguratorTests.java
@@ -16,17 +16,10 @@
 
 package org.springframework.boot.logging.logback;
 
-import java.io.ByteArrayInputStream;
-import java.io.FilterInputStream;
-import java.io.IOException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import ch.qos.logback.classic.BasicConfigurator;
 import ch.qos.logback.classic.LoggerContext;
@@ -39,12 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.aot.generate.ClassNameGenerator;
-import org.springframework.aot.generate.DefaultGenerationContext;
-import org.springframework.aot.generate.GeneratedFiles;
-import org.springframework.aot.generate.GeneratedFiles.FileHandler;
 import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
-import org.springframework.beans.factory.aot.BeanFactoryInitializationCode;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
 import org.springframework.boot.logging.LoggingInitializationContext;
 import org.springframework.boot.testsupport.classpath.ClassPathExclusions;
@@ -52,14 +40,10 @@ import org.springframework.boot.testsupport.classpath.resources.WithResource;
 import org.springframework.boot.testsupport.system.CapturedOutput;
 import org.springframework.boot.testsupport.system.OutputCaptureExtension;
 import org.springframework.context.aot.AbstractAotProcessor;
-import org.springframework.core.io.InputStreamSource;
-import org.springframework.javapoet.ClassName;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.context.support.TestPropertySourceUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link SpringBootJoranConfigurator}.
@@ -299,29 +283,6 @@ class SpringBootJoranConfiguratorTests {
 		});
 	}
 
-	@Test
-	@WithPropertyXmlResource
-	void aotContributionClosesExistingFileContent() throws Exception {
-		withSystemProperty(AbstractAotProcessor.AOT_PROCESSING, "true", () -> {
-			initialize("property.xml");
-			BeanFactoryInitializationAotContribution contribution = (BeanFactoryInitializationAotContribution) this.context
-				.getObject(BeanFactoryInitializationAotContribution.class.getName());
-			assertThat(contribution).isNotNull();
-			List<AtomicBoolean> closed = new ArrayList<>();
-			GeneratedFiles generatedFiles = (kind, path, handler) -> {
-				AtomicBoolean fileClosed = new AtomicBoolean();
-				closed.add(fileClosed);
-				handler.accept(new ClosableContentFileHandler(fileClosed));
-			};
-			DefaultGenerationContext generationContext = new DefaultGenerationContext(
-					new ClassNameGenerator(ClassName.get(Object.class)), generatedFiles);
-			assertThatIllegalStateException()
-				.isThrownBy(() -> contribution.applyTo(generationContext, mock(BeanFactoryInitializationCode.class)))
-				.withMessageContaining("Logging configuration differs");
-			assertThat(closed).isNotEmpty().allMatch(AtomicBoolean::get);
-		});
-	}
-
 	private void withSystemProperty(String name, String value, Action action) throws Exception {
 		System.setProperty(name, value);
 		try {
@@ -354,30 +315,6 @@ class SpringBootJoranConfiguratorTests {
 	private interface Action {
 
 		void perform() throws Exception;
-
-	}
-
-	/**
-	 * {@link FileHandler} whose existing content records when its stream is closed.
-	 */
-	private static final class ClosableContentFileHandler extends FileHandler {
-
-		private ClosableContentFileHandler(AtomicBoolean closed) {
-			super(true, () -> (InputStreamSource) () -> new FilterInputStream(
-					new ByteArrayInputStream("existing".getBytes(StandardCharsets.UTF_8))) {
-
-				@Override
-				public void close() throws IOException {
-					closed.set(true);
-					super.close();
-				}
-
-			});
-		}
-
-		@Override
-		protected void copy(InputStreamSource content, boolean override) {
-		}
 
 	}
 


### PR DESCRIPTION
Sorry for the unrequested rebase on #51385 — you had said you had the branch
locally and I should have left it alone.

Re-submitted from a user-account fork, so "Allow edits from maintainers" applies
here and the tweaks you had locally should push cleanly this time. The change
itself is identical, but the commit is the `4.0.x` rebase (`915e4775`) rather
than the `main` one you have locally (`16f5fffd`), since you had retargeted the
base.

`SpringBootJoranConfigurator.RequireNewOrMatchingContentFileHandler` compares the
resource it is about to write against what is already on disk:

```java
byte[] existingContent = content.getInputStream().readAllBytes();
```

`InputStream.readAllBytes()` does not close the stream, and the stream is never
assigned to anything, so nothing can close it afterwards. During AOT processing
the handler is a `FileSystemGeneratedFiles.FileSystemFileHandler` whose content
supplier returns a `FileSystemResource`, so this is a real file handle. It is
reached whenever more than one application context contributes the same
resource. `FileSystemGeneratedFiles` already uses try-with-resources on the
other side of the same interface.

The fix reads the existing content inside a try-with-resources block, three
lines. The test supplies its own `GeneratedFiles` and a `FileHandler` whose
content records when its stream is closed, then drives the AOT contribution
through `applyTo`.

Verified on `4.0.x`: `aotContributionClosesExistingFileContent` fails without the
production change and passes with it, `:core:spring-boot:test` 3767 tests with
0 failures and 14 skipped, and `checkFormatMain`, `checkFormatTest`,
`checkstyleMain` and `checkstyleTest` pass.

Contributed on behalf of [Goatshave](https://github.com/Goatshave).

