### PR TITLE
Remove duplicate adoc generation in DocumentAutoConfigurationClasses

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/autoconfigure/DocumentAutoConfigurationClasses.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/autoconfigure/DocumentAutoConfigurationClasses.java
@@ -70,15 +70,6 @@ public abstract class DocumentAutoConfigurationClasses extends DefaultTask {
 		FileSystemUtils.deleteRecursively(getOutputDir().getAsFile().get());
 		List<AutoConfiguration> autoConfigurations = load();
 		autoConfigurations.forEach(this::writeModuleAdoc);
-		for (File metadataFile : this.autoConfiguration) {
-			Properties metadata = new Properties();
-			try (Reader reader = new FileReader(metadataFile)) {
-				metadata.load(reader);
-			}
-			AutoConfiguration autoConfiguration = new AutoConfiguration(metadata.getProperty("module"), new TreeSet<>(
-					StringUtils.commaDelimitedListToSet(metadata.getProperty("autoConfigurationClassNames"))));
-			writeModuleAdoc(autoConfiguration);
-		}
 		writeNavAdoc(autoConfigurations);
 	}
 


### PR DESCRIPTION
The task loaded the auto-configuration metadata twice and wrote every module's adoc file twice. When `load()` and `writeNavAdoc()` were introduced, the pre-existing loop that read each metadata file and called `writeModuleAdoc()` was left in place, so each file was generated once from `load()` and then again, identically, by the loop.

Remove the redundant loop. The generated output is unchanged.

