### PR TITLE
WritableJson.toByteArray() may corrupt supplementary characters

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/json/AppendableByteArray.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/json/AppendableByteArray.java
@@ -56,6 +56,8 @@ class AppendableByteArray implements Appendable {
 
 	private ByteBuffer out;
 
+	private char highSurrogate;
+
 	AppendableByteArray(Charset charset) {
 		this(charset, DEFAULT_INITIAL_SIZE, DEFAULT_EXPANSION_SIZE);
 	}
@@ -89,8 +91,19 @@ class AppendableByteArray implements Appendable {
 	}
 
 	private AppendableByteArray append(CharBuffer in) throws IOException {
-		CoderResult result = this.encoder.encode(in, this.out, false);
+		if (this.highSurrogate != 0) {
+			CharBuffer pending = CharBuffer.allocate(in.remaining() + 1);
+			pending.put(this.highSurrogate).put(in).flip();
+			this.highSurrogate = 0;
+			in = pending;
+		}
+		return append(in, false);
+	}
+
+	private AppendableByteArray append(CharBuffer in, boolean endOfInput) throws IOException {
+		CoderResult result = this.encoder.encode(in, this.out, endOfInput);
 		if (result.isUnderflow()) {
+			this.highSurrogate = (in.hasRemaining()) ? in.get() : 0;
 			return this;
 		}
 		if (result.isOverflow()) {
@@ -98,13 +111,18 @@ class AppendableByteArray implements Appendable {
 			this.out = ByteBuffer.allocate(out.capacity() + this.expansionSize);
 			out.flip();
 			this.out.put(out);
-			return append(in);
+			return append(in, endOfInput);
 		}
 		result.throwException();
 		return this;
 	}
 
-	byte[] toByteArray() {
+	byte[] toByteArray() throws IOException {
+		if (this.highSurrogate != 0) {
+			CharBuffer in = CharBuffer.wrap(new char[] { this.highSurrogate });
+			this.highSurrogate = 0;
+			append(in, true);
+		}
 		this.out.flip();
 		int limit = this.out.limit();
 		int position = this.out.position();
@@ -120,6 +138,7 @@ class AppendableByteArray implements Appendable {
 	private void reset() {
 		this.out.clear();
 		this.encoder.reset();
+		this.highSurrogate = 0;
 	}
 
 	static byte[] toByteArray(Charset charset, ThrowingConsumer<Appendable> appendable) throws IOException {

--- a/core/spring-boot/src/test/java/org/springframework/boot/json/AppendableByteArrayTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/json/AppendableByteArrayTests.java
@@ -90,6 +90,22 @@ class AppendableByteArrayTests {
 		assertThat(reused).isEqualTo("clean".getBytes(StandardCharsets.UTF_8));
 	}
 
+	@Test
+	void writesSurrogatePairAppendedAsIndividualChars() throws Exception {
+		assertByteArray(StandardCharsets.UTF_8, (appendable) -> appendable.append('\uD83D').append('\uDE00'));
+		assertByteArray(StandardCharsets.UTF_16, (appendable) -> appendable.append('\uD83D').append('\uDE00'));
+	}
+
+	@Test
+	void writesSurrogatePairSplitAcrossAppendedStrings() throws Exception {
+		assertByteArray(StandardCharsets.UTF_8, (appendable) -> appendable.append("a\uD83D").append("\uDE00b"));
+	}
+
+	@Test
+	void writesUnpairedHighSurrogate() throws Exception {
+		assertByteArray(StandardCharsets.UTF_8, (appendable) -> appendable.append('\uD83D'));
+	}
+
 	private void assertByteArray(Charset charset, ThrowingConsumer<Appendable> action) throws Exception {
 		assertByteArray(4, 4, charset, action);
 	}

--- a/core/spring-boot/src/test/java/org/springframework/boot/json/WritableJsonTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/json/WritableJsonTests.java
@@ -67,6 +67,17 @@ class WritableJsonTests {
 	}
 
 	@Test
+	void toByteArrayWhenContentIsAppendedCharByCharWritesSupplementaryCharacters() {
+		String emoji = new String(Character.toChars(0x1F600));
+		WritableJson writable = (out) -> {
+			for (int i = 0; i < emoji.length(); i++) {
+				out.append(emoji.charAt(i));
+			}
+		};
+		assertThat(writable.toByteArray(StandardCharsets.UTF_8)).isEqualTo(emoji.getBytes(StandardCharsets.UTF_8));
+	}
+
+	@Test
 	void toResourceWritesJson() throws Exception {
 		File file = new File(this.temp, "out.json");
 		WritableJson writable = (out) -> out.append("{}");


### PR DESCRIPTION
## What happened?

`AppendableByteArray` encodes each append call independently with `endOfInput` set to `false`. If the input ends with a high surrogate, `CharsetEncoder` returns `UNDERFLOW` without consuming it. Because that input buffer is then discarded, the high surrogate is lost. The low surrogate in the next append call is malformed on its own and is replaced with `?`.

`JsonValueWriter` writes strings one UTF-16 code unit at a time, so this affects supplementary characters, including many emoji. For example:

```java
String emoji = new String(Character.toChars(0x1F600));
JsonWriter<Map<String, Object>> writer = JsonWriter.standard();
WritableJson json = writer.write(Map.of("msg", "hello " + emoji));

json.toJsonString();                                     // {"msg":"hello 😀"}
new String(json.toByteArray(), StandardCharsets.UTF_8);  // {"msg":"hello ?"}
```

Structured logging is also affected. `StructuredLogEncoder` for Logback and `StructuredLogLayout` for Log4j2 use `formatAsBytes`, which reaches `WritableJson.toByteArray(Charset)`.

This regression was introduced by #49428 in 4.1.0. The previous implementation used an `OutputStreamWriter`, which retains a pending high surrogate across writes, so 4.0.x is not affected.

## What does this PR change?

`AppendableByteArray` now retains an unconsumed high surrogate and prepends it to the input from the next append call.

If no further input arrives, `toByteArray()` encodes the pending surrogate with `endOfInput` set to `true`, so an unpaired high surrogate is replaced instead of being dropped. `reset()` also clears the pending state so it cannot carry over when the cached instance is reused.

There are no public API changes.

## Tests

Added coverage for:

- A surrogate pair appended as individual characters, using UTF-8 and UTF-16
- A surrogate pair split across two appended strings
- An unpaired high surrogate
- Supplementary characters written character by character through `WritableJson`

The `AppendableByteArray` tests compare the result with the output produced by `OutputStreamWriter`. All of these tests fail without this change.

`:core:spring-boot:check` passes on Linux with JDK 25.

Related: #51156 fixed a separate regression introduced by #49428.