### PR TITLE
Add HttpComponents connection pool metrics

### DIFF
--- a/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/HttpComponentsClientHttpRequestFactoryBuilder.java
+++ b/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/HttpComponentsClientHttpRequestFactoryBuilder.java
@@ -26,6 +26,7 @@ import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
 import org.apache.hc.core5.http.io.SocketConfig;
@@ -181,6 +182,21 @@ public final class HttpComponentsClientHttpRequestFactoryBuilder
 	public HttpComponentsClientHttpRequestFactoryBuilder with(
 			UnaryOperator<HttpComponentsClientHttpRequestFactoryBuilder> customizer) {
 		return customizer.apply(this);
+	}
+
+	/**
+	 * Return a new {@link HttpComponentsClientHttpRequestFactoryBuilder} that applies
+	 * additional post-processing to the constructed
+	 * {@link PoolingHttpClientConnectionManager}.
+	 * @param connectionManagerPostConfigurer the post-configurer to apply
+	 * @return a new {@link HttpComponentsClientHttpRequestFactoryBuilder} instance
+	 * @since 3.5.0
+	 */
+	public HttpComponentsClientHttpRequestFactoryBuilder withConnectionManagerPostConfigurer(
+			Consumer<PoolingHttpClientConnectionManager> connectionManagerPostConfigurer) {
+		Assert.notNull(connectionManagerPostConfigurer, "'connectionManagerPostConfigurer' must not be null");
+		return new HttpComponentsClientHttpRequestFactoryBuilder(getCustomizers(),
+				this.httpClientBuilder.withConnectionManagerPostConfigurer(connectionManagerPostConfigurer));
 	}
 
 	@Override

