### PR TITLE
Record Reactor lifecycle metrics for auto-configured R2DBC pools

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/metrics.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/metrics.adoc
@@ -911,6 +911,24 @@ See the {url-spring-graphql-docs}/observability.html[Spring GraphQL reference do
 
 
 
+[[actuator.metrics.supported.r2dbc]]
+=== R2DBC Pool Metrics
+
+Auto-configuration instruments R2DBC connection pools with gauges prefixed with `r2dbc.pool` and tagged with the connection factory bean `name`.
+
+When `io.projectreactor.addons:reactor-pool-micrometer` is on the classpath, the pool auto-configured using `spring.r2dbc.pool` also records Reactor pool lifecycle metrics.
+These include allocation and pending timings, recycling counts, and resource idle and lifetime timings.
+They use Reactor's `reactor.pool` prefix and a `pool.name` tag of `connectionFactory`.
+These metrics describe Reactor pool operations, rather than the complete R2DBC connection acquisition and validation process.
+Recording starts after meter binders have been applied; events during earlier bean initialization are not replayed.
+Use `management.metrics.enable.reactor.pool=false` to disable these lifecycle metrics.
+
+To replace the default recorder for the auto-configured pool, define a `PoolMetricsRecorder` bean named `r2dbcPoolMetricsRecorder`.
+Pools created by application code or through an explicit `r2dbc:pool:` URL retain the gauge instrumentation.
+To record lifecycle metrics for a pool created by application code, configure its builder's `metricsRecorder` with Reactor's `Micrometer.recorder` and the application's meter registry.
+
+
+
 [[actuator.metrics.supported.jdbc]]
 === DataSource Metrics
 

--- a/module/spring-boot-r2dbc/build.gradle
+++ b/module/spring-boot-r2dbc/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 	optional(project(":module:spring-boot-micrometer-metrics"))
 	optional(project(":module:spring-boot-micrometer-observation"))
 	optional("io.micrometer:micrometer-core")
+	optional("io.projectreactor.addons:reactor-pool-micrometer")
 	optional("io.r2dbc:r2dbc-pool")
 	optional("io.r2dbc:r2dbc-proxy")
 	optional("io.r2dbc:r2dbc-spi")

--- a/module/spring-boot-r2dbc/src/main/java/org/springframework/boot/r2dbc/autoconfigure/ConnectionFactoryConfigurations.java
+++ b/module/spring-boot-r2dbc/src/main/java/org/springframework/boot/r2dbc/autoconfigure/ConnectionFactoryConfigurations.java
@@ -22,8 +22,10 @@ import io.r2dbc.pool.ConnectionPool;
 import io.r2dbc.pool.ConnectionPoolConfiguration;
 import io.r2dbc.spi.ConnectionFactory;
 import org.jspecify.annotations.Nullable;
+import reactor.pool.PoolMetricsRecorder;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -50,6 +52,7 @@ import org.springframework.util.StringUtils;
 /**
  * Actual {@link ConnectionFactory} configurations.
  *
+ * @author Goutam Adwant
  * @author Mark Paluch
  * @author Stephane Nicoll
  * @author Rodolpho S. Couto
@@ -99,7 +102,8 @@ abstract class ConnectionFactoryConfigurations {
 			ConnectionPool connectionFactory(R2dbcProperties properties,
 					ObjectProvider<R2dbcConnectionDetails> connectionDetails, ResourceLoader resourceLoader,
 					ObjectProvider<ConnectionFactoryOptionsBuilderCustomizer> customizers,
-					ObjectProvider<ConnectionFactoryDecorator> decorators) {
+					ObjectProvider<ConnectionFactoryDecorator> decorators,
+					@Qualifier("r2dbcPoolMetricsRecorder") ObjectProvider<PoolMetricsRecorder> metricsRecorders) {
 				ConnectionFactory connectionFactory = createConnectionFactory(properties,
 						connectionDetails.getIfAvailable(), resourceLoader.getClassLoader(),
 						customizers.orderedStream().toList(), decorators.orderedStream().toList());
@@ -117,6 +121,7 @@ abstract class ConnectionFactoryConfigurations {
 				map.from(pool.getValidationDepth()).to(builder::validationDepth);
 				map.from(pool.getMinIdle()).to(builder::minIdle);
 				map.from(pool.getMaxValidationTime()).to(builder::maxValidationTime);
+				metricsRecorders.ifUnique(builder::metricsRecorder);
 				return new ConnectionPool(builder.build());
 			}
 

--- a/module/spring-boot-r2dbc/src/main/java/org/springframework/boot/r2dbc/autoconfigure/metrics/ConnectionPoolMetricsAutoConfiguration.java
+++ b/module/spring-boot-r2dbc/src/main/java/org/springframework/boot/r2dbc/autoconfigure/metrics/ConnectionPoolMetricsAutoConfiguration.java
@@ -22,6 +22,7 @@ import io.r2dbc.pool.ConnectionPool;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.Wrapped;
 import org.jspecify.annotations.Nullable;
+import reactor.pool.introspection.micrometer.Micrometer;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -30,8 +31,11 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.r2dbc.autoconfigure.R2dbcAutoConfiguration;
 import org.springframework.boot.r2dbc.metrics.ConnectionPoolMetrics;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for metrics on all available
@@ -39,6 +43,7 @@ import org.springframework.boot.r2dbc.metrics.ConnectionPoolMetrics;
  *
  * @author Tadaya Tsuyukubo
  * @author Stephane Nicoll
+ * @author Goutam Adwant
  * @since 4.0.0
  */
 @AutoConfiguration(after = R2dbcAutoConfiguration.class,
@@ -66,6 +71,18 @@ public final class ConnectionPoolMetricsAutoConfiguration {
 			return extractPool(((Wrapped<?>) candidate).unwrap());
 		}
 		return null;
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(Micrometer.class)
+	static class PoolMetricsRecorderConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean(name = "r2dbcPoolMetricsRecorder")
+		ConnectionPoolMetricsRecorder r2dbcPoolMetricsRecorder() {
+			return new ConnectionPoolMetricsRecorder();
+		}
+
 	}
 
 }

