### PR TITLE
Improve Kafka listener test slice filtering

### DIFF
--- a/core/spring-boot-test-autoconfigure/build.gradle
+++ b/core/spring-boot-test-autoconfigure/build.gradle
@@ -31,10 +31,12 @@ dependencies {
 	optional(project(":core:spring-boot-autoconfigure"))
 	optional("jakarta.json.bind:jakarta.json.bind-api")
 	optional("org.junit.jupiter:junit-jupiter-api")
+	optional("org.springframework.kafka:spring-kafka")
 
 	testImplementation(project(":test-support:spring-boot-test-support"))
 	testImplementation("ch.qos.logback:logback-classic")
 	testImplementation("org.junit.platform:junit-platform-launcher")
+	testImplementation("org.springframework.kafka:spring-kafka-test")
 
 	testRuntimeOnly("org.aspectj:aspectjrt")
 	testRuntimeOnly("org.aspectj:aspectjweaver")

--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/kafka/AutoConfigureKafkaListener.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/kafka/AutoConfigureKafkaListener.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.kafka;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ImportAutoConfiguration
+public @interface AutoConfigureKafkaListener {
+
+}

--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/kafka/KafkaListenerTest.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/kafka/KafkaListenerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.kafka;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTestContextBootstrapper;
+import org.springframework.boot.test.context.filter.annotation.TypeExcludeFilters;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@BootstrapWith(SpringBootTestContextBootstrapper.class)
+@ExtendWith(SpringExtension.class)
+@OverrideAutoConfiguration(enabled = false)
+@TypeExcludeFilters(KafkaListenerTypeExcludeFilter.class)
+@AutoConfigureKafkaListener
+@ImportAutoConfiguration
+public @interface KafkaListenerTest {
+
+	/**
+	 * Specifies the listener classes to test.
+	 * @return the listener classes to test
+	 */
+	@AliasFor("listeners")
+	Class<?>[] value() default {};
+
+	/**
+	 * Specifies the listener classes to test.
+	 * @return the listener classes to test
+	 */
+	@AliasFor("value")
+	Class<?>[] listeners() default {};
+
+	/**
+	 * Determines if default filtering should be used with
+	 * {@link KafkaListenerTest @KafkaListenerTest}.
+	 * @return if default filters should be used
+	 */
+	boolean useDefaultFilters() default true;
+
+	/**
+	 * A set of include filters which can be used to add otherwise excluded beans to the
+	 * application context.
+	 * @return include filters to apply
+	 */
+	Filter[] includeFilters() default {};
+
+	/**
+	 * A set of exclude filters which can be used to filter beans that would otherwise be
+	 * added to the application context.
+	 * @return exclude filters to apply
+	 */
+	Filter[] excludeFilters() default {};
+
+}

--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/kafka/KafkaListenerTypeExcludeFilter.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/kafka/KafkaListenerTypeExcludeFilter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.kafka;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.springframework.boot.test.context.filter.annotation.AnnotationCustomizableTypeExcludeFilter;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.core.annotation.MergedAnnotations;
+
+public class KafkaListenerTypeExcludeFilter extends AnnotationCustomizableTypeExcludeFilter {
+
+	private final KafkaListenerTest annotation;
+
+	KafkaListenerTypeExcludeFilter(Class<?> testClass) {
+		this.annotation = MergedAnnotations.from(testClass, MergedAnnotations.SearchStrategy.TYPE_HIERARCHY)
+			.get(KafkaListenerTest.class)
+			.synthesize();
+	}
+
+	@Override
+	protected boolean hasAnnotation() {
+		return true;
+	}
+
+	@Override
+	protected Filter[] getFilters(FilterType type) {
+		return switch (type) {
+			case INCLUDE -> this.annotation.includeFilters();
+			case EXCLUDE -> this.annotation.excludeFilters();
+		};
+	}
+
+	@Override
+	protected boolean isUseDefaultFilters() {
+		return this.annotation.useDefaultFilters();
+	}
+
+	@Override
+	protected Set<Class<?>> getDefaultIncludes() {
+		if (this.annotation.listeners().length == 0) {
+			return Collections.emptySet();
+		}
+		return new LinkedHashSet<>(Arrays.asList(this.annotation.listeners()));
+	}
+
+	@Override
+	protected Set<Class<?>> getComponentIncludes() {
+		return Collections.emptySet();
+	}
+
+}

--- a/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/kafka/package-info.java
+++ b/core/spring-boot-test-autoconfigure/src/main/java/org/springframework/boot/test/autoconfigure/kafka/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Kafka tests.
+ */
+@NullMarked
+package org.springframework.boot.test.autoconfigure.kafka;
+
+import org.jspecify.annotations.NullMarked;

--- a/core/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/kafka/KafkaListenerTestIntegrationTests.java
+++ b/core/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/kafka/KafkaListenerTestIntegrationTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.kafka;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@KafkaListenerTest(KafkaListenerTestIntegrationTests.ExampleListener.class)
+@Import(KafkaListenerTestIntegrationTests.ExampleListener.class)
+class KafkaListenerTestIntegrationTests {
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Test
+	void shouldIncludeConfiguredListener() {
+		assertThat(this.applicationContext.getBean(ExampleListener.class)).isNotNull();
+	}
+
+	@Test
+	void shouldExcludeUnconfiguredListener() {
+		assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+			.isThrownBy(() -> this.applicationContext.getBean(AnotherListener.class));
+	}
+
+	@Test
+	void shouldExcludeStandardService() {
+		assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+			.isThrownBy(() -> this.applicationContext.getBean(ExampleService.class));
+	}
+
+	@Component
+	static class ExampleListener {
+
+		@KafkaListener(topics = "test-topic", groupId = "test-group")
+		void listen(String message) {
+			assertThat(message).isNotNull();
+		}
+
+	}
+
+	@Component
+	static class AnotherListener {
+
+		@KafkaListener(topics = "another-topic", groupId = "test-group")
+		void listen(String message) {
+			assertThat(message).isNotNull();
+		}
+
+	}
+
+	@Service
+	static class ExampleService {
+
+	}
+
+	@SpringBootApplication
+	static class TestApplication {
+
+	}
+
+}

--- a/core/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/kafka/KafkaListenerTypeExcludeFilterTests.java
+++ b/core/spring-boot-test-autoconfigure/src/test/java/org/springframework/boot/test/autoconfigure/kafka/KafkaListenerTypeExcludeFilterTests.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.test.autoconfigure.kafka;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.core.type.classreading.MetadataReader;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+import org.springframework.core.type.classreading.SimpleMetadataReaderFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link KafkaListenerTypeExcludeFilter}.
+ */
+class KafkaListenerTypeExcludeFilterTests {
+
+	private final MetadataReaderFactory metadataReaderFactory = new SimpleMetadataReaderFactory();
+
+	@Test
+	void matchWhenHasNoListenersIncludesNothing() throws Exception {
+		KafkaListenerTypeExcludeFilter filter = new KafkaListenerTypeExcludeFilter(NoListenersTest.class);
+		assertThat(excludes(filter, ExampleListener.class)).isTrue();
+		assertThat(excludes(filter, ExampleComponent.class)).isTrue();
+	}
+
+	@Test
+	void matchWhenHasListenersIncludesOnlySpecifiedListeners() throws Exception {
+		KafkaListenerTypeExcludeFilter filter = new KafkaListenerTypeExcludeFilter(WithListenersTest.class);
+		assertThat(excludes(filter, ExampleListener.class)).isFalse();
+		assertThat(excludes(filter, AnotherListener.class)).isTrue();
+		assertThat(excludes(filter, ExampleComponent.class)).isTrue();
+	}
+
+	@Test
+	void matchWhenHasMultipleListenersIncludesAllSpecified() throws Exception {
+		KafkaListenerTypeExcludeFilter filter = new KafkaListenerTypeExcludeFilter(WithMultipleListenersTest.class);
+		assertThat(excludes(filter, ExampleListener.class)).isFalse(); // Included!
+		assertThat(excludes(filter, AnotherListener.class)).isFalse(); // Included!
+		assertThat(excludes(filter, ExampleComponent.class)).isTrue(); // Excluded!
+	}
+
+	@Test
+	void matchWhenHasValueAliasIncludesSpecifiedListeners() throws Exception {
+		KafkaListenerTypeExcludeFilter filter = new KafkaListenerTypeExcludeFilter(WithValueTest.class);
+		assertThat(excludes(filter, ExampleListener.class)).isFalse();
+		assertThat(excludes(filter, AnotherListener.class)).isTrue();
+	}
+
+	@Test
+	void matchWhenHasIncludeFilter() throws Exception {
+		KafkaListenerTypeExcludeFilter filter = new KafkaListenerTypeExcludeFilter(WithIncludeFilterTest.class);
+		assertThat(excludes(filter, ExampleListener.class)).isFalse();
+		assertThat(excludes(filter, ExampleService.class)).isFalse();
+		assertThat(excludes(filter, ExampleComponent.class)).isTrue();
+	}
+
+	@Test
+	void matchWhenHasExcludeFilter() throws Exception {
+		KafkaListenerTypeExcludeFilter filter = new KafkaListenerTypeExcludeFilter(WithExcludeFilterTest.class);
+		assertThat(excludes(filter, ExampleListener.class)).isFalse();
+		assertThat(excludes(filter, OverrideListener.class)).isTrue();
+	}
+
+	@Test
+	void matchWhenUseDefaultFiltersIsFalse() throws Exception {
+		KafkaListenerTypeExcludeFilter filter = new KafkaListenerTypeExcludeFilter(WithoutDefaultFiltersTest.class);
+		assertThat(excludes(filter, ExampleListener.class)).isTrue();
+	}
+
+	private boolean excludes(KafkaListenerTypeExcludeFilter filter, Class<?> type) throws IOException {
+		MetadataReader metadataReader = this.metadataReaderFactory.getMetadataReader(type.getName());
+		return filter.match(metadataReader, this.metadataReaderFactory);
+	}
+
+	@KafkaListenerTest
+	static class NoListenersTest {
+
+	}
+
+	@KafkaListenerTest(listeners = ExampleListener.class)
+	static class WithListenersTest {
+
+	}
+
+	@KafkaListenerTest(listeners = { ExampleListener.class, AnotherListener.class })
+	static class WithMultipleListenersTest {
+
+	}
+
+	@KafkaListenerTest(ExampleListener.class)
+	static class WithValueTest {
+
+	}
+
+	@KafkaListenerTest(listeners = ExampleListener.class,
+			includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = ExampleService.class))
+	static class WithIncludeFilterTest {
+
+	}
+
+	@KafkaListenerTest(listeners = { ExampleListener.class, OverrideListener.class },
+			excludeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = OverrideListener.class))
+	static class WithExcludeFilterTest {
+
+	}
+
+	@KafkaListenerTest(listeners = ExampleListener.class, useDefaultFilters = false)
+	static class WithoutDefaultFiltersTest {
+
+	}
+
+	static class ExampleListener {
+
+	}
+
+	static class AnotherListener {
+
+	}
+
+	static class OverrideListener {
+
+	}
+
+	@Service
+	static class ExampleService {
+
+	}
+
+	@Component
+	static class ExampleComponent {
+
+	}
+
+}

--- a/module/spring-boot-kafka/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.kafka.AutoConfigureKafkaListener.imports
+++ b/module/spring-boot-kafka/src/main/resources/META-INF/spring/org.springframework.boot.test.autoconfigure.kafka.AutoConfigureKafkaListener.imports
@@ -1,0 +1,1 @@
+org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration


### PR DESCRIPTION
Fixes #45706 

Update Kafka listener test slice filtering to support explicitly configured listeners, multiple listeners, include/exclude filters, and `useDefaultFilters`, with integration coverage verifying configured listeners are included while unrelated components are excluded.
