### PR TITLE
Document SAML2 back-off in WebFlux security documentation

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/web/spring-security.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/web/spring-security.adoc
@@ -67,10 +67,11 @@ javadoc:org.springframework.boot.security.autoconfigure.ReactiveUserDetailsServi
 To completely switch off the default web application security configuration, including Actuator security, add a bean of type javadoc:org.springframework.security.web.server.WebFilterChainProxy[] (doing so does not disable the javadoc:org.springframework.security.core.userdetails.ReactiveUserDetailsService[] configuration).
 To also switch off the javadoc:org.springframework.security.core.userdetails.ReactiveUserDetailsService[] configuration, add a bean of type javadoc:org.springframework.security.core.userdetails.ReactiveUserDetailsService[] or javadoc:org.springframework.security.authentication.ReactiveAuthenticationManager[].
 
-The auto-configuration will also back off when any of the following Spring Security modules is on the classpath:
+The auto-configuration of a javadoc:org.springframework.security.core.userdetails.ReactiveUserDetailsService[] will also back off when any of the following Spring Security modules is on the classpath:
 
 - `spring-security-oauth2-client`
 - `spring-security-oauth2-resource-server`
+- `spring-security-saml2-service-provider`
 
 To use javadoc:org.springframework.security.core.userdetails.ReactiveUserDetailsService[] in addition to one or more of these dependencies, define your own javadoc:org.springframework.security.core.userdetails.MapReactiveUserDetailsService[] bean.
 


### PR DESCRIPTION
Reactive user details auto-configuration now shares its condition with the servlet side, so it also backs off when
spring-security-saml2-service-provider is on the classpath. The WebFlux back-off list did not mention it.
