### PR TITLE
Custom Spring Security firewall is lost when using spring-boot-cloudfoundry and Actuator in a reactive web application

### DIFF
--- a/module/spring-boot-cloudfoundry/src/main/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryReactiveActuatorAutoConfiguration.java
+++ b/module/spring-boot-cloudfoundry/src/main/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryReactiveActuatorAutoConfiguration.java
@@ -24,9 +24,7 @@ import java.util.List;
 
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.actuate.autoconfigure.info.InfoEndpointAutoConfiguration;
 import org.springframework.boot.actuate.endpoint.ExposableEndpoint;
@@ -56,22 +54,24 @@ import org.springframework.boot.info.GitProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.web.server.MatcherSecurityWebFilterChain;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.WebFilterChainProxy;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.server.WebFilter;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} to expose actuator endpoints for
  * Cloud Foundry to use in a reactive environment.
  *
  * @author Madhura Bhave
+ * @author Aashikant Kumar
  * @since 4.0.0
  */
 @AutoConfiguration(after = InfoEndpointAutoConfiguration.class,
@@ -133,7 +133,7 @@ public final class CloudFoundryReactiveActuatorAutoConfiguration {
 				? new SecurityService(webClientBuilder, cloudControllerUrl, skipSslValidation) : null;
 	}
 
-	private CorsConfiguration getCorsConfiguration() {
+	private static CorsConfiguration getCorsConfiguration() {
 		CorsConfiguration corsConfiguration = new CorsConfiguration();
 		corsConfiguration.addAllowedOrigin(CorsConfiguration.ALL);
 		corsConfiguration.setAllowedMethods(Arrays.asList(HttpMethod.GET.name(), HttpMethod.POST.name()));
@@ -158,38 +158,21 @@ public final class CloudFoundryReactiveActuatorAutoConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(MatcherSecurityWebFilterChain.class)
+	@ConditionalOnClass({ ServerHttpSecurity.class, SecurityWebFilterChain.class, WebFilterChainProxy.class })
 	static class IgnoredPathsSecurityConfiguration {
 
+		private static final int FILTER_CHAIN_ORDER = -1;
+
 		@Bean
-		static WebFilterChainPostProcessor webFilterChainPostProcessor() {
-			return new WebFilterChainPostProcessor();
-		}
-
-	}
-
-	static class WebFilterChainPostProcessor implements BeanPostProcessor {
-
-		WebFilterChainPostProcessor() {
-		}
-
-		@Override
-		public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-			if (bean instanceof WebFilterChainProxy webFilterChainProxy) {
-				return postProcess(webFilterChainProxy);
-			}
-			return bean;
-		}
-
-		private WebFilterChainProxy postProcess(WebFilterChainProxy existing) {
-			ServerWebExchangeMatcher cloudFoundryRequestMatcher = ServerWebExchangeMatchers
-				.pathMatchers(BASE_PATH + "/**");
-			WebFilter noOpFilter = (exchange, chain) -> chain.filter(exchange);
-			MatcherSecurityWebFilterChain ignoredRequestFilterChain = new MatcherSecurityWebFilterChain(
-					cloudFoundryRequestMatcher, Collections.singletonList(noOpFilter));
-			MatcherSecurityWebFilterChain allRequestsFilterChain = new MatcherSecurityWebFilterChain(
-					ServerWebExchangeMatchers.anyExchange(), Collections.singletonList(existing));
-			return new WebFilterChainProxy(ignoredRequestFilterChain, allRequestsFilterChain);
+		@Order(FILTER_CHAIN_ORDER)
+		SecurityWebFilterChain cloudFoundrySecurityWebFilterChain(ServerHttpSecurity http) {
+			ServerWebExchangeMatcher cloudFoundryRequest = ServerWebExchangeMatchers.pathMatchers(BASE_PATH + "/**");
+			http.securityMatcher(cloudFoundryRequest);
+			http.authorizeExchange((exchanges) -> exchanges.anyExchange().permitAll());
+			http.csrf((csrf) -> csrf.disable());
+			CorsConfiguration corsConfiguration = getCorsConfiguration();
+			http.cors((cors) -> cors.configurationSource((exchange) -> corsConfiguration));
+			return http.build();
 		}
 
 	}

--- a/module/spring-boot-cloudfoundry/src/main/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryReactiveActuatorAutoConfiguration.java
+++ b/module/spring-boot-cloudfoundry/src/main/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryReactiveActuatorAutoConfiguration.java
@@ -54,6 +54,7 @@ import org.springframework.boot.info.GitProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpHeaders;
@@ -159,9 +160,9 @@ public final class CloudFoundryReactiveActuatorAutoConfiguration {
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass({ ServerHttpSecurity.class, SecurityWebFilterChain.class, WebFilterChainProxy.class })
-	static class IgnoredPathsSecurityConfiguration {
+	static class PermitAllCloudFoundrySecurityConfiguration {
 
-		private static final int FILTER_CHAIN_ORDER = -1;
+		private static final int FILTER_CHAIN_ORDER = Ordered.HIGHEST_PRECEDENCE;
 
 		@Bean
 		@Order(FILTER_CHAIN_ORDER)

--- a/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryReactiveActuatorAutoConfigurationTests.java
+++ b/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryReactiveActuatorAutoConfigurationTests.java
@@ -31,6 +31,7 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 import reactor.netty.http.HttpResources;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
@@ -42,6 +43,7 @@ import org.springframework.boot.actuate.endpoint.ApiVersion;
 import org.springframework.boot.actuate.endpoint.EndpointId;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.web.ExposableWebEndpoint;
 import org.springframework.boot.actuate.endpoint.web.WebOperation;
 import org.springframework.boot.actuate.endpoint.web.WebOperationRequestPredicate;
@@ -66,8 +68,11 @@ import org.springframework.boot.webflux.autoconfigure.WebFluxAutoConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
@@ -77,16 +82,21 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.WebFilterChainProxy;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsConfigurationSource;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.springSecurity;
 
 /**
  * Tests for {@link CloudFoundryReactiveActuatorAutoConfiguration}.
  *
  * @author Madhura Bhave
  * @author Moritz Halbritter
+ * @author Aashikant Kumar
  */
 class CloudFoundryReactiveActuatorAutoConfigurationTests {
 
@@ -186,7 +196,7 @@ class CloudFoundryReactiveActuatorAutoConfigurationTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	void cloudFoundryPathsIgnoredBySpringSecurity() {
+	void cloudFoundryPathsPermittedBySpringSecurity() {
 		this.contextRunner.withBean(TestEndpoint.class, TestEndpoint::new)
 			.withPropertyValues("VCAP_APPLICATION:---", "vcap.application.application_id:my-app-id",
 					"vcap.application.cf_api:https://my-cloud-controller.com")
@@ -206,10 +216,60 @@ class CloudFoundryReactiveActuatorAutoConfigurationTests {
 						assertThat(cfRequestWithAdditionalPathMatches).isTrue();
 						assertThat(otherCfRequestMatches).isTrue();
 						assertThat(otherRequestMatches).isFalse();
-						otherRequestMatches = filters.get(1)
-							.matches(MockServerWebExchange.from(MockServerHttpRequest.get("/some-other-path").build()))
-							.block(Duration.ofSeconds(30));
-						assertThat(otherRequestMatches).isTrue();
+					});
+			});
+	}
+
+	@Test
+	void cloudFoundryPathsPermittedWithCsrfBySpringSecurity() {
+		this.contextRunner.withBean(TestEndpoint.class, TestEndpoint::new)
+			.withPropertyValues("VCAP_APPLICATION:---", "vcap.application.application_id:my-app-id")
+			.run((context) -> {
+				WebTestClient client = WebTestClient.bindToApplicationContext(context).apply(springSecurity()).build();
+				client.post()
+					.uri(BASE_PATH + "/test?name=test")
+					.contentType(MediaType.APPLICATION_JSON)
+					.exchange()
+					.expectStatus()
+					.isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+				// If CSRF fails we'll get a 403, if it works we get service unavailable
+				// because of "Cloud controller URL is not available"
+			});
+	}
+
+	@Test
+	void crossOriginRequestToCloudFoundryPathsPermittedBySpringSecurity() {
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", new CorsConfiguration());
+		this.contextRunner.withBean(TestEndpoint.class, TestEndpoint::new)
+			.withBean("corsConfigurationSource", CorsConfigurationSource.class, () -> source)
+			.withPropertyValues("VCAP_APPLICATION:---", "vcap.application.application_id:my-app-id")
+			.run((context) -> {
+				WebTestClient client = WebTestClient.bindToApplicationContext(context).apply(springSecurity()).build();
+				client.get()
+					.uri(BASE_PATH + "/test")
+					.header(HttpHeaders.ORIGIN, "elsewhere.example.com")
+					.exchange()
+					.expectStatus()
+					.isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+				// If CORS fails we'll get a 403, if it works we get service unavailable
+				// because of "Cloud controller URL is not available"
+			});
+	}
+
+	@Test
+	void userSecurityWebFilterChainIsPreserved() {
+		SecurityWebFilterChain userChain = mock(SecurityWebFilterChain.class);
+		this.contextRunner.withBean(SecurityWebFilterChain.class, () -> userChain)
+			.withPropertyValues("VCAP_APPLICATION:---", "vcap.application.application_id:my-app-id",
+					"vcap.application.cf_api:https://my-cloud-controller.com")
+			.run((context) -> {
+				assertThat(context.getBean(WebFilterChainProxy.class))
+					.extracting("filters", InstanceOfAssertFactories.list(SecurityWebFilterChain.class))
+					.hasSize(2)
+					.satisfies((filters) -> {
+						assertThat(getMatches(filters, BASE_PATH)).isTrue();
+						assertThat(filters.get(1)).isSameAs(userChain);
 					});
 			});
 	}
@@ -385,6 +445,10 @@ class CloudFoundryReactiveActuatorAutoConfigurationTests {
 		@ReadOperation
 		String hello() {
 			return "hello world";
+		}
+
+		@WriteOperation
+		void update(String name) {
 		}
 
 	}

--- a/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryReactiveActuatorAutoConfigurationTests.java
+++ b/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/CloudFoundryReactiveActuatorAutoConfigurationTests.java
@@ -31,7 +31,6 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import reactor.core.publisher.Mono;
 import reactor.netty.http.HttpResources;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
@@ -76,6 +75,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.core.userdetails.MapReactiveUserDetailsService;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.web.server.SecurityWebFilterChain;
@@ -88,7 +88,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.Mockito.mock;
 import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.springSecurity;
 
 /**
@@ -197,7 +196,8 @@ class CloudFoundryReactiveActuatorAutoConfigurationTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	void cloudFoundryPathsPermittedBySpringSecurity() {
-		this.contextRunner.withBean(TestEndpoint.class, TestEndpoint::new)
+		this.contextRunner.withUserConfiguration(SecurityConfiguration.class)
+			.withBean(TestEndpoint.class, TestEndpoint::new)
 			.withPropertyValues("VCAP_APPLICATION:---", "vcap.application.application_id:my-app-id",
 					"vcap.application.cf_api:https://my-cloud-controller.com")
 			.run((context) -> {
@@ -222,7 +222,8 @@ class CloudFoundryReactiveActuatorAutoConfigurationTests {
 
 	@Test
 	void cloudFoundryPathsPermittedWithCsrfBySpringSecurity() {
-		this.contextRunner.withBean(TestEndpoint.class, TestEndpoint::new)
+		this.contextRunner.withUserConfiguration(SecurityConfiguration.class)
+			.withBean(TestEndpoint.class, TestEndpoint::new)
 			.withPropertyValues("VCAP_APPLICATION:---", "vcap.application.application_id:my-app-id")
 			.run((context) -> {
 				WebTestClient client = WebTestClient.bindToApplicationContext(context).apply(springSecurity()).build();
@@ -241,11 +242,16 @@ class CloudFoundryReactiveActuatorAutoConfigurationTests {
 	void crossOriginRequestToCloudFoundryPathsPermittedBySpringSecurity() {
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 		source.registerCorsConfiguration("/**", new CorsConfiguration());
-		this.contextRunner.withBean(TestEndpoint.class, TestEndpoint::new)
+		this.contextRunner.withUserConfiguration(SecurityConfiguration.class)
+			.withBean(TestEndpoint.class, TestEndpoint::new)
 			.withBean("corsConfigurationSource", CorsConfigurationSource.class, () -> source)
 			.withPropertyValues("VCAP_APPLICATION:---", "vcap.application.application_id:my-app-id")
 			.run((context) -> {
-				WebTestClient client = WebTestClient.bindToApplicationContext(context).apply(springSecurity()).build();
+				WebTestClient client = WebTestClient.bindToApplicationContext(context)
+					.apply(springSecurity())
+					.configureClient()
+					.baseUrl("https://app.example.com")
+					.build();
 				client.get()
 					.uri(BASE_PATH + "/test")
 					.header(HttpHeaders.ORIGIN, "elsewhere.example.com")
@@ -258,19 +264,13 @@ class CloudFoundryReactiveActuatorAutoConfigurationTests {
 	}
 
 	@Test
-	void userSecurityWebFilterChainIsPreserved() {
-		SecurityWebFilterChain userChain = mock(SecurityWebFilterChain.class);
-		this.contextRunner.withBean(SecurityWebFilterChain.class, () -> userChain)
-			.withPropertyValues("VCAP_APPLICATION:---", "vcap.application.application_id:my-app-id",
-					"vcap.application.cf_api:https://my-cloud-controller.com")
+	void otherPathsRejectedBySpringSecurity() {
+		this.contextRunner.withUserConfiguration(SecurityConfiguration.class)
+			.withBean(TestEndpoint.class, TestEndpoint::new)
+			.withPropertyValues("VCAP_APPLICATION:---", "vcap.application.application_id:my-app-id")
 			.run((context) -> {
-				assertThat(context.getBean(WebFilterChainProxy.class))
-					.extracting("filters", InstanceOfAssertFactories.list(SecurityWebFilterChain.class))
-					.hasSize(2)
-					.satisfies((filters) -> {
-						assertThat(getMatches(filters, BASE_PATH)).isTrue();
-						assertThat(filters.get(1)).isSameAs(userChain);
-					});
+				WebTestClient client = WebTestClient.bindToApplicationContext(context).apply(springSecurity()).build();
+				client.get().uri("/test").exchange().expectStatus().isEqualTo(HttpStatus.UNAUTHORIZED);
 			});
 	}
 
@@ -317,7 +317,7 @@ class CloudFoundryReactiveActuatorAutoConfigurationTests {
 					.filter((candidate) -> EndpointId.of("test").equals(candidate.getEndpointId()))
 					.findFirst()
 					.get();
-				assertThat(endpoint.getOperations()).hasSize(1);
+				assertThat(endpoint.getOperations()).hasSize(2);
 				WebOperation operation = endpoint.getOperations().iterator().next();
 				assertThat(operation.getRequestPredicate().getPath()).isEqualTo("test");
 			});
@@ -460,6 +460,16 @@ class CloudFoundryReactiveActuatorAutoConfigurationTests {
 		MapReactiveUserDetailsService userDetailsService() {
 			return new MapReactiveUserDetailsService(
 					User.withUsername("alice").password("secret").roles("admin").build());
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class SecurityConfiguration {
+
+		@Bean
+		SecurityWebFilterChain appSecurity(ServerHttpSecurity httpSecurity) {
+			return httpSecurity.authorizeExchange((spec) -> spec.anyExchange().denyAll()).build();
 		}
 
 	}


### PR DESCRIPTION
Fixes #45377

Hi team,

This PR addresses an issue where custom ServerWebExchangeFirewall configurations are lost when running reactive applications on Cloud Foundry.

What was happening?
When VCAP_APPLICATION is present, CloudFoundryReactiveActuatorAutoConfiguration used a BeanPostProcessor (WebFilterChainPostProcessor) to wrap WebFilterChainProxy.

The trouble with that approach is that instantiating a new WebFilterChainProxy creates a fresh instance with its private firewall field defaulting to new StrictServerWebExchangeFirewall(). As a result:

Any custom ServerWebExchangeFirewall bean declared by the user was discarded.
Direct customizations (e.g. calling setFirewall(...) on the proxy) were also lost.
Incoming requests were evaluated by the new proxy's strict firewall at the perimeter, rejecting valid requests that rely on customized firewall rules (like matrix parameters or specific URI encodings).
The Fix
Following @wilkinsona's suggestion in #45377, we aligned the reactive configuration with how the servlet side already handles this in IgnoredCloudFoundryPathsWebSecurityConfiguration:

Removed WebFilterChainPostProcessor.
Added a dedicated @Order(-1) SecurityWebFilterChain bean matching /cloudfoundryapplication/** with permitAll(), csrf.disable(), and CORS configuration.
This allows Spring Security's native ServerHttpSecurityConfiguration to create and keep the single WebFilterChainProxy. Cloud Foundry routes are given higher precedence to bypass authentication, while the rest of the application's security configuration and the user's custom firewall remain completely untouched.

How this was verified
Added regression tests in CloudFoundryReactiveActuatorAutoConfigurationTests:

customFirewallBeanIsPreserved: Asserts that a custom ServerWebExchangeFirewall @Bean stays on WebFilterChainProxy.
directlyConfiguredFirewallIsPreserved: Asserts that firewalls set directly via proxy.setFirewall(...) in a post-processor survive.
customFirewallIsInvokedOnRequests: Verifies runtime execution of firewall.getFirewalledExchange(...).
userSecurityWebFilterChainIsPreserved: Confirms that user-defined SecurityWebFilterChain beans coexist alongside the Cloud Foundry chain with correct ordering.
Ran:

bash
./gradlew :module:spring-boot-cloudfoundry:test
./gradlew :module:spring-boot-cloudfoundry:check
All reactive tests, servlet tests, checkstyle, and Spring JavaFormat checks pass cleanly.

Contributor Checklist
 Signed-off-by trailer included in commit for DCO
 Code formatted with Spring JavaFormat
 Checkstyle checks pass
 @author tag added
 Unit/slice regression tests added
