### PR TITLE
Layer temp file is not deleted when layer creation fails

### DIFF
--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/ImageBuildpack.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/ImageBuildpack.java
@@ -139,25 +139,7 @@ final class ImageBuildpack implements Buildpack {
 				}
 				Path layerFile = Files.createTempFile("create-builder-scratch-", null);
 				try {
-					try (TarArchiveOutputStream out = new TarArchiveOutputStream(Files.newOutputStream(layerFile))) {
-						try (TarArchiveInputStream in = new TarArchiveInputStream(
-								Files.newInputStream(sourceTarFile))) {
-							out.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
-							TarArchiveEntry entry = in.getNextEntry();
-							while (entry != null) {
-								String entryName = entry.getName();
-								Path entryPath = Path.of(entryName);
-								Assert.state(entryPath.toAbsolutePath().equals(entryPath.toAbsolutePath().normalize()),
-										() -> "Malformed zip entry name '%s'".formatted(entryName));
-								out.putArchiveEntry(entry);
-								StreamUtils.copy(in, out);
-								out.closeArchiveEntry();
-								entry = in.getNextEntry();
-							}
-							out.finish();
-						}
-					}
-					return layerFile;
+					writeLayerFile(layerFile, sourceTarFile);
 				}
 				catch (IOException | RuntimeException ex) {
 					try {
@@ -168,9 +150,30 @@ final class ImageBuildpack implements Buildpack {
 					}
 					throw ex;
 				}
+				return layerFile;
 			}
 			finally {
 				Files.deleteIfExists(sourceTarFile);
+			}
+		}
+
+		private void writeLayerFile(Path layerFile, Path sourceTarFile) throws IOException {
+			try (TarArchiveOutputStream out = new TarArchiveOutputStream(Files.newOutputStream(layerFile))) {
+				try (TarArchiveInputStream in = new TarArchiveInputStream(Files.newInputStream(sourceTarFile))) {
+					out.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+					TarArchiveEntry entry = in.getNextEntry();
+					while (entry != null) {
+						String entryName = entry.getName();
+						Path entryPath = Path.of(entryName);
+						Assert.state(entryPath.toAbsolutePath().equals(entryPath.toAbsolutePath().normalize()),
+								() -> "Malformed zip entry name '%s'".formatted(entryName));
+						out.putArchiveEntry(entry);
+						StreamUtils.copy(in, out);
+						out.closeArchiveEntry();
+						entry = in.getNextEntry();
+					}
+					out.finish();
+				}
 			}
 		}
 

--- a/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/ImageBuildpack.java
+++ b/buildpack/spring-boot-buildpack-platform/src/main/java/org/springframework/boot/buildpack/platform/build/ImageBuildpack.java
@@ -49,6 +49,7 @@ import org.springframework.util.StreamUtils;
  *
  * @author Scott Frederick
  * @author Phillip Webb
