### PR TITLE
Remove unnecessary NullAway suppressions

### DIFF
--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/SpringBootPluginTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/plugin/SpringBootPluginTests.java
@@ -38,7 +38,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SpringBootPluginTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@Test

--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoTests.java
@@ -43,7 +43,6 @@ import static org.assertj.core.api.Assertions.assertThatException;
 class BuildInfoTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@Test

--- a/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/AbstractBootArchiveTests.java
+++ b/build-plugin/spring-boot-gradle-plugin/src/test/java/org/springframework/boot/gradle/tasks/bundling/AbstractBootArchiveTests.java
@@ -80,7 +80,6 @@ import static org.mockito.Mockito.mock;
 abstract class AbstractBootArchiveTests<T extends Jar & BootArchive> {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	private final Class<T> taskClass;

--- a/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunArguments.java
+++ b/build-plugin/spring-boot-maven-plugin/src/main/java/org/springframework/boot/maven/RunArguments.java
@@ -38,7 +38,6 @@ class RunArguments {
 		this(parseArgs(arguments));
 	}
 
-	@SuppressWarnings("NullAway") // Maven can't handle nullable arrays
 	RunArguments(@Nullable String[] args) {
 		this((args != null) ? Arrays.asList(args) : null);
 	}

--- a/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ArtifactsLibrariesTests.java
+++ b/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/ArtifactsLibrariesTests.java
@@ -57,11 +57,9 @@ import static org.mockito.Mockito.times;
 class ArtifactsLibrariesTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Artifact artifact;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ArtifactHandler artifactHandler;
 
 	private Set<Artifact> artifacts;
@@ -71,11 +69,9 @@ class ArtifactsLibrariesTests {
 	private ArtifactsLibraries libs;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private LibraryCallback callback;
 
 	@Captor
-	@SuppressWarnings("NullAway.Init")
 	private ArgumentCaptor<Library> libraryCaptor;
 
 	@BeforeEach

--- a/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/DependencyFilterMojoTests.java
+++ b/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/DependencyFilterMojoTests.java
@@ -49,7 +49,6 @@ import static org.mockito.Mockito.mock;
 class DependencyFilterMojoTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	static Path temp;
 
 	@Test

--- a/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/JarTypeFilterTests.java
+++ b/build-plugin/spring-boot-maven-plugin/src/test/java/org/springframework/boot/maven/JarTypeFilterTests.java
@@ -39,7 +39,6 @@ import static org.mockito.Mockito.mock;
 class JarTypeFilterTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	Path temp;
 
 	@Test

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildRequestTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/BuildRequestTests.java
@@ -61,7 +61,6 @@ class BuildRequestTests {
 	private static final ZoneId UTC = ZoneId.of("UTC");
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	@Test

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/DirectoryBuildpackTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/DirectoryBuildpackTests.java
@@ -50,7 +50,6 @@ import static org.mockito.Mockito.mock;
 class DirectoryBuildpackTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	private File buildpackDir;

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/EphemeralBuilderTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/build/EphemeralBuilderTests.java
@@ -62,7 +62,6 @@ class EphemeralBuilderTests extends AbstractJsonTests {
 	private static final int EXISTING_IMAGE_LAYER_COUNT = 43;
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	private final BuildOwner owner = BuildOwner.of(123, 456);

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/DockerApiTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/DockerApiTests.java
@@ -105,7 +105,6 @@ class DockerApiTests {
 			StandardCharsets.UTF_8);
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private HttpTransport http;
 
 	private DockerApi dockerApi;
@@ -222,19 +221,15 @@ class DockerApiTests {
 		private ImageApi api;
 
 		@Mock
-		@SuppressWarnings("NullAway.Init")
 		private UpdateListener<PullImageUpdateEvent> pullListener;
 
 		@Mock
-		@SuppressWarnings("NullAway.Init")
 		private UpdateListener<PushImageUpdateEvent> pushListener;
 
 		@Mock
-		@SuppressWarnings("NullAway.Init")
 		private UpdateListener<LoadImageUpdateEvent> loadListener;
 
 		@Captor
-		@SuppressWarnings("NullAway.Init")
 		private ArgumentCaptor<IOConsumer<OutputStream>> writer;
 
 		@BeforeEach
@@ -632,11 +627,9 @@ class DockerApiTests {
 		private ContainerApi api;
 
 		@Captor
-		@SuppressWarnings("NullAway.Init")
 		private ArgumentCaptor<IOConsumer<OutputStream>> writer;
 
 		@Mock
-		@SuppressWarnings("NullAway.Init")
 		private UpdateListener<LogUpdateEvent> logListener;
 
 		@BeforeEach

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/HttpClientTransportTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/docker/transport/HttpClientTransportTests.java
@@ -68,19 +68,15 @@ class HttpClientTransportTests {
 	private static final String APPLICATION_X_TAR = "application/x-tar";
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private HttpClient client;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ClassicHttpResponse response;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private HttpEntity entity;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private InputStream content;
 
 	private HttpClientTransport http;

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/FilePermissionsTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/FilePermissionsTests.java
@@ -45,7 +45,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 class FilePermissionsTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	Path tempDir;
 
 	@Test

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/TarArchiveTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/TarArchiveTests.java
@@ -40,7 +40,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TarArchiveTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	@Test

--- a/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/ZipFileTarArchiveTests.java
+++ b/buildpack/spring-boot-buildpack-platform/src/test/java/org/springframework/boot/buildpack/platform/io/ZipFileTarArchiveTests.java
@@ -42,7 +42,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 class ZipFileTarArchiveTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	@Test

--- a/cli/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/CommandRunnerTests.java
+++ b/cli/spring-boot-cli/src/test/java/org/springframework/boot/cli/command/CommandRunnerTests.java
@@ -48,11 +48,9 @@ class CommandRunnerTests {
 	private CommandRunner commandRunner;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Command regularCommand;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Command anotherCommand;
 
 	private final Set<Call> calls = EnumSet.noneOf(Call.class);

--- a/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionEvaluationReportTests.java
+++ b/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/condition/ConditionEvaluationReportTests.java
@@ -63,15 +63,12 @@ class ConditionEvaluationReportTests {
 	private ConditionEvaluationReport report;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Condition condition1;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Condition condition2;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Condition condition3;
 
 	private @Nullable ConditionOutcome outcome1;

--- a/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/context/PropertyPlaceholderAutoConfigurationTests.java
+++ b/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/context/PropertyPlaceholderAutoConfigurationTests.java
@@ -101,7 +101,6 @@ class PropertyPlaceholderAutoConfigurationTests {
 	static class PlaceholderConfig {
 
 		@Value("${fruit:apple}")
-		@SuppressWarnings("NullAway.Init")
 		private String fruit;
 
 	}

--- a/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/template/TemplateAvailabilityProvidersTests.java
+++ b/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/template/TemplateAvailabilityProvidersTests.java
@@ -53,7 +53,6 @@ class TemplateAvailabilityProvidersTests {
 	private TemplateAvailabilityProviders providers;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private TemplateAvailabilityProvider provider;
 
 	private final String view = "view";
@@ -63,7 +62,6 @@ class TemplateAvailabilityProvidersTests {
 	private final MockEnvironment environment = new MockEnvironment();
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ResourceLoader resourceLoader;
 
 	@BeforeEach

--- a/core/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/core/DockerCliIntegrationTests.java
+++ b/core/spring-boot-docker-compose/src/dockerTest/java/org/springframework/boot/docker/compose/core/DockerCliIntegrationTests.java
@@ -59,7 +59,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DockerCliIntegrationTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	private static Path tempDir;
 
 	@Test

--- a/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DefaultRunningServiceTests.java
+++ b/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DefaultRunningServiceTests.java
@@ -47,7 +47,6 @@ import static org.assertj.core.api.Assertions.entry;
 class DefaultRunningServiceTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	private DefaultRunningService runningService;

--- a/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DockerComposeFileTests.java
+++ b/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DockerComposeFileTests.java
@@ -39,7 +39,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 class DockerComposeFileTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@Test

--- a/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DockerComposeOriginTests.java
+++ b/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DockerComposeOriginTests.java
@@ -37,7 +37,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DockerComposeOriginTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@Test

--- a/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/lifecycle/DockerComposeLifecycleManagerTests.java
+++ b/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/lifecycle/DockerComposeLifecycleManagerTests.java
@@ -69,7 +69,6 @@ import static org.mockito.Mockito.never;
 class DockerComposeLifecycleManagerTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	private DockerComposeFile dockerComposeFile;

--- a/core/spring-boot-test/src/test/java/org/springframework/boot/test/json/JsonContentAssertTests.java
+++ b/core/spring-boot-test/src/test/java/org/springframework/boot/test/json/JsonContentAssertTests.java
@@ -64,7 +64,6 @@ class JsonContentAssertTests {
 	private static final JSONComparator COMPARATOR = new DefaultComparator(JSONCompareMode.LENIENT);
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	public Path tempDir;
 
 	private File temp;

--- a/core/spring-boot/src/main/java/org/springframework/boot/DefaultApplicationContextFactory.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/DefaultApplicationContextFactory.java
@@ -38,7 +38,6 @@ import org.springframework.lang.Contract;
 class DefaultApplicationContextFactory implements ApplicationContextFactory {
 
 	// Method reference is not detected with correct nullability
-	@SuppressWarnings("NullAway")
 	@Override
 	public @Nullable Class<? extends ConfigurableEnvironment> getEnvironmentType(
 			@Nullable WebApplicationType webApplicationType) {
@@ -46,14 +45,12 @@ class DefaultApplicationContextFactory implements ApplicationContextFactory {
 	}
 
 	// Method reference is not detected with correct nullability
-	@SuppressWarnings("NullAway")
 	@Override
 	public @Nullable ConfigurableEnvironment createEnvironment(@Nullable WebApplicationType webApplicationType) {
 		return getFromSpringFactories(webApplicationType, ApplicationContextFactory::createEnvironment, null);
 	}
 
 	// Method reference is not detected with correct nullability
-	@SuppressWarnings("NullAway")
 	@Override
 	public ConfigurableApplicationContext create(@Nullable WebApplicationType webApplicationType) {
 		try {

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Binder.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/Binder.java
@@ -345,7 +345,6 @@ public class Binder {
 	 * @return the bound or created object
 	 * @since 2.2.0
 	 */
-	@SuppressWarnings("NullAway") // https://github.com/uber/NullAway/issues/1232
 	public <T> T bindOrCreate(ConfigurationPropertyName name, Bindable<T> target, @Nullable BindHandler handler) {
 		return bind(name, target, handler, true);
 	}

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/source/ConfigurationPropertyName.java
@@ -635,7 +635,6 @@ public final class ConfigurationPropertyName implements Comparable<Configuration
 	 * @return a {@link ConfigurationPropertyName} instance
 	 * @throws InvalidConfigurationPropertyNameException if the name is not valid
 	 */
-	@SuppressWarnings("NullAway") // See https://github.com/uber/NullAway/issues/1232
 	public static ConfigurationPropertyName of(@Nullable CharSequence name) {
 		return of(name, false);
 	}
@@ -665,7 +664,6 @@ public final class ConfigurationPropertyName implements Comparable<Configuration
 		return (elements != null) ? new ConfigurationPropertyName(elements) : null;
 	}
 
-	@SuppressWarnings("NullAway") // See https://github.com/uber/NullAway/issues/1232
 	private static Elements probablySingleElementOf(CharSequence name) {
 		return elementsOf(name, false, 1);
 	}

--- a/core/spring-boot/src/main/java/org/springframework/boot/json/JsonValueWriter.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/json/JsonValueWriter.java
@@ -347,7 +347,7 @@ class JsonValueWriter {
 	}
 
 	// Lambda isn't detected with the correct nullability
-	@SuppressWarnings({ "unchecked", "NullAway" })
+	@SuppressWarnings("unchecked")
 	private <V> @Nullable V processValue(@Nullable V value, ValueProcessor<?> valueProcessor) {
 		return (V) LambdaSafe
 			.callback(ValueProcessor.class, valueProcessor, this.path, new @Nullable Object[] { value })

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/StructuredLogLayout.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/log4j2/StructuredLogLayout.java
@@ -84,7 +84,6 @@ final class StructuredLogLayout extends AbstractStringLayout {
 		private String format;
 
 		@PluginBuilderAttribute
-		@SuppressWarnings("NullAway.Init")
 		private String charset = StandardCharsets.UTF_8.name();
 
 		public Builder setFormat(String format) {

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/ContextPairs.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/ContextPairs.java
@@ -136,7 +136,6 @@ public class ContextPairs {
 		 * @param <V> the map value type
 		 * @param extractor the extractor used to provide the map
 		 */
-		@SuppressWarnings("NullAway") // Doesn't detect lambda with correct nullability
 		public <V> void addMapEntries(Function<T, Map<String, V>> extractor) {
 			Function<T, @Nullable Iterable<Map.Entry<String, V>>> elementsExtractor = extractor.andThen(Map::entrySet);
 			add(elementsExtractor, Map.Entry::getKey, Map.Entry::getValue);

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/ElasticCommonSchemaProperties.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/ElasticCommonSchemaProperties.java
@@ -82,7 +82,6 @@ public record ElasticCommonSchemaProperties(Service service) {
 
 		static final Service NONE = new Service(null, null, null, null);
 
-		@SuppressWarnings("NullAway") // Doesn't detect lambda with correct nullability
 		void jsonMembers(Members<?> members) {
 			members.add("service").usingMembers((service) -> {
 				service.add("name", this::name).whenHasLength();

--- a/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/GraylogExtendedLogFormatProperties.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/logging/structured/GraylogExtendedLogFormatProperties.java
@@ -58,7 +58,6 @@ public record GraylogExtendedLogFormatProperties(@Nullable String host, Service 
 	 * Add {@link JsonWriter} members for the service.
 	 * @param members the members to add to
 	 */
-	@SuppressWarnings("NullAway") // Doesn't detect lambda with correct nullability
 	public void jsonMembers(JsonWriter.Members<?> members) {
 		members.add("host", this::host).whenHasLength();
 		this.service.jsonMembers(members);
@@ -91,7 +90,6 @@ public record GraylogExtendedLogFormatProperties(@Nullable String host, Service 
 			return new Service(version);
 		}
 
-		@SuppressWarnings("NullAway") // Doesn't detect lambda with correct nullability
 		void jsonMembers(JsonWriter.Members<?> members) {
 			members.add("_service_version", this::version).whenHasLength();
 		}

--- a/core/spring-boot/src/test/java/org/springframework/boot/BannerTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/BannerTests.java
@@ -60,7 +60,6 @@ class BannerTests {
 	}
 
 	@Captor
-	@SuppressWarnings("NullAway.Init")
 	private ArgumentCaptor<Class<?>> sourceClassCaptor;
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/ApplicationPidFileWriterTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/ApplicationPidFileWriterTests.java
@@ -57,7 +57,6 @@ class ApplicationPidFileWriterTests {
 			new String[] {}, mock(ConfigurableApplicationContext.class));
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	@BeforeEach

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorImportCombinedWithProfileSpecificIntegrationTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorImportCombinedWithProfileSpecificIntegrationTests.java
@@ -63,7 +63,6 @@ class ConfigDataEnvironmentPostProcessorImportCombinedWithProfileSpecificIntegra
 	private SpringApplication application;
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	public File temp;
 
 	@BeforeEach

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataEnvironmentPostProcessorIntegrationTests.java
@@ -86,7 +86,6 @@ class ConfigDataEnvironmentPostProcessorIntegrationTests {
 	private SpringApplication application;
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	public File temp;
 
 	@BeforeEach

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataImporterTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataImporterTests.java
@@ -47,31 +47,24 @@ class ConfigDataImporterTests {
 	private final DeferredLogFactory logFactory = Supplier::get;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ConfigDataLocationResolvers resolvers;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ConfigDataLoaders loaders;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Binder binder;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ConfigDataLocationResolverContext locationResolverContext;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ConfigDataLoaderContext loaderContext;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ConfigDataActivationContext activationContext;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Profiles profiles;
 
 	@BeforeEach

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataLocationResolversTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataLocationResolversTests.java
@@ -56,19 +56,15 @@ class ConfigDataLocationResolversTests {
 	private final DefaultBootstrapContext bootstrapContext = new DefaultBootstrapContext();
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Binder binder;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ConfigDataLocationResolverContext context;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Profiles profiles;
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	private File tempDir;
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataResourceNotFoundExceptionTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigDataResourceNotFoundExceptionTests.java
@@ -49,7 +49,6 @@ class ConfigDataResourceNotFoundExceptionTests {
 	private File missing;
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@BeforeEach

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigTreeConfigDataLoaderTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigTreeConfigDataLoaderTests.java
@@ -44,7 +44,6 @@ class ConfigTreeConfigDataLoaderTests {
 	private final ConfigDataLoaderContext loaderContext = mock(ConfigDataLoaderContext.class);
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	Path directory;
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigTreeConfigDataLocationResolverTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/config/ConfigTreeConfigDataLocationResolverTests.java
@@ -42,7 +42,6 @@ class ConfigTreeConfigDataLocationResolverTests {
 	private final ConfigDataLocationResolverContext context = mock(ConfigDataLocationResolverContext.class);
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/config/LocationResourceLoaderTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/config/LocationResourceLoaderTests.java
@@ -40,7 +40,6 @@ class LocationResourceLoaderTests {
 	private final LocationResourceLoader loader = new LocationResourceLoader(new DefaultResourceLoader());
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/logging/LoggingApplicationListenerTests.java
@@ -120,7 +120,6 @@ class LoggingApplicationListenerTests {
 	private final GenericApplicationContext context = new GenericApplicationContext();
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	public Path tempDir;
 
 	private File logFile;

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/BindConverterTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/BindConverterTests.java
@@ -54,7 +54,6 @@ import static org.mockito.BDDMockito.then;
 class BindConverterTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Consumer<PropertyEditorRegistry> propertyEditorInitializer;
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/BindResultTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/BindResultTests.java
@@ -44,15 +44,12 @@ import static org.mockito.BDDMockito.then;
 class BindResultTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Consumer<String> consumer;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Function<String, String> mapper;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Supplier<String> supplier;
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/BoundPropertiesTrackingBindHandlerTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/BoundPropertiesTrackingBindHandlerTests.java
@@ -49,7 +49,6 @@ class BoundPropertiesTrackingBindHandlerTests {
 	private Binder binder;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Consumer<ConfigurationProperty> consumer;
 
 	@BeforeEach

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/source/ConfigurationPropertyNameTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/source/ConfigurationPropertyNameTests.java
@@ -40,7 +40,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 class ConfigurationPropertyNameTests {
 
 	@Test
-	@SuppressWarnings("NullAway") // Test null check
 	void ofNameShouldNotBeNull() {
 		assertThatIllegalArgumentException().isThrownBy(() -> ConfigurationPropertyName.of(null))
 			.withMessageContaining("'name' must not be null");

--- a/core/spring-boot/src/test/java/org/springframework/boot/convert/StringToFileConverterTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/convert/StringToFileConverterTests.java
@@ -39,7 +39,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class StringToFileConverterTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@ConversionServiceTest

--- a/core/spring-boot/src/test/java/org/springframework/boot/env/ConfigTreePropertySourceTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/env/ConfigTreePropertySourceTests.java
@@ -49,7 +49,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 class ConfigTreePropertySourceTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	Path directory;
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/env/DefaultPropertiesPropertySourceTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/env/DefaultPropertiesPropertySourceTests.java
@@ -44,7 +44,6 @@ import static org.mockito.BDDMockito.then;
 class DefaultPropertiesPropertySourceTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Consumer<DefaultPropertiesPropertySource> action;
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/json/WritableJsonTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/json/WritableJsonTests.java
@@ -41,7 +41,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 class WritableJsonTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/AbstractStructuredLoggingTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/AbstractStructuredLoggingTests.java
@@ -48,7 +48,6 @@ abstract class AbstractStructuredLoggingTests {
 	private static final JsonMapper JSON_MAPPER = new JsonMapper();
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	StructuredLoggingJsonMembersCustomizer<?> customizer;
 
 	MockStructuredLoggingJsonMembersCustomizerBuilder<?> customizerBuilder = new MockStructuredLoggingJsonMembersCustomizerBuilder<>(

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4j2FileXmlTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/log4j2/Log4j2FileXmlTests.java
@@ -36,7 +36,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class Log4j2FileXmlTests extends Log4j2XmlTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@Override

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/AbstractStructuredLoggingTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/logback/AbstractStructuredLoggingTests.java
@@ -60,7 +60,6 @@ abstract class AbstractStructuredLoggingTests {
 	private BasicMarkerFactory markerFactory;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	StructuredLoggingJsonMembersCustomizer<?> customizer;
 
 	MockStructuredLoggingJsonMembersCustomizerBuilder<?> customizerBuilder = new MockStructuredLoggingJsonMembersCustomizerBuilder<>(

--- a/core/spring-boot/src/test/java/org/springframework/boot/logging/structured/StructuredLoggingJsonPropertiesJsonMembersCustomizerTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/logging/structured/StructuredLoggingJsonPropertiesJsonMembersCustomizerTests.java
@@ -43,7 +43,7 @@ import static org.mockito.BDDMockito.given;
 class StructuredLoggingJsonPropertiesJsonMembersCustomizerTests {
 
 	@Mock
-	@SuppressWarnings({ "rawtypes", "NullAway.Init" })
+	@SuppressWarnings("rawtypes")
 	private Instantiator instantiator;
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/system/ApplicationHomeTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/system/ApplicationHomeTests.java
@@ -40,7 +40,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ApplicationHomeTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/system/ApplicationPidTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/system/ApplicationPidTests.java
@@ -40,7 +40,6 @@ import static org.assertj.core.api.Assertions.contentOf;
 class ApplicationPidTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/web/servlet/AbstractFilterRegistrationBeanTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/web/servlet/AbstractFilterRegistrationBeanTests.java
@@ -61,11 +61,9 @@ import static org.mockito.Mockito.never;
 abstract class AbstractFilterRegistrationBeanTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	ServletContext servletContext;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	FilterRegistration.Dynamic registration;
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/web/servlet/DelegatingFilterProxyRegistrationBeanTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/web/servlet/DelegatingFilterProxyRegistrationBeanTests.java
@@ -56,7 +56,6 @@ class DelegatingFilterProxyRegistrationBeanTests extends AbstractFilterRegistrat
 	}
 
 	@Test
-	@SuppressWarnings("NullAway") // Test null check
 	void targetBeanNameMustNotBeEmpty() {
 		assertThatIllegalArgumentException().isThrownBy(() -> new DelegatingFilterProxyRegistrationBean(""))
 			.withMessageContaining("'targetBeanName' must not be empty");

--- a/core/spring-boot/src/test/java/org/springframework/boot/web/servlet/ServletListenerRegistrationBeanTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/web/servlet/ServletListenerRegistrationBeanTests.java
@@ -39,11 +39,9 @@ import static org.mockito.Mockito.never;
 class ServletListenerRegistrationBeanTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ServletContextListener listener;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ServletContext servletContext;
 
 	@Test

--- a/core/spring-boot/src/test/java/org/springframework/boot/web/servlet/ServletRegistrationBeanTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/web/servlet/ServletRegistrationBeanTests.java
@@ -52,11 +52,9 @@ class ServletRegistrationBeanTests {
 	private final MockServlet servlet = new MockServlet();
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ServletContext servletContext;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ServletRegistration.Dynamic registration;
 
 	@Test

--- a/loader/spring-boot-jarmode-tools/src/test/java/org/springframework/boot/jarmode/tools/AbstractJarModeTests.java
+++ b/loader/spring-boot-jarmode-tools/src/test/java/org/springframework/boot/jarmode/tools/AbstractJarModeTests.java
@@ -54,7 +54,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 abstract class AbstractJarModeTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	Manifest createManifest(String... entries) {

--- a/loader/spring-boot-jarmode-tools/src/test/java/org/springframework/boot/jarmode/tools/ContextTests.java
+++ b/loader/spring-boot-jarmode-tools/src/test/java/org/springframework/boot/jarmode/tools/ContextTests.java
@@ -34,7 +34,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 class ContextTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@Test

--- a/loader/spring-boot-jarmode-tools/src/test/java/org/springframework/boot/jarmode/tools/ExtractLayersCommandTests.java
+++ b/loader/spring-boot-jarmode-tools/src/test/java/org/springframework/boot/jarmode/tools/ExtractLayersCommandTests.java
@@ -69,11 +69,9 @@ class ExtractLayersCommandTests {
 	private static final FileTime LAST_ACCESS_TIME = FileTime.from(NOW.minus(1, ChronoUnit.DAYS));
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Context context;
 
 	private File jarFile;

--- a/loader/spring-boot-jarmode-tools/src/test/java/org/springframework/boot/jarmode/tools/HelpCommandTests.java
+++ b/loader/spring-boot-jarmode-tools/src/test/java/org/springframework/boot/jarmode/tools/HelpCommandTests.java
@@ -40,7 +40,6 @@ class HelpCommandTests {
 	private TestPrintStream out;
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	Path temp;
 
 	@BeforeEach

--- a/loader/spring-boot-jarmode-tools/src/test/java/org/springframework/boot/jarmode/tools/IndexedLayersTests.java
+++ b/loader/spring-boot-jarmode-tools/src/test/java/org/springframework/boot/jarmode/tools/IndexedLayersTests.java
@@ -42,7 +42,6 @@ import static org.mockito.Mockito.mock;
 class IndexedLayersTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@Test

--- a/loader/spring-boot-jarmode-tools/src/test/java/org/springframework/boot/jarmode/tools/ListCommandTests.java
+++ b/loader/spring-boot-jarmode-tools/src/test/java/org/springframework/boot/jarmode/tools/ListCommandTests.java
@@ -48,11 +48,9 @@ import static org.mockito.BDDMockito.given;
 class ListCommandTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Context context;
 
 	private ListCommand command;

--- a/loader/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/AbstractPackagerTests.java
+++ b/loader/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/AbstractPackagerTests.java
@@ -89,7 +89,6 @@ abstract class AbstractPackagerTests<P extends Packager> {
 	}
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	protected TestJarFile testJarFile;

--- a/loader/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/FileUtilsTests.java
+++ b/loader/spring-boot-loader-tools/src/test/java/org/springframework/boot/loader/tools/FileUtilsTests.java
@@ -39,7 +39,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FileUtilsTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	private File outputDirectory;

--- a/module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/EndpointDiscoverer.java
+++ b/module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/annotation/EndpointDiscoverer.java
@@ -342,8 +342,7 @@ public abstract class EndpointDiscoverer<E extends ExposableEndpoint<O>, O exten
 		return isFilterMatch(filter, getFilterEndpoint(endpointBean));
 	}
 
-	// Doesn't detect lambda with correct nullability
-	@SuppressWarnings({ "unchecked", "NullAway" })
+	@SuppressWarnings("unchecked")
 	private boolean isFilterMatch(EndpointFilter<E> filter, E endpoint) {
 		Boolean result = LambdaSafe.callback(EndpointFilter.class, filter, endpoint)
 			.withLogger(EndpointDiscoverer.class)
@@ -362,8 +361,7 @@ public abstract class EndpointDiscoverer<E extends ExposableEndpoint<O>, O exten
 		return false;
 	}
 
-	// Doesn't detect lambda with correct nullability
-	@SuppressWarnings({ "unchecked", "NullAway" })
+	@SuppressWarnings("unchecked")
 	private boolean isFilterMatch(OperationFilter<O> filter, Operation operation, EndpointId endpointId,
 			Access defaultAccess) {
 		Boolean result = LambdaSafe.callback(OperationFilter.class, filter, operation)

--- a/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/EndpointIdTests.java
+++ b/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/EndpointIdTests.java
@@ -42,7 +42,6 @@ class EndpointIdTests {
 	}
 
 	@Test
-	@SuppressWarnings("NullAway") // Test null check
 	void ofWhenEmptyThrowsException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> EndpointId.of(""))
 			.withMessage("'value' must not be empty");

--- a/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/invoker/cache/CachingOperationInvokerAdvisorTests.java
+++ b/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/invoker/cache/CachingOperationInvokerAdvisorTests.java
@@ -51,11 +51,9 @@ import static org.mockito.BDDMockito.then;
 class CachingOperationInvokerAdvisorTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private OperationInvoker invoker;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Function<EndpointId, @Nullable Long> timeToLive;
 
 	private CachingOperationInvokerAdvisor advisor;

--- a/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/jmx/JmxEndpointExporterTests.java
+++ b/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/jmx/JmxEndpointExporterTests.java
@@ -59,11 +59,9 @@ class JmxEndpointExporterTests {
 	private final List<ExposableJmxEndpoint> endpoints = new ArrayList<>();
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private MBeanServer mBeanServer;
 
 	@Spy
-	@SuppressWarnings("NullAway.Init")
 	private EndpointObjectNameFactory objectNameFactory = new TestEndpointObjectNameFactory();
 
 	private JmxEndpointExporter exporter;

--- a/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/ServletEndpointRegistrarTests.java
+++ b/module/spring-boot-actuator/src/test/java/org/springframework/boot/actuate/endpoint/web/ServletEndpointRegistrarTests.java
@@ -58,15 +58,12 @@ import static org.mockito.Mockito.mock;
 class ServletEndpointRegistrarTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ServletContext servletContext;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ServletRegistration.Dynamic servletDynamic;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private FilterRegistration.Dynamic filterDynamic;
 
 	@Test

--- a/module/spring-boot-amqp/src/test/java/org/springframework/boot/amqp/health/RabbitHealthIndicatorTests.java
+++ b/module/spring-boot-amqp/src/test/java/org/springframework/boot/amqp/health/RabbitHealthIndicatorTests.java
@@ -45,11 +45,9 @@ import static org.mockito.Mockito.mock;
 class RabbitHealthIndicatorTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private RabbitTemplate rabbitTemplate;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Channel channel;
 
 	@Test

--- a/module/spring-boot-cache/src/main/java/org/springframework/boot/cache/metrics/CacheMetricsRegistrar.java
+++ b/module/spring-boot-cache/src/main/java/org/springframework/boot/cache/metrics/CacheMetricsRegistrar.java
@@ -69,8 +69,7 @@ public class CacheMetricsRegistrar {
 		return false;
 	}
 
-	// Lambda isn't detected with the correct nullability
-	@SuppressWarnings({ "unchecked", "NullAway" })
+	@SuppressWarnings("unchecked")
 	private @Nullable MeterBinder getMeterBinder(Cache cache, Tags tags) {
 		Tags cacheTags = tags.and(getAdditionalTags(cache));
 		return LambdaSafe.callbacks(CacheMeterBinderProvider.class, this.binderProviders, cache)

--- a/module/spring-boot-cache/src/test/java/org/springframework/boot/cache/metrics/JCacheCacheMeterBinderProviderTests.java
+++ b/module/spring-boot-cache/src/test/java/org/springframework/boot/cache/metrics/JCacheCacheMeterBinderProviderTests.java
@@ -42,7 +42,6 @@ import static org.mockito.Mockito.mock;
 class JCacheCacheMeterBinderProviderTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private javax.cache.Cache<Object, Object> nativeCache;
 
 	@Test

--- a/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/SecurityInterceptorTests.java
+++ b/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/SecurityInterceptorTests.java
@@ -48,11 +48,9 @@ import static org.mockito.BDDMockito.given;
 class SecurityInterceptorTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private TokenValidator tokenValidator;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private SecurityService securityService;
 
 	private SecurityInterceptor interceptor;

--- a/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/TokenValidatorTests.java
+++ b/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/reactive/TokenValidatorTests.java
@@ -60,7 +60,6 @@ class TokenValidatorTests {
 	private static final byte[] DOT = ".".getBytes();
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private SecurityService securityService;
 
 	private TokenValidator tokenValidator;

--- a/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/servlet/SecurityInterceptorTests.java
+++ b/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/servlet/SecurityInterceptorTests.java
@@ -46,11 +46,9 @@ import static org.mockito.BDDMockito.then;
 class SecurityInterceptorTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private TokenValidator tokenValidator;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private SecurityService securityService;
 
 	private SecurityInterceptor interceptor;

--- a/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/servlet/TokenValidatorTests.java
+++ b/module/spring-boot-cloudfoundry/src/test/java/org/springframework/boot/cloudfoundry/autoconfigure/actuate/endpoint/servlet/TokenValidatorTests.java
@@ -59,7 +59,6 @@ class TokenValidatorTests {
 	private static final byte[] DOT = ".".getBytes();
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private SecurityService securityService;
 
 	private TokenValidator tokenValidator;

--- a/module/spring-boot-data-jpa/src/test/java/org/springframework/boot/data/jpa/autoconfigure/domain/country/Country.java
+++ b/module/spring-boot-data-jpa/src/test/java/org/springframework/boot/data/jpa/autoconfigure/domain/country/Country.java
@@ -31,12 +31,10 @@ public class Country implements Serializable {
 
 	@Id
 	@GeneratedValue
-	@SuppressWarnings("NullAway.Init")
 	private Long id;
 
 	@Audited
 	@Column
-	@SuppressWarnings("NullAway.Init")
 	private String name;
 
 	public Long getId() {

--- a/module/spring-boot-devtools/src/intTest/java/org/springframework/boot/devtools/tests/AbstractDevToolsIntegrationTests.java
+++ b/module/spring-boot-devtools/src/intTest/java/org/springframework/boot/devtools/tests/AbstractDevToolsIntegrationTests.java
@@ -52,7 +52,6 @@ abstract class AbstractDevToolsIntegrationTests {
 	protected final JvmLauncher javaLauncher = new JvmLauncher();
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	protected static File temp;
 
 	private @Nullable LaunchedApplication launchedApplication;

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/TriggerFileFilterTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/autoconfigure/TriggerFileFilterTests.java
@@ -32,7 +32,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 class TriggerFileFilterTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	@Test

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/classpath/ClassPathFileChangeListenerTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/classpath/ClassPathFileChangeListenerTests.java
@@ -47,15 +47,12 @@ import static org.mockito.Mockito.never;
 class ClassPathFileChangeListenerTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ApplicationEventPublisher eventPublisher;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ClassPathRestartStrategy restartStrategy;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private FileSystemWatcher fileSystemWatcher;
 
 	@Test

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/ChangedFileTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/ChangedFileTests.java
@@ -34,7 +34,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 class ChangedFileTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	@Test

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/DirectorySnapshotTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/DirectorySnapshotTests.java
@@ -38,7 +38,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 class DirectorySnapshotTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	private File directory;

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/FileSnapshotTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/FileSnapshotTests.java
@@ -42,7 +42,6 @@ class FileSnapshotTests {
 	private static final long MODIFIED = new Date().getTime() - TimeUnit.DAYS.toMillis(10);
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	@Test

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/FileSystemWatcherTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/filewatch/FileSystemWatcherTests.java
@@ -54,7 +54,6 @@ class FileSystemWatcherTests {
 	private final List<Set<ChangedFiles>> changes = Collections.synchronizedList(new ArrayList<>());
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	@BeforeEach

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/client/DelayedLiveReloadTriggerTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/client/DelayedLiveReloadTriggerTests.java
@@ -49,27 +49,21 @@ class DelayedLiveReloadTriggerTests {
 	private static final String URL = "http://localhost:8080";
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private OptionalLiveReloadServer liveReloadServer;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ClientHttpRequestFactory requestFactory;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ClientHttpRequest errorRequest;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ClientHttpRequest okRequest;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ClientHttpResponse errorResponse;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ClientHttpResponse okResponse;
 
 	private DelayedLiveReloadTrigger trigger;

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/client/HttpHeaderInterceptorTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/client/HttpHeaderInterceptorTests.java
@@ -54,11 +54,9 @@ class HttpHeaderInterceptorTests {
 	private byte[] body;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ClientHttpRequestExecution execution;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ClientHttpResponse response;
 
 	private MockHttpServletRequest httpRequest;

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/server/DispatcherFilterTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/server/DispatcherFilterTests.java
@@ -51,11 +51,9 @@ import static org.mockito.Mockito.mock;
 class DispatcherFilterTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Dispatcher dispatcher;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private FilterChain chain;
 
 	private DispatcherFilter filter;

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/server/DispatcherTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/remote/server/DispatcherTests.java
@@ -52,7 +52,6 @@ import static org.mockito.Mockito.withSettings;
 class DispatcherTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private AccessManager accessManager;
 
 	private final MockHttpServletResponse response = new MockHttpServletResponse();

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/ChangeableUrlsTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/ChangeableUrlsTests.java
@@ -43,7 +43,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ChangeableUrlsTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	@Test

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/classloader/ClassLoaderFileTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/classloader/ClassLoaderFileTests.java
@@ -40,21 +40,18 @@ class ClassLoaderFileTests {
 	}
 
 	@Test
-	@SuppressWarnings("NullAway") // Test null check
 	void addedContentsMustNotBeNull() {
 		assertThatIllegalArgumentException().isThrownBy(() -> new ClassLoaderFile(Kind.ADDED, null))
 			.withMessageContaining("'contents' must not be null");
 	}
 
 	@Test
-	@SuppressWarnings("NullAway") // Test null check
 	void modifiedContentsMustNotBeNull() {
 		assertThatIllegalArgumentException().isThrownBy(() -> new ClassLoaderFile(Kind.MODIFIED, null))
 			.withMessageContaining("'contents' must not be null");
 	}
 
 	@Test
-	@SuppressWarnings("NullAway") // Test null check
 	void deletedContentsMustBeNull() {
 		assertThatIllegalArgumentException().isThrownBy(() -> new ClassLoaderFile(Kind.DELETED, new byte[10]))
 			.withMessageContaining("'contents' must be null");

--- a/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/server/HttpRestartServerTests.java
+++ b/module/spring-boot-devtools/src/test/java/org/springframework/boot/devtools/restart/server/HttpRestartServerTests.java
@@ -52,7 +52,6 @@ import static org.mockito.BDDMockito.then;
 class HttpRestartServerTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private RestartServer delegate;
 
 	private HttpRestartServer server;

--- a/module/spring-boot-health/src/test/java/org/springframework/boot/health/application/AvailabilityStateHealthIndicatorTests.java
+++ b/module/spring-boot-health/src/test/java/org/springframework/boot/health/application/AvailabilityStateHealthIndicatorTests.java
@@ -41,7 +41,6 @@ import static org.mockito.BDDMockito.given;
 class AvailabilityStateHealthIndicatorTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ApplicationAvailability applicationAvailability;
 
 	@Test

--- a/module/spring-boot-health/src/test/java/org/springframework/boot/health/application/DiskSpaceHealthIndicatorTests.java
+++ b/module/spring-boot-health/src/test/java/org/springframework/boot/health/application/DiskSpaceHealthIndicatorTests.java
@@ -46,7 +46,6 @@ class DiskSpaceHealthIndicatorTests {
 	private static final DataSize TOTAL_SPACE = DataSize.ofKilobytes(10);
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private File fileMock;
 
 	private HealthIndicator healthIndicator;

--- a/module/spring-boot-health/src/test/java/org/springframework/boot/health/autoconfigure/actuate/endpoint/AutoConfiguredHealthEndpointGroupTests.java
+++ b/module/spring-boot-health/src/test/java/org/springframework/boot/health/autoconfigure/actuate/endpoint/AutoConfiguredHealthEndpointGroupTests.java
@@ -45,19 +45,15 @@ import static org.mockito.Mockito.mock;
 class AutoConfiguredHealthEndpointGroupTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private StatusAggregator statusAggregator;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private HttpCodeStatusMapper httpCodeStatusMapper;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private SecurityContext securityContext;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Principal principal;
 
 	@Test

--- a/module/spring-boot-hibernate/src/test/java/org/springframework/boot/hibernate/autoconfigure/HibernatePropertiesTests.java
+++ b/module/spring-boot-hibernate/src/test/java/org/springframework/boot/hibernate/autoconfigure/HibernatePropertiesTests.java
@@ -56,7 +56,6 @@ class HibernatePropertiesTests {
 		.withUserConfiguration(TestConfiguration.class);
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Supplier<String> ddlAutoSupplier;
 
 	@Test

--- a/module/spring-boot-hibernate/src/test/java/org/springframework/boot/hibernate/autoconfigure/test/country/Country.java
+++ b/module/spring-boot-hibernate/src/test/java/org/springframework/boot/hibernate/autoconfigure/test/country/Country.java
@@ -31,12 +31,10 @@ public class Country implements Serializable {
 
 	@Id
 	@GeneratedValue
-	@SuppressWarnings("NullAway.Init")
 	private Long id;
 
 	@Audited
 	@Column
-	@SuppressWarnings("NullAway.Init")
 	private String name;
 
 	public Long getId() {

--- a/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/metrics/DataSourcePoolMetrics.java
+++ b/module/spring-boot-jdbc/src/main/java/org/springframework/boot/jdbc/metrics/DataSourcePoolMetrics.java
@@ -65,7 +65,6 @@ public class DataSourcePoolMetrics implements MeterBinder {
 	}
 
 	@Override
-	@SuppressWarnings("NullAway") // Lambda isn't detected with the correct nullability
 	public void bindTo(MeterRegistry registry) {
 		if (this.metadataProvider.getDataSourcePoolMetadata(this.dataSource) != null) {
 			bindPoolMetadata(registry, "active",

--- a/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/metadata/CompositeDataSourcePoolMetadataProviderTests.java
+++ b/module/spring-boot-jdbc/src/test/java/org/springframework/boot/jdbc/metadata/CompositeDataSourcePoolMetadataProviderTests.java
@@ -38,31 +38,24 @@ import static org.mockito.BDDMockito.given;
 class CompositeDataSourcePoolMetadataProviderTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private DataSourcePoolMetadataProvider firstProvider;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private DataSourcePoolMetadata first;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private DataSource firstDataSource;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private DataSourcePoolMetadataProvider secondProvider;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private DataSourcePoolMetadata second;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private DataSource secondDataSource;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private DataSource unknownDataSource;
 
 	@BeforeEach

--- a/module/spring-boot-jpa-test/src/test/java/org/springframework/boot/jpa/test/autoconfigure/TestEntityManagerTests.java
+++ b/module/spring-boot-jpa-test/src/test/java/org/springframework/boot/jpa/test/autoconfigure/TestEntityManagerTests.java
@@ -43,15 +43,12 @@ import static org.mockito.BDDMockito.then;
 class TestEntityManagerTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private EntityManagerFactory entityManagerFactory;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private EntityManager entityManager;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private PersistenceUnitUtil persistenceUnitUtil;
 
 	private TestEntityManager testEntityManager;

--- a/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaProperties.java
+++ b/module/spring-boot-kafka/src/main/java/org/springframework/boot/kafka/autoconfigure/KafkaProperties.java
@@ -1421,7 +1421,6 @@ public class KafkaProperties {
 			return properties;
 		}
 
-		@SuppressWarnings("NullAway") // Doesn't detect lambda with correct nullability
 		private void validate() {
 			MutuallyExclusiveConfigurationPropertiesException.throwIfMultipleMatchingValuesIn((entries) -> {
 				entries.put("spring.kafka.ssl.key-store-key", getKeyStoreKey());

--- a/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/autoconfigure/MeterRegistryPostProcessorTests.java
+++ b/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/autoconfigure/MeterRegistryPostProcessorTests.java
@@ -67,23 +67,18 @@ class MeterRegistryPostProcessorTests {
 	private final List<MeterBinder> binders = new ArrayList<>();
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private MeterRegistryCustomizer<MeterRegistry> mockCustomizer;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private MeterFilter mockFilter;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private MeterBinder mockBinder;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private MeterRegistry mockRegistry;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private Config mockConfig;
 
 	private final ApplicationContext meterRegistryCloserContext = mock(ApplicationContext.class);

--- a/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/export/prometheus/PrometheusPushGatewayManagerTests.java
+++ b/module/spring-boot-micrometer-metrics/src/test/java/org/springframework/boot/micrometer/metrics/export/prometheus/PrometheusPushGatewayManagerTests.java
@@ -50,21 +50,17 @@ import static org.mockito.Mockito.never;
 class PrometheusPushGatewayManagerTests {
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private PushGateway pushGateway;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private TaskScheduler scheduler;
 
 	private final Duration pushRate = Duration.ofSeconds(1);
 
 	@Captor
-	@SuppressWarnings("NullAway.Init")
 	private ArgumentCaptor<Runnable> task;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ScheduledFuture<Object> future;
 
 	@Test

--- a/module/spring-boot-reactor-netty/src/test/java/org/springframework/boot/reactor/netty/SslServerCustomizerTests.java
+++ b/module/spring-boot-reactor-netty/src/test/java/org/springframework/boot/reactor/netty/SslServerCustomizerTests.java
@@ -60,7 +60,6 @@ class SslServerCustomizerTests {
 
 	@Test
 	@WithPackageResources({ "1.key", "1.crt" })
-	@SuppressWarnings("NullAway") // Test null check
 	void getSslProviderReturnsDefaultWhenServerNameIsNull() {
 		SslBundle defaultBundle = createBundle("1.key", "1.crt");
 		SslServerCustomizer customizer = new SslServerCustomizer(null, Ssl.ClientAuth.NONE, defaultBundle,

--- a/module/spring-boot-reactor-netty/src/test/java/org/springframework/boot/reactor/netty/autoconfigure/NettyReactiveWebServerFactoryCustomizerTests.java
+++ b/module/spring-boot-reactor-netty/src/test/java/org/springframework/boot/reactor/netty/autoconfigure/NettyReactiveWebServerFactoryCustomizerTests.java
@@ -63,7 +63,6 @@ class NettyReactiveWebServerFactoryCustomizerTests {
 	private NettyReactiveWebServerFactoryCustomizer customizer;
 
 	@Captor
-	@SuppressWarnings("NullAway.Init")
 	private ArgumentCaptor<NettyServerCustomizer> customizerCaptor;
 
 	@BeforeEach

--- a/module/spring-boot-restclient-test/src/test/java/org/springframework/boot/restclient/test/RootUriRequestExpectationManagerTests.java
+++ b/module/spring-boot-restclient-test/src/test/java/org/springframework/boot/restclient/test/RootUriRequestExpectationManagerTests.java
@@ -55,7 +55,6 @@ class RootUriRequestExpectationManagerTests {
 	private final String uri = "https://example.com";
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private RequestExpectationManager delegate;
 
 	private RootUriRequestExpectationManager manager;

--- a/module/spring-boot-restclient/src/test/java/org/springframework/boot/restclient/RestTemplateBuilderTests.java
+++ b/module/spring-boot-restclient/src/test/java/org/springframework/boot/restclient/RestTemplateBuilderTests.java
@@ -86,11 +86,9 @@ class RestTemplateBuilderTests {
 	private final RestTemplateBuilder builder = new RestTemplateBuilder();
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private HttpMessageConverter<Object> messageConverter;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ClientHttpRequestInterceptor interceptor;
 
 	@Test

--- a/module/spring-boot-restclient/src/test/java/org/springframework/boot/restclient/RootUriTemplateHandlerTests.java
+++ b/module/spring-boot-restclient/src/test/java/org/springframework/boot/restclient/RootUriTemplateHandlerTests.java
@@ -48,7 +48,6 @@ class RootUriTemplateHandlerTests {
 	private URI uri;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	public UriTemplateHandler delegate;
 
 	public UriTemplateHandler handler;

--- a/module/spring-boot-restclient/src/test/java/org/springframework/boot/restclient/autoconfigure/AutoConfiguredRestClientSslTests.java
+++ b/module/spring-boot-restclient/src/test/java/org/springframework/boot/restclient/autoconfigure/AutoConfiguredRestClientSslTests.java
@@ -52,15 +52,12 @@ class AutoConfiguredRestClientSslTests {
 		.withConnectTimeout(Duration.ofSeconds(30));
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private SslBundles sslBundles;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ClientHttpRequestFactoryBuilder<ClientHttpRequestFactory> factoryBuilder;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ClientHttpRequestFactory factory;
 
 	private AutoConfiguredRestClientSsl restClientSsl;

--- a/module/spring-boot-rsocket/src/test/java/org/springframework/boot/rsocket/netty/NettyRSocketServerFactoryTests.java
+++ b/module/spring-boot-rsocket/src/test/java/org/springframework/boot/rsocket/netty/NettyRSocketServerFactoryTests.java
@@ -281,7 +281,6 @@ class NettyRSocketServerFactoryTests {
 
 	@Test
 	@WithPackageResources({ "test-cert.pem", "test-key.pem" })
-	@SuppressWarnings("NullAway") // Test null check
 	void websocketTransportSslProviderReturnsDefaultWhenServerNameIsNull() {
 		SslBundle defaultBundle = createBundle("test-cert.pem", "test-key.pem");
 		NettyRSocketServerFactory.HttpServerSslCustomizer customizer = new NettyRSocketServerFactory.HttpServerSslCustomizer(

--- a/module/spring-boot-sql/src/test/java/org/springframework/boot/sql/init/dependency/DatabaseInitializationDependencyConfigurerTests.java
+++ b/module/spring-boot-sql/src/test/java/org/springframework/boot/sql/init/dependency/DatabaseInitializationDependencyConfigurerTests.java
@@ -68,7 +68,6 @@ class DatabaseInitializationDependencyConfigurerTests {
 	private final ConfigurableEnvironment environment = new MockEnvironment();
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@BeforeEach

--- a/module/spring-boot-tomcat/src/test/java/org/springframework/boot/tomcat/TomcatEmbeddedWebappClassLoaderTests.java
+++ b/module/spring-boot-tomcat/src/test/java/org/springframework/boot/tomcat/TomcatEmbeddedWebappClassLoaderTests.java
@@ -45,7 +45,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TomcatEmbeddedWebappClassLoaderTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	@Test

--- a/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/WebServerFactoryCustomizerBeanPostProcessorTests.java
+++ b/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/WebServerFactoryCustomizerBeanPostProcessorTests.java
@@ -46,7 +46,6 @@ class WebServerFactoryCustomizerBeanPostProcessorTests {
 	private final WebServerFactoryCustomizerBeanPostProcessor processor = new WebServerFactoryCustomizerBeanPostProcessor();
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ListableBeanFactory beanFactory;
 
 	@BeforeEach

--- a/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/context/WebServerPortFileWriterTests.java
+++ b/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/context/WebServerPortFileWriterTests.java
@@ -44,7 +44,6 @@ import static org.mockito.Mockito.mock;
 class WebServerPortFileWriterTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	@BeforeEach

--- a/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/servlet/DocumentRootTests.java
+++ b/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/servlet/DocumentRootTests.java
@@ -35,7 +35,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DocumentRootTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	private final DocumentRoot documentRoot = new DocumentRoot(LogFactory.getLog(getClass()));

--- a/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/servlet/StaticResourceJarsTests.java
+++ b/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/servlet/StaticResourceJarsTests.java
@@ -47,7 +47,6 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 class StaticResourceJarsTests {
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File tempDir;
 
 	@Test

--- a/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/servlet/context/MockWebEnvironmentServletComponentScanIntegrationTests.java
+++ b/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/servlet/context/MockWebEnvironmentServletComponentScanIntegrationTests.java
@@ -60,7 +60,6 @@ class MockWebEnvironmentServletComponentScanIntegrationTests {
 	private @Nullable AnnotationConfigServletWebApplicationContext context;
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@AfterEach

--- a/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/servlet/context/ServletComponentScanIntegrationTests.java
+++ b/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/servlet/context/ServletComponentScanIntegrationTests.java
@@ -58,7 +58,6 @@ class ServletComponentScanIntegrationTests {
 	private @Nullable AnnotationConfigServletWebServerApplicationContext context;
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	File temp;
 
 	@AfterEach

--- a/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/servlet/context/ServletWebServerApplicationContextTests.java
+++ b/module/spring-boot-web-server/src/test/java/org/springframework/boot/web/server/servlet/context/ServletWebServerApplicationContextTests.java
@@ -102,7 +102,6 @@ class ServletWebServerApplicationContextTests {
 	private final ServletWebServerApplicationContext context = new ServletWebServerApplicationContext();
 
 	@Captor
-	@SuppressWarnings("NullAway.Init")
 	private ArgumentCaptor<Filter> filterCaptor;
 
 	@AfterEach

--- a/module/spring-boot-webflux/src/test/java/org/springframework/boot/webflux/autoconfigure/actuate/web/WebFluxManagementChildContextConfigurationIntegrationTests.java
+++ b/module/spring-boot-webflux/src/test/java/org/springframework/boot/webflux/autoconfigure/actuate/web/WebFluxManagementChildContextConfigurationIntegrationTests.java
@@ -84,7 +84,6 @@ class WebFluxManagementChildContextConfigurationIntegrationTests {
 		.withPropertyValues("server.port=0", "management.server.port=0", "management.endpoints.web.exposure.include=*");
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	Path temp;
 
 	@Test

--- a/module/spring-boot-webmvc/src/test/java/org/springframework/boot/webmvc/autoconfigure/actuate/web/WebMvcEndpointChildContextConfigurationIntegrationTests.java
+++ b/module/spring-boot-webmvc/src/test/java/org/springframework/boot/webmvc/autoconfigure/actuate/web/WebMvcEndpointChildContextConfigurationIntegrationTests.java
@@ -83,7 +83,6 @@ class WebMvcEndpointChildContextConfigurationIntegrationTests {
 				"spring.web.error.include-binding-errors=always");
 
 	@TempDir
-	@SuppressWarnings("NullAway.Init")
 	Path temp;
 
 	@Test // gh-17938

--- a/module/spring-boot-webmvc/src/test/java/org/springframework/boot/webmvc/autoconfigure/error/DefaultErrorViewResolverTests.java
+++ b/module/spring-boot-webmvc/src/test/java/org/springframework/boot/webmvc/autoconfigure/error/DefaultErrorViewResolverTests.java
@@ -62,7 +62,6 @@ class DefaultErrorViewResolverTests {
 	private DefaultErrorViewResolver resolver;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private TemplateAvailabilityProvider templateAvailabilityProvider;
 
 	private Resources resourcesProperties;

--- a/module/spring-boot-webservices/src/test/java/org/springframework/boot/webservices/client/WebServiceTemplateBuilderTests.java
+++ b/module/spring-boot-webservices/src/test/java/org/springframework/boot/webservices/client/WebServiceTemplateBuilderTests.java
@@ -62,11 +62,9 @@ class WebServiceTemplateBuilderTests {
 	private final WebServiceTemplateBuilder builder = new WebServiceTemplateBuilder();
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private WebServiceMessageSender messageSender;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private ClientInterceptor interceptor;
 
 	@Test

--- a/smoke-test/spring-boot-smoke-test-aspectj/src/main/java/smoketest/aspectj/service/HelloWorldService.java
+++ b/smoke-test/spring-boot-smoke-test-aspectj/src/main/java/smoketest/aspectj/service/HelloWorldService.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Component;
 public class HelloWorldService {
 
 	@Value("${test.name:World}")
-	@SuppressWarnings("NullAway.Init")
 	private String name;
 
 	public String getHelloMessage() {

--- a/smoke-test/spring-boot-smoke-test-data-rest/src/main/java/smoketest/data/rest/domain/City.java
+++ b/smoke-test/spring-boot-smoke-test-data-rest/src/main/java/smoketest/data/rest/domain/City.java
@@ -36,19 +36,15 @@ public class City implements Serializable {
 	private @Nullable Long id;
 
 	@Column(nullable = false)
-	@SuppressWarnings("NullAway.Init")
 	private String name;
 
 	@Column(nullable = false)
-	@SuppressWarnings("NullAway.Init")
 	private String state;
 
 	@Column(nullable = false)
-	@SuppressWarnings("NullAway.Init")
 	private String country;
 
 	@Column(nullable = false)
-	@SuppressWarnings("NullAway.Init")
 	private String map;
 
 	protected City() {

--- a/smoke-test/spring-boot-smoke-test-data-rest/src/main/java/smoketest/data/rest/domain/Hotel.java
+++ b/smoke-test/spring-boot-smoke-test-data-rest/src/main/java/smoketest/data/rest/domain/Hotel.java
@@ -39,20 +39,16 @@ public class Hotel implements Serializable {
 
 	@ManyToOne(optional = false)
 	@NaturalId
-	@SuppressWarnings("NullAway.Init")
 	private City city;
 
 	@Column(nullable = false)
 	@NaturalId
-	@SuppressWarnings("NullAway.Init")
 	private String name;
 
 	@Column(nullable = false)
-	@SuppressWarnings("NullAway.Init")
 	private String address;
 
 	@Column(nullable = false)
-	@SuppressWarnings("NullAway.Init")
 	private String zip;
 
 	protected Hotel() {

--- a/smoke-test/spring-boot-smoke-test-flyway/src/main/java/smoketest/flyway/Person.java
+++ b/smoke-test/spring-boot-smoke-test-flyway/src/main/java/smoketest/flyway/Person.java
@@ -32,11 +32,9 @@ public class Person {
 	private @Nullable Long id;
 
 	@Column(nullable = false)
-	@SuppressWarnings("NullAway.Init")
 	private String firstName;
 
 	@Column(nullable = false)
-	@SuppressWarnings("NullAway.Init")
 	private String lastName;
 
 	public String getFirstName() {

--- a/smoke-test/spring-boot-smoke-test-jersey/src/main/java/smoketest/jersey/Service.java
+++ b/smoke-test/spring-boot-smoke-test-jersey/src/main/java/smoketest/jersey/Service.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Component;
 public class Service {
 
 	@Value("${message:World}")
-	@SuppressWarnings("NullAway.Init")
 	private String msg;
 
 	public String message() {

--- a/smoke-test/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/service/HelloWorldService.java
+++ b/smoke-test/spring-boot-smoke-test-jetty/src/main/java/smoketest/jetty/service/HelloWorldService.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Component;
 public class HelloWorldService {
 
 	@Value("${test.name:World}")
-	@SuppressWarnings("NullAway.Init")
 	private String name;
 
 	public String getHelloMessage() {

--- a/smoke-test/spring-boot-smoke-test-profile/src/main/java/smoketest/profile/service/GenericService.java
+++ b/smoke-test/spring-boot-smoke-test-profile/src/main/java/smoketest/profile/service/GenericService.java
@@ -25,11 +25,9 @@ import org.springframework.stereotype.Component;
 public class GenericService implements MessageService {
 
 	@Value("${test.hello:Hello}")
-	@SuppressWarnings("NullAway.Init")
 	private String hello;
 
 	@Value("${test.name:World}")
-	@SuppressWarnings("NullAway.Init")
 	private String name;
 
 	@Override

--- a/smoke-test/spring-boot-smoke-test-profile/src/main/java/smoketest/profile/service/GoodbyeWorldService.java
+++ b/smoke-test/spring-boot-smoke-test-profile/src/main/java/smoketest/profile/service/GoodbyeWorldService.java
@@ -25,7 +25,6 @@ import org.springframework.stereotype.Component;
 public class GoodbyeWorldService implements MessageService {
 
 	@Value("${test.name:World}")
-	@SuppressWarnings("NullAway.Init")
 	private String name;
 
 	@Override

--- a/smoke-test/spring-boot-smoke-test-profile/src/main/java/smoketest/profile/service/HelloWorldService.java
+++ b/smoke-test/spring-boot-smoke-test-profile/src/main/java/smoketest/profile/service/HelloWorldService.java
@@ -25,7 +25,6 @@ import org.springframework.stereotype.Component;
 public class HelloWorldService implements MessageService {
 
 	@Value("${test.name:World}")
-	@SuppressWarnings("NullAway.Init")
 	private String name;
 
 	@Override

--- a/smoke-test/spring-boot-smoke-test-secure-jersey/src/main/java/smoketest/secure/jersey/Service.java
+++ b/smoke-test/spring-boot-smoke-test-secure-jersey/src/main/java/smoketest/secure/jersey/Service.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Component;
 public class Service {
 
 	@Value("${message:World}")
-	@SuppressWarnings("NullAway.Init")
 	private String msg;
 
 	public String message() {

--- a/smoke-test/spring-boot-smoke-test-simple/src/main/java/smoketest/simple/service/HelloWorldService.java
+++ b/smoke-test/spring-boot-smoke-test-simple/src/main/java/smoketest/simple/service/HelloWorldService.java
@@ -25,11 +25,9 @@ import org.springframework.stereotype.Component;
 public class HelloWorldService {
 
 	@Value("${test.name:World}")
-	@SuppressWarnings("NullAway.Init")
 	private String name;
 
 	@Value("${test.duration:10s}")
-	@SuppressWarnings("NullAway.Init")
 	private Duration duration;
 
 	public String getHelloMessage() {

--- a/smoke-test/spring-boot-smoke-test-test/src/main/java/smoketest/test/domain/User.java
+++ b/smoke-test/spring-boot-smoke-test-test/src/main/java/smoketest/test/domain/User.java
@@ -39,10 +39,8 @@ public class User {
 	private @Nullable Long id;
 
 	@Column(unique = true)
-	@SuppressWarnings("NullAway.Init")
 	private String username;
 
-	@SuppressWarnings("NullAway.Init")
 	private VehicleIdentificationNumber vin;
 
 	protected User() {

--- a/smoke-test/spring-boot-smoke-test-test/src/test/java/smoketest/test/web/UserVehicleServiceTests.java
+++ b/smoke-test/spring-boot-smoke-test-test/src/test/java/smoketest/test/web/UserVehicleServiceTests.java
@@ -44,11 +44,9 @@ class UserVehicleServiceTests {
 	private static final VehicleIdentificationNumber VIN = new VehicleIdentificationNumber("00000000000000000");
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private VehicleDetailsService vehicleDetailsService;
 
 	@Mock
-	@SuppressWarnings("NullAway.Init")
 	private UserRepository userRepository;
 
 	private UserVehicleService service;

--- a/smoke-test/spring-boot-smoke-test-testng/src/main/java/smoketest/testng/service/HelloWorldService.java
+++ b/smoke-test/spring-boot-smoke-test-testng/src/main/java/smoketest/testng/service/HelloWorldService.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Component;
 public class HelloWorldService {
 
 	@Value("${test.name:World}")
-	@SuppressWarnings("NullAway.Init")
 	private String name;
 
 	public String getHelloMessage() {

--- a/smoke-test/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/service/HelloWorldService.java
+++ b/smoke-test/spring-boot-smoke-test-tomcat/src/main/java/smoketest/tomcat/service/HelloWorldService.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Component;
 public class HelloWorldService {
 
 	@Value("${test.name:World}")
-	@SuppressWarnings("NullAway.Init")
 	private String name;
 
 	public String getHelloMessage() {

--- a/smoke-test/spring-boot-smoke-test-websocket-jetty/src/test/java/smoketest/websocket/jetty/SampleWebSocketsApplicationTests.java
+++ b/smoke-test/spring-boot-smoke-test-websocket-jetty/src/test/java/smoketest/websocket/jetty/SampleWebSocketsApplicationTests.java
@@ -80,7 +80,6 @@ class SampleWebSocketsApplicationTests {
 	static class ClientConfiguration implements CommandLineRunner {
 
 		@Value("${websocket.uri}")
-		@SuppressWarnings("NullAway.Init")
 		private String webSocketUri;
 
 		private final CountDownLatch latch = new CountDownLatch(1);

--- a/smoke-test/spring-boot-smoke-test-websocket-jetty/src/test/java/smoketest/websocket/jetty/echo/CustomContainerWebSocketsApplicationTests.java
+++ b/smoke-test/spring-boot-smoke-test-websocket-jetty/src/test/java/smoketest/websocket/jetty/echo/CustomContainerWebSocketsApplicationTests.java
@@ -95,7 +95,6 @@ class CustomContainerWebSocketsApplicationTests {
 	static class ClientConfiguration implements CommandLineRunner {
 
 		@Value("${websocket.uri}")
-		@SuppressWarnings("NullAway.Init")
 		private String webSocketUri;
 
 		private final CountDownLatch latch = new CountDownLatch(1);

--- a/smoke-test/spring-boot-smoke-test-websocket-tomcat/src/test/java/smoketest/websocket/tomcat/SampleWebSocketsApplicationTests.java
+++ b/smoke-test/spring-boot-smoke-test-websocket-tomcat/src/test/java/smoketest/websocket/tomcat/SampleWebSocketsApplicationTests.java
@@ -80,7 +80,6 @@ class SampleWebSocketsApplicationTests {
 	static class ClientConfiguration implements CommandLineRunner {
 
 		@Value("${websocket.uri}")
-		@SuppressWarnings("NullAway.Init")
 		private String webSocketUri;
 
 		private final CountDownLatch latch = new CountDownLatch(1);

--- a/smoke-test/spring-boot-smoke-test-websocket-tomcat/src/test/java/smoketest/websocket/tomcat/echo/CustomContainerWebSocketsApplicationTests.java
+++ b/smoke-test/spring-boot-smoke-test-websocket-tomcat/src/test/java/smoketest/websocket/tomcat/echo/CustomContainerWebSocketsApplicationTests.java
@@ -95,7 +95,6 @@ class CustomContainerWebSocketsApplicationTests {
 	static class ClientConfiguration implements CommandLineRunner {
 
 		@Value("${websocket.uri}")
-		@SuppressWarnings("NullAway.Init")
 		private String webSocketUri;
 
 		private final CountDownLatch latch = new CountDownLatch(1);

--- a/smoke-test/spring-boot-smoke-test-xml/src/main/java/smoketest/xml/service/HelloWorldService.java
+++ b/smoke-test/spring-boot-smoke-test-xml/src/main/java/smoketest/xml/service/HelloWorldService.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Component;
 public class HelloWorldService {
 
 	@Value("${test.name:World}")
-	@SuppressWarnings("NullAway.Init")
 	private String name;
 
 	public String getHelloMessage() {


### PR DESCRIPTION
These were discovered using the new suppression remover script from https://github.com/uber/NullAway/pull/1803.  Specifically, once that script was set up, I ran (in the root repo directory):
```
suppression-remover . NullAway --alt-suppression NullAway.Init --build-cmd "./gradlew assemble compileTestJava compileDockerTestJava compileSystemTestJava --continue" --max-iterations 100
```

It looks like the script was able to delete about 240 unnecessary suppressions.  They must have become unnecessary due to NullAway improvements over the past few releases.  It's good to remove the suppressions so that future modifications to this code gets checked by NullAway.

I manually deleted 3 outdated comments after the script ran.