### PR TITLE
Fix typos across the codebase

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/JavaConventions.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/JavaConventions.java
@@ -393,14 +393,14 @@ class JavaConventions {
 			// https://github.com/spring-projects/spring-graphql/issues/1515
 			String group = details.getId().getGroup();
 			if ("org.springframework".equals(group) || "org.springframework.graphql".equals(group)) {
-				addDocumentaionVariant(project, details, "javadocElements", DocsType.JAVADOC, "javadoc");
-				addDocumentaionVariant(project, details, "sourcesElements", DocsType.SOURCES, "sources");
+				addDocumentationVariant(project, details, "javadocElements", DocsType.JAVADOC, "javadoc");
+				addDocumentationVariant(project, details, "sourcesElements", DocsType.SOURCES, "sources");
 			}
 		});
 	}
 
-	private void addDocumentaionVariant(Project project, ComponentMetadataDetails details, String name, String docsType,
-			String classifier) {
+	private void addDocumentationVariant(Project project, ComponentMetadataDetails details, String name,
+			String docsType, String classifier) {
 		ModuleVersionIdentifier id = details.getId();
 		String file = "%s-%s-%s.jar".formatted(id.getName(), id.getVersion(), classifier);
 		details.addVariant(name, (variant) -> {

--- a/buildSrc/src/main/java/org/springframework/boot/build/bom/Library.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/bom/Library.java
@@ -528,8 +528,8 @@ public class Library {
 				return Collections.emptyList();
 			}
 			return manager.getGroups().stream().flatMap((group) -> group.getBoms().stream().map((bom) -> {
-				String plaform = group.getId() + ":" + bom.name() + ":" + manager.getVersion();
-				return this.project.getDependencies().platform(plaform);
+				String platform = group.getId() + ":" + bom.name() + ":" + manager.getVersion();
+				return this.project.getDependencies().platform(platform);
 			})).toList();
 		}
 

--- a/buildSrc/src/test/java/org/springframework/boot/build/bom/bomr/InteractiveUpgradeResolverTests.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/bom/bomr/InteractiveUpgradeResolverTests.java
@@ -41,9 +41,9 @@ class InteractiveUpgradeResolverTests {
 	@Test
 	void resolveUpgradeUpdateVersionNumberInLibrary() {
 		UserInputHandler userInputHandler = mock(UserInputHandler.class);
-		LibraryUpdateResolver libaryUpdateResolver = mock(LibraryUpdateResolver.class);
+		LibraryUpdateResolver libraryUpdateResolver = mock(LibraryUpdateResolver.class);
 		InteractiveUpgradeResolver upgradeResolver = new InteractiveUpgradeResolver(userInputHandler,
-				libaryUpdateResolver);
+				libraryUpdateResolver);
 		List<Library> libraries = new ArrayList<>();
 		DependencyVersion version = DependencyVersion.parse("1.0.0");
 		Library library = new Library("test", null, version, null, null, null, null, null, null, null, null, null);
@@ -54,7 +54,7 @@ class InteractiveUpgradeResolverTests {
 		DependencyVersion updateVersion = DependencyVersion.parse("1.0.1");
 		VersionOption versionOption = new VersionOption(updateVersion);
 		updates.add(new LibraryWithVersionOptions(library, List.of(versionOption)));
-		given(libaryUpdateResolver.findLibraryUpdates(any(), any())).willReturn(updates);
+		given(libraryUpdateResolver.findLibraryUpdates(any(), any())).willReturn(updates);
 		Provider<Object> providerOfVersionOption = providerOf(versionOption);
 		given(userInputHandler.askUser(any())).willReturn(providerOfVersionOption);
 		List<Upgrade> upgrades = upgradeResolver.resolveUpgrades(librariesToUpgrade, libraries);

--- a/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/test/CompiledMetadataReader.java
+++ b/configuration-metadata/spring-boot-configuration-processor/src/test/java/org/springframework/boot/configurationprocessor/test/CompiledMetadataReader.java
@@ -51,7 +51,7 @@ public final class CompiledMetadataReader {
 			}
 		}
 		catch (Exception ex) {
-			throw new RuntimeException("Failed to read metadata fom '%s'".formatted(location), ex);
+			throw new RuntimeException("Failed to read metadata from '%s'".formatted(location), ex);
 		}
 	}
 

--- a/core/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/lifecycle/TestcontainersStartup.java
+++ b/core/spring-boot-testcontainers/src/main/java/org/springframework/boot/testcontainers/lifecycle/TestcontainersStartup.java
@@ -100,7 +100,7 @@ public enum TestcontainersStartup {
 	}
 
 	/**
-	 * Start the given {@link Startable} unless is's detected as already running.
+	 * Start the given {@link Startable} unless it's detected as already running.
 	 * @param startable the startable to start
 	 * @since 3.4.1
 	 */

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
@@ -1021,13 +1021,13 @@ class ConfigDataEnvironmentPostProcessorIntegrationTests {
 	@Test
 	void runWhenHasNonOptionalImportThrowsException() {
 		assertThatExceptionOfType(ConfigDataResourceNotFoundException.class).isThrownBy(
-				() -> this.application.run("--spring.config.location=classpath:missing-appplication.properties"));
+				() -> this.application.run("--spring.config.location=classpath:missing-application.properties"));
 	}
 
 	@Test
 	void runWhenHasNonOptionalImportAndIgnoreNotFoundPropertyDoesNotThrowException() {
 		this.application.run("--spring.config.on-not-found=ignore",
-				"--spring.config.location=classpath:missing-appplication.properties");
+				"--spring.config.location=classpath:missing-application.properties");
 	}
 
 	@Test

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/task-execution-and-scheduling.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/task-execution-and-scheduling.adoc
@@ -23,7 +23,7 @@ For Spring MVC and Spring WebFlux, this bean must be of type javadoc:org.springf
 
 Spring WebSocket and JPA will use javadoc:org.springframework.core.task.AsyncTaskExecutor[] if either a single bean of this type is available or a bean named `applicationTaskExecutor` is defined.
 
-Finally, the boostrap executor of the `ApplicationContext` uses a bean named `applicationTaskExecutor` unless a bean named `bootstrapExecutor` is defined.
+Finally, the bootstrap executor of the `ApplicationContext` uses a bean named `applicationTaskExecutor` unless a bean named `bootstrapExecutor` is defined.
 
 The following code snippet demonstrates how to register a custom javadoc:org.springframework.core.task.AsyncTaskExecutor[] to be used with Spring MVC, Spring WebFlux, Spring GraphQL, Spring WebSocket, JPA, and background initialization of beans.
 

--- a/loader/spring-boot-jarmode-tools/src/main/java/org/springframework/boot/jarmode/tools/ExtractCommand.java
+++ b/loader/spring-boot-jarmode-tools/src/main/java/org/springframework/boot/jarmode/tools/ExtractCommand.java
@@ -248,7 +248,7 @@ class ExtractCommand extends Command {
 		Manifest manifest = jarStructure.createLauncherManifest((library) -> librariesDirectory + library);
 		mkdirs(file.getParentFile());
 		try (JarOutputStream output = new JarOutputStream(new FileOutputStream(file))) {
-			ManfiestWriter manfiestWriter = (sourceJarFile) -> {
+			ManifestWriter manifestWriter = (sourceJarFile) -> {
 				JarEntry entry = createJarEntry(JarFile.MANIFEST_NAME,
 						sourceJarFile.getJarEntry(JarFile.MANIFEST_NAME));
 				output.putNextEntry(entry);
@@ -257,7 +257,7 @@ class ExtractCommand extends Command {
 			};
 			EnumSet<Type> allowedTypes = EnumSet.of(Type.APPLICATION_CLASS_OR_RESOURCE, Type.META_INF);
 			Set<String> writtenEntries = new HashSet<>();
-			withJarEntries(this.context.getArchiveFile(), manfiestWriter, ((stream, jarEntry) -> {
+			withJarEntries(this.context.getArchiveFile(), manifestWriter, ((stream, jarEntry) -> {
 				Entry entry = jarStructure.resolve(jarEntry);
 				if (entry != null && allowedTypes.contains(entry.type()) && StringUtils.hasLength(entry.location())) {
 					JarEntry newJarEntry = createJarEntry(entry.location(), jarEntry);
@@ -346,11 +346,11 @@ class ExtractCommand extends Command {
 		withJarEntries(file, null, callback);
 	}
 
-	private static void withJarEntries(File file, @Nullable ManfiestWriter manfiestWriter, ThrowingConsumer callback)
+	private static void withJarEntries(File file, @Nullable ManifestWriter manifestWriter, ThrowingConsumer callback)
 			throws IOException {
 		try (JarFile jarFile = new JarFile(file)) {
-			if (manfiestWriter != null) {
-				manfiestWriter.writeManifest(jarFile);
+			if (manifestWriter != null) {
+				manifestWriter.writeManifest(jarFile);
 			}
 			Enumeration<JarEntry> entries = jarFile.entries();
 			while (entries.hasMoreElements()) {
@@ -385,7 +385,7 @@ class ExtractCommand extends Command {
 	}
 
 	@FunctionalInterface
-	private interface ManfiestWriter {
+	private interface ManifestWriter {
 
 		void writeManifest(JarFile sourceJarFile) throws IOException;
 

--- a/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/nio/file/NestedPath.java
+++ b/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/nio/file/NestedPath.java
@@ -50,7 +50,7 @@ final class NestedPath implements Path {
 
 	NestedPath(NestedFileSystem fileSystem, String nestedEntryName) {
 		if (fileSystem == null) {
-			throw new IllegalArgumentException("'filesSystem' must not be null");
+			throw new IllegalArgumentException("'fileSystem' must not be null");
 		}
 		this.fileSystem = fileSystem;
 		this.nestedEntryName = (nestedEntryName != null && !nestedEntryName.isBlank()) ? nestedEntryName : null;

--- a/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/zip/ZipContent.java
+++ b/loader/spring-boot-loader/src/main/java/org/springframework/boot/loader/zip/ZipContent.java
@@ -697,10 +697,10 @@ public final class ZipContent implements Closeable {
 		}
 
 		void detect(ZipCentralDirectoryFileHeaderRecord centralRecord, FileDataBlock data, long pos,
-				ByteBuffer loadeBuffer) throws IOException {
+				ByteBuffer loadedBuffer) throws IOException {
 			if (!this.detected) {
 				long filenamePos = pos + ZipCentralDirectoryFileHeaderRecord.FILE_NAME_OFFSET;
-				if (centralRecord.fileNameLength() > this.buffer.capacity() && ZipString.startsWith(loadeBuffer, data,
+				if (centralRecord.fileNameLength() > this.buffer.capacity() && ZipString.startsWith(loadedBuffer, data,
 						filenamePos, centralRecord.fileNameLength(), META_INF) >= 0) {
 					this.buffer.clear();
 					data.readFully(this.buffer, filenamePos + centralRecord.fileNameLength() - this.buffer.capacity());

--- a/loader/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/NestedJarFileTests.java
+++ b/loader/spring-boot-loader/src/test/java/org/springframework/boot/loader/jar/NestedJarFileTests.java
@@ -193,7 +193,7 @@ class NestedJarFileTests {
 
 	@Test
 	void getEntryWhenMultiReleaseEntryReturnsEntry() throws IOException {
-		File multiReleaseFile = new File(this.tempDir, "mutli.zip");
+		File multiReleaseFile = new File(this.tempDir, "multi.zip");
 		try (ZipContent zip = ZipContent.open(this.file.toPath(), "multi-release.jar")) {
 			try (InputStream in = zip.openRawZipData().asInputStream()) {
 				try (FileOutputStream out = new FileOutputStream(multiReleaseFile)) {

--- a/module/spring-boot-jetty/src/test/java/org/springframework/boot/jetty/autoconfigure/servlet/JettyServletWebServerAutoConfigurationTests.java
+++ b/module/spring-boot-jetty/src/test/java/org/springframework/boot/jetty/autoconfigure/servlet/JettyServletWebServerAutoConfigurationTests.java
@@ -75,7 +75,7 @@ class JettyServletWebServerAutoConfigurationTests extends AbstractServletWebServ
 	}
 
 	@Test
-	void jettyWebSocketUpgradeFilterIsAddedToServletContex() {
+	void jettyWebSocketUpgradeFilterIsAddedToServletContext() {
 		this.serverRunner.run((context) -> {
 			ServletContext servletContext = context.getServletContext();
 			assertThat(servletContext).isNotNull();

--- a/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/ConnectionFactoryUnwrapper.java
+++ b/module/spring-boot-jms/src/main/java/org/springframework/boot/jms/ConnectionFactoryUnwrapper.java
@@ -44,8 +44,8 @@ public final class ConnectionFactoryUnwrapper {
 	 */
 	public static ConnectionFactory unwrapCaching(ConnectionFactory connectionFactory) {
 		if (connectionFactory instanceof CachingConnectionFactory cachingConnectionFactory) {
-			ConnectionFactory unwrapedConnectionFactory = cachingConnectionFactory.getTargetConnectionFactory();
-			return (unwrapedConnectionFactory != null) ? unwrapCaching(unwrapedConnectionFactory) : connectionFactory;
+			ConnectionFactory unwrappedConnectionFactory = cachingConnectionFactory.getTargetConnectionFactory();
+			return (unwrappedConnectionFactory != null) ? unwrapCaching(unwrappedConnectionFactory) : connectionFactory;
 		}
 		return connectionFactory;
 	}

--- a/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/autoconfigure/export/otlp/OtlpMetricsPropertiesConfigAdapterTests.java
+++ b/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/autoconfigure/export/otlp/OtlpMetricsPropertiesConfigAdapterTests.java
@@ -197,7 +197,7 @@ class OtlpMetricsPropertiesConfigAdapterTests {
 	}
 
 	@Test
-	void shouldUseApplicationGroupIfServiceNamspaceIsNotSet() {
+	void shouldUseApplicationGroupIfServiceNamespaceIsNotSet() {
 		this.environment.setProperty("spring.application.group", "alpha");
 		assertThat(createAdapter().resourceAttributes()).containsEntry("service.namespace", "alpha");
 	}

--- a/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/autoconfigure/startup/StartupTimeMetricsListenerAutoConfigurationTests.java
+++ b/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/autoconfigure/startup/StartupTimeMetricsListenerAutoConfigurationTests.java
@@ -55,9 +55,9 @@ class StartupTimeMetricsListenerAutoConfigurationTests {
 			SimpleMeterRegistry registry = context.getBean(SimpleMeterRegistry.class);
 			context.publishEvent(new ApplicationStartedEvent(new SpringApplication(), new String[0],
 					context.getSourceApplicationContext(), Duration.ofMillis(1500)));
-			TimeGauge startedTimeGage = registry.find("application.started.time").timeGauge();
-			assertThat(startedTimeGage).isNotNull();
-			assertThat(startedTimeGage.value(TimeUnit.MILLISECONDS)).isEqualTo(1500L);
+			TimeGauge startedTimeGauge = registry.find("application.started.time").timeGauge();
+			assertThat(startedTimeGauge).isNotNull();
+			assertThat(startedTimeGauge.value(TimeUnit.MILLISECONDS)).isEqualTo(1500L);
 			context.publishEvent(new ApplicationReadyEvent(new SpringApplication(), new String[0],
 					context.getSourceApplicationContext(), Duration.ofMillis(2000)));
 			TimeGauge readyTimeGage = registry.find("application.ready.time").timeGauge();

--- a/platform/spring-boot-dependencies/build.gradle
+++ b/platform/spring-boot-dependencies/build.gradle
@@ -482,7 +482,7 @@ bom {
 	library("GraphQL Java", "25.0") {
 		prohibit {
 			startsWith(["2018-", "2019-", "2020-", "2021-", "230521-"])
-			because "we don't want thses snapshots"
+			because "we don't want these snapshots"
 		}
 		alignWith {
 			version {


### PR DESCRIPTION
This PR fixes several spelling errors across the codebase.

No public API is changed. The changes are intended to be behavior-neutral.

All tests (including system tests) passed locally using the following commands:
```bash
$ ./gradlew clean build
$ ./gradlew clean systemTest
```

<details>
<summary>Corrections by file</summary>

| File | Before | After |
| --- | --- | --- |
| JavaConventions.java | `addDocumentaionVariant` | `addDocumentationVariant` |
| Library.java | `plaform` | `platform` |
| InteractiveUpgradeResolverTests.java | `libaryUpdateResolver` | `libraryUpdateResolver` |
| CompiledMetadataReader.java | `fom` | `from` |
| TestcontainersStartup.java | `is's` | `it's` |
| ConfigDataEnvironmentPostProcessorIntegrationTests.java | `missing-appplication.properties` | `missing-application.properties` |
| InfoEndpointDocumentationTests.java | `availabe` | `available` |
| task-execution-and-scheduling.adoc | `boostrap` | `bootstrap` |
| grpc.adoc | `auto-configre` | `auto-configure` |
| ExtractCommand.java | `Manfiest` / `manfiest` | `Manifest` / `manifest` |
| NestedPath.java | `filesSystem` | `fileSystem` |
| ZipContent.java | `loadeBuffer` | `loadedBuffer` |
| NestedJarFileTests.java | `mutli.zip` | `multi.zip` |
| GrpcServerHealthSchedulerTests.java | `registartion` | `registration` |
| HibernateJpaAutoConfigurationTests.java | `Bootstraping` / `Taks` | `Bootstrapping` / `Task` |
| InetAddressFilter.java | `spcified` | `specified` |
| InternalInetAddressFilter.java | `addess` | `address` |
| JettyServletWebServerAutoConfigurationTests.java | `Contex` | `Context` |
| ConnectionFactoryUnwrapper.java | `unwraped` | `unwrapped` |
| OtlpMetricsPropertiesConfigAdapterTests.java | `Namspace` | `Namespace` |
| StartupTimeMetricsListenerAutoConfigurationTests.java | `Gage` | `Gauge` |
| JwtDecoderConfiguration.java | `propery` | `property` |
| ReactiveJwtDecoderConfiguration.java | `propery` | `property` |
| spring-boot-dependencies/build.gradle | `thses` | `these` |

</details>