### PR TITLE
Fix typos in service containers javadoc and reference documentation

### DIFF
--- a/core/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/ServiceConnection.java
+++ b/core/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/service/connection/ServiceConnection.java
@@ -32,7 +32,7 @@ import org.springframework.core.annotation.AliasFor;
  * Indicates that a field or method is a {@link ContainerConnectionSource} which provides
  * a service that can be connected to.
  * <p>
- * If the underling connection supports SSL, the {@link PemKeyStore @PemKeyStore},
+ * If the underlying connection supports SSL, the {@link PemKeyStore @PemKeyStore},
  * {@link PemTrustStore @PemTrustStore}, {@link JksKeyStore @JksKeyStore},
  * {@link JksTrustStore @JksTrustStore}, {@link Ssl @Ssl} annotations may be used to
  * provide additional configuration.

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/testing/testcontainers.adoc
@@ -223,7 +223,7 @@ Please note that you still have to enable SSL on the service which is running in
 
 include-code::MyRedisWithSslIntegrationTests[]
 
-The above code uses the javadoc:org.springframework.boot.testcontainers.service.connection.PemKeyStore[format=annotation] annotation to load the client certificate and key into the keystore and the and javadoc:org.springframework.boot.testcontainers.service.connection.PemTrustStore[format=annotation] annotation to load the CA certificate into the truststore.
+The above code uses the javadoc:org.springframework.boot.testcontainers.service.connection.PemKeyStore[format=annotation] annotation to load the client certificate and key into the keystore and the javadoc:org.springframework.boot.testcontainers.service.connection.PemTrustStore[format=annotation] annotation to load the CA certificate into the truststore.
 This will authenticate the client against the server, and the CA certificate in the truststore makes sure that the server certificate is valid and trusted.
 
 The `SecureRedisContainer` in this example is a custom subclass of `RedisContainer` which copies certificates to the correct places and invokes `redis-server` with commandline parameters enabling SSL.


### PR DESCRIPTION
  Document that `@ServiceConnection` can be used as a meta-annotation for composed service connection annotations.

  Add a regression test and a Testcontainers documentation example. Also fix two related documentation typos.

  Tests:
  - `.\gradlew.bat :core:spring-boot-testcontainers:test --tests org.springframework.boot.testcontainers.service.connection.ServiceConnectionContextCustomizerFactoryTests`

<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a straightforward dependency upgrade (one that
only updates the version property). We have a semi-automated process for such upgrades
that we prefer to use. However, if the upgrade is more involved (such as requiring
changes for removed or deprecated API) your pull request is most welcome.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
