### PR TITLE
Override Redis SSL property with ServiceConnection details

### DIFF
--- a/module/spring-boot-data-redis/src/dockerTest/java/org/springframework/boot/data/redis/testcontainers/RedisContainerConnectionDetailsFactoryTests.java
+++ b/module/spring-boot-data-redis/src/dockerTest/java/org/springframework/boot/data/redis/testcontainers/RedisContainerConnectionDetailsFactoryTests.java
@@ -17,6 +17,7 @@
 package org.springframework.boot.data.redis.testcontainers;
 
 import com.redis.testcontainers.RedisContainer;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -30,6 +31,7 @@ import org.springframework.boot.testsupport.container.TestImage;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,6 +66,26 @@ class RedisContainerConnectionDetailsFactoryTests {
 	@Configuration(proxyBeanMethods = false)
 	@ImportAutoConfiguration(DataRedisAutoConfiguration.class)
 	static class TestConfiguration {
+
+	}
+
+	@Nested
+	@TestPropertySource(properties = "spring.data.redis.ssl.enabled=true")
+	class WithSslEnabledProperty {
+
+		@Autowired
+		private DataRedisConnectionDetails connectionDetails;
+
+		@Autowired
+		private RedisConnectionFactory connectionFactory;
+
+		@Test
+		void connectionDetailsOverridesSslProperty() {
+			assertThat(this.connectionDetails.isSslEnabled()).isFalse();
+			try (RedisConnection connection = this.connectionFactory.getConnection()) {
+				assertThat(connection.commands().echo("Hello, World".getBytes())).isEqualTo("Hello, World".getBytes());
+			}
+		}
 
 	}
 

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/DataRedisConnectionConfiguration.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/DataRedisConnectionConfiguration.java
@@ -185,7 +185,7 @@ abstract class DataRedisConnectionConfiguration {
 	}
 
 	protected final boolean isSslEnabled() {
-		return getProperties().getSsl().isEnabled();
+		return this.connectionDetails.isSslEnabled();
 	}
 
 	protected final boolean urlUsesSsl(String url) {

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/DataRedisConnectionDetails.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/DataRedisConnectionDetails.java
@@ -58,6 +58,14 @@ public interface DataRedisConnectionDetails extends ConnectionDetails {
 	}
 
 	/**
+	 * Whether the connection should use SSL.
+	 * @return {@code true} if SSL should be used, {@code false} otherwise.
+	 */
+	default boolean isSslEnabled() {
+		return false;
+	}
+
+	/**
 	 * Redis standalone configuration. Mutually exclusive with {@link #getSentinel()},
 	 * {@link #getCluster()} and {@link #getMasterReplica()}.
 	 * @return the Redis standalone configuration

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/LettuceConnectionConfiguration.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/LettuceConnectionConfiguration.java
@@ -167,7 +167,7 @@ class LettuceConnectionConfiguration extends DataRedisConnectionConfiguration {
 	}
 
 	private void applyProperties(LettuceClientConfigurationBuilder builder, @Nullable SslBundle sslBundle) {
-		if (sslBundle != null) {
+		if (isSslEnabled() || sslBundle != null) {
 			builder.useSsl();
 		}
 		if (getProperties().getTimeout() != null) {

--- a/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/PropertiesDataRedisConnectionDetails.java
+++ b/module/spring-boot-data-redis/src/main/java/org/springframework/boot/data/redis/autoconfigure/PropertiesDataRedisConnectionDetails.java
@@ -73,6 +73,15 @@ class PropertiesDataRedisConnectionDetails implements DataRedisConnectionDetails
 	}
 
 	@Override
+	public boolean isSslEnabled() {
+		DataRedisUrl redisUrl = getRedisUrl();
+		if (redisUrl != null) {
+			return redisUrl.useSsl();
+		}
+		return this.properties.getSsl().isEnabled();
+	}
+
+	@Override
 	public Standalone getStandalone() {
 		DataRedisUrl redisUrl = getRedisUrl();
 		return (redisUrl != null)


### PR DESCRIPTION
Fixes #43977 

Fix Redis ServiceConnection SSL configuration. ServiceConnection-provided Redis connection details should take precedence over the spring.data.redis.ssl.enabled property. Add a regression test to verify that a Redis Testcontainer remains non-SSL even when SSL is enabled through application properties.