### PR TITLE
Support Podman for Docker Compose

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/antora/AntoraAsciidocAttributes.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/antora/AntoraAsciidocAttributes.java
@@ -37,7 +37,6 @@ import org.springframework.boot.build.bom.ResolvedBom;
 import org.springframework.boot.build.bom.ResolvedBom.ResolvedLibrary;
 import org.springframework.boot.build.properties.BuildProperties;
 import org.springframework.boot.build.properties.BuildType;
-import org.springframework.util.Assert;
 
 /**
  * Generates Asciidoctor attributes for use with Antora.
@@ -60,8 +59,6 @@ public class AntoraAsciidocAttributes {
 
 	private final ResolvedBom resolvedBom;
 
-	private final Map<String, String> dependencyVersions;
-
 	private final Map<String, ?> projectProperties;
 
 	public AntoraAsciidocAttributes(Project project, BomExtension dependencyBom, ResolvedBom resolvedBom) {
@@ -71,7 +68,6 @@ public class AntoraAsciidocAttributes {
 		this.artifactRelease = ArtifactRelease.forProject(project);
 		this.libraries = dependencyBom.getLibraries();
 		this.resolvedBom = resolvedBom;
-		this.dependencyVersions = resolvedBom.dependencyVersions();
 		this.projectProperties = project.getProperties();
 	}
 
@@ -116,7 +112,6 @@ public class AntoraAsciidocAttributes {
 		attributes.put("version-graal", (String) this.projectProperties.get("graalVersion"));
 		attributes.put("version-protobuf-gradle-plugin",
 				(String) this.projectProperties.get("protobufGradlePluginVersion"));
-		addDependencyVersion(attributes, "grpc-api", "io.grpc:grpc-api");
 	}
 
 	private void addVersionAttributes(Map<String, String> attributes, Library library) {
@@ -126,16 +121,6 @@ public class AntoraAsciidocAttributes {
 			String moduleVersion = resolvedLibrary.moduleVersion(module);
 			attributes.put("version-" + module.rootName(), moduleVersion);
 		});
-	}
-
-	private void addDependencyVersion(Map<String, String> attributes, String name, String groupAndArtifactId) {
-		attributes.put("version-" + name, getVersion(groupAndArtifactId));
-	}
-
-	private String getVersion(String groupAndArtifactId) {
-		String version = this.dependencyVersions.get(groupAndArtifactId);
-		Assert.notNull(version, () -> "No version found for " + groupAndArtifactId);
-		return version;
 	}
 
 	private void addArtifactAttributes(Map<String, String> attributes) {

--- a/buildSrc/src/main/resources/org/springframework/boot/build/antora/antora-asciidoc-attributes.properties
+++ b/buildSrc/src/main/resources/org/springframework/boot/build/antora/antora-asciidoc-attributes.properties
@@ -37,11 +37,6 @@ url-native-build-tools-docs-maven-plugin={url-native-build-tools-docs}/maven-plu
 url-paketo-docs=https://paketo.io/docs
 url-paketo-docs-java-buildpack={url-paketo-docs}/buildpacks/language-family-buildpacks/java
 url-protobuf-docs-gradle-plugin=https://github.com/google/protobuf-gradle-plugin
-https://javadoc.io/doc/io.grpc/grpc-api/latest/io/grpc/package-summary.html
-
-# === Javadoc Locations ===
-
-javadoc-location-io-grpc={url-grpc-api-javadoc}
 
 # === API References ===
 

--- a/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/ContainerEngine.java
+++ b/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/ContainerEngine.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docker.compose.core;
+
+/**
+ * The active container engine.
+ *
+ * @author Somil Jain
+ */
+enum ContainerEngine {
+
+	/**
+	 * Docker engine.
+	 */
+	DOCKER,
+
+	/**
+	 * Podman engine.
+	 */
+	PODMAN
+
+}

--- a/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DockerCli.java
+++ b/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DockerCli.java
@@ -24,11 +24,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.boot.docker.compose.core.DockerCliCommand.ComposeContext;
 import org.springframework.boot.docker.compose.core.DockerCliCommand.ComposeVersion;
 import org.springframework.boot.docker.compose.core.DockerCliCommand.Type;
 import org.springframework.boot.logging.LogLevel;
