### PR TITLE
Avoid URL parsing for cached nested jar lookups

### DIFF
--- a/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/JarFileUrlKey.java
+++ b/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/JarFileUrlKey.java
@@ -23,8 +23,11 @@ import java.util.Objects;
  * A fast cache key for a jar file {@link URL} that doesn't trigger DNS lookups.
  *
  * @author Phillip Webb
+ * @author Greg Taube
  */
 final class JarFileUrlKey {
+
+	private static final String NESTED_PROTOCOL = "nested";
 
 	private final String protocol;
 
@@ -37,11 +40,21 @@ final class JarFileUrlKey {
 	private final boolean runtimeRef;
 
 	JarFileUrlKey(URL url) {
-		this.protocol = url.getProtocol();
-		this.host = url.getHost();
-		this.port = (url.getPort() != -1) ? url.getPort() : url.getDefaultPort();
-		this.file = url.getFile();
-		this.runtimeRef = "runtime".equals(url.getRef());
+		this(url.getProtocol(), url.getHost(), (url.getPort() != -1) ? url.getPort() : url.getDefaultPort(),
+				url.getFile(), "runtime".equals(url.getRef()));
+	}
+
+	private JarFileUrlKey(String protocol, String host, int port, String file, boolean runtimeRef) {
+		this.protocol = protocol;
+		this.host = host;
+		this.port = port;
+		this.file = file;
+		this.runtimeRef = runtimeRef;
+	}
+
+	static JarFileUrlKey ofNestedFile(String spec, int separator, boolean runtimeRef) {
+		return new JarFileUrlKey(NESTED_PROTOCOL, "", -1, spec.substring(NESTED_PROTOCOL.length() + 1, separator),
+				runtimeRef);
 	}
 
 	@Override

--- a/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/JarUrlConnection.java
+++ b/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/JarUrlConnection.java
@@ -45,6 +45,7 @@ import org.springframework.boot.loader.net.util.UrlDecoder;
  * @author Phillip Webb
  * @author Andy Wilkinson
  * @author Rostyslav Dudka
+ * @author Greg Taube
  */
 final class JarUrlConnection extends java.net.JarURLConnection {
 
@@ -337,13 +338,8 @@ final class JarUrlConnection extends java.net.JarURLConnection {
 			int separator = spec.indexOf("!/");
 			boolean specHasEntry = (separator != -1) && (separator + 2 != spec.length());
 			if (specHasEntry) {
-				URL jarFileUrl = new URL(spec.substring(0, separator));
-				if ("runtime".equals(url.getRef())) {
-					jarFileUrl = new URL(jarFileUrl, "#runtime");
-				}
 				String entryName = UrlDecoder.decode(spec.substring(separator + 2));
-				JarFile jarFile = jarFiles.getOrCreate(true, jarFileUrl);
-				jarFiles.cacheIfAbsent(true, jarFileUrl, jarFile);
+				JarFile jarFile = jarFiles.getOrCreateNested(spec, separator, "runtime".equals(url.getRef()));
 				if (!hasEntry(jarFile, entryName)) {
 					return notFoundConnection(jarFile.getName(), entryName);
 				}

--- a/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/UrlJarFiles.java
+++ b/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/net/protocol/jar/UrlJarFiles.java
@@ -31,6 +31,7 @@ import java.util.jar.JarFile;
  * instances.
  *
  * @author Phillip Webb
+ * @author Greg Taube
  */
 class UrlJarFiles {
 
@@ -70,6 +71,30 @@ class UrlJarFiles {
 			}
 		}
 		return this.factory.createJarFile(jarFileUrl, this::onClose);
+	}
+
+	/**
+	 * Get an existing nested {@link JarFile} instance from the cache, or create and cache
+	 * a new one.
+	 * @param spec the complete jar URL file
+	 * @param separator the separator between the nested jar file and entry
+	 * @param runtimeRef if the jar file URL has a runtime reference
+	 * @return a new or existing {@link JarFile} instance
+	 * @throws IOException on I/O error
+	 */
+	JarFile getOrCreateNested(String spec, int separator, boolean runtimeRef) throws IOException {
+		JarFileUrlKey urlKey = JarFileUrlKey.ofNestedFile(spec, separator, runtimeRef);
+		JarFile cached = this.cache.get(urlKey);
+		if (cached != null) {
+			return cached;
+		}
+		URL jarFileUrl = new URL(spec.substring(0, separator));
+		if (runtimeRef) {
+			jarFileUrl = new URL(jarFileUrl, "#runtime");
+		}
+		JarFile jarFile = this.factory.createJarFile(jarFileUrl, this::onClose);
+		this.cache.putIfAbsent(urlKey, jarFileUrl, jarFile);
+		return jarFile;
 	}
 
 	/**
@@ -155,6 +180,10 @@ class UrlJarFiles {
 		 */
 		JarFile get(URL jarFileUrl) {
 			JarFileUrlKey urlKey = new JarFileUrlKey(jarFileUrl);
+			return get(urlKey);
+		}
+
+		private JarFile get(JarFileUrlKey urlKey) {
 			synchronized (this) {
 				return this.jarFileUrlToJarFile.get(urlKey);
 			}
@@ -181,6 +210,10 @@ class UrlJarFiles {
 		 */
 		boolean putIfAbsent(URL jarFileUrl, JarFile jarFile) {
 			JarFileUrlKey urlKey = new JarFileUrlKey(jarFileUrl);
+			return putIfAbsent(urlKey, jarFileUrl, jarFile);
+		}
+
+		private boolean putIfAbsent(JarFileUrlKey urlKey, URL jarFileUrl, JarFile jarFile) {
 			synchronized (this) {
 				JarFile cached = this.jarFileUrlToJarFile.get(urlKey);
 				if (cached == null) {

--- a/loader/spring-boot-loader/src/test/java/org/springframework/boot/loader/net/protocol/jar/JarFileUrlKeyTests.java
+++ b/loader/spring-boot-loader/src/test/java/org/springframework/boot/loader/net/protocol/jar/JarFileUrlKeyTests.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link JarFileUrlKey}.
  *
  * @author Phillip Webb
+ * @author Greg Taube
  */
 class JarFileUrlKeyTests {
 
@@ -88,6 +89,24 @@ class JarFileUrlKeyTests {
 		JarFileUrlKey k1 = key("jar:nested:/my.jar/!mynested.jar!/my/path#runtime");
 		JarFileUrlKey k2 = key("jar:nested:/my.jar/!mynested.jar!/my/path#runtime");
 		assertThat(k1).isEqualTo(k2);
+	}
+
+	@Test
+	void nestedFileKeyIsEqualToUrlKey() throws Exception {
+		String spec = "nested:/my.jar/!mynested.jar!/my/path";
+		int separator = spec.indexOf("!/");
+		JarFileUrlKey k1 = JarFileUrlKey.ofNestedFile(spec, separator, false);
+		JarFileUrlKey k2 = new JarFileUrlKey(new URL(spec.substring(0, separator)));
+		assertThat(k1).isEqualTo(k2).hasSameHashCodeAs(k2);
+	}
+
+	@Test
+	void nestedFileKeyWithRuntimeRefIsEqualToUrlKey() throws Exception {
+		String spec = "nested:/my.jar/!mynested.jar!/my/path";
+		int separator = spec.indexOf("!/");
+		JarFileUrlKey k1 = JarFileUrlKey.ofNestedFile(spec, separator, true);
+		JarFileUrlKey k2 = new JarFileUrlKey(new URL(spec.substring(0, separator) + "#runtime"));
+		assertThat(k1).isEqualTo(k2).hasSameHashCodeAs(k2);
 	}
 
 	@Test

--- a/loader/spring-boot-loader/src/test/java/org/springframework/boot/loader/net/protocol/jar/UrlJarFilesTests.java
+++ b/loader/spring-boot-loader/src/test/java/org/springframework/boot/loader/net/protocol/jar/UrlJarFilesTests.java
@@ -19,6 +19,13 @@ package org.springframework.boot.loader.net.protocol.jar;
 import java.io.File;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.jar.JarFile;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -36,11 +43,13 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 /**
  * Tests for {@link UrlJarFiles}.
  *
  * @author Phillip Webb
+ * @author Greg Taube
  */
 @AssertFileChannelDataBlocksClosed
 class UrlJarFilesTests {
@@ -85,6 +94,59 @@ class UrlJarFilesTests {
 		JarFile jarFile2 = this.jarFiles.getOrCreate(true, this.url);
 		JarFile jarFile3 = this.jarFiles.getOrCreate(true, this.url);
 		assertThat(jarFile1).isSameAs(jarFile2).isSameAs(jarFile3);
+	}
+
+	@Test
+	void getOrCreateNestedCachesColdLookupAndReturnsItForWarmLookups() throws Exception {
+		given(this.factory.createJarFile(any(), any())).willCallRealMethod();
+		String spec = this.url + "!/3.dat";
+		int separator = spec.indexOf("!/");
+		JarFile jarFile1 = this.jarFiles.getOrCreateNested(spec, separator, false);
+		JarFile jarFile2 = this.jarFiles.getOrCreateNested(spec, separator, false);
+		JarFile jarFile3 = this.jarFiles.getOrCreateNested(spec, separator, false);
+		assertThat(jarFile1).isSameAs(jarFile2).isSameAs(jarFile3);
+		assertThat(this.jarFiles.getCached(this.url)).isSameAs(jarFile1);
+		then(this.factory).should(times(1)).createJarFile(any(), any());
+	}
+
+	@Test
+	void getOrCreateNestedWhenCallsRaceReturnsEachCreatedJarAndCachesOne() throws Exception {
+		JarFile jarFile1 = mock(JarFile.class);
+		JarFile jarFile2 = mock(JarFile.class);
+		List<JarFile> jarFiles = List.of(jarFile1, jarFile2);
+		AtomicInteger created = new AtomicInteger();
+		CountDownLatch bothCreating = new CountDownLatch(2);
+		given(this.factory.createJarFile(any(), any())).willAnswer((invocation) -> {
+			JarFile jarFile = jarFiles.get(created.getAndIncrement());
+			bothCreating.countDown();
+			assertThat(bothCreating.await(10, TimeUnit.SECONDS)).isTrue();
+			return jarFile;
+		});
+		String spec = this.url + "!/3.dat";
+		int separator = spec.indexOf("!/");
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			Future<JarFile> result1 = executor.submit(() -> this.jarFiles.getOrCreateNested(spec, separator, false));
+			Future<JarFile> result2 = executor.submit(() -> this.jarFiles.getOrCreateNested(spec, separator, false));
+			assertThat(List.of(result1.get(), result2.get())).containsExactlyInAnyOrderElementsOf(jarFiles);
+		}
+		finally {
+			executor.shutdownNow();
+		}
+		assertThat(this.jarFiles.getCached(this.url)).isIn(jarFile1, jarFile2);
+	}
+
+	@Test
+	void getOrCreateNestedKeepsRuntimeRefSeparate() throws Exception {
+		JarFile jarFile = mock(JarFile.class);
+		JarFile runtimeJarFile = mock(JarFile.class);
+		given(this.factory.createJarFile(any(), any())).willReturn(jarFile, runtimeJarFile);
+		String spec = this.url + "!/3.dat";
+		int separator = spec.indexOf("!/");
+		assertThat(this.jarFiles.getOrCreateNested(spec, separator, false)).isSameAs(jarFile);
+		assertThat(this.jarFiles.getOrCreateNested(spec, separator, true)).isSameAs(runtimeJarFile);
+		assertThat(this.jarFiles.getCached(this.url)).isSameAs(jarFile);
+		assertThat(this.jarFiles.getCached(new URL(this.url + "#runtime"))).isSameAs(runtimeJarFile);
 	}
 
 	@Test


### PR DESCRIPTION
fix #51503