### PR TITLE
Docker Compose integration for RabbitMQ skips credential fallbacks when an environment variable has no value

### DIFF
--- a/module/spring-boot-amqp/src/main/java/org/springframework/boot/amqp/docker/compose/RabbitEnvironment.java
+++ b/module/spring-boot-amqp/src/main/java/org/springframework/boot/amqp/docker/compose/RabbitEnvironment.java
@@ -35,8 +35,14 @@ class RabbitEnvironment {
 	private final @Nullable String password;
 
 	RabbitEnvironment(Map<String, @Nullable String> env) {
-		this.username = env.getOrDefault("RABBITMQ_DEFAULT_USER", env.getOrDefault("RABBITMQ_USERNAME", "guest"));
-		this.password = env.getOrDefault("RABBITMQ_DEFAULT_PASS", env.getOrDefault("RABBITMQ_PASSWORD", "guest"));
+		this.username = extract(env, "RABBITMQ_DEFAULT_USER", "RABBITMQ_USERNAME");
+		this.password = extract(env, "RABBITMQ_DEFAULT_PASS", "RABBITMQ_PASSWORD");
+	}
+
+	private static String extract(Map<String, @Nullable String> env, String key, String fallbackKey) {
+		String value = env.get(key);
+		value = (value != null) ? value : env.get(fallbackKey);
+		return (value != null) ? value : "guest";
 	}
 
 	@Nullable String getUsername() {

--- a/module/spring-boot-amqp/src/test/java/org/springframework/boot/amqp/docker/compose/RabbitEnvironmentTests.java
+++ b/module/spring-boot-amqp/src/test/java/org/springframework/boot/amqp/docker/compose/RabbitEnvironmentTests.java
@@ -17,8 +17,10 @@
 package org.springframework.boot.amqp.docker.compose;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,6 +69,31 @@ class RabbitEnvironmentTests {
 	void getUsernameWhenHasRabbitmqPassword() {
 		RabbitEnvironment environment = new RabbitEnvironment(Map.of("RABBITMQ_PASSWORD", "secret"));
 		assertThat(environment.getPassword()).isEqualTo("secret");
+	}
+
+	@Test
+	void getUsernameWhenRabbitmqDefaultUserHasNoValue() {
+		Map<String, @Nullable String> env = new HashMap<>();
+		env.put("RABBITMQ_DEFAULT_USER", null);
+		RabbitEnvironment environment = new RabbitEnvironment(env);
+		assertThat(environment.getUsername()).isEqualTo("guest");
+	}
+
+	@Test
+	void getPasswordWhenRabbitmqDefaultPassHasNoValue() {
+		Map<String, @Nullable String> env = new HashMap<>();
+		env.put("RABBITMQ_DEFAULT_PASS", null);
+		RabbitEnvironment environment = new RabbitEnvironment(env);
+		assertThat(environment.getPassword()).isEqualTo("guest");
+	}
+
+	@Test
+	void getUsernameWhenRabbitmqDefaultUserHasNoValueAndHasRabbitmqUsername() {
+		Map<String, @Nullable String> env = new HashMap<>();
+		env.put("RABBITMQ_DEFAULT_USER", null);
+		env.put("RABBITMQ_USERNAME", "me");
+		RabbitEnvironment environment = new RabbitEnvironment(env);
+		assertThat(environment.getUsername()).isEqualTo("me");
 	}
 
 }


### PR DESCRIPTION
## What happened?

Docker records an environment variable declared without a value as a bare name. For example, with this Compose file and neither variable set on the host:

```yaml
services:
  rabbitmq:
    image: rabbitmq
    environment:
      - RABBITMQ_DEFAULT_USER
      - RABBITMQ_DEFAULT_PASS
```

`docker inspect` reports:

```json
["RABBITMQ_DEFAULT_USER","RABBITMQ_DEFAULT_PASS","PATH=/usr/local/sbin:..."]
```

`DockerEnv` maps such an entry to a null value rather than omitting the key. `DockerEnvTests` covers this directly:

```java
@Test
void createParsesEnv() {
	DockerEnv env = new DockerEnv(List.of("a=b", "c"));
	assertThat(env.asMap()).containsExactly(entry("a", "b"), entry("c", null));
}
```

`RabbitEnvironment` reads these entries with `Map.getOrDefault`:

```java
this.username = env.getOrDefault("RABBITMQ_DEFAULT_USER", env.getOrDefault("RABBITMQ_USERNAME", "guest"));
this.password = env.getOrDefault("RABBITMQ_DEFAULT_PASS", env.getOrDefault("RABBITMQ_PASSWORD", "guest"));
```

`getOrDefault` returns the default only when the key is absent, so it returns null when the key is present but mapped to null. For the username, this bypasses both the `RABBITMQ_USERNAME` fallback and the `guest` default. The same problem affects the password.

The other environment classes in this area check for null before falling back. For example, `PostgresEnvironment` uses:

```java
private String extract(Map<String, @Nullable String> env, String[] keys, String defaultValue) {
	for (String key : keys) {
		String value = env.get(key);
		if (value != null) {
			return value;
		}
	}
	return defaultValue;
}
```

`MySqlEnvironment`, `MariaDbEnvironment`, `OracleEnvironment`, `ClickHouseEnvironment` and `SqlServerEnvironment` follow the same approach.

When no fallback credentials are configured, the existing consumers mask the missing default. `RabbitConnectionFactoryBeanConfigurer` and `RabbitStreamConfiguration` filter out null values through `PropertyMapper`, leaving the connection factories to use their own `guest` defaults.

However, when a primary key is present with a null value and its fallback key has a value, `RabbitEnvironment` ignores the configured fallback. For example, if `RABBITMQ_DEFAULT_USER` is null and `RABBITMQ_USERNAME` is `alice`, `getUsername()` returns null instead of `alice`.

## What does this PR change?

`RabbitEnvironment` now reads each key with `get` and falls back when the value is null, matching the sibling classes:

```java
private static String extract(Map<String, @Nullable String> env, String key, String fallbackKey) {
	String value = env.get(key);
	value = (value != null) ? value : env.get(fallbackKey);
	return (value != null) ? value : "guest";
}
```

A non-null primary value is preserved. Otherwise, the fallback value is used, or `guest` if neither key has a non-null value. Empty strings are still treated as explicit values.

There are no public API changes.

## Tests

Added to `RabbitEnvironmentTests`:

- `getUsernameWhenRabbitmqDefaultUserHasNoValue`, where `RABBITMQ_DEFAULT_USER` is present with a null value
- `getPasswordWhenRabbitmqDefaultPassHasNoValue`, where `RABBITMQ_DEFAULT_PASS` is present with a null value
- `getUsernameWhenRabbitmqDefaultUserHasNoValueAndHasRabbitmqUsername`, where the fallback key should still be used

All three fail without the change.

`:module:spring-boot-amqp:test`, `checkFormatMain`, `checkFormatTest`, `checkstyleMain` and `checkstyleTest` pass.