@@ -36,7 +39,8 @@ import org.springframework.core.log.LogMessage;
 import org.springframework.util.CollectionUtils;
 
 /**
- * Wrapper around {@code docker} and {@code docker-compose} command line tools.
+ * Wrapper around {@code docker}, {@code docker-compose}, {@code podman}, and
+ * {@code podman-compose} command line tools.
  *
  * @author Moritz Halbritter
  * @author Andy Wilkinson
@@ -48,13 +52,16 @@ class DockerCli {
 
 	private static final Log logger = LogFactory.getLog(DockerCli.class);
 
+	private static final Pattern PODMAN_COMPOSE_VERSION_PATTERN = Pattern
+		.compile("podman-compose version (\\d+\\.\\d+\\.\\d+)");
+
 	private final ProcessRunner processRunner;
 
 	private final DockerCommands dockerCommands;
 
 	private final DockerComposeOptions dockerComposeOptions;
 
-	private final ComposeVersion composeVersion;
+	private final ComposeContext composeContext;
 
 	/**
 	 * Create a new {@link DockerCli} instance.
@@ -66,21 +73,27 @@ class DockerCli {
 		this.dockerCommands = dockerCommandsCache.computeIfAbsent(workingDirectory,
 				(key) -> new DockerCommands(this.processRunner));
 		this.dockerComposeOptions = (dockerComposeOptions != null) ? dockerComposeOptions : DockerComposeOptions.none();
-		this.composeVersion = ComposeVersion.of(this.dockerCommands.get(Type.DOCKER_COMPOSE).version());
+		ComposeVersion composeVersion = ComposeVersion.of(this.dockerCommands.get(Type.DOCKER_COMPOSE).version());
+		this.composeContext = new ComposeContext(this.dockerCommands.engine(), composeVersion);
 	}
 
-	/**
-	 * Run the given {@link DockerCli} command and return the response.
-	 * @param <R> the response type
-	 * @param dockerCommand the command to run
-	 * @return the response
-	 */
+	DockerCli(ProcessRunner processRunner) {
+		this.processRunner = processRunner;
+		this.dockerCommands = new DockerCommands(this.processRunner);
+		this.dockerComposeOptions = DockerComposeOptions.none();
+		ComposeVersion composeVersion = ComposeVersion.of(this.dockerCommands.get(Type.DOCKER_COMPOSE).version());
+		this.composeContext = new ComposeContext(this.dockerCommands.engine(), composeVersion);
+	}
+
 	<R> R run(DockerCliCommand<R> dockerCommand) {
+		if (!dockerCommand.isSupported(this.composeContext)) {
+			return dockerCommand.emptyResponse();
+		}
 		List<String> command = createCommand(dockerCommand.getType());
-		command.addAll(dockerCommand.getCommand(this.composeVersion));
+		command.addAll(dockerCommand.getCommand(this.composeContext));
 		Consumer<String> outputConsumer = createOutputConsumer(dockerCommand.getLogLevel());
 		String response = this.processRunner.run(outputConsumer, command.toArray(new String[0]));
-		return dockerCommand.convert(response);
+		return dockerCommand.convert(response, this.composeContext);
 	}
 
 	private @Nullable Consumer<String> createOutputConsumer(@Nullable LogLevel logLevel) {
@@ -94,7 +107,8 @@ class DockerCli {
 		return switch (type) {
 			case DOCKER -> new ArrayList<>(this.dockerCommands.get(type).command());
 			case DOCKER_COMPOSE -> {
-				List<String> result = new ArrayList<>(this.dockerCommands.get(type).command());
+				DockerCommand composeCmd = this.dockerCommands.get(type);
+				List<String> result = new ArrayList<>(composeCmd.command());
 				DockerComposeFile composeFile = this.dockerComposeOptions.composeFile();
 				if (composeFile != null) {
 					for (File file : composeFile.getFiles()) {
@@ -102,8 +116,12 @@ class DockerCli {
 						result.add(file.getPath());
 					}
 				}
-				result.add("--ansi");
-				result.add("never");
+
+				if (composeCmd.supportsAnsi()) {
+					result.add("--ansi");
+					result.add("never");
+				}
+
 				Set<String> activeProfiles = this.dockerComposeOptions.activeProfiles();
 				if (!CollectionUtils.isEmpty(activeProfiles)) {
 					for (String profile : activeProfiles) {
@@ -133,57 +151,131 @@ class DockerCli {
 	 */
 	private static class DockerCommands {
 
+		private final ContainerEngine engine;
+
 		private final DockerCommand dockerCommand;
 
 		private final DockerCommand dockerComposeCommand;
 
 		DockerCommands(ProcessRunner processRunner) {
-			this.dockerCommand = getDockerCommand(processRunner);
-			this.dockerComposeCommand = getDockerComposeCommand(processRunner);
+			Provider provider = discoverProvider(processRunner);
+			this.engine = provider.engine();
+			this.dockerCommand = provider.engineCommand();
+			this.dockerComposeCommand = provider.composeCommand();
 		}
 
-		private DockerCommand getDockerCommand(ProcessRunner processRunner) {
+		ContainerEngine engine() {
+			return this.engine;
+		}
+
+		private Provider discoverProvider(ProcessRunner processRunner) {
 			try {
-				String version = processRunner.run("docker", "version", "--format", "{{.Client.Version}}");
-				logger.trace(LogMessage.format("Using docker %s", version));
-				return new DockerCommand(version, List.of("docker"));
+				return getDockerProvider(processRunner);
 			}
-			catch (ProcessStartException ex) {
-				throw new DockerProcessStartException("Unable to start docker process. Is docker correctly installed?",
-						ex);
+			catch (ProcessStartException ex1) {
+				// Only fall back to Podman if 'docker' executable is completely missing
+				// on PATH
+				try {
+					return getPodmanProvider(processRunner);
+				}
+				catch (ProcessStartException ex2) {
+					DockerProcessStartException exception = new DockerProcessStartException(
+							"Unable to find 'docker' or 'podman' executable on PATH.", ex1);
+					exception.addSuppressed(ex2);
+					throw exception;
+				}
+			}
+		}
+
+		private Provider getDockerProvider(ProcessRunner processRunner) {
+			DockerCommand engine = fetchEngineCommand(processRunner, "docker");
+			try {
+				return new Provider(ContainerEngine.DOCKER, engine, fetchDockerComposePlugin(processRunner));
+			}
+			catch (ProcessStartException | ProcessExitException ex1) {
+				try {
+					return new Provider(ContainerEngine.DOCKER, engine, fetchDockerComposeStandalone(processRunner));
+				}
+				catch (ProcessStartException | ProcessExitException ex2) {
+					throw new DockerProcessStartException(
+							"Docker binary was found, but neither 'docker compose' nor 'docker-compose' could be executed.",
+							ex1);
+				}
+			}
+		}
+
+		private Provider getPodmanProvider(ProcessRunner processRunner) {
+			DockerCommand engine = fetchEngineCommand(processRunner, "podman");
+			try {
+				return new Provider(ContainerEngine.PODMAN, engine, fetchPodmanComposePlugin(processRunner));
+			}
+			catch (ProcessStartException | ProcessExitException ex1) {
+				try {
+					return new Provider(ContainerEngine.PODMAN, engine, fetchPodmanComposeStandalone(processRunner));
+				}
+				catch (ProcessStartException | ProcessExitException ex2) {
+					throw new DockerProcessStartException(
+							"Podman binary was found, but neither 'podman compose' nor 'podman-compose' could be executed.",
+							ex1);
+				}
+			}
+		}
+
+		private DockerCommand fetchEngineCommand(ProcessRunner processRunner, String executable) {
+			try {
+				String version = processRunner.run(executable, "version", "--format", "{{.Client.Version}}");
+				logger.trace(LogMessage.format("Using %s %s", executable, version.trim()));
+				return new DockerCommand(version.trim(), List.of(executable), false);
 			}
 			catch (ProcessExitException ex) {
-				if (ex.getStdErr().contains("docker daemon is not running")
-						|| ex.getStdErr().contains("Cannot connect to the Docker daemon")) {
+				if ("docker".equals(executable) && isDaemonNotRunning(ex.getStdErr())) {
 					throw new DockerNotRunningException(ex.getStdErr(), ex);
 				}
-				throw ex;
+				throw new DockerProcessStartException(executable + " process failed to run correctly", ex);
 			}
 		}
 
-		private DockerCommand getDockerComposeCommand(ProcessRunner processRunner) {
-			try {
-				DockerCliComposeVersionResponse response = DockerJson.deserialize(
-						processRunner.run("docker", "compose", "version", "--format", "json"),
-						DockerCliComposeVersionResponse.class);
-				logger.trace(LogMessage.format("Using Docker Compose %s", response.version()));
-				return new DockerCommand(response.version(), List.of("docker", "compose"));
+		private DockerCommand fetchDockerComposePlugin(ProcessRunner processRunner) {
+			String output = processRunner.run("docker", "compose", "version", "--format", "json");
+			DockerCliComposeVersionResponse response = DockerJson.deserialize(output,
+					DockerCliComposeVersionResponse.class);
+			logger.trace(LogMessage.format("Using docker compose %s", response.version()));
+			return new DockerCommand(response.version(), List.of("docker", "compose"), true);
+		}
+
+		private DockerCommand fetchDockerComposeStandalone(ProcessRunner processRunner) {
+			String output = processRunner.run("docker-compose", "version", "--format", "json");
+			DockerCliComposeVersionResponse response = DockerJson.deserialize(output,
+					DockerCliComposeVersionResponse.class);
+			logger.trace(LogMessage.format("Using docker-compose %s", response.version()));
+			return new DockerCommand(response.version(), List.of("docker-compose"), true);
+		}
+
+		private DockerCommand fetchPodmanComposePlugin(ProcessRunner processRunner) {
+			String output = processRunner.run("podman", "compose", "version");
+			String version = parsePodmanComposeVersion(output);
+			logger.trace(LogMessage.format("Using podman compose %s", version));
+			return new DockerCommand(version, List.of("podman", "compose"), false);
+		}
+
+		private DockerCommand fetchPodmanComposeStandalone(ProcessRunner processRunner) {
+			String output = processRunner.run("podman-compose", "version");
+			String version = parsePodmanComposeVersion(output);
+			logger.trace(LogMessage.format("Using podman-compose %s", version));
+			return new DockerCommand(version, List.of("podman-compose"), false);
+		}
+
+		private static String parsePodmanComposeVersion(String rawOutput) {
+			Matcher matcher = PODMAN_COMPOSE_VERSION_PATTERN.matcher(rawOutput);
+			if (matcher.find()) {
+				return matcher.group(1);
 			}
-			catch (ProcessExitException ex) {
-				// Ignore and try docker-compose
-			}
-			try {
-				DockerCliComposeVersionResponse response = DockerJson.deserialize(
-						processRunner.run("docker-compose", "version", "--format", "json"),
-						DockerCliComposeVersionResponse.class);
-				logger.trace(LogMessage.format("Using docker-compose %s", response.version()));
-				return new DockerCommand(response.version(), List.of("docker-compose"));
-			}
-			catch (ProcessStartException ex) {
-				throw new DockerProcessStartException(
-						"Unable to start 'docker-compose' process or use 'docker compose'. Is docker correctly installed?",
-						ex);
-			}
+			throw new IllegalStateException("Unable to parse version from podman-compose output: " + rawOutput);
+		}
+
+		private static boolean isDaemonNotRunning(String stdErr) {
+			return stdErr.contains("docker daemon is not running")
+					|| stdErr.contains("Cannot connect to the Docker daemon");
 		}
 
 		DockerCommand get(Type type) {
@@ -195,17 +287,14 @@ class DockerCli {
 
 	}
 
-	private record DockerCommand(String version, List<String> command) {
+	private record Provider(ContainerEngine engine, DockerCommand engineCommand, DockerCommand composeCommand) {
 
 	}
 
-	/**
-	 * Options for Docker Compose.
-	 *
-	 * @param composeFile the Docker Compose file to use
-	 * @param activeProfiles the profiles to activate
-	 * @param arguments the arguments to pass to Docker Compose
-	 */
+	private record DockerCommand(String version, List<String> command, boolean supportsAnsi) {
+
+	}
+
 	record DockerComposeOptions(@Nullable DockerComposeFile composeFile, Set<String> activeProfiles,
 			List<String> arguments) {
 

--- a/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DockerCliCommand.java
+++ b/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/DockerCliCommand.java
@@ -44,7 +44,7 @@ abstract sealed class DockerCliCommand<R> {
 
 	private final boolean listResponse;
 
-	private final Function<ComposeVersion, List<String>> command;
+	private final Function<ComposeContext, List<String>> command;
 
 	private DockerCliCommand(Type type, Class<?> responseType, boolean listResponse, String... command) {
 		this(type, LogLevel.OFF, responseType, listResponse, command);
@@ -52,11 +52,11 @@ abstract sealed class DockerCliCommand<R> {
 
 	private DockerCliCommand(Type type, LogLevel logLevel, Class<?> responseType, boolean listResponse,
 			String... command) {
-		this(type, logLevel, responseType, listResponse, (version) -> List.of(command));
+		this(type, logLevel, responseType, listResponse, (context) -> List.of(command));
 	}
 
 	private DockerCliCommand(Type type, LogLevel logLevel, Class<?> responseType, boolean listResponse,
-			Function<ComposeVersion, List<String>> command) {
+			Function<ComposeContext, List<String>> command) {
 		this.type = type;
 		this.logLevel = logLevel;
 		this.responseType = responseType;
@@ -72,12 +72,20 @@ abstract sealed class DockerCliCommand<R> {
 		return this.logLevel;
 	}
 
-	List<String> getCommand(ComposeVersion composeVersion) {
-		return this.command.apply(composeVersion);
+	List<String> getCommand(ComposeContext context) {
+		return this.command.apply(context);
+	}
+
+	boolean isSupported(ComposeContext context) {
+		return true;
+	}
+
+	R emptyResponse() {
+		throw new UnsupportedOperationException("Command is not supported and provides no empty response");
 	}
 
 	@SuppressWarnings("unchecked")
-	R convert(String response) {
+	R convert(String response, ComposeContext context) {
 		if (this.responseType == None.class) {
 			return (R) None.INSTANCE;
 		}
@@ -101,7 +109,7 @@ abstract sealed class DockerCliCommand<R> {
 		result = result && this.responseType == other.responseType;
 		result = result && this.listResponse == other.listResponse;
 		result = result
-				&& this.command.apply(ComposeVersion.UNKNOWN).equals(other.command.apply(ComposeVersion.UNKNOWN));
+				&& this.command.apply(ComposeContext.UNKNOWN).equals(other.command.apply(ComposeContext.UNKNOWN));
 		return result;
 	}
 
@@ -131,6 +139,16 @@ abstract sealed class DockerCliCommand<R> {
 			super(Type.DOCKER, DockerCliContextResponse.class, true, "context", "ls", "--format={{ json . }}");
 		}
 
+		@Override
+		boolean isSupported(ComposeContext context) {
+			return context.engine() == ContainerEngine.DOCKER;
+		}
+
+		@Override
+		List<DockerCliContextResponse> emptyResponse() {
+			return java.util.Collections.emptyList();
+		}
+
 	}
 
 	/**
@@ -150,8 +168,25 @@ abstract sealed class DockerCliCommand<R> {
 	 */
 	static final class ComposeConfig extends DockerCliCommand<DockerCliComposeConfigResponse> {
 
+		private static final List<String> DOCKER_COMMAND = List.of("config", "--format=json");
+
+		private static final List<String> PODMAN_COMMAND = List.of("config");
+
 		ComposeConfig() {
-			super(Type.DOCKER_COMPOSE, DockerCliComposeConfigResponse.class, false, "config", "--format=json");
+			super(Type.DOCKER_COMPOSE, LogLevel.OFF, DockerCliComposeConfigResponse.class, false,
+					ComposeConfig::getConfigCommand);
+		}
+
+		private static List<String> getConfigCommand(ComposeContext context) {
+			return (context.engine() == ContainerEngine.PODMAN) ? PODMAN_COMMAND : DOCKER_COMMAND;
+		}
+
+		@Override
+		DockerCliComposeConfigResponse convert(String response, ComposeContext context) {
+			if (context.engine() == ContainerEngine.PODMAN) {
+				return PodmanComposeConfigYamlParser.parse(response);
+			}
+			return super.convert(response, context);
 		}
 
 	}
@@ -169,8 +204,11 @@ abstract sealed class DockerCliCommand<R> {
 			super(Type.DOCKER_COMPOSE, LogLevel.OFF, DockerCliComposePsResponse.class, true, ComposePs::getPsCommand);
 		}
 
-		private static List<String> getPsCommand(ComposeVersion composeVersion) {
-			return (composeVersion.isLessThan(2, 24)) ? WITHOUT_ORPHANS : WITH_ORPHANS;
+		private static List<String> getPsCommand(ComposeContext context) {
+			if (context.engine() == ContainerEngine.DOCKER && !context.composeVersion().isLessThan(2, 24)) {
+				return WITH_ORPHANS;
+			}
+			return WITHOUT_ORPHANS;
 		}
 
 	}
@@ -181,17 +219,19 @@ abstract sealed class DockerCliCommand<R> {
 	static final class ComposeUp extends DockerCliCommand<None> {
 
 		ComposeUp(LogLevel logLevel, List<String> arguments) {
-			super(Type.DOCKER_COMPOSE, logLevel, None.class, false, getCommand(arguments));
+			super(Type.DOCKER_COMPOSE, logLevel, None.class, false, (context) -> getCommand(context, arguments));
 		}
 
-		private static String[] getCommand(List<String> arguments) {
+		private static List<String> getCommand(ComposeContext context, List<String> arguments) {
 			List<String> result = new ArrayList<>();
 			result.add("up");
 			result.add("--no-color");
 			result.add("--detach");
-			result.add("--wait");
+			if (context.engine() == ContainerEngine.DOCKER) {
+				result.add("--wait");
+			}
 			result.addAll(arguments);
-			return result.toArray(String[]::new);
+			return result;
 		}
 
 	}
@@ -315,6 +355,19 @@ abstract sealed class DockerCliCommand<R> {
 				return UNKNOWN;
 			}
 		}
+
+	}
+
+	/**
+	 * The active compose context, combining the container engine with the compose
+	 * version.
+	 *
+	 * @param engine the active container engine
+	 * @param composeVersion the compose version
+	 */
+	record ComposeContext(ContainerEngine engine, ComposeVersion composeVersion) {
+
+		static final ComposeContext UNKNOWN = new ComposeContext(ContainerEngine.DOCKER, ComposeVersion.UNKNOWN);
 
 	}
 

--- a/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/PodmanComposeConfigYamlParser.java
+++ b/core/spring-boot-docker-compose/src/main/java/org/springframework/boot/docker/compose/core/PodmanComposeConfigYamlParser.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docker.compose.core;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Parses simple YAML output from podman-compose config.
+ *
+ * @author Somil Jain
+ */
+final class PodmanComposeConfigYamlParser {
+
+	private PodmanComposeConfigYamlParser() {
+	}
+
+	static DockerCliComposeConfigResponse parse(String yaml) {
+		String name = "";
+		Map<String, DockerCliComposeConfigResponse.Service> services = new HashMap<>();
+
+		String currentService = null;
+		boolean inServices = false;
+		int servicesIndent = -1;
+
+		for (String line : yaml.split("\\r?\\n")) {
+			if (line.trim().isEmpty() || line.trim().startsWith("#")) {
+				continue;
+			}
+			int indent = getIndent(line);
+			String trimmed = line.trim();
+
+			if (indent == 0) {
+				inServices = false;
+				if (trimmed.startsWith("name:")) {
+					name = extractValue(trimmed, "name:");
+				}
+				else if (trimmed.startsWith("services:")) {
+					inServices = true;
+				}
+			}
+			else if (inServices) {
+				if (servicesIndent == -1) {
+					servicesIndent = indent;
+				}
+				if (indent == servicesIndent && trimmed.endsWith(":")) {
+					currentService = trimmed.substring(0, trimmed.length() - 1);
+				}
+				else if (currentService != null && trimmed.startsWith("image:")) {
+					String image = extractValue(trimmed, "image:");
+					services.put(currentService, new DockerCliComposeConfigResponse.Service(image));
+				}
+			}
+		}
+
+		return new DockerCliComposeConfigResponse(name, services);
+	}
+
+	private static int getIndent(String line) {
+		int i = 0;
+		while (i < line.length() && line.charAt(i) == ' ') {
+			i++;
+		}
+		return i;
+	}
+
+	private static String extractValue(String line, String prefix) {
+		String value = line.substring(prefix.length()).trim();
+		if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
+			return value.substring(1, value.length() - 1);
+		}
+		return value;
+	}
+
+}

--- a/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DockerCliCommandTests.java
+++ b/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DockerCliCommandTests.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.docker.compose.core.DockerCliCommand.ComposeContext;
 import org.springframework.boot.docker.compose.core.DockerCliCommand.ComposeVersion;
 import org.springframework.boot.docker.compose.core.DockerCliCommand.None;
 import org.springframework.boot.logging.LogLevel;
@@ -38,45 +39,59 @@ class DockerCliCommandTests {
 
 	private static final ComposeVersion COMPOSE_VERSION = ComposeVersion.of("2.31.0");
 
+	private static final ComposeContext DOCKER_CONTEXT = new ComposeContext(ContainerEngine.DOCKER, COMPOSE_VERSION);
+
+	private static final ComposeContext PODMAN_CONTEXT = new ComposeContext(ContainerEngine.PODMAN, COMPOSE_VERSION);
+
 	@Test
 	void context() {
 		DockerCliCommand<?> command = new DockerCliCommand.Context();
 		assertThat(command.getType()).isEqualTo(DockerCliCommand.Type.DOCKER);
-		assertThat(command.getCommand(COMPOSE_VERSION)).containsExactly("context", "ls", "--format={{ json . }}");
-		assertThat(command.convert("[]")).isInstanceOf(List.class);
+		assertThat(command.getCommand(DOCKER_CONTEXT)).containsExactly("context", "ls", "--format={{ json . }}");
+		assertThat(command.convert("[]", DOCKER_CONTEXT)).isInstanceOf(List.class);
 	}
 
 	@Test
 	void inspect() {
 		DockerCliCommand<?> command = new DockerCliCommand.Inspect(List.of("123", "345"));
 		assertThat(command.getType()).isEqualTo(DockerCliCommand.Type.DOCKER);
-		assertThat(command.getCommand(COMPOSE_VERSION)).containsExactly("inspect", "--format={{ json . }}", "123",
+		assertThat(command.getCommand(DOCKER_CONTEXT)).containsExactly("inspect", "--format={{ json . }}", "123",
 				"345");
-		assertThat(command.convert("[]")).isInstanceOf(List.class);
+		assertThat(command.convert("[]", DOCKER_CONTEXT)).isInstanceOf(List.class);
 	}
 
 	@Test
 	void composeConfig() {
 		DockerCliCommand<?> command = new DockerCliCommand.ComposeConfig();
 		assertThat(command.getType()).isEqualTo(DockerCliCommand.Type.DOCKER_COMPOSE);
-		assertThat(command.getCommand(COMPOSE_VERSION)).containsExactly("config", "--format=json");
-		assertThat(command.convert("{}")).isInstanceOf(DockerCliComposeConfigResponse.class);
+		assertThat(command.getCommand(DOCKER_CONTEXT)).containsExactly("config", "--format=json");
+		assertThat(command.getCommand(PODMAN_CONTEXT)).containsExactly("config");
+		assertThat(command.convert("{}", DOCKER_CONTEXT)).isInstanceOf(DockerCliComposeConfigResponse.class);
+		assertThat(command.convert("name: test", PODMAN_CONTEXT)).isInstanceOf(DockerCliComposeConfigResponse.class);
 	}
 
 	@Test
 	void composePs() {
 		DockerCliCommand<?> command = new DockerCliCommand.ComposePs();
 		assertThat(command.getType()).isEqualTo(DockerCliCommand.Type.DOCKER_COMPOSE);
-		assertThat(command.getCommand(COMPOSE_VERSION)).containsExactly("ps", "--orphans=false", "--format=json");
-		assertThat(command.convert("[]")).isInstanceOf(List.class);
+		assertThat(command.getCommand(DOCKER_CONTEXT)).containsExactly("ps", "--orphans=false", "--format=json");
+		assertThat(command.convert("[]", DOCKER_CONTEXT)).isInstanceOf(List.class);
 	}
 
 	@Test
 	void composePsWhenLessThanV224() {
 		DockerCliCommand<?> command = new DockerCliCommand.ComposePs();
 		assertThat(command.getType()).isEqualTo(DockerCliCommand.Type.DOCKER_COMPOSE);
-		assertThat(command.getCommand(ComposeVersion.of("2.23"))).containsExactly("ps", "--format=json");
-		assertThat(command.convert("[]")).isInstanceOf(List.class);
+		assertThat(command.getCommand(new ComposeContext(ContainerEngine.DOCKER, ComposeVersion.of("2.23"))))
+			.containsExactly("ps", "--format=json");
+		assertThat(command.convert("[]", DOCKER_CONTEXT)).isInstanceOf(List.class);
+	}
+
+	@Test
+	void composePsWithPodmanDoesNotUseOrphansFlag() {
+		DockerCliCommand<?> command = new DockerCliCommand.ComposePs();
+		assertThat(command.getType()).isEqualTo(DockerCliCommand.Type.DOCKER_COMPOSE);
+		assertThat(command.getCommand(PODMAN_CONTEXT)).containsExactly("ps", "--format=json");
 	}
 
 	@Test
@@ -84,9 +99,17 @@ class DockerCliCommandTests {
 		DockerCliCommand<?> command = new DockerCliCommand.ComposeUp(LogLevel.INFO, List.of("--renew-anon-volumes"));
 		assertThat(command.getType()).isEqualTo(DockerCliCommand.Type.DOCKER_COMPOSE);
 		assertThat(command.getLogLevel()).isEqualTo(LogLevel.INFO);
-		assertThat(command.getCommand(COMPOSE_VERSION)).containsExactly("up", "--no-color", "--detach", "--wait",
+		assertThat(command.getCommand(DOCKER_CONTEXT)).containsExactly("up", "--no-color", "--detach", "--wait",
 				"--renew-anon-volumes");
-		assertThat(command.convert("[]")).isSameAs(None.INSTANCE);
+		assertThat(command.convert("[]", DOCKER_CONTEXT)).isSameAs(None.INSTANCE);
+	}
+
+	@Test
+	void composeUpWithPodmanDoesNotUseWaitFlag() {
+		DockerCliCommand<?> command = new DockerCliCommand.ComposeUp(LogLevel.INFO, List.of("--renew-anon-volumes"));
+		assertThat(command.getType()).isEqualTo(DockerCliCommand.Type.DOCKER_COMPOSE);
+		assertThat(command.getCommand(PODMAN_CONTEXT)).containsExactly("up", "--no-color", "--detach",
+				"--renew-anon-volumes");
 	}
 
 	@Test
@@ -94,8 +117,8 @@ class DockerCliCommandTests {
 		DockerCliCommand<?> command = new DockerCliCommand.ComposeDown(Duration.ofSeconds(1),
 				List.of("--remove-orphans"));
 		assertThat(command.getType()).isEqualTo(DockerCliCommand.Type.DOCKER_COMPOSE);
-		assertThat(command.getCommand(COMPOSE_VERSION)).containsExactly("down", "--timeout", "1", "--remove-orphans");
-		assertThat(command.convert("[]")).isSameAs(None.INSTANCE);
+		assertThat(command.getCommand(DOCKER_CONTEXT)).containsExactly("down", "--timeout", "1", "--remove-orphans");
+		assertThat(command.convert("[]", DOCKER_CONTEXT)).isSameAs(None.INSTANCE);
 	}
 
 	@Test
@@ -103,16 +126,16 @@ class DockerCliCommandTests {
 		DockerCliCommand<?> command = new DockerCliCommand.ComposeStart(LogLevel.INFO, List.of("--dry-run"));
 		assertThat(command.getType()).isEqualTo(DockerCliCommand.Type.DOCKER_COMPOSE);
 		assertThat(command.getLogLevel()).isEqualTo(LogLevel.INFO);
-		assertThat(command.getCommand(COMPOSE_VERSION)).containsExactly("start", "--dry-run");
-		assertThat(command.convert("[]")).isSameAs(None.INSTANCE);
+		assertThat(command.getCommand(DOCKER_CONTEXT)).containsExactly("start", "--dry-run");
+		assertThat(command.convert("[]", DOCKER_CONTEXT)).isSameAs(None.INSTANCE);
 	}
 
 	@Test
 	void composeStop() {
 		DockerCliCommand<?> command = new DockerCliCommand.ComposeStop(Duration.ofSeconds(1), List.of("--dry-run"));
 		assertThat(command.getType()).isEqualTo(DockerCliCommand.Type.DOCKER_COMPOSE);
-		assertThat(command.getCommand(COMPOSE_VERSION)).containsExactly("stop", "--timeout", "1", "--dry-run");
-		assertThat(command.convert("[]")).isSameAs(None.INSTANCE);
+		assertThat(command.getCommand(DOCKER_CONTEXT)).containsExactly("stop", "--timeout", "1", "--dry-run");
+		assertThat(command.convert("[]", DOCKER_CONTEXT)).isSameAs(None.INSTANCE);
 	}
 
 	@Test
@@ -134,11 +157,11 @@ class DockerCliCommandTests {
 	void composeLogs() {
 		DockerCliCommand<?> command = new DockerCliCommand.ComposeLogs();
 		assertThat(command.getType()).isEqualTo(DockerCliCommand.Type.DOCKER_COMPOSE);
-		assertThat(command.getCommand(COMPOSE_VERSION)).containsExactly("logs");
+		assertThat(command.getCommand(DOCKER_CONTEXT)).containsExactly("logs");
 		assertThat(command.convert("""
 				multi
 				line
-				logs""")).isEqualTo("""
+				logs""", DOCKER_CONTEXT)).isEqualTo("""
 				multi
 				line
 				logs""");

--- a/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DockerCliTests.java
+++ b/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/DockerCliTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docker.compose.core;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link DockerCli}.
+ *
+ * @author Somil Jain
+ */
+class DockerCliTests {
+
+	private final ProcessRunner processRunner = mock(ProcessRunner.class);
+
+	@BeforeEach
+	void setUp() {
+		lenient().when(this.processRunner.run(any(), any(String[].class))).thenReturn("[]");
+	}
+
+	@Test
+	void discoversDockerWithComposePlugin() {
+		given(this.processRunner.run("docker", "version", "--format", "{{.Client.Version}}")).willReturn("24.0.0");
+		given(this.processRunner.run("docker", "compose", "version", "--format", "json"))
+			.willReturn("{\"version\": \"2.17.0\"}");
+		DockerCli cli = new DockerCli(this.processRunner);
+
+		cli.run(new DockerCliCommand.Context());
+
+		ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
+		then(this.processRunner).should().run(any(), captor.capture());
+		assertThat(captor.getValue()).containsExactly("docker", "context", "ls", "--format={{ json . }}");
+	}
+
+	@Test
+	void discoversDockerWithStandaloneComposeFallback() {
+		given(this.processRunner.run("docker", "version", "--format", "{{.Client.Version}}")).willReturn("24.0.0");
+		given(this.processRunner.run("docker", "compose", "version", "--format", "json"))
+			.willThrow(new ProcessExitException(1, new String[] { "docker", "compose" }, "", "No such command"));
+		given(this.processRunner.run("docker-compose", "version", "--format", "json"))
+			.willReturn("{\"version\": \"1.29.2\"}");
+		lenient().when(this.processRunner.run(any(), any(String[].class))).thenReturn("{}");
+		DockerCli cli = new DockerCli(this.processRunner);
+
+		cli.run(new DockerCliCommand.ComposeConfig());
+
+		ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
+		then(this.processRunner).should().run(any(), captor.capture());
+		assertThat(captor.getValue()).containsExactly("docker-compose", "--ansi", "never", "config", "--format=json");
+	}
+
+	@Test
+	void discoversPodmanWithComposePluginWhenDockerMissing() {
+		given(this.processRunner.run("docker", "version", "--format", "{{.Client.Version}}"))
+			.willThrow(new ProcessStartException(new String[] { "docker" }, new IOException("missing")));
+		given(this.processRunner.run("podman", "version", "--format", "{{.Client.Version}}")).willReturn("4.5.0");
+		given(this.processRunner.run("podman", "compose", "version")).willReturn("podman-compose version 1.0.6");
+		DockerCli cli = new DockerCli(this.processRunner);
+
+		List<?> result = cli.run(new DockerCliCommand.Context());
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void discoversPodmanWithStandaloneComposeFallback() {
+		given(this.processRunner.run("docker", "version", "--format", "{{.Client.Version}}"))
+			.willThrow(new ProcessStartException(new String[] { "docker" }, new IOException("missing")));
+		given(this.processRunner.run("podman", "version", "--format", "{{.Client.Version}}")).willReturn("4.5.0");
+		given(this.processRunner.run("podman", "compose", "version"))
+			.willThrow(new ProcessExitException(1, new String[] { "podman", "compose" }, "", "No such command"));
+		given(this.processRunner.run("podman-compose", "version")).willReturn("podman-compose version 1.0.6");
+		lenient().when(this.processRunner.run(any(), any(String[].class))).thenReturn("{}");
+		DockerCli cli = new DockerCli(this.processRunner);
+
+		cli.run(new DockerCliCommand.ComposeConfig());
+
+		ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
+		then(this.processRunner).should().run(any(), captor.capture());
+		assertThat(captor.getValue()).containsExactly("podman-compose", "config");
+	}
+
+	@Test
+	void preservesDockerNotRunningException() {
+		given(this.processRunner.run("docker", "version", "--format", "{{.Client.Version}}")).willThrow(
+				new ProcessExitException(1, new String[] { "docker" }, "", "Cannot connect to the Docker daemon"));
+
+		assertThatExceptionOfType(DockerNotRunningException.class).isThrownBy(() -> new DockerCli(this.processRunner));
+	}
+
+	@Test
+	void throwsDockerProcessStartExceptionWhenNeitherEngineAvailable() {
+		given(this.processRunner.run("docker", "version", "--format", "{{.Client.Version}}"))
+			.willThrow(new ProcessStartException(new String[] { "docker" }, new IOException("missing docker")));
+		given(this.processRunner.run("podman", "version", "--format", "{{.Client.Version}}"))
+			.willThrow(new ProcessStartException(new String[] { "podman" }, new IOException("missing podman")));
+
+		assertThatExceptionOfType(DockerProcessStartException.class).isThrownBy(() -> new DockerCli(this.processRunner))
+			.withMessageContaining("Unable to find 'docker' or 'podman' executable");
+	}
+
+}

--- a/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/PodmanComposeConfigYamlParserTests.java
+++ b/core/spring-boot-docker-compose/src/test/java/org/springframework/boot/docker/compose/core/PodmanComposeConfigYamlParserTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.docker.compose.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link PodmanComposeConfigYamlParser}.
+ */
+class PodmanComposeConfigYamlParserTests {
+
+	@Test
+	void parsesRealisticYaml() {
+		String yaml = """
+				name: test-project
+				services:
+				  app:
+				    image: my-app:latest
+				  db:
+				    image: "postgres:15"
+				  cache:
+				    image: 'redis:alpine'
+				    environment:
+				      - REDIS_PASSWORD=secret
+				""";
+		DockerCliComposeConfigResponse response = PodmanComposeConfigYamlParser.parse(yaml);
+		assertThat(response.name()).isEqualTo("test-project");
+		assertThat(response.services()).hasSize(3);
+
+		DockerCliComposeConfigResponse.Service app = response.services().get("app");
+		assertThat(app).isNotNull();
+		assertThat(app.image()).isEqualTo("my-app:latest");
+
+		DockerCliComposeConfigResponse.Service db = response.services().get("db");
+		assertThat(db).isNotNull();
+		assertThat(db.image()).isEqualTo("postgres:15");
+
+		DockerCliComposeConfigResponse.Service cache = response.services().get("cache");
+		assertThat(cache).isNotNull();
+		assertThat(cache.image()).isEqualTo("redis:alpine");
+	}
+
+	@Test
+	void parsesServiceWithoutImage() {
+		String yaml = """
+				name: test-project
+				services:
+				  app:
+				    image: nginx:latest
+				  worker:
+				    command: ./worker
+				""";
+
+		DockerCliComposeConfigResponse response = PodmanComposeConfigYamlParser.parse(yaml);
+
+		assertThat(response.name()).isEqualTo("test-project");
+		assertThat(response.services()).containsOnlyKeys("app");
+
+		DockerCliComposeConfigResponse.Service app = response.services().get("app");
+		assertThat(app).isNotNull();
+		assertThat(app.image()).isEqualTo("nginx:latest");
+	}
+
+}

--- a/platform/spring-boot-dependencies/build.gradle
+++ b/platform/spring-boot-dependencies/build.gradle
@@ -574,6 +574,9 @@ bom {
 			github("https://github.com/grpc/grpc-java")
 			docs("https://grpc.io/docs/languages/java/")
 			releaseNotes("https://github.com/grpc/grpc-java/releases/tag/v{version}")
+			module("grpc-api") {
+				javadoc("https://javadoc.io/doc/io.grpc/grpc-api/{version}", "io.grpc")
+			}
 		}
 	}
 	library("Grpc Kotlin", "1.5.0") {


### PR DESCRIPTION
Fixes #43440 

Support Podman for Docker Compose integration by adding engine-aware command handling, Podman Compose version discovery and fallbacks, compatible Compose command options, and YAML-based Compose config parsing while preserving existing Docker behavior.