### PR TITLE
Honour a wrapper's unwrap when resolving the root DataSource

### DIFF
--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/DataSourceUnwrapper.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/DataSourceUnwrapper.java
@@ -94,9 +94,10 @@ public final class DataSourceUnwrapper {
 	}
 
 	/**
-	 * Return the root {@link DataSource} by recursively unwrapping all
-	 * {@link org.springframework.jdbc.datasource.DelegatingDataSource delegating}, proxy,
-	 * and {@link java.sql.Wrapper} layers until no further unwrapping is possible.
+	 * Return the root {@link DataSource} by recursively unwrapping
+	 * {@link java.sql.Wrapper},
+	 * {@link org.springframework.jdbc.datasource.DelegatingDataSource delegating}, and
+	 * proxy layers until no further unwrapping is possible.
 	 * @param dataSource the datasource to unwrap
 	 * @return the root {@link DataSource}
 	 * @since 4.1.0

--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/DataSourceUnwrapper.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/DataSourceUnwrapper.java
@@ -102,6 +102,10 @@ public final class DataSourceUnwrapper {
 	 * @since 4.1.0
 	 */
 	public static DataSource unwrapRoot(DataSource dataSource) {
+		DataSource unwrapped = safeUnwrap(dataSource);
+		if (unwrapped != null && unwrapped != dataSource) {
+			return unwrapRoot(unwrapped);
+		}
 		if (DELEGATING_DATA_SOURCE_PRESENT) {
 			DataSource targetDataSource = DelegatingDataSourceUnwrapper.getTargetDataSource(dataSource);
 			if (targetDataSource != null) {
@@ -113,13 +117,6 @@ public final class DataSourceUnwrapper {
 			if (proxyTarget instanceof DataSource proxyDataSource) {
 				return unwrapRoot(proxyDataSource);
 			}
-		}
-		DataSource unwrapped = safeUnwrap(dataSource);
-		if (unwrapped != null) {
-			if (unwrapped == dataSource) {
-				return unwrapped;
-			}
-			return unwrapRoot(unwrapped);
 		}
 		return dataSource;
 	}

--- a/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/DataSourceUnwrapperTests.java
+++ b/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/DataSourceUnwrapperTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.jdbc;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.function.Consumer;
 
@@ -28,6 +29,7 @@ import org.apache.tomcat.jdbc.pool.PoolConfiguration;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.jdbc.datasource.AbstractDataSource;
 import org.springframework.jdbc.datasource.DelegatingDataSource;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 import org.springframework.jdbc.datasource.SingleConnectionDataSource;
@@ -141,6 +143,19 @@ class DataSourceUnwrapperTests {
 	}
 
 	@Test
+	void unwrapRootWithSelfReturningWrapper() {
+		DataSource dataSource = new SelfReturningDataSource();
+		assertThat(DataSourceUnwrapper.unwrapRoot(dataSource)).isSameAs(dataSource);
+	}
+
+	@Test
+	void unwrapRootWithDelegateWrappingSelfReturningWrapper() {
+		DataSource dataSource = new HikariDataSource();
+		DataSource actual = new RootAwareDelegatingDataSource(new SelfReturningDataSource(), dataSource);
+		assertThat(DataSourceUnwrapper.unwrapRoot(actual)).isSameAs(dataSource);
+	}
+
+	@Test
 	void unwrappingIsNotAttemptedWhenTargetIsNotAnInterface() {
 		DataSource dataSource = mock(DataSource.class);
 		assertThat(DataSourceUnwrapper.unwrap(dataSource, HikariDataSource.class)).isNull();
@@ -161,6 +176,36 @@ class DataSourceUnwrapperTests {
 
 	private DataSource wrapInDelegate(DataSource dataSource) {
 		return new DelegatingDataSource(dataSource);
+	}
+
+	private static final class SelfReturningDataSource extends AbstractDataSource {
+
+		@Override
+		public Connection getConnection() throws SQLException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Connection getConnection(String username, String password) throws SQLException {
+			throw new UnsupportedOperationException();
+		}
+
+	}
+
+	private static final class RootAwareDelegatingDataSource extends DelegatingDataSource {
+
+		private final DataSource root;
+
+		private RootAwareDelegatingDataSource(DataSource target, DataSource root) {
+			super(target);
+			this.root = root;
+		}
+
+		@Override
+		public <T> T unwrap(Class<T> iface) throws SQLException {
+			return (iface.isInstance(this.root)) ? iface.cast(this.root) : super.unwrap(iface);
+		}
+
 	}
 
 }

--- a/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/DataSourceUnwrapperTests.java
+++ b/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/DataSourceUnwrapperTests.java
@@ -181,12 +181,12 @@ class DataSourceUnwrapperTests {
 	private static final class SelfReturningDataSource extends AbstractDataSource {
 
 		@Override
-		public Connection getConnection() throws SQLException {
+		public Connection getConnection() {
 			throw new UnsupportedOperationException();
 		}
 
 		@Override
-		public Connection getConnection(String username, String password) throws SQLException {
+		public Connection getConnection(String username, String password) {
 			throw new UnsupportedOperationException();
 		}
 


### PR DESCRIPTION
`DataSourceUnwrapper.unwrapRoot` checks the delegate chain and the AOP target before it
looks at `Wrapper.unwrap`, and it stops as soon as a wrapper unwraps to itself.
`unwrap(DataSource, Class, Class)`, right above it, does the opposite and calls
`safeUnwrap` first.

`DecoratedDataSource` from spring-boot-data-source-decorator 2.0.1 extends
`DelegatingDataSource` and overrides `unwrap` to return the `HikariDataSource`, but its
target is datasource-proxy's `ProxyDataSource`. Following the delegate chain lands on the
proxy, and a `Wrapper` that implements the requested interface is meant to return itself
from `unwrap`. The search therefore ends at the proxy and `DecoratedDataSource.unwrap`
never runs. `DataSourceBuilder.derivedFrom` is the only caller, so it derives from the proxy instead
of the pool. Nothing throws. Reported downstream as
gavlyukovskiy/spring-boot-data-source-decorator#197.

This calls `unwrap` first and keeps going through the delegate chain and the AOP target
when a wrapper returns itself. `DelegatingDataSource` and `LazyConnectionDataSourceProxy`
both return themselves, so the delegate chain still handles them and the lazy connection
proxy case from #50271 is unaffected. The new test fails on 4.1.x without the change.