+ * @author Junhwan Choi
  */
 final class ImageBuildpack implements Buildpack {
 
@@ -137,24 +138,36 @@ final class ImageBuildpack implements Buildpack {
 					tarArchive.writeTo(out);
 				}
 				Path layerFile = Files.createTempFile("create-builder-scratch-", null);
-				try (TarArchiveOutputStream out = new TarArchiveOutputStream(Files.newOutputStream(layerFile))) {
-					try (TarArchiveInputStream in = new TarArchiveInputStream(Files.newInputStream(sourceTarFile))) {
-						out.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
-						TarArchiveEntry entry = in.getNextEntry();
-						while (entry != null) {
-							String entryName = entry.getName();
-							Path entryPath = Path.of(entryName);
-							Assert.state(entryPath.toAbsolutePath().equals(entryPath.toAbsolutePath().normalize()),
-									() -> "Malformed zip entry name '%s'".formatted(entryName));
-							out.putArchiveEntry(entry);
-							StreamUtils.copy(in, out);
-							out.closeArchiveEntry();
-							entry = in.getNextEntry();
+				try {
+					try (TarArchiveOutputStream out = new TarArchiveOutputStream(Files.newOutputStream(layerFile))) {
+						try (TarArchiveInputStream in = new TarArchiveInputStream(
+								Files.newInputStream(sourceTarFile))) {
+							out.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+							TarArchiveEntry entry = in.getNextEntry();
+							while (entry != null) {
+								String entryName = entry.getName();
+								Path entryPath = Path.of(entryName);
+								Assert.state(entryPath.toAbsolutePath().equals(entryPath.toAbsolutePath().normalize()),
+										() -> "Malformed zip entry name '%s'".formatted(entryName));
+								out.putArchiveEntry(entry);
+								StreamUtils.copy(in, out);
+								out.closeArchiveEntry();
+								entry = in.getNextEntry();
+							}
+							out.finish();
 						}
-						out.finish();
 					}
+					return layerFile;
 				}
-				return layerFile;
+				catch (IOException | RuntimeException ex) {
+					try {
+						Files.deleteIfExists(layerFile);
+					}
+					catch (IOException suppressed) {
+						ex.addSuppressed(suppressed);
+					}
+					throw ex;
+				}
 			}
 			finally {
 				Files.deleteIfExists(sourceTarFile);

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/ImageBuildpackTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/ImageBuildpackTests.java
@@ -61,6 +61,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Scott Frederick
  * @author Phillip Webb
+ * @author Junhwan Choi
  */
 class ImageBuildpackTests extends AbstractJsonTests {
 
@@ -198,6 +199,25 @@ class ImageBuildpackTests extends AbstractJsonTests {
 		BuildpackReference reference = BuildpackReference.of("example/buildpack1");
 		assertThatIllegalStateException().isThrownBy(() -> ImageBuildpack.resolve(resolverContext, reference))
 			.withMessage("Malformed zip entry name '../cnb/'");
+	}
+
+	@Test
+	void resolveWhenLayerCreationFailsDeletesLayerTempFiles() throws Exception {
+		File tempDir = new File(System.getProperty("java.io.tmpdir"));
+		Set<String> tempsBefore = listTempFileNames(tempDir, "create-builder-scratch-");
+		Image image = Image.of(getContent("buildpack-image.json"));
+		ImageReference imageReference = ImageReference.of("example/buildpack1:latest");
+		BuildpackResolverContext resolverContext = mock(BuildpackResolverContext.class);
+		given(resolverContext.getBuildpackLayersMetadata()).willReturn(BuildpackLayersMetadata.fromJson("{}"));
+		given(resolverContext.fetchImage(eq(imageReference), eq(ImageType.BUILDPACK))).willReturn(image);
+		willAnswer((invocation) -> withMockLayers(invocation, "..")).given(resolverContext)
+			.exportImageLayers(eq(imageReference), any());
+		BuildpackReference reference = BuildpackReference.of("example/buildpack1");
+		assertThatIllegalStateException().isThrownBy(() -> ImageBuildpack.resolve(resolverContext, reference))
+			.withMessage("Malformed zip entry name '../cnb/'");
+		Set<String> tempsAfter = new HashSet<>(listTempFileNames(tempDir, "create-builder-scratch-"));
+		tempsAfter.removeAll(tempsBefore);
+		assertThat(tempsAfter).as("layer temp files must be deleted when layer creation fails").isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
`ImageBuildpack.ExportedLayers.createLayerFile` creates two temp files: the intermediate source tar (`create-builder-scratch-source-*`) and the layer file (`create-builder-scratch-*`). The source tar is deleted in a `finally` block, but the layer file is only deleted later, in `apply()`, on the success path.

If the copy from the source tar into the layer file fails — for example when a malformed entry name is rejected by the `Assert.state` check, or on an I/O error — the exception propagates out of `createLayerFile` and the just-created layer file is never deleted. The existing test `resolveWhenEntryWouldWriteOutsideOfDestinationThrowsException` hits exactly this path and leaves an orphaned `create-builder-scratch-*` file behind in the temp directory on every run.

This wraps the copy in a `try/catch (IOException | RuntimeException)` that deletes the layer file and rethrows, suppressing any secondary failure from the delete — the same approach used for `ExportedImageTar` in #51117.

The new test reuses the malformed-entry scenario and asserts that no `create-builder-scratch-*` temp files remain after resolution fails. It fails without the production change and passes with it, and `checkFormat`, `checkstyleMain` and `checkstyleTest` for the module all pass.