### PR TITLE
Fix StackOverflowError with JsonValueWriter re-entrancy in ValueProce…

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/json/JsonValueWriter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/json/JsonValueWriter.java
@@ -61,6 +61,8 @@ class JsonValueWriter {
 
 	private final Deque<ActiveSeries> activeSeries = new ArrayDeque<>();
 
+	private boolean processingValue;
+
 	/**
 	 * Create a new {@link JsonValueWriter} instance.
 	 * @param out the {@link Appendable} used to receive the JSON output
@@ -337,13 +339,28 @@ class JsonValueWriter {
 		return name;
 	}
 
+	/**
+	 * Process a value through active {@link ValueProcessor} instances with re-entrancy protection
+	 * to prevent infinite recursion and {@link StackOverflowError}.
+	 * @param value the value to process
+	 * @param <V> the value type
+	 * @return the processed value
+	 */
 	private <V> @Nullable V processValue(@Nullable V value) {
-		for (JsonWriterFiltersAndProcessors filtersAndProcessors : this.filtersAndProcessors) {
-			for (ValueProcessor<?> valueProcessor : filtersAndProcessors.valueProcessors()) {
-				value = processValue(value, valueProcessor);
-			}
+		if (this.processingValue) {
+			return value;
 		}
-		return value;
+		this.processingValue = true;
+		try {
+			for (JsonWriterFiltersAndProcessors filtersAndProcessors : this.filtersAndProcessors) {
+				value = filtersAndProcessors.valueProcessors().stream()
+					.reduce(value, (v, processor) -> processValue(v, processor), (v1, v2) -> v2);
+			}
+			return value;
+		}
+		finally {
+			this.processingValue = false;
+		}
 	}
 
 	// Lambda isn't detected with the correct nullability

--- a/core/spring-boot/src/test/java/org/springframework/boot/json/JsonValueWriterTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/json/JsonValueWriterTests.java
@@ -31,9 +31,10 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import org.springframework.boot.json.JsonValueWriter.Series;
+import org.springframework.boot.json.JsonWriter.ValueProcessor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
@@ -321,6 +322,23 @@ class JsonValueWriterTests {
 		writer.end(Series.ARRAY);
 		writer.end(Series.ARRAY);
 		assertThat(out).hasToString("[[[]]]");
+	}
+
+	@Test // gh-50651
+	void valueProcessorShouldNotAllowReentrancy() {
+		// Ensures that a ValueProcessor attempting recursive writing/processing
+		// does not trigger infinite recursion or StackOverflowError.
+		StringBuilder out = new StringBuilder();
+		JsonValueWriter writer = new JsonValueWriter(out);
+		JsonWriterFiltersAndProcessors processors = new JsonWriterFiltersAndProcessors(
+				List.of(), List.of(), List.of(),
+				List.of(ValueProcessor.of((value) -> {
+					writer.write("nested");
+					return value;
+				}))
+		);
+		writer.pushProcessors(processors);
+		assertThatCode(() -> writer.write("test")).doesNotThrowAnyException();
 	}
 
 	private <V> String write(@Nullable V value) {


### PR DESCRIPTION
## Fix: StackOverflowError at startup with embedded Tomcat, ecs, debug level, and members value processor

This pull request fixes issue #50651 where applications experienced a `StackOverflowError` at startup when combining embedded Tomcat, ECS structured logging, debug log level, and a custom `StructuredLoggingJsonMembersCustomizer` applying a members `ValueProcessor`.

### Broken Behavior
During structured JSON serialization of log events (such as exceptions/throwables via Logback's `ThrowableProxy`), evaluating `ValueProcessor` instances can inadvertently trigger logging operations or class loading (`TomcatEmbeddedWebappClassLoader`). If these internal triggers attempt to write JSON or re-evaluate values, it leads to unconstrained re-entrancy and infinite recursion (`StackOverflowError`).

### How the Changes Fix It
- Added a re-entrancy guard (`processingValue` flag) to `JsonValueWriter#processValue(V)` utilizing Java Streams and `.reduce()` for functional elegance.
- If value processing is already active for the current writer instance, nested/re-entrant calls safely bypass further processor evaluation.
- Added a dedicated unit test (`valueProcessorShouldNotAllowReentrancy`) in `JsonValueWriterTests` to ensure re-entrant value processing does not cause infinite recursion or throw exceptions.

Fixes #50651
