### PR TITLE
Fix unrecognized JSpecify nullable annotation locations

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/PropertyMapper.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/PropertyMapper.java
@@ -430,7 +430,7 @@ public final class PropertyMapper {
 			 * @param consumer the consumer that should accept the value if it's not been
 			 * filtered
 			 */
-			public void to(Consumer<@Nullable ? super T> consumer) {
+			public void to(Consumer<? super @Nullable T> consumer) {
 				Assert.notNull(consumer, "'consumer' must not be null");
 				T value = getValue();
 				if (value == null || test(value)) {

--- a/module/spring-boot-webflux/src/main/java/org/springframework/boot/webflux/actuate/endpoint/web/AbstractWebFluxEndpointHandlerMapping.java
+++ b/module/spring-boot-webflux/src/main/java/org/springframework/boot/webflux/actuate/endpoint/web/AbstractWebFluxEndpointHandlerMapping.java
@@ -416,7 +416,7 @@ public abstract class AbstractWebFluxEndpointHandlerMapping extends RequestMappi
 		}
 
 		private @Nullable Publisher<?> invoke(InvocationContext invocationContext) {
-			return (@Nullable Publisher<?>) this.invoker.invoke(invocationContext);
+			return (Publisher<?>) this.invoker.invoke(invocationContext);
 		}
 
 		private Map<String, Object> getArguments(ServerWebExchange exchange, @Nullable Map<String, String> body) {


### PR DESCRIPTION
## Why

NullAway’s new `JSpecifyUnrecognizedAnnotationLocation` checker found five `@Nullable` annotations in locations that JSpecify does not recognize. Those annotations do not express the intended nullness to JSpecify-aware tools.

## What

Move wildcard annotations onto their bounds, where JSpecify recognizes them, and remove annotations from a cast and a local-variable root type where the enclosing declarations already express or infer the nullable result.

## How to verify

- Built all `compileJava` tasks with the NullAway snapshot from uber/NullAway#1787 and `JSpecifyUnrecognizedAnnotationLocation` configured at `ERROR` severity.
- `./gradlew :core:spring-boot:test --tests org.springframework.boot.context.properties.PropertyMapperTests`
- `./gradlew :module:spring-boot-jpa:test --tests org.springframework.boot.jpa.EntityManagerFactoryBuilderTests`
- `./gradlew :module:spring-boot-webflux:test --tests org.springframework.boot.webflux.actuate.endpoint.web.AbstractWebFluxEndpointHandlerMappingTests`