### PR TITLE
jarmode tools commands print stacktrace instead of an error message

### DIFF
--- a/loader/spring-boot-jarmode-tools/src/main/java/org/springframework/boot/jarmode/tools/ToolsJarMode.java
+++ b/loader/spring-boot-jarmode-tools/src/main/java/org/springframework/boot/jarmode/tools/ToolsJarMode.java
@@ -22,11 +22,13 @@ import java.util.List;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.boot.loader.jarmode.JarMode;
+import org.springframework.boot.loader.jarmode.JarModeErrorException;
 
 /**
  * {@link JarMode} providing {@code "tools"} support.
  *
  * @author Moritz Halbritter
+ * @author Hyeongjun Cho
  * @since 3.3.0
  */
 public class ToolsJarMode implements JarMode {
@@ -53,6 +55,9 @@ public class ToolsJarMode implements JarMode {
 	public void run(String mode, String[] args) {
 		try {
 			new Runner(this.out, this.context, getCommands(this.context)).run(args);
+		}
+		catch (JarModeErrorException ex) {
+			throw ex;
 		}
 		catch (Exception ex) {
 			throw new IllegalStateException(ex);

--- a/loader/spring-boot-jarmode-tools/src/test/java/org/springframework/boot/jarmode/tools/ToolsJarModeTests.java
+++ b/loader/spring-boot-jarmode-tools/src/test/java/org/springframework/boot/jarmode/tools/ToolsJarModeTests.java
@@ -21,12 +21,16 @@ import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.loader.jarmode.JarModeErrorException;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * Tests for {@link ToolsJarMode}.
  *
  * @author Moritz Halbritter
+ * @author Hyeongjun Cho
  */
 class ToolsJarModeTests extends AbstractJarModeTests {
 
@@ -93,6 +97,11 @@ class ToolsJarModeTests extends AbstractJarModeTests {
 	void optionMissingRequiredValueShowsErrorAndCommandHelp() {
 		run("extract", "--destination");
 		assertThat(this.out).hasSameContentAsResource("tools-error-option-missing-value-output.txt");
+	}
+
+	@Test
+	void commandFailureIsThrownAsJarModeErrorException() {
+		assertThatExceptionOfType(JarModeErrorException.class).isThrownBy(() -> run("list-layers"));
 	}
 
 	private void run(String... args) {


### PR DESCRIPTION
Split out of #51505 at @mhalbritter's request.

The tools jar mode wraps every exception in `IllegalStateException`, so a `JarModeErrorException` thrown by a command never reaches the branch of `JarModeRunner` that prints `Error: <message>`. Running `list-layers` against a jar built without layers shows a stack trace instead of `Error: Layers are not enabled`.

`JarMode` declares `run` as `throws JarModeErrorException` "on an error that should print a simple error message", so the wrapping breaks that contract. It predates the exception: #43435 added JarModeErrorException` and converted `ExtractCommand` and `Layers`, but left `ToolsJarMode` alone. Rethrowing ahead of the generic catch restores the branch.