### PR TITLE
Index indexed children rather than scanning per element

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/IndexedElementsBinder.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/IndexedElementsBinder.java
@@ -40,6 +40,7 @@ import org.springframework.core.ResolvableType;
  * @param <T> the type being bound
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Tommy Karlsson
  */
 abstract class IndexedElementsBinder<T> extends AggregateBinder<T> {
 
@@ -129,10 +130,9 @@ abstract class IndexedElementsBinder<T> extends AggregateBinder<T> {
 	private Set<String> getKnownIndexedChildren(IterableConfigurationPropertySource source,
 			ConfigurationPropertyName root) {
 		Set<String> knownIndexedChildren = new HashSet<>();
-		for (ConfigurationPropertyName name : source.filter(root::isAncestorOf)) {
-			ConfigurationPropertyName choppedName = name.chop(root.getNumberOfElements() + 1);
-			if (choppedName.isLastElementIndexed()) {
-				knownIndexedChildren.add(choppedName.getLastElement(Form.UNIFORM));
+		for (ConfigurationPropertyName child : source.getChildrenOf(root)) {
+			if (child.isLastElementIndexed()) {
+				knownIndexedChildren.add(child.getLastElement(Form.UNIFORM));
 			}
 		}
 		return knownIndexedChildren;

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/source/IterableConfigurationPropertySource.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/source/IterableConfigurationPropertySource.java
@@ -17,6 +17,8 @@
 package org.springframework.boot.context.properties.source;
 
 import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -34,6 +36,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Tommy Karlsson
  * @since 2.0.0
  * @see ConfigurationPropertyName
  * @see OriginTrackedValue
@@ -64,6 +67,31 @@ public interface IterableConfigurationPropertySource
 	@Override
 	default ConfigurationPropertyState containsDescendantOf(ConfigurationPropertyName name) {
 		return ConfigurationPropertyState.search(this, name::isAncestorOf);
+	}
+
+	/**
+	 * Return the names directly beneath the given name. For example, if this source
+	 * contains {@code foo.bar} and {@code foo.baz[0]}, the children of {@code foo} are
+	 * {@code foo.bar} and {@code foo.baz}.
+	 * <p>
+	 * A returned name is not necessarily a name that this source has a value for. Given
+	 * only {@code foo.bar.baz}, the children of {@code foo} are {@code foo.bar}, for
+	 * which {@link #getConfigurationProperty(ConfigurationPropertyName)} returns
+	 * {@code null}.
+	 * <p>
+	 * Implementations that can answer without inspecting every name they contain should
+	 * override this method, since callers may ask about many names in turn.
+	 * @param name the name whose children should be returned
+	 * @return the child names (never {@code null})
+	 * @since 4.2.0
+	 */
+	default Set<ConfigurationPropertyName> getChildrenOf(ConfigurationPropertyName name) {
+		Set<ConfigurationPropertyName> children = new LinkedHashSet<>();
+		int childElements = name.getNumberOfElements() + 1;
+		for (ConfigurationPropertyName candidate : this.filter(name::isAncestorOf)) {
+			children.add(candidate.chop(childElements));
+		}
+		return children;
 	}
 
 	@Override

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySource.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySource.java
@@ -150,14 +150,8 @@ class SpringIterableConfigurationPropertySource extends SpringConfigurationPrope
 			return result;
 		}
 		if (this.ancestorOfCheck == PropertyMapper.DEFAULT_ANCESTOR_OF_CHECK) {
-			Set<ConfigurationPropertyName> descendants = getCache().getDescendants();
-			if (descendants != null) {
-				if (name.isEmpty() && !descendants.isEmpty()) {
-					return ConfigurationPropertyState.PRESENT;
-				}
-				return !descendants.contains(name) ? ConfigurationPropertyState.ABSENT
-						: ConfigurationPropertyState.PRESENT;
-			}
+			return getCache().hasChildren(name) ? ConfigurationPropertyState.PRESENT
+					: ConfigurationPropertyState.ABSENT;
 		}
 		result = (this.containsDescendantOfCache != null) ? this.containsDescendantOfCache.get(name) : null;
 		if (result == null) {
@@ -198,8 +192,7 @@ class SpringIterableConfigurationPropertySource extends SpringConfigurationPrope
 
 	private Cache createCache() {
 		boolean immutable = isImmutablePropertySource();
-		boolean captureDescendants = this.ancestorOfCheck == PropertyMapper.DEFAULT_ANCESTOR_OF_CHECK;
-		return new Cache(getMappers(), immutable, captureDescendants, isSystemEnvironmentSource());
+		return new Cache(getMappers(), immutable, isSystemEnvironmentSource());
 	}
 
 	private Cache updateCache(Cache cache) {
@@ -231,17 +224,13 @@ class SpringIterableConfigurationPropertySource extends SpringConfigurationPrope
 
 		private final boolean immutable;
 
-		private final boolean captureDescendants;
-
 		private final boolean systemEnvironmentSource;
 
 		private volatile @Nullable Data data;
 
-		Cache(PropertyMapper[] mappers, boolean immutable, boolean captureDescendants,
-				boolean systemEnvironmentSource) {
+		Cache(PropertyMapper[] mappers, boolean immutable, boolean systemEnvironmentSource) {
 			this.mappers = mappers;
 			this.immutable = immutable;
-			this.captureDescendants = captureDescendants;
 			this.systemEnvironmentSource = systemEnvironmentSource;
 		}
 
@@ -274,7 +263,6 @@ class SpringIterableConfigurationPropertySource extends SpringConfigurationPrope
 					(data != null) ? data.mappings() : null, size);
 			Map<String, ConfigurationPropertyName> reverseMappings = cloneOrCreate(
 					(data != null) ? data.reverseMappings() : null, size);
-			Set<ConfigurationPropertyName> descendants = (!this.captureDescendants) ? null : new HashSet<>();
 			Map<String, Object> systemEnvironmentCopy = (!this.systemEnvironmentSource) ? null
 					: copySource(propertySource);
 			for (PropertyMapper propertyMapper : this.mappers) {
@@ -290,15 +278,13 @@ class SpringIterableConfigurationPropertySource extends SpringConfigurationPrope
 			}
 			Map<ConfigurationPropertyName, Set<ConfigurationPropertyName>> children = new HashMap<>(size);
 			for (String propertyName : propertyNames) {
-				ConfigurationPropertyName name = reverseMappings.get(propertyName);
-				addParents(descendants, name);
-				addChildren(children, name);
+				addChildren(children, reverseMappings.get(propertyName));
 			}
 			ConfigurationPropertyName[] configurationPropertyNames = this.immutable
 					? reverseMappings.values().toArray(new ConfigurationPropertyName[0]) : null;
 			lastUpdated = this.immutable ? null : propertyNames;
-			this.data = new Data(mappings, reverseMappings, descendants, children, configurationPropertyNames,
-					systemEnvironmentCopy, lastUpdated);
+			this.data = new Data(mappings, reverseMappings, children, configurationPropertyNames, systemEnvironmentCopy,
+					lastUpdated);
 		}
 
 		@SuppressWarnings("unchecked")
@@ -311,9 +297,9 @@ class SpringIterableConfigurationPropertySource extends SpringConfigurationPrope
 		}
 
 		/**
-		 * Record each name against its parent. Unlike
-		 * {@link #addParents(Set, ConfigurationPropertyName)} this cannot stop early when
-		 * a parent has been seen before, since the child recorded differs at each level.
+		 * Record the given name against its parent, and each of its ancestors against
+		 * theirs. The walk stops as soon as a parent is already known, since whichever
+		 * name first recorded it walked the rest of the way up.
 		 * @param children the children to update
 		 * @param name the name to record
 		 */
@@ -325,25 +311,18 @@ class SpringIterableConfigurationPropertySource extends SpringConfigurationPrope
 			ConfigurationPropertyName child = name;
 			ConfigurationPropertyName parent = name.getParent();
 			while (true) {
-				children.computeIfAbsent(parent, (key) -> new LinkedHashSet<>()).add(child);
+				Set<ConfigurationPropertyName> known = children.get(parent);
+				if (known != null) {
+					known.add(child);
+					return;
+				}
+				Set<ConfigurationPropertyName> added = new LinkedHashSet<>();
+				added.add(child);
+				children.put(parent, added);
 				if (parent.isEmpty()) {
 					return;
 				}
 				child = parent;
-				parent = parent.getParent();
-			}
-		}
-
-		private void addParents(@Nullable Set<ConfigurationPropertyName> descendants,
-				@Nullable ConfigurationPropertyName name) {
-			if (descendants == null || name == null || name.isEmpty()) {
-				return;
-			}
-			ConfigurationPropertyName parent = name.getParent();
-			while (!parent.isEmpty()) {
-				if (!descendants.add(parent)) {
-					return;
-				}
 				parent = parent.getParent();
 			}
 		}
@@ -376,10 +355,10 @@ class SpringIterableConfigurationPropertySource extends SpringConfigurationPrope
 			return names;
 		}
 
-		@Nullable Set<ConfigurationPropertyName> getDescendants() {
+		boolean hasChildren(ConfigurationPropertyName name) {
 			Data data = this.data;
 			Assert.state(data != null, "'data' must not be null");
-			return data.descendants();
+			return data.children().containsKey(name);
 		}
 
 		@Nullable Object getSystemEnvironmentProperty(String name) {
@@ -398,7 +377,6 @@ class SpringIterableConfigurationPropertySource extends SpringConfigurationPrope
 
 		private record Data(Map<ConfigurationPropertyName, Set<String>> mappings,
 				Map<String, ConfigurationPropertyName> reverseMappings,
-				@Nullable Set<ConfigurationPropertyName> descendants,
 				Map<ConfigurationPropertyName, Set<ConfigurationPropertyName>> children,
 				ConfigurationPropertyName @Nullable [] configurationPropertyNames,
 				@Nullable Map<String, Object> systemEnvironmentCopy, String @Nullable [] lastUpdated) {

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySource.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySource.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -52,6 +53,7 @@ import org.springframework.util.ConcurrentReferenceHashMap;
  *
  * @author Phillip Webb
  * @author Madhura Bhave
+ * @author Tommy Karlsson
  * @see PropertyMapper
  */
 class SpringIterableConfigurationPropertySource extends SpringConfigurationPropertySource
@@ -134,6 +136,11 @@ class SpringIterableConfigurationPropertySource extends SpringConfigurationPrope
 	@Override
 	public Iterator<ConfigurationPropertyName> iterator() {
 		return new ConfigurationPropertyNamesIterator(getConfigurationPropertyNames());
+	}
+
+	@Override
+	public Set<ConfigurationPropertyName> getChildrenOf(ConfigurationPropertyName name) {
+		return getCache().getChildren(name);
 	}
 
 	@Override
@@ -281,13 +288,16 @@ class SpringIterableConfigurationPropertySource extends SpringConfigurationPrope
 					}
 				}
 			}
+			Map<ConfigurationPropertyName, Set<ConfigurationPropertyName>> children = new HashMap<>(size);
 			for (String propertyName : propertyNames) {
-				addParents(descendants, reverseMappings.get(propertyName));
+				ConfigurationPropertyName name = reverseMappings.get(propertyName);
+				addParents(descendants, name);
+				addChildren(children, name);
 			}
 			ConfigurationPropertyName[] configurationPropertyNames = this.immutable
 					? reverseMappings.values().toArray(new ConfigurationPropertyName[0]) : null;
 			lastUpdated = this.immutable ? null : propertyNames;
-			this.data = new Data(mappings, reverseMappings, descendants, configurationPropertyNames,
+			this.data = new Data(mappings, reverseMappings, descendants, children, configurationPropertyNames,
 					systemEnvironmentCopy, lastUpdated);
 		}
 
@@ -298,6 +308,30 @@ class SpringIterableConfigurationPropertySource extends SpringConfigurationPrope
 
 		private <K, V> Map<K, V> cloneOrCreate(@Nullable Map<K, V> source, int size) {
 			return (source != null) ? new LinkedHashMap<>(source) : new LinkedHashMap<>(size);
+		}
+
+		/**
+		 * Record each name against its parent. Unlike
+		 * {@link #addParents(Set, ConfigurationPropertyName)} this cannot stop early when
+		 * a parent has been seen before, since the child recorded differs at each level.
+		 * @param children the children to update
+		 * @param name the name to record
+		 */
+		private void addChildren(Map<ConfigurationPropertyName, Set<ConfigurationPropertyName>> children,
+				@Nullable ConfigurationPropertyName name) {
+			if (name == null || name.isEmpty()) {
+				return;
+			}
+			ConfigurationPropertyName child = name;
+			ConfigurationPropertyName parent = name.getParent();
+			while (true) {
+				children.computeIfAbsent(parent, (key) -> new LinkedHashSet<>()).add(child);
+				if (parent.isEmpty()) {
+					return;
+				}
+				child = parent;
+				parent = parent.getParent();
+			}
 		}
 
 		private void addParents(@Nullable Set<ConfigurationPropertyName> descendants,
@@ -356,9 +390,16 @@ class SpringIterableConfigurationPropertySource extends SpringConfigurationPrope
 			return systemEnvironmentCopy.get(name);
 		}
 
+		Set<ConfigurationPropertyName> getChildren(ConfigurationPropertyName name) {
+			Data data = this.data;
+			Assert.state(data != null, "'data' must not be null");
+			return data.children().getOrDefault(name, Collections.emptySet());
+		}
+
 		private record Data(Map<ConfigurationPropertyName, Set<String>> mappings,
 				Map<String, ConfigurationPropertyName> reverseMappings,
 				@Nullable Set<ConfigurationPropertyName> descendants,
+				Map<ConfigurationPropertyName, Set<ConfigurationPropertyName>> children,
 				ConfigurationPropertyName @Nullable [] configurationPropertyNames,
 				@Nullable Map<String, Object> systemEnvironmentCopy, String @Nullable [] lastUpdated) {
 

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySourceTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySourceTests.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.mock;
  * @author Phillip Webb
  * @author Madhura Bhave
  * @author Fahim Farook
+ * @author Tommy Karlsson
  */
 class SpringIterableConfigurationPropertySourceTests {
 
@@ -141,6 +142,66 @@ class SpringIterableConfigurationPropertySourceTests {
 		ConfigurationProperty configurationProperty = adapter.getConfigurationProperty(name);
 		assertThat(configurationProperty).isNotNull();
 		assertThat(configurationProperty.getOrigin()).hasToString("TestOrigin key");
+	}
+
+	@Test
+	void getChildrenOfShouldReturnDirectChildren() {
+		Map<String, Object> source = new LinkedHashMap<>();
+		source.put("foo.bar", "value");
+		source.put("foo.baz[0]", "value");
+		source.put("foo.baz[1]", "value");
+		source.put("foo.qux.deep", "value");
+		source.put("faf", "value");
+		SpringIterableConfigurationPropertySource adapter = new SpringIterableConfigurationPropertySource(
+				new OriginCapablePropertySource<>(new MapPropertySource("test", source)), false,
+				DefaultPropertyMapper.INSTANCE);
+		assertThat(adapter.getChildrenOf(ConfigurationPropertyName.of("foo"))).containsExactlyInAnyOrder(
+				ConfigurationPropertyName.of("foo.bar"), ConfigurationPropertyName.of("foo.baz"),
+				ConfigurationPropertyName.of("foo.qux"));
+		assertThat(adapter.getChildrenOf(ConfigurationPropertyName.of("foo.baz"))).containsExactlyInAnyOrder(
+				ConfigurationPropertyName.of("foo.baz[0]"), ConfigurationPropertyName.of("foo.baz[1]"));
+		assertThat(adapter.getChildrenOf(ConfigurationPropertyName.of("faf"))).isEmpty();
+		assertThat(adapter.getChildrenOf(ConfigurationPropertyName.of("missing"))).isEmpty();
+	}
+
+	@Test
+	void getChildrenOfShouldMatchDefaultImplementation() {
+		Map<String, Object> source = new LinkedHashMap<>();
+		source.put("foo.bar-baz[0].name", "value");
+		source.put("foo.bar-baz[1].name", "value");
+		source.put("foo.bazBar", "value");
+		source.put("foo.other", "value");
+		SpringIterableConfigurationPropertySource adapter = new SpringIterableConfigurationPropertySource(
+				new OriginCapablePropertySource<>(new MapPropertySource("test", source)), false,
+				DefaultPropertyMapper.INSTANCE);
+		for (String name : new String[] { "", "foo", "foo.bar-baz", "foo.barbaz", "foo.bar-baz[0]", "foo.bazbar" }) {
+			ConfigurationPropertyName propertyName = ConfigurationPropertyName.of(name);
+			assertThat(adapter.getChildrenOf(propertyName)).as("children of '%s'", name)
+				.isEqualTo(defaultGetChildrenOf(adapter, propertyName));
+		}
+	}
+
+	private Set<ConfigurationPropertyName> defaultGetChildrenOf(IterableConfigurationPropertySource source,
+			ConfigurationPropertyName name) {
+		Set<ConfigurationPropertyName> children = new LinkedHashSet<>();
+		int childElements = name.getNumberOfElements() + 1;
+		for (ConfigurationPropertyName candidate : source.filter(name::isAncestorOf)) {
+			children.add(candidate.chop(childElements));
+		}
+		return children;
+	}
+
+	@Test
+	void getChildrenOfShouldCombineChildrenOfEquivalentNames() {
+		Map<String, Object> source = new LinkedHashMap<>();
+		source.put("foo-bar.baz", "x");
+		source.put("fooBar.zoo", "y");
+		SpringIterableConfigurationPropertySource adapter = new SpringIterableConfigurationPropertySource(
+				new MapPropertySource("test", source), false, DefaultPropertyMapper.INSTANCE);
+		Set<ConfigurationPropertyName> expected = Set.of(ConfigurationPropertyName.of("foo-bar.baz"),
+				ConfigurationPropertyName.of("foobar.zoo"));
+		assertThat(adapter.getChildrenOf(ConfigurationPropertyName.of("foo-bar"))).isEqualTo(expected);
+		assertThat(adapter.getChildrenOf(ConfigurationPropertyName.of("foobar"))).isEqualTo(expected);
 	}
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySourceTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/source/SpringIterableConfigurationPropertySourceTests.java
@@ -205,6 +205,22 @@ class SpringIterableConfigurationPropertySourceTests {
 	}
 
 	@Test
+	void getChildrenOfShouldMatchDefaultImplementationForSystemEnvironmentSource() {
+		Map<String, Object> source = new LinkedHashMap<>();
+		source.put("FOO_BARBAZ_BONG", "bing");
+		source.put("FOO_BAR_BAZ", "value");
+		SystemEnvironmentPropertySource propertySource = new SystemEnvironmentPropertySource(
+				StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, source);
+		SpringIterableConfigurationPropertySource adapter = new SpringIterableConfigurationPropertySource(
+				propertySource, true, SystemEnvironmentPropertyMapper.INSTANCE);
+		for (String name : new String[] { "", "foo", "foo.bar-baz", "foo.barbaz" }) {
+			ConfigurationPropertyName propertyName = ConfigurationPropertyName.of(name);
+			assertThat(adapter.getChildrenOf(propertyName)).as("children of '%s'", name)
+				.isEqualTo(defaultGetChildrenOf(adapter, propertyName));
+		}
+	}
+
+	@Test
 	void containsDescendantOfShouldCheckSourceNames() {
 		Map<String, Object> source = new LinkedHashMap<>();
 		source.put("foo.bar", "value");


### PR DESCRIPTION
`IndexedElementsBinder` discovers which indices exist beneath a name by scanning every
property name in the source:

```java
for (ConfigurationPropertyName name : source.filter(root::isAncestorOf)) {
    ConfigurationPropertyName choppedName = name.chop(root.getNumberOfElements() + 1);
    if (choppedName.isLastElementIndexed()) { ... }
}
```

The indexed property-name syntax carries no length, so the only evidence that `tags[0]`
exists is that some name happens to look like `tags[0].name`. That means one full scan per
indexed element. When many indexed elements share a namespace — a large `Map` whose values
contain lists, say — binding becomes quadratic in the number of elements.

Binding a `Map` whose values each contain two lists:

| entries | before | after |
| --- | --- | --- |
| 100 | 22.7ms | 12.7ms |
| 400 | 130.9ms | 21.3ms |
| 800 | 456.5ms | 30.1ms |
| 1600 | 1879ms | 59ms |

The per-element cost stops growing with the size of the source.

## Changes

**Add `getChildrenOf` to `IterableConfigurationPropertySource`.** The default implementation
performs the same scan as before, so sources that cannot answer more cheaply are unaffected.
`SpringIterableConfigurationPropertySource` overrides it and answers from mappings built
during the pass its cache already makes over property names.

**Answer `containsDescendantOf` from those mappings.** The cache built a separate descendants
set purely so `containsDescendantOf` could avoid scanning. The children mappings have the
same key set, so that set is now redundant and is removed along with `addParents` and its
capture flag.

Like `addParents` before it, `addChildren` stops walking as soon as it reaches a parent that
is already known — whichever name first recorded that parent walked the rest of the way up.
Without that short-circuit the mappings take roughly twice as long to build. With it,
building the mappings for 6000 property names takes 3.6-4.2ms, against 3.6-4.1ms for the
descendants set they replace.

The `ancestorOfCheck` guard is kept in `containsDescendantOf`, since a mapper with a custom
check (`SystemEnvironmentPropertyMapper`) still needs its own ancestor logic. The children
mappings themselves are built for every source, because `getChildrenOf` needs them
regardless of which mapper is in use.

## Notes

- `getChildrenOf` has one caller today. I looked at the other `isAncestorOf`/`isParentOf`
  sites (`NoUnboundElementsBindHandler`, `ValidationBindHandler`,
  `assertNoUnboundChildren`); they all want *descendants* rather than direct children, so
  none migrate cleanly.
- Memory use of the children mappings is not measured. They hold a `Set` per parent where
  the descendants set held one flat set of parents.
- Tests cover direct children, agreement with the default implementation, equivalent names
  written differently (`foo-bar` / `fooBar`), and system environment sources.
