### PR TITLE
Fix warning from NullAway 0.14.0 related to override

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/convert/LenientObjectToEnumConverterFactory.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/convert/LenientObjectToEnumConverterFactory.java
@@ -51,7 +51,7 @@ abstract class LenientObjectToEnumConverterFactory<T> implements ConverterFactor
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <E extends Enum<?>> Converter<T, E> getConverter(Class<E> targetType) {
+	public <E extends Enum<?>> Converter<T, ? extends @Nullable E> getConverter(Class<E> targetType) {
 		Class<?> enumType = targetType;
 		while (enumType != null && !enumType.isEnum()) {
 			enumType = enumType.getSuperclass();


### PR DESCRIPTION
This code causes a warning in NullAway 0.14.0, as the return of a `new LenientToEnumConverter`, which implements `Converter<T, @Nullable E>`, is not compatible with the previous return type `Converter<T, E>`.  Changing the return type to `Converter<T, ? extends @Nullable E>` (matching that of the overridden method `org.springframework.core.convert.converter.ConverterFactory#getConverter`) fixes the warning.

With this fix, the project builds cleanly under NullAway 0.14.0, i.e., `./gradlew -PnullAwayVersion="0.14.0" assemble` succeeds.  We leave the actual update to NullAway 0.14.0 for a separate PR.
