### PR TITLE
Fix deadlock participation in NestedJarFile

### DIFF
--- a/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/NestedJarFile.java
+++ b/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/jar/NestedJarFile.java
@@ -32,6 +32,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Spliterator;
 import java.util.Spliterators.AbstractSpliterator;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
@@ -55,6 +56,7 @@ import org.springframework.boot.loader.zip.ZipContent.Entry;
  *
  * @author Phillip Webb
  * @author Andy Wilkinson
+ * @author Ian Kettle
  * @since 3.2.0
  */
 public class NestedJarFile extends JarFile {
@@ -70,6 +72,13 @@ public class NestedJarFile extends JarFile {
 	private static final DebugLogger debug = DebugLogger.get(NestedJarFile.class);
 
 	private final Cleaner cleaner;
+
+	/**
+	 * Provide concurrency control for this instance. {@link ReentrantReadWriteLock} lock
+	 * preferred over synchronized blocks as this allows greater read throughput with
+	 * reduced potential for participating in deadlocks from calling code.
+	 */
+	private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
 	private final NestedJarFileResources resources;
 
@@ -171,29 +180,41 @@ public class NestedJarFile extends JarFile {
 
 	@Override
 	public Enumeration<JarEntry> entries() {
-		synchronized (this) {
+		this.lock.readLock().lock();
+		try {
 			ensureOpen();
 			return new JarEntriesEnumeration(this.resources.zipContent());
+		}
+		finally {
+			this.lock.readLock().unlock();
 		}
 	}
 
 	@Override
 	public Stream<JarEntry> stream() {
-		synchronized (this) {
+		this.lock.readLock().lock();
+		try {
 			ensureOpen();
 			return streamContentEntries().map(NestedJarEntry::new);
+		}
+		finally {
+			this.lock.readLock().unlock();
 		}
 	}
 
 	@Override
 	public Stream<JarEntry> versionedStream() {
-		synchronized (this) {
+		this.lock.readLock().lock();
+		try {
 			ensureOpen();
 			return streamContentEntries().map(this::getBaseName)
 				.filter(Objects::nonNull)
 				.distinct()
 				.map(this::getJarEntry)
 				.filter(Objects::nonNull);
+		}
+		finally {
+			this.lock.readLock().unlock();
 		}
 	}
 
@@ -248,9 +269,13 @@ public class NestedJarFile extends JarFile {
 		if (entry != null) {
 			return true;
 		}
-		synchronized (this) {
+		this.lock.readLock().lock();
+		try {
 			ensureOpen();
 			return this.resources.zipContent().hasEntry(null, name);
+		}
+		finally {
+			this.lock.readLock().unlock();
 		}
 	}
 
@@ -291,9 +316,13 @@ public class NestedJarFile extends JarFile {
 	}
 
 	private ZipContent.Entry getContentEntry(String namePrefix, String name) {
-		synchronized (this) {
+		this.lock.readLock().lock();
+		try {
 			ensureOpen();
 			return this.resources.zipContent().getEntry(namePrefix, name);
+		}
+		finally {
+			this.lock.readLock().unlock();
 		}
 	}
 
@@ -302,9 +331,13 @@ public class NestedJarFile extends JarFile {
 		if (manifestInfo != null) {
 			return manifestInfo;
 		}
-		synchronized (this) {
+		this.lock.readLock().lock();
+		try {
 			ensureOpen();
 			manifestInfo = this.resources.zipContent().getInfo(ManifestInfo.class, this::getManifestInfo);
+		}
+		finally {
+			this.lock.readLock().unlock();
 		}
 		this.manifestInfo = manifestInfo;
 		return manifestInfo;
@@ -331,10 +364,14 @@ public class NestedJarFile extends JarFile {
 		if (metaInfVersionsInfo != null) {
 			return metaInfVersionsInfo;
 		}
-		synchronized (this) {
+		this.lock.readLock().lock();
+		try {
 			ensureOpen();
 			metaInfVersionsInfo = this.resources.zipContent()
 				.getInfo(MetaInfVersionsInfo.class, MetaInfVersionsInfo::get);
+		}
+		finally {
+			this.lock.readLock().unlock();
 		}
 		this.metaInfVersionsInfo = metaInfVersionsInfo;
 		return metaInfVersionsInfo;
@@ -354,7 +391,8 @@ public class NestedJarFile extends JarFile {
 		if (compression != ZipEntry.STORED && compression != ZipEntry.DEFLATED) {
 			throw new ZipException("invalid compression method");
 		}
-		synchronized (this) {
+		this.lock.readLock().lock();
+		try {
 			ensureOpen();
 			InputStream inputStream = new JarEntryInputStream(contentEntry);
 			try {
@@ -369,21 +407,32 @@ public class NestedJarFile extends JarFile {
 				throw ex;
 			}
 		}
+		finally {
+			this.lock.readLock().unlock();
+		}
 	}
 
 	@Override
 	public String getComment() {
-		synchronized (this) {
+		this.lock.readLock().lock();
+		try {
 			ensureOpen();
 			return this.resources.zipContent().getComment();
+		}
+		finally {
+			this.lock.readLock().unlock();
 		}
 	}
 
 	@Override
 	public int size() {
-		synchronized (this) {
+		this.lock.readLock().lock();
+		try {
 			ensureOpen();
 			return this.resources.zipContent().size();
+		}
+		finally {
+			this.lock.readLock().unlock();
 		}
 	}
 
@@ -394,13 +443,15 @@ public class NestedJarFile extends JarFile {
 			return;
 		}
 		this.closed = true;
-		synchronized (this) {
-			try {
-				this.cleanup.clean();
-			}
-			catch (UncheckedIOException ex) {
-				throw ex.getCause();
-			}
+		this.lock.writeLock().lock();
+		try {
+			this.cleanup.clean();
+		}
+		catch (UncheckedIOException ex) {
+			throw ex.getCause();
+		}
+		finally {
+			this.lock.writeLock().unlock();
 		}
 	}
 
@@ -422,8 +473,12 @@ public class NestedJarFile extends JarFile {
 	 * Clear any internal caches.
 	 */
 	public void clearCache() {
-		synchronized (this) {
+		this.lock.writeLock().lock();
+		try {
 			this.lastEntry = null;
+		}
+		finally {
+			this.lock.writeLock().unlock();
 		}
 	}
 
@@ -649,9 +704,13 @@ public class NestedJarFile extends JarFile {
 			if (!hasMoreElements()) {
 				throw new NoSuchElementException();
 			}
-			synchronized (NestedJarFile.this) {
+			NestedJarFile.this.lock.readLock().lock();
+			try {
 				ensureOpen();
 				return new NestedJarEntry(this.zipContent.getEntry(this.cursor++));
+			}
+			finally {
+				NestedJarFile.this.lock.readLock().unlock();
 			}
 		}
 
@@ -677,9 +736,13 @@ public class NestedJarFile extends JarFile {
 		@Override
 		public boolean tryAdvance(Consumer<? super ZipContent.Entry> action) {
 			if (this.cursor < this.zipContent.size()) {
-				synchronized (NestedJarFile.this) {
+				NestedJarFile.this.lock.readLock().lock();
+				try {
 					ensureOpen();
 					action.accept(this.zipContent.getEntry(this.cursor++));
+				}
+				finally {
+					NestedJarFile.this.lock.readLock().unlock();
 				}
 				return true;
 			}
@@ -718,7 +781,8 @@ public class NestedJarFile extends JarFile {
 		@Override
 		public int read(byte[] b, int off, int len) throws IOException {
 			int result;
-			synchronized (NestedJarFile.this) {
+			NestedJarFile.this.lock.readLock().lock();
+			try {
 				ensureOpen();
 				ByteBuffer dst = ByteBuffer.wrap(b, off, len);
 				int count = this.content.read(dst, this.pos);
@@ -728,16 +792,23 @@ public class NestedJarFile extends JarFile {
 				}
 				result = count;
 			}
+			finally {
+				NestedJarFile.this.lock.readLock().unlock();
+			}
 			return result;
 		}
 
 		@Override
 		public long skip(long n) throws IOException {
 			long result;
-			synchronized (NestedJarFile.this) {
+			NestedJarFile.this.lock.readLock().lock();
+			try {
 				result = (n > 0) ? maxForwardSkip(n) : maxBackwardSkip(n);
 				this.pos += result;
 				this.remaining -= result;
+			}
+			finally {
+				NestedJarFile.this.lock.readLock().unlock();
 			}
 			return result;
 		}

--- a/loader/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/NestedJarFileLockOrderingDeadlockTests.java
+++ b/loader/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/NestedJarFileLockOrderingDeadlockTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.loader.jar;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.springframework.boot.loader.testsupport.TestJar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduces a deadlock caused by {@link NestedJarFile} locking on
+ * {@code synchronized (this)}. One thread can hold an unrelated lock while waiting on
+ * {@code NestedJarFile}'s monitor, while another thread holds that monitor while waiting
+ * on the unrelated lock.
+ *
+ * <p>
+ * Two {@link CountDownLatch}es force each thread into "holding one lock, about to request
+ * the other" before either attempts the second lock, making the deadlock easily
+ * reprodicible. The test fails (times out) against the {@code synchronized (this)}
+ * implementation, and passes once {@code NestedJarFile} stops exposing its monitor.
+ *
+ * @author Ian Kettle
+ */
+class NestedJarFileLockOrderingDeadlockTests {
+
+	@TempDir
+	File tempDir;
+
+	@Test
+	void forceContentionForLock() throws Exception {
+		File jarFile = new File(this.tempDir, "test.jar");
+		TestJar.create(jarFile);
+		NestedJarFile jar = new NestedJarFile(jarFile);
+
+		Object externalLock = new Object();
+		CountDownLatch thread1HoldsExternalLock = new CountDownLatch(1);
+		CountDownLatch thread2HoldsJarMonitor = new CountDownLatch(1);
+		CountDownLatch bothThreadsFinished = new CountDownLatch(2);
+
+		Thread holdsExternalLockThenWantsJarMonitor = new Thread(() -> {
+			synchronized (externalLock) {
+				thread1HoldsExternalLock.countDown();
+				awaitUninterruptibly(thread2HoldsJarMonitor);
+				jar.hasEntry("1.dat");
+			}
+			bothThreadsFinished.countDown();
+		}, "holds-external-lock-then-wants-jar-monitor");
+		holdsExternalLockThenWantsJarMonitor.setDaemon(true);
+
+		// Only possible because NestedJarFile exposes its monitor via
+		// synchronized (this); external code can acquire it directly.
+		Thread holdsJarMonitorThenWantsExternalLock = new Thread(() -> {
+			synchronized (jar) {
+				thread2HoldsJarMonitor.countDown();
+				awaitUninterruptibly(thread1HoldsExternalLock);
+				synchronized (externalLock) {
+					// Unreachable while the deadlock exists.
+
+				}
+			}
+			bothThreadsFinished.countDown();
+		}, "holds-jar-monitor-then-wants-external-lock");
+		holdsJarMonitorThenWantsExternalLock.setDaemon(true);
+
+		holdsExternalLockThenWantsJarMonitor.start();
+		holdsJarMonitorThenWantsExternalLock.start();
+
+		boolean completed = bothThreadsFinished.await(5, TimeUnit.SECONDS);
+
+		// A deadlock leaves jar's monitor held forever, so jar.close() would also hang.
+		if (completed) {
+			jar.close();
+		}
+
+		assertThat(completed)
+			.as("NestedJarFile's synchronized (this) monitor is exposed to external code, "
+					+ "allowing a lock-order-inversion deadlock")
+			.isTrue();
+	}
+
+	private static void awaitUninterruptibly(CountDownLatch latch) {
+		try {
+			latch.await();
+		}
+		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+}


### PR DESCRIPTION
Replace synchronized blocks with ReentrantReadWriteLock to ensure that external code cannot participate in the NestedJarFile instance's own concurrency handling. The previous synchronized approach could lead to external code synchronizing on the same monitor which can result in a deadlock.

## Reproduction

`NestedJarFileLockOrderingDeadlockTests` (added in this PR) reproduces the deadlock deterministically using plain threads - two `CountDownLatch`es force one thread to hold an external lock while waiting on `NestedJarFile`'s monitor, and another to hold that monitor while waiting on the external lock. As shipped, the test uses a 5 second timeout so it fails fast in CI rather than hanging.

Removing that timeout (`bothThreadsFinished.await(5, TimeUnit.SECONDS)` -> `bothThreadsFinished.await()`) and running it against the current `synchronized (this)` implementation hangs the JVM indefinitely. A `jcmd <pid> Thread.print` against the hung process confirms the exact deadlock:

```
Found one Java-level deadlock:
=============================
"holds-external-lock-then-wants-jar-monitor":
  waiting to lock monitor 0x0000000c8127b020 (object 0x00000007a06f3450, a org.springframework.boot.loader.jar.NestedJarFile),
  which is held by "holds-jar-monitor-then-wants-external-lock"

"holds-jar-monitor-then-wants-external-lock":
  waiting to lock monitor 0x0000000c8127af40 (object 0x00000007a06f34b0, a java.lang.Object),
  which is held by "holds-external-lock-then-wants-jar-monitor"

Java stack information for the threads listed above:
===================================================
"holds-external-lock-then-wants-jar-monitor":
	at org.springframework.boot.loader.jar.NestedJarFile.hasEntry(NestedJarFile.java:252)
	- waiting to lock <0x00000007a06f3450> (a org.springframework.boot.loader.jar.NestedJarFile)
	at org.springframework.boot.loader.jar.PreChangeNestedJarFileLockOrderingDeadlockTests.lambda$forceContentionForLock$0(PreChangeNestedJarFileLockOrderingDeadlockTests.java:61)
	- locked <0x00000007a06f34b0> (a java.lang.Object)
"holds-jar-monitor-then-wants-external-lock":
	at org.springframework.boot.loader.jar.PreChangeNestedJarFileLockOrderingDeadlockTests.lambda$forceContentionForLock$1(PreChangeNestedJarFileLockOrderingDeadlockTests.java:76)
	- waiting to lock <0x00000007a06f34b0> (a java.lang.Object)
	- locked <0x00000007a06f3450> (a org.springframework.boot.loader.jar.NestedJarFile)

Found 1 deadlock.
```

This is the same shape as the thread dumps in gh-51463 and gh-51379 - `NestedJarFile.hasEntry()` blocked waiting to lock a `NestedJarFile`/`UrlNestedJarFile` instance, with a second thread holding that same lock while blocked on something else. gh-51379 was closed for lack of a minimal reproduction; this test and dump are that reproduction.

This also isn't specific to virtual threads - the reproduction above uses plain platform threads. The underlying defect is `NestedJarFile` locking on `synchronized (this)`, exposing its own monitor to any external code that happens to synchronize on the same instance. Virtual threads make it easier to hit in practice (no thread-pool queueing to throttle concurrent classloading traffic), but they're not the cause.

Closes gh-51463
Closes gh-51379