--- a/module/spring-boot-r2dbc/src/main/java/org/springframework/boot/r2dbc/autoconfigure/metrics/ConnectionPoolMetricsRecorder.java
+++ b/module/spring-boot-r2dbc/src/main/java/org/springframework/boot/r2dbc/autoconfigure/metrics/ConnectionPoolMetricsRecorder.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.r2dbc.autoconfigure.metrics;
+
+import java.util.Set;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import org.jspecify.annotations.Nullable;
+import reactor.pool.PoolMetricsRecorder;
+import reactor.pool.introspection.micrometer.Micrometer;
+
+import org.springframework.beans.factory.DisposableBean;
+
+/**
+ * Records metrics for the auto-configured connection pool once meter binding is complete.
+ *
+ * @author Goutam Adwant
+ */
+final class ConnectionPoolMetricsRecorder implements PoolMetricsRecorder, MeterBinder, DisposableBean {
+
+	private final CompositeMeterRegistry registry = new CompositeMeterRegistry();
+
+	private volatile @Nullable PoolMetricsRecorder delegate;
+
+	@Override
+	public void bindTo(MeterRegistry registry) {
+		this.registry.add(registry);
+	}
+
+	@Override
+	public void destroy() {
+		Set.copyOf(this.registry.getRegistries()).forEach(this.registry::remove);
+		this.registry.close();
+	}
+
+	private PoolMetricsRecorder getDelegate() {
+		PoolMetricsRecorder delegate = this.delegate;
+		if (delegate == null) {
+			synchronized (this) {
+				delegate = this.delegate;
+				if (delegate == null) {
+					delegate = Micrometer.recorder("connectionFactory", this.registry);
+					this.delegate = delegate;
+				}
+			}
+		}
+		return delegate;
+	}
+
+	@Override
+	public void recordAllocationSuccessAndLatency(long latencyMs) {
+		getDelegate().recordAllocationSuccessAndLatency(latencyMs);
+	}
+
+	@Override
+	public void recordAllocationFailureAndLatency(long latencyMs) {
+		getDelegate().recordAllocationFailureAndLatency(latencyMs);
+	}
+
+	@Override
+	public void recordResetLatency(long latencyMs) {
+		getDelegate().recordResetLatency(latencyMs);
+	}
+
+	@Override
+	public void recordDestroyLatency(long latencyMs) {
+		getDelegate().recordDestroyLatency(latencyMs);
+	}
+
+	@Override
+	public void recordRecycled() {
+		getDelegate().recordRecycled();
+	}
+
+	@Override
+	public void recordLifetimeDuration(long millisecondsSinceAllocation) {
+		getDelegate().recordLifetimeDuration(millisecondsSinceAllocation);
+	}
+
+	@Override
+	public void recordIdleTime(long millisecondsIdle) {
+		getDelegate().recordIdleTime(millisecondsIdle);
+	}
+
+	@Override
+	public void recordSlowPath() {
+		getDelegate().recordSlowPath();
+	}
+
+	@Override
+	public void recordFastPath() {
+		getDelegate().recordFastPath();
+	}
+
+	@Override
+	public void recordPendingSuccessAndLatency(long latencyMs) {
+		getDelegate().recordPendingSuccessAndLatency(latencyMs);
+	}
+
+	@Override
+	public void recordPendingFailureAndLatency(long latencyMs) {
+		getDelegate().recordPendingFailureAndLatency(latencyMs);
+	}
+
+}

