### PR TITLE
Add authentication required operation types for embedded LDAP

### DIFF
--- a/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/autoconfigure/embedded/EmbeddedLdapAutoConfiguration.java
+++ b/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/autoconfigure/embedded/EmbeddedLdapAutoConfiguration.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLServerSocketFactory;
@@ -30,6 +31,7 @@ import com.unboundid.ldap.listener.InMemoryDirectoryServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
 import com.unboundid.ldap.listener.InMemoryListenerConfig;
 import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.OperationType;
 import com.unboundid.ldap.sdk.schema.Schema;
 import com.unboundid.ldif.LDIFReader;
 import org.jspecify.annotations.Nullable;
@@ -108,6 +110,10 @@ public final class EmbeddedLdapAutoConfiguration implements DisposableBean {
 		String password = this.embeddedProperties.getCredential().getPassword();
 		if (StringUtils.hasText(username) && StringUtils.hasText(password)) {
 			config.addAdditionalBindCredentials(username, password);
+		}
+		Set<OperationType> requiredOps = this.embeddedProperties.getAuthenticationRequiredOperationTypes();
+		if (!requiredOps.isEmpty()) {
+			config.setAuthenticationRequiredOperationTypes(requiredOps);
 		}
 		config.setListenerConfigs(createListenerConfig(sslBundles));
 		setSchema(config);

--- a/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/autoconfigure/embedded/EmbeddedLdapProperties.java
+++ b/module/spring-boot-ldap/src/main/java/org/springframework/boot/ldap/autoconfigure/embedded/EmbeddedLdapProperties.java
@@ -17,8 +17,11 @@
 package org.springframework.boot.ldap.autoconfigure.embedded;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import com.unboundid.ldap.sdk.OperationType;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -40,6 +43,11 @@ public class EmbeddedLdapProperties {
 	 * Embedded LDAP port.
 	 */
 	private int port;
+
+	/**
+	 * LDAP operation types that require authentication.
+	 */
+	private Set<OperationType> authenticationRequiredOperationTypes = new HashSet<>();
 
 	/**
 	 * Embedded LDAP credentials.
@@ -105,6 +113,15 @@ public class EmbeddedLdapProperties {
 
 	public Ssl getSsl() {
 		return this.ssl;
+	}
+
+	public Set<OperationType> getAuthenticationRequiredOperationTypes() {
+		return this.authenticationRequiredOperationTypes;
+	}
+
+	@SuppressWarnings("unused")
+	public void setAuthenticationRequiredOperationTypes(Set<OperationType> authenticationRequiredOperationTypes) {
+		this.authenticationRequiredOperationTypes = authenticationRequiredOperationTypes;
 	}
 
 	public static class Credential {

--- a/module/spring-boot-ldap/src/test/java/org/springframework/boot/ldap/autoconfigure/embedded/EmbeddedLdapAutoConfigurationTests.java
+++ b/module/spring-boot-ldap/src/test/java/org/springframework/boot/ldap/autoconfigure/embedded/EmbeddedLdapAutoConfigurationTests.java
@@ -29,6 +29,9 @@ import com.unboundid.ldap.sdk.BindResult;
 import com.unboundid.ldap.sdk.DN;
 import com.unboundid.ldap.sdk.LDAPConnection;
 import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.ResultCode;
+import com.unboundid.ldap.sdk.SearchRequest;
+import com.unboundid.ldap.sdk.SearchScope;
 import com.unboundid.ldap.sdk.schema.Schema;
 import org.junit.jupiter.api.Test;
 
@@ -49,6 +52,7 @@ import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.core.support.LdapContextSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * Tests for {@link EmbeddedLdapAutoConfiguration}
@@ -416,6 +420,28 @@ class EmbeddedLdapAutoConfigurationTests {
 		EmbeddedLdapProperties properties = new EmbeddedLdapProperties();
 		properties.getSsl().setBundle("");
 		assertThat(properties.getSsl().isEnabled()).isFalse();
+	}
+
+	@Test
+	@WithSchemaLdifResource
+	void authenticationRequiredOperationTypesAreApplied() {
+		this.contextRunner.withPropertyValues("spring.ldap.embedded.base-dn=dc=spring,dc=org",
+				"spring.ldap.embedded.credential.username=uid=root", "spring.ldap.embedded.credential.password=boot",
+				"spring.ldap.embedded.authentication-required-operation-types=search")
+			.run((context) -> {
+				InMemoryDirectoryServer server = context.getBean(InMemoryDirectoryServer.class);
+				try (LDAPConnection connection = new LDAPConnection("localhost", server.getListenPort())) {
+					SearchRequest searchRequest = new SearchRequest("dc=spring,dc=org", SearchScope.SUB,
+							"(objectClass=*)");
+
+					assertThatExceptionOfType(LDAPException.class).isThrownBy(() -> connection.search(searchRequest))
+						.satisfies((ex) -> assertThat(ex.getResultCode())
+							.isEqualTo(ResultCode.INSUFFICIENT_ACCESS_RIGHTS));
+
+					connection.bind("uid=root", "boot");
+					assertThat(connection.search(searchRequest).getEntryCount()).isGreaterThan(0);
+				}
+			});
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
Fixes #51437 

Add authentication requirements for embedded LDAP operations. Expose `authentication-required-operation-types` through `EmbeddedLdapProperties` and apply the configured operation types to the embedded UnboundID LDAP server. Add test coverage to verify that configured search operations require authentication.