--- a/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/HttpComponentsHttpClientBuilder.java
+++ b/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/HttpComponentsHttpClientBuilder.java
@@ -54,6 +54,8 @@ public final class HttpComponentsHttpClientBuilder {
 
 	private final Consumer<PoolingHttpClientConnectionManagerBuilder> connectionManagerCustomizer;
 
+	private final Consumer<PoolingHttpClientConnectionManager> connectionManagerPostConfigurer;
+
 	private final Consumer<SocketConfig.Builder> socketConfigCustomizer;
 
 	private final Consumer<ConnectionConfig.Builder> connectionConfigCustomizer;
@@ -65,18 +67,20 @@ public final class HttpComponentsHttpClientBuilder {
 	private final DnsResolver dnsResolver;
 
 	public HttpComponentsHttpClientBuilder() {
-		this(Empty.consumer(), Empty.consumer(), Empty.consumer(), Empty.consumer(), Empty.consumer(),
+		this(Empty.consumer(), Empty.consumer(), Empty.consumer(), Empty.consumer(), Empty.consumer(), Empty.consumer(),
 				HttpComponentsSslBundleTlsStrategy::get, SystemDefaultDnsResolver.INSTANCE);
 	}
 
 	private HttpComponentsHttpClientBuilder(Consumer<HttpClientBuilder> customizer,
 			Consumer<PoolingHttpClientConnectionManagerBuilder> connectionManagerCustomizer,
+			Consumer<PoolingHttpClientConnectionManager> connectionManagerPostConfigurer,
 			Consumer<SocketConfig.Builder> socketConfigCustomizer,
 			Consumer<ConnectionConfig.Builder> connectionConfigCustomizer,
 			Consumer<RequestConfig.Builder> defaultRequestConfigCustomizer,
 			TlsSocketStrategyFactory tlsSocketStrategyFactory, DnsResolver dnsResolver) {
 		this.customizer = customizer;
 		this.connectionManagerCustomizer = connectionManagerCustomizer;
+		this.connectionManagerPostConfigurer = connectionManagerPostConfigurer;
 		this.socketConfigCustomizer = socketConfigCustomizer;
 		this.connectionConfigCustomizer = connectionConfigCustomizer;
 		this.defaultRequestConfigCustomizer = defaultRequestConfigCustomizer;
@@ -93,8 +97,9 @@ public final class HttpComponentsHttpClientBuilder {
 	public HttpComponentsHttpClientBuilder withCustomizer(Consumer<HttpClientBuilder> customizer) {
 		Assert.notNull(customizer, "'customizer' must not be null");
 		return new HttpComponentsHttpClientBuilder(this.customizer.andThen(customizer),
-				this.connectionManagerCustomizer, this.socketConfigCustomizer, this.connectionConfigCustomizer,
-				this.defaultRequestConfigCustomizer, this.tlsSocketStrategyFactory, this.dnsResolver);
+				this.connectionManagerCustomizer, this.connectionManagerPostConfigurer, this.socketConfigCustomizer,
+				this.connectionConfigCustomizer, this.defaultRequestConfigCustomizer, this.tlsSocketStrategyFactory,
+				this.dnsResolver);
 	}
 
 	/**
@@ -107,9 +112,9 @@ public final class HttpComponentsHttpClientBuilder {
 			Consumer<PoolingHttpClientConnectionManagerBuilder> connectionManagerCustomizer) {
 		Assert.notNull(connectionManagerCustomizer, "'connectionManagerCustomizer' must not be null");
 		return new HttpComponentsHttpClientBuilder(this.customizer,
-				this.connectionManagerCustomizer.andThen(connectionManagerCustomizer), this.socketConfigCustomizer,
-				this.connectionConfigCustomizer, this.defaultRequestConfigCustomizer, this.tlsSocketStrategyFactory,
-				this.dnsResolver);
+				this.connectionManagerCustomizer.andThen(connectionManagerCustomizer),
+				this.connectionManagerPostConfigurer, this.socketConfigCustomizer, this.connectionConfigCustomizer,
+				this.defaultRequestConfigCustomizer, this.tlsSocketStrategyFactory, this.dnsResolver);
 	}
 
 	/**
@@ -123,8 +128,9 @@ public final class HttpComponentsHttpClientBuilder {
 			Consumer<SocketConfig.Builder> socketConfigCustomizer) {
 		Assert.notNull(socketConfigCustomizer, "'socketConfigCustomizer' must not be null");
 		return new HttpComponentsHttpClientBuilder(this.customizer, this.connectionManagerCustomizer,
-				this.socketConfigCustomizer.andThen(socketConfigCustomizer), this.connectionConfigCustomizer,
-				this.defaultRequestConfigCustomizer, this.tlsSocketStrategyFactory, this.dnsResolver);
+				this.connectionManagerPostConfigurer, this.socketConfigCustomizer.andThen(socketConfigCustomizer),
+				this.connectionConfigCustomizer, this.defaultRequestConfigCustomizer, this.tlsSocketStrategyFactory,
+				this.dnsResolver);
 	}
 
 	/**
@@ -138,7 +144,8 @@ public final class HttpComponentsHttpClientBuilder {
 			Consumer<ConnectionConfig.Builder> connectionConfigCustomizer) {
 		Assert.notNull(connectionConfigCustomizer, "'connectionConfigCustomizer' must not be null");
 		return new HttpComponentsHttpClientBuilder(this.customizer, this.connectionManagerCustomizer,
-				this.socketConfigCustomizer, this.connectionConfigCustomizer.andThen(connectionConfigCustomizer),
+				this.connectionManagerPostConfigurer, this.socketConfigCustomizer,
+				this.connectionConfigCustomizer.andThen(connectionConfigCustomizer),
 				this.defaultRequestConfigCustomizer, this.tlsSocketStrategyFactory, this.dnsResolver);
 	}
 
@@ -155,8 +162,8 @@ public final class HttpComponentsHttpClientBuilder {
 			TlsSocketStrategyFactory tlsSocketStrategyFactory) {
 		Assert.notNull(tlsSocketStrategyFactory, "'tlsSocketStrategyFactory' must not be null");
 		return new HttpComponentsHttpClientBuilder(this.customizer, this.connectionManagerCustomizer,
-				this.socketConfigCustomizer, this.connectionConfigCustomizer, this.defaultRequestConfigCustomizer,
-				tlsSocketStrategyFactory, this.dnsResolver);
+				this.connectionManagerPostConfigurer, this.socketConfigCustomizer, this.connectionConfigCustomizer,
+				this.defaultRequestConfigCustomizer, tlsSocketStrategyFactory, this.dnsResolver);
 	}
 
 	/**
@@ -171,7 +178,7 @@ public final class HttpComponentsHttpClientBuilder {
 			Consumer<RequestConfig.Builder> defaultRequestConfigCustomizer) {
 		Assert.notNull(defaultRequestConfigCustomizer, "'defaultRequestConfigCustomizer' must not be null");
 		return new HttpComponentsHttpClientBuilder(this.customizer, this.connectionManagerCustomizer,
-				this.socketConfigCustomizer, this.connectionConfigCustomizer,
+				this.connectionManagerPostConfigurer, this.socketConfigCustomizer, this.connectionConfigCustomizer,
 				this.defaultRequestConfigCustomizer.andThen(defaultRequestConfigCustomizer),
 				this.tlsSocketStrategyFactory, this.dnsResolver);
 	}
@@ -186,8 +193,23 @@ public final class HttpComponentsHttpClientBuilder {
 	public HttpComponentsHttpClientBuilder withDnsResolver(DnsResolver dnsResolver) {
 		Assert.notNull(dnsResolver, "'dnsResolver' must not be null");
 		return new HttpComponentsHttpClientBuilder(this.customizer, this.connectionManagerCustomizer,
+				this.connectionManagerPostConfigurer, this.socketConfigCustomizer, this.connectionConfigCustomizer,
+				this.defaultRequestConfigCustomizer, this.tlsSocketStrategyFactory, dnsResolver);
+	}
+
+	/**
+	 * Return a new {@link HttpComponentsHttpClientBuilder} that applies additional
+	 * post-processing to the underlying {@link PoolingHttpClientConnectionManager}.
+	 * @param connectionManagerPostConfigurer the customizer to apply
+	 * @return a new {@link HttpComponentsHttpClientBuilder} instance
+	 */
+	public HttpComponentsHttpClientBuilder withConnectionManagerPostConfigurer(
+			Consumer<PoolingHttpClientConnectionManager> connectionManagerPostConfigurer) {
+		Assert.notNull(connectionManagerPostConfigurer, "'connectionManagerPostConfigurer' must not be null");
+		return new HttpComponentsHttpClientBuilder(this.customizer, this.connectionManagerCustomizer,
+				this.connectionManagerPostConfigurer.andThen(connectionManagerPostConfigurer),
 				this.socketConfigCustomizer, this.connectionConfigCustomizer, this.defaultRequestConfigCustomizer,
-				this.tlsSocketStrategyFactory, dnsResolver);
+				this.tlsSocketStrategyFactory, this.dnsResolver);
 	}
 
 	/**
@@ -222,7 +244,9 @@ public final class HttpComponentsHttpClientBuilder {
 		}
 		builder.setDnsResolver(dnsResolver);
 		this.connectionManagerCustomizer.accept(builder);
-		return builder.build();
+		PoolingHttpClientConnectionManager connectionManager = builder.build();
+		this.connectionManagerPostConfigurer.accept(connectionManager);
+		return connectionManager;
 	}
 
 	private SocketConfig createSocketConfig() {

--- a/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/autoconfigure/metrics/HttpClientMetricsAutoConfiguration.java
+++ b/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/autoconfigure/metrics/HttpClientMetricsAutoConfiguration.java
@@ -17,17 +17,22 @@
 package org.springframework.boot.http.client.autoconfigure.metrics;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.httpcomponents.hc5.PoolingHttpClientConnectionManagerMetricsBinder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.http.client.HttpComponentsClientHttpRequestFactoryBuilder;
+import org.springframework.boot.http.client.autoconfigure.ClientHttpRequestFactoryBuilderCustomizer;
 import org.springframework.boot.micrometer.metrics.MaximumAllowableTagsMeterFilter;
 import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsProperties;
 import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsProperties.Web.Client;
 import org.springframework.boot.micrometer.observation.autoconfigure.ObservationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 
 /**
@@ -56,6 +61,22 @@ public final class HttpClientMetricsAutoConfiguration {
 		String meterNamePrefix = observationProperties.getHttp().getClient().getRequests().getName();
 		int maxUriTags = clientProperties.getMaxUriTags();
 		return new MaximumAllowableTagsMeterFilter(meterNamePrefix, "uri", maxUriTags, "Are you using 'uriVariables'?");
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(PoolingHttpClientConnectionManager.class)
+	static class HttpComponentsPoolMetricsConfiguration {
+
+		@Bean
+		@SuppressWarnings("deprecation")
+		ClientHttpRequestFactoryBuilderCustomizer<HttpComponentsClientHttpRequestFactoryBuilder> httpComponentsPoolMetricsCustomizer(
+				MeterRegistry meterRegistry) {
+			return (builder) -> builder.withConnectionManagerPostConfigurer(
+					(connectionManager) -> new PoolingHttpClientConnectionManagerMetricsBinder(connectionManager,
+							"httpcomponents.httpclient.pool")
+						.bindTo(meterRegistry));
+		}
+
 	}
 
 }

--- a/module/spring-boot-http-client/src/test/java/org/springframework/boot/http/client/HttpComponentsClientHttpRequestFactoryBuilderTests.java
+++ b/module/spring-boot-http-client/src/test/java/org/springframework/boot/http/client/HttpComponentsClientHttpRequestFactoryBuilderTests.java
@@ -26,6 +26,7 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.StandardCookieSpec;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.core5.function.Resolver;
 import org.apache.hc.core5.http.io.SocketConfig;
@@ -62,22 +63,27 @@ class HttpComponentsClientHttpRequestFactoryBuilderTests
 		TestCustomizer<HttpClientBuilder> httpClientCustomizer1 = new TestCustomizer<>();
 		TestCustomizer<HttpClientBuilder> httpClientCustomizer2 = new TestCustomizer<>();
 		TestCustomizer<PoolingHttpClientConnectionManagerBuilder> connectionManagerCustomizer = new TestCustomizer<>();
+		TestCustomizer<PoolingHttpClientConnectionManager> connectionManagerPostConfigurer = new TestCustomizer<>(); // ADDED
 		TestCustomizer<SocketConfig.Builder> socketConfigCustomizer = new TestCustomizer<>();
 		TestCustomizer<SocketConfig.Builder> socketConfigCustomizer1 = new TestCustomizer<>();
 		TestCustomizer<RequestConfig.Builder> defaultRequestConfigCustomizer = new TestCustomizer<>();
 		TestCustomizer<RequestConfig.Builder> defaultRequestConfigCustomizer1 = new TestCustomizer<>();
+
 		ClientHttpRequestFactoryBuilder.httpComponents()
 			.withHttpClientCustomizer(httpClientCustomizer1)
 			.withHttpClientCustomizer(httpClientCustomizer2)
 			.withConnectionManagerCustomizer(connectionManagerCustomizer)
+			.withConnectionManagerPostConfigurer(connectionManagerPostConfigurer)
 			.withSocketConfigCustomizer(socketConfigCustomizer)
 			.withSocketConfigCustomizer(socketConfigCustomizer1)
 			.withDefaultRequestConfigCustomizer(defaultRequestConfigCustomizer)
 			.withDefaultRequestConfigCustomizer(defaultRequestConfigCustomizer1)
 			.build();
+
 		httpClientCustomizer1.assertCalled();
 		httpClientCustomizer2.assertCalled();
 		connectionManagerCustomizer.assertCalled();
+		connectionManagerPostConfigurer.assertCalled();
 		socketConfigCustomizer.assertCalled();
 		socketConfigCustomizer1.assertCalled();
 		defaultRequestConfigCustomizer.assertCalled();

--- a/module/spring-boot-http-client/src/test/java/org/springframework/boot/http/client/autoconfigure/metrics/HttpClientMetricsAutoConfigurationTests.java
+++ b/module/spring-boot-http-client/src/test/java/org/springframework/boot/http/client/autoconfigure/metrics/HttpClientMetricsAutoConfigurationTests.java
@@ -24,10 +24,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
+import org.springframework.boot.http.client.HttpComponentsClientHttpRequestFactoryBuilder;
+import org.springframework.boot.http.client.autoconfigure.ClientHttpRequestFactoryBuilderCustomizer;
 import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -54,6 +58,32 @@ class HttpClientMetricsAutoConfigurationTests {
 				assertThat(meterRegistry.find("http.client.requests").timers()).hasSize(2);
 				assertThat(output).contains("Reached the maximum number of 'uri' tags for 'http.client.requests'.")
 					.contains("Are you using 'uriVariables'?");
+			});
+	}
+
+	@Test
+	void httpComponentsPoolMetricsAreAutoConfigured() {
+		new ApplicationContextRunner()
+			.withConfiguration(
+					AutoConfigurations.of(HttpClientMetricsAutoConfiguration.class, MetricsAutoConfiguration.class))
+			.withBean(SimpleMeterRegistry.class)
+			.run((context) -> {
+				assertThat(context).hasSingleBean(ClientHttpRequestFactoryBuilderCustomizer.class);
+
+				@SuppressWarnings("unchecked")
+				ClientHttpRequestFactoryBuilderCustomizer<HttpComponentsClientHttpRequestFactoryBuilder> customizer = context
+					.getBean(ClientHttpRequestFactoryBuilderCustomizer.class);
+
+				HttpComponentsClientHttpRequestFactoryBuilder builder = ClientHttpRequestFactoryBuilder
+					.httpComponents();
+				builder = customizer.customize(builder);
+				HttpComponentsClientHttpRequestFactory factory = builder.build();
+
+				MeterRegistry meterRegistry = context.getBean(MeterRegistry.class);
+				assertThat(meterRegistry.find("httpcomponents.httpclient.pool.total.connections").gauge()).isNotNull();
+				assertThat(meterRegistry.find("httpcomponents.httpclient.pool.route.max.default").gauge()).isNotNull();
+
+				factory.destroy();
 			});
 	}
 


### PR DESCRIPTION
Fixes #44643 

Add support for configuring HttpComponents connection manager post-configurers and auto-configure Micrometer pool metrics for HttpComponents HTTP clients, with tests covering the new customization API and automatic pool metric registration.