### PR TITLE
Retain the cause when wrapping checked exceptions

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ResolveMainClassName.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ResolveMainClassName.java
@@ -181,7 +181,7 @@ public class ResolveMainClassName extends DefaultTask {
 				return Files.readString(output);
 			}
 			catch (IOException ex) {
-				throw new RuntimeException("Failed to read main class name from '" + output + "'");
+				throw new RuntimeException("Failed to read main class name from '" + output + "'", ex);
 			}
 		}
 

--- a/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/CustomLayersProvider.java
+++ b/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/CustomLayersProvider.java
@@ -79,7 +79,7 @@ class CustomLayersProvider {
 			return factory.newSchema(getClass().getResource("layers.xsd"));
 		}
 		catch (SAXException ex) {
-			throw new IllegalStateException("Unable to load layers XSD");
+			throw new IllegalStateException("Unable to load layers XSD", ex);
 		}
 	}
 

--- a/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StartMojo.java
+++ b/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/StartMojo.java
@@ -212,7 +212,7 @@ public class StartMojo extends AbstractRunMojo {
 				}
 				catch (InterruptedException ex) {
 					Thread.currentThread().interrupt();
-					throw new IllegalStateException("Interrupted while waiting for Spring Boot app to start.");
+					throw new IllegalStateException("Interrupted while waiting for Spring Boot app to start.", ex);
 				}
 			}
 		}

--- a/core/spring-boot/src/main/java/org/springframework/boot/BeanDefinitionLoader.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/BeanDefinitionLoader.java
@@ -230,7 +230,7 @@ class BeanDefinitionLoader {
 			return new Resource[] { loader.getResource(source) };
 		}
 		catch (IOException ex) {
-			throw new IllegalStateException("Error reading source '" + source + "'");
+			throw new IllegalStateException("Error reading source '" + source + "'", ex);
 		}
 	}
 

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/SpringBootTriggeringPolicy.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/SpringBootTriggeringPolicy.java
@@ -119,7 +119,7 @@ public abstract class SpringBootTriggeringPolicy implements TriggeringPolicy {
 			}
 			catch (ConversionException ex) {
 				throw new IllegalArgumentException(
-						"Unsupported rolling policy strategy '%s'".formatted(resolvedStrategy));
+						"Unsupported rolling policy strategy '%s'".formatted(resolvedStrategy), ex);
 			}
 		}
 


### PR DESCRIPTION
Several call sites catch a checked exception and immediately wrap it in a new unchecked exception without passing the original as the cause. This discards the underlying stack trace and makes the resulting failure much harder to diagnose.

Affected classes:
- `BeanDefinitionLoader`
- `CustomLayersProvider`
- `ResolveMainClassName`
- `SpringBootTriggeringPolicy`
- `StartMojo`

No behavioral change other than exposing the original exception via `Throwable.getCause()`.