### PR TITLE
Avoid Gradle deprecation warnings for Project object as a dependency notation

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/aggregation/AggregatorPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/aggregation/AggregatorPlugin.java
@@ -47,7 +47,8 @@ public class AggregatorPlugin implements Plugin<Project> {
 					configureAttributes(configuration, aggregate, target.getObjects());
 				});
 			target.getRootProject()
-				.allprojects((project) -> target.getDependencies().add(dependencies.getName(), project));
+				.allprojects((project) -> target.getDependencies()
+					.add(dependencies.getName(), project.getDependencyFactory().createProjectDependency()));
 			aggregate.getFiles()
 				.convention(aggregated.map((configuration) -> configuration.getIncoming()
 					.artifactView((view) -> view.setLenient(true))


### PR DESCRIPTION
Currently, running the build with `--warning-mode=all` reports the following deprecation warning:

```text
> Configure project :documentation:spring-boot-docs
Using a Project object as a dependency notation has been deprecated. This will fail with an error in Gradle 10. Please use the project(String) method on DependencyHandler or the createProjectDependency(String) method on DependencyFactory instead. Consult the upgrading guide for further information: https://docs.gradle.org/9.7.0/userguide/upgrading_version_9.html#dependency_project_notation
```

This PR updates AggregatorPlugin to create explicit project dependencies with DependencyFactory#createProjectDependency(...).

Reference: https://docs.gradle.org/9.7.0/userguide/upgrading_version_9.html#dependency_project_notation

Note that --warning-mode=all still reports other, unrelated deprecation warnings (implicit property lookup in parent projects, and the IDE plugins' file generation types). 
Those are left out of this PR to keep it focused, but I'm happy to follow up on them if that would be useful.