### PR TITLE
Source is not closed when a JSON tester read fails

### DIFF
--- a/core/spring-boot-test/src/main/java/org/springframework/boot/test/json/AbstractJsonMarshalTester.java
+++ b/core/spring-boot-test/src/main/java/org/springframework/boot/test/json/AbstractJsonMarshalTester.java
@@ -297,9 +297,13 @@ public abstract class AbstractJsonMarshalTester<T> {
 		verify();
 		Assert.notNull(resource, "'resource' must not be null");
 		InputStream inputStream = resource.getInputStream();
-		T object = readObject(inputStream, getTypeNotNull());
-		closeQuietly(inputStream);
-		return new ObjectContent<>(this.type, object);
+		try {
+			T object = readObject(inputStream, getTypeNotNull());
+			return new ObjectContent<>(this.type, object);
+		}
+		finally {
+			closeQuietly(inputStream);
+		}
 	}
 
 	/**
@@ -322,9 +326,13 @@ public abstract class AbstractJsonMarshalTester<T> {
 	public ObjectContent<T> read(Reader reader) throws IOException {
 		verify();
 		Assert.notNull(reader, "'reader' must not be null");
-		T object = readObject(reader, getTypeNotNull());
-		closeQuietly(reader);
-		return new ObjectContent<>(this.type, object);
+		try {
+			T object = readObject(reader, getTypeNotNull());
+			return new ObjectContent<>(this.type, object);
+		}
+		finally {
+			closeQuietly(reader);
+		}
 	}
 
 	private void closeQuietly(Closeable closeable) {

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/json/AbstractJsonMarshalTesterTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/json/AbstractJsonMarshalTesterTests.java
@@ -18,6 +18,9 @@ package org.springframework.boot.test.json;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FilterInputStream;
+import java.io.FilterReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
@@ -27,6 +30,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.jspecify.annotations.Nullable;
@@ -40,6 +44,7 @@ import org.springframework.util.FileCopyUtils;
 import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
@@ -54,6 +59,8 @@ abstract class AbstractJsonMarshalTesterTests {
 	private static final String MAP_JSON = "{\"a\":" + JSON + "}";
 
 	private static final String ARRAY_JSON = "[" + JSON + "]";
+
+	private static final String TRUNCATED_JSON = "{\"name\":\"Spring\",";
 
 	private static final ExampleObject OBJECT = createExampleObject("Spring", 123);
 
@@ -146,10 +153,51 @@ abstract class AbstractJsonMarshalTesterTests {
 	}
 
 	@Test
+	void readResourceWhenReadFailsShouldCloseInputStream() {
+		AtomicBoolean closed = new AtomicBoolean();
+		Resource resource = new ByteArrayResource(TRUNCATED_JSON.getBytes()) {
+
+			@Override
+			public InputStream getInputStream() throws IOException {
+				return new FilterInputStream(super.getInputStream()) {
+
+					@Override
+					public void close() throws IOException {
+						closed.set(true);
+						super.close();
+					}
+
+				};
+			}
+
+		};
+		AbstractJsonMarshalTester<Object> tester = createTester(TYPE);
+		assertThatException().isThrownBy(() -> tester.read(resource));
+		assertThat(closed).isTrue();
+	}
+
+	@Test
 	void readReaderShouldReturnObject() throws Exception {
 		Reader reader = new StringReader(JSON);
 		AbstractJsonMarshalTester<Object> tester = createTester(TYPE);
 		assertThat(tester.read(reader)).isEqualTo(OBJECT);
+	}
+
+	@Test
+	void readReaderWhenReadFailsShouldCloseReader() {
+		AtomicBoolean closed = new AtomicBoolean();
+		Reader reader = new FilterReader(new StringReader(TRUNCATED_JSON)) {
+
+			@Override
+			public void close() throws IOException {
+				closed.set(true);
+				super.close();
+			}
+
+		};
+		AbstractJsonMarshalTester<Object> tester = createTester(TYPE);
+		assertThatException().isThrownBy(() -> tester.read(reader));
+		assertThat(closed).isTrue();
 	}
 
 	@Test

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/json/AbstractJsonMarshalTesterTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/json/AbstractJsonMarshalTesterTests.java
@@ -18,8 +18,6 @@ package org.springframework.boot.test.json;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FilterInputStream;
-import java.io.FilterReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -30,7 +28,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.jspecify.annotations.Nullable;
@@ -46,6 +43,11 @@ import org.springframework.util.ReflectionUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 /**
  * Tests for {@link AbstractJsonMarshalTester}.
@@ -153,27 +155,13 @@ abstract class AbstractJsonMarshalTesterTests {
 	}
 
 	@Test
-	void readResourceWhenReadFailsShouldCloseInputStream() {
-		AtomicBoolean closed = new AtomicBoolean();
-		Resource resource = new ByteArrayResource(TRUNCATED_JSON.getBytes()) {
-
-			@Override
-			public InputStream getInputStream() throws IOException {
-				return new FilterInputStream(super.getInputStream()) {
-
-					@Override
-					public void close() throws IOException {
-						closed.set(true);
-						super.close();
-					}
-
-				};
-			}
-
-		};
+	void readResourceWhenReadFailsShouldCloseInputStream() throws IOException {
+		Resource resource = mock();
+		InputStream inputStream = spy(new ByteArrayInputStream(TRUNCATED_JSON.getBytes()));
+		given(resource.getInputStream()).willReturn(inputStream);
 		AbstractJsonMarshalTester<Object> tester = createTester(TYPE);
 		assertThatException().isThrownBy(() -> tester.read(resource));
-		assertThat(closed).isTrue();
+		then(inputStream).should(atLeastOnce()).close();
 	}
 
 	@Test
@@ -184,20 +172,11 @@ abstract class AbstractJsonMarshalTesterTests {
 	}
 
 	@Test
-	void readReaderWhenReadFailsShouldCloseReader() {
-		AtomicBoolean closed = new AtomicBoolean();
-		Reader reader = new FilterReader(new StringReader(TRUNCATED_JSON)) {
-
-			@Override
-			public void close() throws IOException {
-				closed.set(true);
-				super.close();
-			}
-
-		};
+	void readReaderWhenReadFailsShouldCloseReader() throws IOException {
+		Reader reader = spy(new StringReader(TRUNCATED_JSON));
 		AbstractJsonMarshalTester<Object> tester = createTester(TYPE);
 		assertThatException().isThrownBy(() -> tester.read(reader));
-		assertThat(closed).isTrue();
+		then(reader).should(atLeastOnce()).close();
 	}
 
 	@Test


### PR DESCRIPTION
Re-submitted from a user-account fork, replacing #51384. Carries your review: the
close is verified with a spy rather than an `AtomicBoolean`.

`AbstractJsonMarshalTester.read(Resource)` and `read(Reader)` take ownership of a
source, hand it to `readObject(...)` and close it afterwards, so the close is
skipped when `readObject` throws, most commonly on malformed JSON.

Whether that leaks depends on the delegate, which the base class cannot control.
Measured rather than assumed: `JacksonTester`, `Jackson2Tester` and `JsonbTester`
close the source themselves, `GsonTester` does not, so `GsonTester.read(...)`
leaks a file handle on every failed read. Three of its four public entry points
open a real file.

The fix closes the source in a `finally` block in both methods. For the three
delegates that already close it, `close()` runs a second time. That is a no-op by
contract, since `Closeable` specifies that closing an already closed stream has
no effect, so the tests verify with `atLeastOnce()` rather than pinning the
count. If you would rather the tester close exactly once, that needs a wrapper
tracking what the delegate already did, and I am happy to go that way instead.

Verified: both new tests fail for `GsonTesterTests` without the production change
and pass for all four testers with it, `:core:spring-boot-test:test` 755 tests
with 0 failures, and `checkFormatMain`, `checkFormatTest`, `checkstyleMain` and
`checkstyleTest` pass.

Contributed on behalf of [Goatshave](https://github.com/Goatshave).
