### PR TITLE
Treat empty HTTP client SSL bundle as unset

### DIFF
--- a/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/autoconfigure/HttpClientSettingsPropertyMapper.java
+++ b/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/autoconfigure/HttpClientSettingsPropertyMapper.java
@@ -52,6 +52,7 @@ public class HttpClientSettingsPropertyMapper {
 			settings = map.from(properties::getCookieHandling).to(settings, HttpClientSettings::withCookieHandling);
 			settings = map.from(properties::getSsl)
 				.as(HttpClientSettingsProperties.Ssl::getBundle)
+				.whenHasText()
 				.as(this::getSslBundle)
 				.to(settings, HttpClientSettings::withSslBundle);
 		}

--- a/module/spring-boot-http-client/src/test/java/org/springframework/boot/http/client/autoconfigure/HttpClientSettingsPropertyMapperTests.java
+++ b/module/spring-boot-http-client/src/test/java/org/springframework/boot/http/client/autoconfigure/HttpClientSettingsPropertyMapperTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.http.client.HttpClientSettings;
 import org.springframework.boot.http.client.HttpCookieHandling;
 import org.springframework.boot.http.client.HttpRedirects;
+import org.springframework.boot.ssl.DefaultSslBundleRegistry;
 import org.springframework.boot.ssl.SslBundle;
 import org.springframework.boot.ssl.SslBundles;
 
@@ -121,6 +122,16 @@ class HttpClientSettingsPropertyMapperTests {
 		properties.getSsl().setBundle("test-bundle");
 		assertThatIllegalStateException().isThrownBy(() -> mapper.map(properties))
 			.withMessage("No 'sslBundles' available");
+	}
+
+	@Test
+	void mapWhenSslBundleIsEmptyStringTreatsBundleAsUnset() {
+		SslBundles sslBundles = new DefaultSslBundleRegistry();
+		HttpClientSettingsPropertyMapper mapper = new HttpClientSettingsPropertyMapper(sslBundles, null);
+		TestHttpClientSettingsProperties properties = new TestHttpClientSettingsProperties();
+		properties.getSsl().setBundle("");
+		HttpClientSettings result = mapper.map(properties);
+		assertThat(result.sslBundle()).isNull();
 	}
 
 	static class TestHttpClientSettingsProperties extends HttpClientSettingsProperties {


### PR DESCRIPTION
### Broken behaviour

`HttpClientSettingsPropertyMapper.map` resolves the configured SSL bundle name into an `SslBundle` as soon as the value is non-null:

```java
settings = map.from(properties::getSsl)
    .as(HttpClientSettingsProperties.Ssl::getBundle)
    .as(this::getSslBundle)
    .to(settings, HttpClientSettings::withSslBundle);
```

`PropertyMapper.Source.as` only skips its adapter when the value is `null`:

```java
return (value != null && this.predicate.test(value)) ? adapter.adapt(value) : null;
```

An empty string is not null, so `getSslBundle("")` runs and `DefaultSslBundleRegistry.getRegistered` throws:

```
NoSuchSslBundleException: SSL bundle name '' cannot be found
```

This happens during auto-configuration, so the application context fails to start.

### Why it matters

Nobody writes `bundle: ""` by hand, but property sources produce empty values routinely:

* An environment variable such as `SPRING_HTTP_CLIENTS_SSL_BUNDLE`, rendered from an unset Helm or ConfigMap value, is defined as an empty string rather than being absent.
* A profile that clears a bundle inherited from a shared `application.yml` may write `bundle: ""` where `bundle:` (null) was intended. Both express the same intent to the person editing the file, but only one of them works.

The failure message does not name the property that caused it. The reported bundle name is `''`, so the natural place to look is the `spring.ssl.bundle.*` registration rather than the consumer property that is actually empty.

The same mapper backs `spring.http.clients.*`, its imperative and reactive variants, and the per-group settings used by RestClient and WebClient HTTP service groups.

### Fix

Filter the name with `whenHasText` so an empty or blank value is skipped exactly like an absent one:

```java
settings = map.from(properties::getSsl)
    .as(HttpClientSettingsProperties.Ssl::getBundle)
    .whenHasText()
    .as(this::getSslBundle)
    .to(settings, HttpClientSettings::withSslBundle);
```

This matches how neighbouring code already treats string properties:

* `PropertiesApiVersionInserter`, in the same package, uses `whenHasText` for `header` and `queryParameter`.
* `PropertiesRestClientHttpServiceGroupConfigurer` and `PropertiesWebClientHttpServiceGroupConfigurer`, both of which construct this mapper, use `whenHasText` for `baseUrl`.

Behaviour for every other input is unchanged. A name that is present but not registered still throws `NoSuchSslBundleException`, so a typo is still reported.

| Configured value | Before | After |
| --- | --- | --- |
| absent (`null`) | skipped | skipped |
| `prod-tls` (registered) | bundle applied | bundle applied |
| `nope` (not registered) | `NoSuchSslBundleException` | `NoSuchSslBundleException` |
| `""` or `"   "` | `NoSuchSslBundleException` | skipped |

### Test

`HttpClientSettingsPropertyMapperTests.mapWhenSslBundleIsEmptyStringTreatsBundleAsUnset` maps an empty bundle name against an empty `DefaultSslBundleRegistry` and asserts that the resulting `sslBundle()` is `null`. It fails before the change and passes after.

I ran the full test suites of the affected module and of the two modules that construct this mapper: `spring-boot-http-client` (525), `spring-boot-restclient` (122) and `spring-boot-webclient` (17), for 664 tests with no failures. `format`, `checkstyleMain` and `checkstyleTest` are clean.
