### PR TITLE
LdapHealthIndicator reports UNKNOWN instead of UP when LDAP server doesn't expose a protocol version

### DIFF
--- a/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/health/LdapHealthIndicator.java
+++ b/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/health/LdapHealthIndicator.java
@@ -50,8 +50,9 @@ public class LdapHealthIndicator extends AbstractHealthIndicator {
 	@Override
 	protected void doHealthCheck(Health.Builder builder) throws Exception {
 		String version = this.ldapOperations.executeReadOnly(versionContextExecutor);
+		builder.up();
 		if (version != null) {
-			builder.up().withDetail("version", version);
+			builder.withDetail("version", version);
 		}
 	}
 

--- a/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/health/LdapHealthIndicator.java
+++ b/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/health/LdapHealthIndicator.java
@@ -16,9 +16,6 @@
 
 package org.springframework.boot.ldap.health;
 
-import javax.naming.NamingException;
-import javax.naming.directory.DirContext;
-
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.boot.health.contributor.AbstractHealthIndicator;
@@ -37,7 +34,8 @@ import org.springframework.util.Assert;
  */
 public class LdapHealthIndicator extends AbstractHealthIndicator {
 
-	private static final ContextExecutor<@Nullable String> versionContextExecutor = new VersionContextExecutor();
+	private static final ContextExecutor<@Nullable String> versionContextExecutor = (
+			dirContext) -> (String) dirContext.getEnvironment().get("java.naming.ldap.version");
 
 	private final LdapOperations ldapOperations;
 
@@ -49,24 +47,11 @@ public class LdapHealthIndicator extends AbstractHealthIndicator {
 
 	@Override
 	protected void doHealthCheck(Health.Builder builder) throws Exception {
-		String version = this.ldapOperations.executeReadOnly(versionContextExecutor);
 		builder.up();
+		String version = this.ldapOperations.executeReadOnly(versionContextExecutor);
 		if (version != null) {
 			builder.withDetail("version", version);
 		}
-	}
-
-	private static final class VersionContextExecutor implements ContextExecutor<@Nullable String> {
-
-		@Override
-		public @Nullable String executeWithContext(DirContext ctx) throws NamingException {
-			Object version = ctx.getEnvironment().get("java.naming.ldap.version");
-			if (version != null) {
-				return (String) version;
-			}
-			return null;
-		}
-
 	}
 
 }

--- a/module/spring-boot-ldap/src/test/java/org/springframework/boot/ldap/health/LdapHealthIndicatorTests.java
+++ b/module/spring-boot-ldap/src/test/java/org/springframework/boot/ldap/health/LdapHealthIndicatorTests.java
@@ -51,6 +51,18 @@ class LdapHealthIndicatorTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
+	void ldapIsUpWhenVersionIsUnavailable() {
+		LdapTemplate ldapTemplate = mock(LdapTemplate.class);
+		given(ldapTemplate.executeReadOnly((ContextExecutor<String>) any())).willReturn(null);
+		LdapHealthIndicator healthIndicator = new LdapHealthIndicator(ldapTemplate);
+		Health health = healthIndicator.health();
+		assertThat(health.getStatus()).isEqualTo(Status.UP);
+		assertThat(health.getDetails()).doesNotContainKey("version");
+		then(ldapTemplate).should().executeReadOnly((ContextExecutor<String>) any());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
 	void ldapIsDown() {
 		LdapTemplate ldapTemplate = mock(LdapTemplate.class);
 		given(ldapTemplate.executeReadOnly((ContextExecutor<String>) any()))


### PR DESCRIPTION
## What happened?

`LdapHealthIndicator.doHealthCheck()` reads the LDAP server's protocol version from a JNDI environment attribute and only reports the health status as `UP` if that version is present:

```java
String version = this.ldapOperations.executeReadOnly(versionContextExecutor);
if (version != null) {
    builder.up().withDetail("version", version);
}
```

However, `executeReadOnly()` returning without throwing already means the LDAP connection succeeded.

`java.naming.ldap.version` is a JNDI environment attribute that a client requests explicitly. It is not something the server always echoes back, and Spring LDAP's default `LdapContextSource` configuration does not set it.

As a result, in a common setup, `version` can be `null` even though the LDAP connection is perfectly healthy.

When this happens, `builder.up()` is never called. Since `Health.Builder` defaults to `Status.UNKNOWN`, the indicator incorrectly reports `UNKNOWN` for a working LDAP connection instead of `UP`.

## What should happen?

A successful LDAP round trip should report `UP`, regardless of whether the optional version detail is available.

## How to reproduce?

Added `LdapHealthIndicatorTests#ldapIsUpWhenVersionIsUnavailable`.

The test stubs `executeReadOnly()` to return `null`, representing a successful connection where the LDAP version is unavailable, and asserts that:

* The health status is `UP`.
* No `version` detail is included.

On the current code, this test fails because the status is `UNKNOWN` instead of `UP`.

## What does this PR change?

`doHealthCheck()` now calls `builder.up()` unconditionally after a successful `executeReadOnly()` call.

The `version` detail is only added when the version is available:

```java
String version = this.ldapOperations.executeReadOnly(versionContextExecutor);
builder.up();

if (version != null) {
    builder.withDetail("version", version);
}
```

No public API changes are introduced.

## Impact / risk

* **Connection succeeds + version available:** Unchanged. Reports `UP` with the `version` detail.
* **Connection succeeds + version unavailable:** Now correctly reports `UP` instead of `UNKNOWN`. This is the fix.
* **Connection fails:** Unchanged. Reports `DOWN` through `AbstractHealthIndicator`'s exception handling.

## Tests

* Added the regression test `ldapIsUpWhenVersionIsUnavailable`.
* Existing `LdapHealthIndicatorTests` continue to pass.
* `checkstyleMain` passes.
* `checkstyleTest` passes.
* `format` passes.
* `:module:spring-boot-ldap:test` passes.

ps. Sorry for the noise. I originally opened this against the wrong base branch (4.1.x) and closed it (#51440). This PR targets main as intended.