--- a/module/spring-boot-r2dbc/src/test/java/org/springframework/boot/r2dbc/autoconfigure/metrics/ConnectionPoolMetricsAutoConfigurationTests.java
+++ b/module/spring-boot-r2dbc/src/test/java/org/springframework/boot/r2dbc/autoconfigure/metrics/ConnectionPoolMetricsAutoConfigurationTests.java
@@ -16,8 +16,11 @@
 
 package org.springframework.boot.r2dbc.autoconfigure.metrics;
 
+import java.time.Duration;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -33,21 +36,34 @@ import io.r2dbc.spi.ConnectionFactoryMetadata;
 import io.r2dbc.spi.Wrapped;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+import reactor.pool.PoolMetricsRecorder;
+import reactor.pool.introspection.micrometer.Micrometer;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MeterRegistryCustomizer;
 import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration;
+import org.springframework.boot.r2dbc.ConnectionFactoryDecorator;
 import org.springframework.boot.r2dbc.autoconfigure.R2dbcAutoConfiguration;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link ConnectionPoolMetricsAutoConfiguration}.
  *
  * @author Tadaya Tsuyukubo
  * @author Stephane Nicoll
+ * @author Goutam Adwant
  */
 class ConnectionPoolMetricsAutoConfigurationTests {
 
@@ -56,6 +72,20 @@ class ConnectionPoolMetricsAutoConfigurationTests {
 		.withBean(SimpleMeterRegistry.class)
 		.withConfiguration(
 				AutoConfigurations.of(ConnectionPoolMetricsAutoConfiguration.class, MetricsAutoConfiguration.class));
+
+	@Test
+	void autoConfiguredPoolRecordsAllocation() {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(R2dbcAutoConfiguration.class)).run((context) -> {
+			Connection connection = Mono.from(context.getBean(ConnectionFactory.class).create()).block();
+			assertThat(connection).isNotNull();
+			Mono.from(connection.close()).block();
+			assertThat(context.getBean(MeterRegistry.class)
+				.get("reactor.pool.allocation")
+				.tags("pool.name", "connectionFactory", "pool.allocation.outcome", "success")
+				.timer()
+				.count()).isPositive();
+		});
+	}
 
 	@Test
 	void autoConfiguredDataSourceIsInstrumented() {
@@ -114,6 +144,187 @@ class ConnectionPoolMetricsAutoConfigurationTests {
 			assertThat(registry.find("r2dbc.pool.acquired").meters()).map((meter) -> meter.getId().getTag("name"))
 				.containsOnly("standardPool", "nonDefaultPool");
 		});
+	}
+
+	@Test
+	void recorderDependencyIsOptional() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader(Micrometer.class))
+			.withConfiguration(AutoConfigurations.of(R2dbcAutoConfiguration.class))
+			.run((context) -> {
+				assertThat(context).hasNotFailed().doesNotHaveBean(ConnectionPoolMetricsRecorder.class);
+				useConnection(context.getBean(ConnectionFactory.class));
+				assertThat(context.getBean(MeterRegistry.class).find("r2dbc.pool.acquired").gauge()).isNotNull();
+				assertThat(context.getBean(MeterRegistry.class).find("reactor.pool.allocation").timer()).isNull();
+			});
+	}
+
+	@Test
+	void urlConfiguredPoolHasOnlyGauges() {
+		this.contextRunner.withPropertyValues("spring.r2dbc.url=r2dbc:pool:h2:mem:///urlPool")
+			.withConfiguration(AutoConfigurations.of(R2dbcAutoConfiguration.class))
+			.run((context) -> {
+				useConnection(context.getBean(ConnectionFactory.class));
+				assertThat(context.getBean(MeterRegistry.class).find("r2dbc.pool.acquired").gauge()).isNotNull();
+				assertThat(context.getBean(MeterRegistry.class).find("reactor.pool.allocation").timer()).isNull();
+			});
+	}
+
+	@Test
+	void manuallyConfiguredPoolHasOnlyGauges() {
+		this.contextRunner.withUserConfiguration(ConnectionFactoryConfiguration.class).run((context) -> {
+			useConnection(context.getBean(ConnectionFactory.class));
+			assertThat(context.getBean(MeterRegistry.class).find("r2dbc.pool.acquired").gauge()).isNotNull();
+			assertThat(context.getBean(MeterRegistry.class).find("reactor.pool.allocation").timer()).isNull();
+		});
+	}
+
+	@Test
+	void customRecorderReplacesDefault() {
+		PoolMetricsRecorder recorder = mock(PoolMetricsRecorder.class);
+		this.contextRunner.withBean("r2dbcPoolMetricsRecorder", PoolMetricsRecorder.class, () -> recorder)
+			.withConfiguration(AutoConfigurations.of(R2dbcAutoConfiguration.class))
+			.run((context) -> {
+				assertThat(context).doesNotHaveBean(ConnectionPoolMetricsRecorder.class);
+				useConnection(context.getBean(ConnectionFactory.class));
+				then(recorder).should(atLeastOnce()).recordAllocationSuccessAndLatency(anyLong());
+				assertThat(context.getBean(MeterRegistry.class).find("reactor.pool.allocation").timer()).isNull();
+			});
+	}
+
+	@Test
+	void unrelatedUniqueRecorderDoesNotReplaceDefault() {
+		PoolMetricsRecorder recorder = mock(PoolMetricsRecorder.class);
+		this.contextRunner.withBean("otherPoolRecorder", PoolMetricsRecorder.class, () -> recorder)
+			.withConfiguration(AutoConfigurations.of(R2dbcAutoConfiguration.class))
+			.run((context) -> {
+				assertThat(context).hasSingleBean(ConnectionPoolMetricsRecorder.class);
+				useConnection(context.getBean(ConnectionFactory.class));
+				then(recorder).shouldHaveNoInteractions();
+				assertThat(context.getBean(MeterRegistry.class)
+					.get("reactor.pool.allocation")
+					.tags("pool.allocation.outcome", "success")
+					.timer()
+					.count()).isPositive();
+			});
+	}
+
+	@Test
+	void unrelatedRecordersDoNotReplaceDefault() {
+		PoolMetricsRecorder first = mock(PoolMetricsRecorder.class);
+		PoolMetricsRecorder second = mock(PoolMetricsRecorder.class);
+		this.contextRunner.withBean("firstRecorder", PoolMetricsRecorder.class, () -> first)
+			.withBean("secondRecorder", PoolMetricsRecorder.class, () -> second)
+			.withConfiguration(AutoConfigurations.of(R2dbcAutoConfiguration.class))
+			.run((context) -> {
+				assertThat(context).hasNotFailed().hasSingleBean(ConnectionPoolMetricsRecorder.class);
+				useConnection(context.getBean(ConnectionFactory.class));
+				then(first).shouldHaveNoInteractions();
+				then(second).shouldHaveNoInteractions();
+			});
+	}
+
+	@Test
+	void unrelatedPrimaryRecorderDoesNotReplaceDefault() {
+		PoolMetricsRecorder first = mock(PoolMetricsRecorder.class);
+		PoolMetricsRecorder second = mock(PoolMetricsRecorder.class);
+		this.contextRunner.withBean("firstRecorder", PoolMetricsRecorder.class, () -> first)
+			.withBean("secondRecorder", PoolMetricsRecorder.class, () -> second,
+					(definition) -> definition.setPrimary(true))
+			.withConfiguration(AutoConfigurations.of(R2dbcAutoConfiguration.class))
+			.run((context) -> {
+				useConnection(context.getBean(ConnectionFactory.class));
+				assertThat(context).hasSingleBean(ConnectionPoolMetricsRecorder.class);
+				then(first).shouldHaveNoInteractions();
+				then(second).shouldHaveNoInteractions();
+			});
+	}
+
+	@Test
+	void registryCustomizerCanUseConnectionFactory() {
+		this.contextRunner.withUserConfiguration(RegistryCustomizerConfiguration.class)
+			.withConfiguration(AutoConfigurations.of(R2dbcAutoConfiguration.class))
+			.run((context) -> {
+				assertThat(context).hasNotFailed();
+				useConnection(context.getBean(ConnectionFactory.class));
+				assertThat(context.getBean(MeterRegistry.class)
+					.get("reactor.pool.allocation")
+					.tags("pool.allocation.outcome", "success", "database", "h2")
+					.timer()
+					.count()).isPositive();
+			});
+	}
+
+	@Test
+	void lifecycleMetricsCanBeDisabled() {
+		this.contextRunner.withPropertyValues("management.metrics.enable.reactor.pool=false")
+			.withConfiguration(AutoConfigurations.of(R2dbcAutoConfiguration.class))
+			.run((context) -> {
+				useConnection(context.getBean(ConnectionFactory.class));
+				assertThat(context.getBean(MeterRegistry.class).find("reactor.pool.allocation").timer()).isNull();
+				assertThat(context.getBean(MeterRegistry.class).find("r2dbc.pool.acquired").gauge()).isNotNull();
+			});
+	}
+
+	@Test
+	void failedAllocationsAreRecorded() {
+		this.contextRunner.withPropertyValues("spring.r2dbc.pool.acquire-retry=0")
+			.withBean(ConnectionFactoryDecorator.class, () -> (factory) -> {
+				ConnectionFactory failing = mock(ConnectionFactory.class);
+				given(failing.create())
+					.willAnswer((invocation) -> Mono.error(new IllegalStateException("Connection unavailable")));
+				given(failing.getMetadata()).willReturn(factory.getMetadata());
+				return failing;
+			})
+			.withConfiguration(AutoConfigurations.of(R2dbcAutoConfiguration.class))
+			.run((context) -> {
+				assertThatIllegalStateException()
+					.isThrownBy(() -> Mono.from(context.getBean(ConnectionFactory.class).create()).block())
+					.withMessage("Connection unavailable");
+				assertThat(context.getBean(MeterRegistry.class)
+					.get("reactor.pool.allocation")
+					.tags("pool.name", "connectionFactory", "pool.allocation.outcome", "failure")
+					.timer()
+					.count()).isPositive();
+			});
+	}
+
+	@Test
+	void pendingAcquisitionIsRecorded() {
+		this.contextRunner.withPropertyValues("spring.r2dbc.pool.initial-size=1", "spring.r2dbc.pool.max-size=1")
+			.withConfiguration(AutoConfigurations.of(R2dbcAutoConfiguration.class))
+			.run((context) -> {
+				ConnectionFactory factory = context.getBean(ConnectionFactory.class);
+				Connection first = Mono.from(factory.create()).block(Duration.ofSeconds(5));
+				assertThat(first).isNotNull();
+				CompletableFuture<? extends Connection> pending = Mono.from(factory.create()).toFuture();
+				assertThat(pending).isNotDone();
+				Mono.from(first.close()).block(Duration.ofSeconds(5));
+				Connection second = Mono.fromFuture(pending).block(Duration.ofSeconds(5));
+				assertThat(second).isNotNull();
+				Mono.from(second.close()).block(Duration.ofSeconds(5));
+				assertThat(context.getBean(MeterRegistry.class)
+					.get("reactor.pool.pending")
+					.tags("pool.name", "connectionFactory", "pool.pending.outcome", "success")
+					.timer()
+					.count()).isEqualTo(1);
+			});
+	}
+
+	private void useConnection(ConnectionFactory connectionFactory) {
+		Connection connection = Mono.from(connectionFactory.create()).block();
+		assertThat(connection).isNotNull();
+		Mono.from(connection.close()).block();
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class RegistryCustomizerConfiguration {
+
+		@Bean
+		MeterRegistryCustomizer<MeterRegistry> registryCustomizer(ConnectionFactory connectionFactory) {
+			return (registry) -> registry.config()
+				.commonTags("database", connectionFactory.getMetadata().getName().toLowerCase(Locale.ROOT));
+		}
+
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/module/spring-boot-r2dbc/src/test/java/org/springframework/boot/r2dbc/autoconfigure/metrics/ConnectionPoolMetricsRecorderTests.java
+++ b/module/spring-boot-r2dbc/src/test/java/org/springframework/boot/r2dbc/autoconfigure/metrics/ConnectionPoolMetricsRecorderTests.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.r2dbc.autoconfigure.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConnectionPoolMetricsRecorder}.
+ *
+ * @author Goutam Adwant
+ */
+class ConnectionPoolMetricsRecorderTests {
+
+	@Test
+	void unusedRecorderDoesNotRegisterMeters() {
+		SimpleMeterRegistry registry = new SimpleMeterRegistry();
+		try {
+			new ConnectionPoolMetricsRecorder().bindTo(registry);
+			assertThat(registry.getMeters()).isEmpty();
+		}
+		finally {
+			registry.close();
+		}
+	}
+
+	@Test
+	void recordsAllLifecycleEvents() {
+		SimpleMeterRegistry registry = new SimpleMeterRegistry();
+		try {
+			ConnectionPoolMetricsRecorder recorder = new ConnectionPoolMetricsRecorder();
+			recorder.bindTo(registry);
+			recorder.recordAllocationSuccessAndLatency(10);
+			recorder.recordAllocationFailureAndLatency(20);
+			recorder.recordResetLatency(30);
+			recorder.recordDestroyLatency(40);
+			recorder.recordRecycled();
+			recorder.recordLifetimeDuration(50);
+			recorder.recordIdleTime(60);
+			recorder.recordSlowPath();
+			recorder.recordFastPath();
+			recorder.recordPendingSuccessAndLatency(70);
+			recorder.recordPendingFailureAndLatency(80);
+			assertThat(registry.get("reactor.pool.allocation")
+				.tag("pool.allocation.outcome", "success")
+				.timer()
+				.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(10);
+			assertThat(registry.get("reactor.pool.allocation")
+				.tag("pool.allocation.outcome", "failure")
+				.timer()
+				.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(20);
+			assertThat(registry.get("reactor.pool.reset").timer().totalTime(TimeUnit.MILLISECONDS)).isEqualTo(30);
+			assertThat(registry.get("reactor.pool.destroyed").timer().totalTime(TimeUnit.MILLISECONDS)).isEqualTo(40);
+			assertThat(registry.get("reactor.pool.recycled").counter().count()).isEqualTo(1);
+			assertThat(registry.get("reactor.pool.resources.summary.lifetime").timer().totalTime(TimeUnit.MILLISECONDS))
+				.isEqualTo(50);
+			assertThat(registry.get("reactor.pool.resources.summary.idleness").timer().totalTime(TimeUnit.MILLISECONDS))
+				.isEqualTo(60);
+			assertThat(
+					registry.get("reactor.pool.recycled.notable").tag("pool.recycling.path", "slow").counter().count())
+				.isEqualTo(1);
+			assertThat(
+					registry.get("reactor.pool.recycled.notable").tag("pool.recycling.path", "fast").counter().count())
+				.isEqualTo(1);
+			assertThat(registry.get("reactor.pool.pending")
+				.tag("pool.pending.outcome", "success")
+				.timer()
+				.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(70);
+			assertThat(registry.get("reactor.pool.pending")
+				.tag("pool.pending.outcome", "failure")
+				.timer()
+				.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(80);
+			assertThat(registry.getMeters())
+				.allSatisfy((meter) -> assertThat(meter.getId().getTag("pool.name")).isEqualTo("connectionFactory"));
+		}
+		finally {
+			registry.close();
+		}
+	}
+
+	@Test
+	void eventsBeforeBindingAreNotReplayed() {
+		SimpleMeterRegistry registry = new SimpleMeterRegistry();
+		try {
+			ConnectionPoolMetricsRecorder recorder = new ConnectionPoolMetricsRecorder();
+			recorder.recordAllocationSuccessAndLatency(10);
+			recorder.bindTo(registry);
+			recorder.recordAllocationSuccessAndLatency(20);
+			assertThat(
+					registry.get("reactor.pool.allocation").tag("pool.allocation.outcome", "success").timer().count())
+				.isEqualTo(1);
+			assertThat(registry.get("reactor.pool.allocation")
+				.tag("pool.allocation.outcome", "success")
+				.timer()
+				.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(20);
+		}
+		finally {
+			registry.close();
+		}
+	}
+
+	@Test
+	void bindingMultipleRegistriesIsIdempotent() {
+		SimpleMeterRegistry first = new SimpleMeterRegistry();
+		SimpleMeterRegistry second = new SimpleMeterRegistry();
+		try {
+			ConnectionPoolMetricsRecorder recorder = new ConnectionPoolMetricsRecorder();
+			recorder.bindTo(first);
+			recorder.bindTo(first);
+			recorder.bindTo(second);
+			recorder.recordRecycled();
+			assertThat(first.get("reactor.pool.recycled").counter().count()).isEqualTo(1);
+			assertThat(second.get("reactor.pool.recycled").counter().count()).isEqualTo(1);
+		}
+		finally {
+			first.close();
+			second.close();
+		}
+	}
+
+	@Test
+	void destructionDetachesWithoutClosingSharedRegistry() {
+		SimpleMeterRegistry registry = new SimpleMeterRegistry();
+		try {
+			ConnectionPoolMetricsRecorder recorder = new ConnectionPoolMetricsRecorder();
+			recorder.bindTo(registry);
+			recorder.recordRecycled();
+			recorder.destroy();
+			recorder.recordRecycled();
+			assertThat(registry.isClosed()).isFalse();
+			assertThat(registry.get("reactor.pool.recycled").counter().count()).isEqualTo(1);
+			registry.counter("application.requests").increment();
+			assertThat(registry.get("application.requests").counter().count()).isEqualTo(1);
+		}
+		finally {
+			registry.close();
+		}
+	}
+
+	@Test
+	void bindingCompositeAndChildDoesNotDuplicateEvents() {
+		SimpleMeterRegistry child = new SimpleMeterRegistry();
+		CompositeMeterRegistry composite = new CompositeMeterRegistry();
+		composite.add(child);
+		try {
+			ConnectionPoolMetricsRecorder recorder = new ConnectionPoolMetricsRecorder();
+			recorder.bindTo(composite);
+			recorder.bindTo(child);
+			recorder.recordRecycled();
+			assertThat(child.get("reactor.pool.recycled").counter().count()).isEqualTo(1);
+			recorder.destroy();
+			assertThat(composite.isClosed()).isFalse();
+			assertThat(child.isClosed()).isFalse();
+		}
+		finally {
+			composite.close();
+			child.close();
+		}
+	}
+
+}


### PR DESCRIPTION
Adds Reactor pool lifecycle metrics to the R2DBC pool configured through `spring.r2dbc.pool` when `reactor-pool-micrometer` is available. This exposes allocation and pending timings, recycling counts, and resource lifetime and idle timings alongside the existing pool gauges.

The recorder binds after registry customization to avoid a dependency cycle when a registry customizer needs the connection factory. An explicitly named `r2dbcPoolMetricsRecorder` bean replaces the default; unrelated Reactor pool recorders are left alone. Documentation covers the optional dependency, Reactor meter names, early initialization events, and the existing behavior of URL-created and application-created pools.

Related to #32072.

Validation: `./gradlew :module:spring-boot-r2dbc:check -x :module:spring-boot-r2dbc:dockerTest -x :module:spring-boot-r2dbc:reclaimDockerSpace --no-build-cache --rerun-tasks` passed with 237 tests. Database-container tests were not run.