### PR TITLE
Resolve merge conflict left in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,15 +13,9 @@ graalVersion=25
 hamcrestVersion=3.0
 jackson2Version=2.21.5
 jacksonVersion=3.1.5
-<<<<<<< HEAD
-javaFormatVersion=0.0.47
+javaFormatVersion=0.0.48
 junitJupiterVersion=6.1.3
 kotlinVersion=2.4.10
-=======
-javaFormatVersion=0.0.48
-junitJupiterVersion=6.0.3
-kotlinVersion=2.3.21
->>>>>>> 4.1.x
 mavenVersion=3.9.13
 mockitoVersion=5.23.0
 nativeBuildToolsVersion=1.1.8


### PR DESCRIPTION
`gradle.properties` on `main` still contains the conflict markers from ef4f1404 (`Merge branch '4.1.x'`, closes gh-51455):

```
<<<<<<< HEAD
javaFormatVersion=0.0.47
junitJupiterVersion=6.1.3
kotlinVersion=2.4.10
=======
javaFormatVersion=0.0.48
junitJupiterVersion=6.0.3
kotlinVersion=2.3.21
>>>>>>> 4.1.x
```

This is not a dependency upgrade. The only version change that merge was bringing forward was spring-javaformat 0.0.48 (gh-51452 on 4.0.9, forward-ported as gh-51455). `junitJupiterVersion` and `kotlinVersion` were not meant to change on `main`; they were only pulled into the conflict because the three lines sit next to each other.

The build does not fail on this, which is why it has gone unnoticed. `Properties` reads `<<<<<<< HEAD` as a key of `<<<<<<<`, `=======` as an empty key and `>>>>>>> 4.1.x` as a key of `>>>>>>>`. Each of the three real keys is then defined twice and the later one wins.

`./gradlew properties` on `main` as it is today:

```
javaFormatVersion: 0.0.48
junitJupiterVersion: 6.0.3
kotlinVersion: 2.3.21
```

and with this change:

```
javaFormatVersion: 0.0.48
junitJupiterVersion: 6.1.3
kotlinVersion: 2.4.10
```

So since 25 August `main` has been building against JUnit 6.0.3 and Kotlin 2.3.21 rather than the 6.1.3 and 2.4.10 it had before the merge.

This removes the markers so the file says what both sides intended: `main` keeps its own JUnit and Kotlin, and the spring-javaformat bump from 4.1.x is kept. Happy to resolve it another way if you would prefer.

`./gradlew help` configures successfully with the change. I have not run a full `./gradlew check`.
