### PR TITLE
Remove reference to removed SpringBootWebSecurityConfiguration

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/web/spring-security.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/web/spring-security.adoc
@@ -36,7 +36,6 @@ You can provide a different javadoc:org.springframework.security.authentication.
 == MVC Security
 
 The default security configuration is implemented in javadoc:org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration[] and javadoc:org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration[].
-javadoc:org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration[] auto-configures web security and javadoc:org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration[] auto-configures authentication.
 
 To completely switch off the default web application security configuration, including Actuator security, or to combine multiple Spring Security components such as OAuth2 Client and Resource Server, add a bean of type javadoc:org.springframework.security.web.SecurityFilterChain[] (doing so does not disable the javadoc:org.springframework.security.core.userdetails.UserDetailsService[] configuration).
 To also switch off the javadoc:org.springframework.security.core.userdetails.UserDetailsService[] configuration, add a bean of type javadoc:org.springframework.security.core.userdetails.UserDetailsService[], javadoc:org.springframework.security.authentication.AuthenticationProvider[], or javadoc:org.springframework.security.authentication.AuthenticationManager[].

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/web/spring-security.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/web/spring-security.adoc
@@ -35,8 +35,8 @@ You can provide a different javadoc:org.springframework.security.authentication.
 [[web.security.spring-mvc]]
 == MVC Security
 
-The default security configuration is implemented in javadoc:org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration[] and javadoc:org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration[].
-javadoc:org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration[] imports `SpringBootWebSecurityConfiguration` for web security and javadoc:org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration[] for authentication.
+The default security configuration is implemented in javadoc:org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration[] and javadoc:org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration[].
+javadoc:org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration[] auto-configures web security and javadoc:org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration[] auto-configures authentication.
 
 To completely switch off the default web application security configuration, including Actuator security, or to combine multiple Spring Security components such as OAuth2 Client and Resource Server, add a bean of type javadoc:org.springframework.security.web.SecurityFilterChain[] (doing so does not disable the javadoc:org.springframework.security.core.userdetails.UserDetailsService[] configuration).
 To also switch off the javadoc:org.springframework.security.core.userdetails.UserDetailsService[] configuration, add a bean of type javadoc:org.springframework.security.core.userdetails.UserDetailsService[], javadoc:org.springframework.security.authentication.AuthenticationProvider[], or javadoc:org.springframework.security.authentication.AuthenticationManager[].


### PR DESCRIPTION
Default servlet web security moved to ServletWebSecurityAutoConfiguration, but the MVC Security section still described SecurityAutoConfiguration importing SpringBootWebSecurityConfiguration, which no longer exists.
