### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -49,7 +49,7 @@ jobs:
           path: send-notification
           sparse-checkout: .github/actions/send-notification
       - name: Set Up Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'liberica'
           java-version: 17


### PR DESCRIPTION
Upgrade the verification workflow from `actions/setup-java@v5` to `actions/setup-java@v6`.

Verified that no older setup-java references remain in active workflow files.