### PR TITLE
SSL host config customizations may be lost during Tomcat initialization

### DIFF
--- a/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/SslConnectorCustomizer.java
+++ b/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/SslConnectorCustomizer.java
@@ -68,7 +68,7 @@ public class SslConnectorCustomizer {
 		AbstractHttp11Protocol<?> protocol = (AbstractHttp11Protocol<?>) this.connector.getProtocolHandler();
 		String hostName = (serverName != null) ? serverName : protocol.getDefaultSSLHostConfigName();
 		this.logger.debug("SSL Bundle for host " + hostName + " has been updated, reloading SSL configuration");
-		addSslHostConfig(protocol, hostName, updatedSslBundle);
+		configureSslHostConfig(protocol, hostName, updatedSslBundle);
 	}
 
 	public void customize(SslBundle sslBundle, Map<String, SslBundle> serverNameSslBundles) {
@@ -90,12 +90,12 @@ public class SslConnectorCustomizer {
 			Map<String, SslBundle> serverNameSslBundles) {
 		protocol.setSSLEnabled(true);
 		if (sslBundle != null) {
-			addSslHostConfig(protocol, protocol.getDefaultSSLHostConfigName(), sslBundle);
+			configureSslHostConfig(protocol, protocol.getDefaultSSLHostConfigName(), sslBundle);
 		}
-		serverNameSslBundles.forEach((serverName, bundle) -> addSslHostConfig(protocol, serverName, bundle));
+		serverNameSslBundles.forEach((serverName, bundle) -> configureSslHostConfig(protocol, serverName, bundle));
 	}
 
-	private void addSslHostConfig(AbstractHttp11Protocol<?> protocol, String hostName, SslBundle sslBundle) {
+	private void configureSslHostConfig(AbstractHttp11Protocol<?> protocol, String hostName, SslBundle sslBundle) {
 		SSLHostConfig sslHostConfig = findSslHostConfig(protocol, hostName);
 		if (sslHostConfig == null) {
 			sslHostConfig = new SSLHostConfig();

--- a/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/SslConnectorCustomizer.java
+++ b/module/spring-boot-tomcat/src/main/java/org/springframework/boot/tomcat/SslConnectorCustomizer.java
@@ -68,13 +68,7 @@ public class SslConnectorCustomizer {
 		AbstractHttp11Protocol<?> protocol = (AbstractHttp11Protocol<?>) this.connector.getProtocolHandler();
 		String hostName = (serverName != null) ? serverName : protocol.getDefaultSSLHostConfigName();
 		this.logger.debug("SSL Bundle for host " + hostName + " has been updated, reloading SSL configuration");
-		SSLHostConfig sslHostConfig = findSslHostConfig(protocol, hostName);
-		if (sslHostConfig == null) {
-			addSslHostConfig(protocol, hostName, updatedSslBundle);
-			return;
-		}
-		applySslBundle(protocol, sslHostConfig, updatedSslBundle);
-		protocol.addSslHostConfig(sslHostConfig, true);
+		addSslHostConfig(protocol, hostName, updatedSslBundle);
 	}
 
 	public void customize(SslBundle sslBundle, Map<String, SslBundle> serverNameSslBundles) {
@@ -102,9 +96,12 @@ public class SslConnectorCustomizer {
 	}
 
 	private void addSslHostConfig(AbstractHttp11Protocol<?> protocol, String hostName, SslBundle sslBundle) {
-		SSLHostConfig sslHostConfig = new SSLHostConfig();
-		sslHostConfig.setHostName(hostName);
-		configureSslClientAuth(sslHostConfig);
+		SSLHostConfig sslHostConfig = findSslHostConfig(protocol, hostName);
+		if (sslHostConfig == null) {
+			sslHostConfig = new SSLHostConfig();
+			sslHostConfig.setHostName(hostName);
+			configureSslClientAuth(sslHostConfig);
+		}
 		applySslBundle(protocol, sslHostConfig, sslBundle);
 		protocol.addSslHostConfig(sslHostConfig, true);
 	}

--- a/module/spring-boot-tomcat/src/test/java/org/springframework/boot/tomcat/SslConnectorCustomizerTests.java
+++ b/module/spring-boot-tomcat/src/test/java/org/springframework/boot/tomcat/SslConnectorCustomizerTests.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.coyote.http11.AbstractHttp11Protocol;
 import org.apache.tomcat.util.net.SSLHostConfig;
+import org.apache.tomcat.util.net.SSLHostConfig.CertificateVerification;
 import org.apache.tomcat.util.net.openssl.ciphers.Cipher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -160,6 +161,26 @@ class SslConnectorCustomizerTests {
 
 	@Test
 	@WithPackageResources("test.jks")
+	void customizeRetainsCustomizationsAppliedToExistingSslHostConfig() {
+		Ssl ssl = new Ssl();
+		ssl.setKeyPassword("password");
+		ssl.setKeyStore("classpath:test.jks");
+		Connector connector = this.tomcat.getConnector();
+		AbstractHttp11Protocol<?> protocol = (AbstractHttp11Protocol<?>) connector.getProtocolHandler();
+		SSLHostConfig existing = new SSLHostConfig();
+		existing.setHostName(protocol.getDefaultSSLHostConfigName());
+		existing.setTruststoreProvider(MockPkcs11SecurityProvider.NAME);
+		protocol.addSslHostConfig(existing);
+		SslConnectorCustomizer customizer = new SslConnectorCustomizer(this.logger, connector, ssl.getClientAuth());
+		customizer.customize(WebServerSslBundle.get(ssl), Collections.emptyMap());
+		assertThat(protocol.findSslHostConfigs()).hasSize(1);
+		SSLHostConfig sslHostConfig = protocol.findSslHostConfigs()[0];
+		assertThat(sslHostConfig.getTruststoreProvider()).isEqualTo(MockPkcs11SecurityProvider.NAME);
+		assertThat(sslHostConfig.getCertificates()).hasSize(1);
+	}
+
+	@Test
+	@WithPackageResources("test.jks")
 	void updateRetainsCustomizationsAppliedToSslHostConfig() {
 		Ssl ssl = new Ssl();
 		ssl.setKeyPassword("password");
@@ -175,6 +196,23 @@ class SslConnectorCustomizerTests {
 		SSLHostConfig updated = protocol.findSslHostConfigs()[0];
 		assertThat(updated.getTruststoreProvider()).isEqualTo(MockPkcs11SecurityProvider.NAME);
 		assertThat(updated.getCertificates()).hasSize(1);
+	}
+
+	@Test
+	@WithPackageResources("test.jks")
+	void updateRetainsClientAuthConfiguredOnSslHostConfig() {
+		Ssl ssl = new Ssl();
+		ssl.setKeyPassword("password");
+		ssl.setKeyStore("classpath:test.jks");
+		Connector connector = this.tomcat.getConnector();
+		AbstractHttp11Protocol<?> protocol = (AbstractHttp11Protocol<?>) connector.getProtocolHandler();
+		SslConnectorCustomizer customizer = new SslConnectorCustomizer(this.logger, connector, ssl.getClientAuth());
+		customizer.customize(WebServerSslBundle.get(ssl), Collections.emptyMap());
+		SSLHostConfig sslHostConfig = protocol.findSslHostConfigs()[0];
+		sslHostConfig.setCertificateVerification("required");
+		customizer.update(null, WebServerSslBundle.get(ssl));
+		SSLHostConfig updated = protocol.findSslHostConfigs()[0];
+		assertThat(updated.getCertificateVerification()).isEqualTo(CertificateVerification.REQUIRED);
 	}
 
 	@Test


### PR DESCRIPTION
This is a follow-up to #51290, which retained `SSLHostConfig` customizations when reloading an SSL bundle. These changes align the initialization and reload code paths by moving all find-or-reuse logic into `addSslHostConfig` so that neither path discards configuration that already exists in the connector. 