### PR TITLE
Document baggage propagation over gRPC

### DIFF
--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/tracing.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/tracing.adoc
@@ -242,6 +242,7 @@ The baggage is automatically propagated over the network if you're using W3C pro
 If you're using B3 propagation, baggage is not automatically propagated.
 To manually propagate baggage over the network, use the configprop:management.tracing.baggage.remote-fields[] configuration property (this works for W3C, too).
 For the example above, setting this property to `baggage1` results in an HTTP header `baggage1: value1`.
+Baggage is propagated wherever Micrometer Observation instruments the transport, for example xref:io/grpc.adoc#io.grpc.server.observability[gRPC metadata] as well as HTTP headers.
 
 If you want to propagate the baggage to the MDC, use the configprop:management.tracing.baggage.correlation.fields[] configuration property.
 For the example above, setting this property to `baggage1` results in an MDC entry named `baggage1`.

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/io/grpc.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/io/grpc.adoc
@@ -484,6 +484,21 @@ For details of how to configure an OAuth2 Resource Server to use with your gRPC 
 
 
 
+[[io.grpc.server.observability]]
+=== Observability
+
+Spring Boot provides auto-configuration of the javadoc:io.micrometer.core.instrument.binder.grpc.ObservationGrpcServerInterceptor[] whenever Micrometer is available.
+This interceptor provides observability into your gRPC server applications.
+
+When Micrometer Tracing is also available, the observation carries the trace context and any xref:actuator/tracing.adoc#actuator.micrometer-tracing.baggage[baggage] found in the incoming gRPC metadata.
+This includes the W3C `baggage` header as well as the individual metadata keys listed in configprop:management.tracing.baggage.remote-fields[], so no additional interceptor is required to propagate baggage over gRPC.
+
+NOTE: The interceptor is provided by `micrometer-core`, so it is only auto-configured when that dependency is on the classpath (for example through `spring-boot-starter-actuator`).
+
+TIP: If you use Micrometer, but prefer to not to use it for gRPC, you can set configprop:spring.grpc.server.observation.enabled[] to `false`.
+
+
+
 [[io.grpc.client]]
 == Writing a gRPC Client Application
 
@@ -682,6 +697,10 @@ TIP: To disable the in-process channel factory, you can set the configprop:sprin
 
 Spring Boot provides auto-configuration of the javadoc:io.micrometer.core.instrument.binder.grpc.ObservationGrpcClientInterceptor[] whenever Micrometer is available.
 This interceptor provides observability into your gRPC client applications.
+
+When Micrometer Tracing is also available, the trace context and the current xref:actuator/tracing.adoc#actuator.micrometer-tracing.baggage[baggage] are written to the metadata of outgoing calls, using the W3C `baggage` header as well as the individual metadata keys listed in configprop:management.tracing.baggage.remote-fields[].
+
+NOTE: The interceptor is provided by `micrometer-core`, so it is only auto-configured when that dependency is on the classpath (for example through `spring-boot-starter-actuator`).
 
 TIP: If you use Micrometer, but prefer to not to use it for gRPC, you can set configprop:spring.grpc.client.observation.enabled[] to `false`.
 


### PR DESCRIPTION
Documentation-only, targeting **4.1.x** — split as requested by @wilkinsona; the `BaggageTaggingSpanProcessor` enhancement is now proposed separately in https://github.com/spring-projects/spring-boot/pull/51656.

### What this documents

Baggage is already propagated over gRPC by the auto-configured Micrometer observation interceptors: `ObservationGrpcServerInterceptor` hands the incoming metadata to the tracing observation handlers, which extract the W3C `baggage` header as well as the individual metadata keys listed in `management.tracing.baggage.remote-fields`; `ObservationGrpcClientInterceptor` writes them to the metadata of outgoing calls. None of this was documented, and the prerequisite — `micrometer-core` on the classpath, since the interceptors live there — is easy to miss: without it there is no gRPC observation and therefore no propagation, silently.

I verified the behaviour end-to-end (in-process gRPC server + client, OTel SDK, W3C propagation, `remote-fields` configured) on `main` and on 4.1.1: both header forms are extracted on the server and available inside unary and streaming methods, the client injects both forms plus `traceparent`, and nothing leaks between calls.

### Changes

- gRPC reference: new server "Observability" section (interceptor, propagation of trace context and baggage, `micrometer-core` prerequisite, `spring.grpc.server.observation.enabled`), and the client "Observability" section extended the same way.
- Tracing reference: the baggage section mentions that propagation also covers gRPC metadata.

Closes #49832 — the issue turned out to be a documentation gap; the remaining tagging problem is tracked upstream in micrometer-metrics/tracing#933 and in https://github.com/spring-projects/spring-boot/pull/51656.
