### PR TITLE
OAuth2 resource server ignores authorities-claim-delimiter when set on its own

### DIFF
--- a/module/spring-boot-security-oauth2-resource-server/src/main/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/reactive/ReactiveOAuth2ResourceServerJwtConfiguration.java
+++ b/module/spring-boot-security-oauth2-resource-server/src/main/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/reactive/ReactiveOAuth2ResourceServerJwtConfiguration.java
@@ -265,6 +265,11 @@ class ReactiveOAuth2ResourceServerJwtConfiguration {
 
 		}
 
+		@ConditionalOnProperty("spring.security.oauth2.resourceserver.jwt.authorities-claim-delimiter")
+		static class OnAuthoritiesClaimDelimiter {
+
+		}
+
 	}
 
 }

--- a/module/spring-boot-security-oauth2-resource-server/src/main/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/servlet/OAuth2ResourceServerJwtConfiguration.java
+++ b/module/spring-boot-security-oauth2-resource-server/src/main/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/servlet/OAuth2ResourceServerJwtConfiguration.java
@@ -257,6 +257,11 @@ class OAuth2ResourceServerJwtConfiguration {
 
 		}
 
+		@ConditionalOnProperty("spring.security.oauth2.resourceserver.jwt.authorities-claim-delimiter")
+		static class OnAuthoritiesClaimDelimiter {
+
+		}
+
 	}
 
 }

--- a/module/spring-boot-security-oauth2-resource-server/src/test/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/JwtConverterCustomizationsArgumentsProvider.java
+++ b/module/spring-boot-security-oauth2-resource-server/src/test/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/JwtConverterCustomizationsArgumentsProvider.java
@@ -53,7 +53,7 @@ public final class JwtConverterCustomizationsArgumentsProvider implements Argume
 		String principalClaimProperty = "spring.security.oauth2.resourceserver.jwt.principal-claim-name="
 				+ customPrincipalClaim;
 		String[] customPrefixProps = { jwkSetUriProperty, authorityPrefixProperty };
-		String[] customDelimiterProps = { jwkSetUriProperty, authorityPrefixProperty, authoritiesDelimiterProperty };
+		String[] customDelimiterProps = { jwkSetUriProperty, authoritiesDelimiterProperty };
 		String[] customAuthoritiesClaimProps = { jwkSetUriProperty, authoritiesClaimProperty };
 		String[] customPrincipalClaimProps = { jwkSetUriProperty, principalClaimProperty };
 		String[] allJwtConverterProps = { jwkSetUriProperty, authorityPrefixProperty, authoritiesDelimiterProperty,
@@ -84,7 +84,7 @@ public final class JwtConverterCustomizationsArgumentsProvider implements Argume
 				Arguments.of(Named.named("Custom prefix for GrantedAuthority", customPrefixProps),
 						noAuthoritiesCustomizationsJwt, subjectValue, customPrefixAuthorities),
 				Arguments.of(Named.named("Custom delimiter for JWT scopes", customDelimiterProps),
-						customAuthoritiesDelimiterJwt, subjectValue, customPrefixAuthorities),
+						customAuthoritiesDelimiterJwt, subjectValue, defaultPrefixAuthorities),
 				Arguments.of(Named.named("Custom JWT authority claim name", customAuthoritiesClaimProps),
 						customAuthoritiesClaimJwt, subjectValue, defaultPrefixAuthorities),
 				Arguments.of(Named.named("Custom JWT principal claim name", customPrincipalClaimProps),

--- a/module/spring-boot-security-oauth2-resource-server/src/test/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
+++ b/module/spring-boot-security-oauth2-resource-server/src/test/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/reactive/ReactiveOAuth2ResourceServerAutoConfigurationTests.java
@@ -701,6 +701,13 @@ class ReactiveOAuth2ResourceServerAutoConfigurationTests {
 			.run((context) -> assertThat(context).hasSingleBean(ReactiveJwtAuthenticationConverter.class));
 	}
 
+	@Test
+	void shouldConfigureJwtConverterIfAuthoritiesClaimDelimiterIsSet() {
+		this.contextRunner
+			.withPropertyValues("spring.security.oauth2.resourceserver.jwt.authorities-claim-delimiter=dummy")
+			.run((context) -> assertThat(context).hasSingleBean(ReactiveJwtAuthenticationConverter.class));
+	}
+
 	@ParameterizedTest(name = "{0}")
 	@ArgumentsSource(JwtConverterCustomizationsArgumentsProvider.class)
 	void autoConfigurationShouldConfigureResourceServerWithJwtConverterCustomizations(String[] properties, Jwt jwt,

--- a/module/spring-boot-security-oauth2-resource-server/src/test/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/servlet/OAuth2ResourceServerAutoConfigurationTests.java
+++ b/module/spring-boot-security-oauth2-resource-server/src/test/java/org/springframework/boot/security/oauth2/server/resource/autoconfigure/servlet/OAuth2ResourceServerAutoConfigurationTests.java
@@ -739,6 +739,13 @@ class OAuth2ResourceServerAutoConfigurationTests {
 	}
 
 	@Test
+	void shouldConfigureJwtConverterIfAuthoritiesClaimDelimiterIsSet() {
+		this.contextRunner
+			.withPropertyValues("spring.security.oauth2.resourceserver.jwt.authorities-claim-delimiter=dummy")
+			.run((context) -> assertThat(context).hasSingleBean(JwtAuthenticationConverter.class));
+	}
+
+	@Test
 	void jwtAuthenticationConverterByJwtConfigIsConditionalOnMissingBean() {
 		String propertiesPrincipalClaim = "principal_from_properties";
 		String propertiesPrincipalValue = "from_props";


### PR DESCRIPTION
## What happened?

Setting `spring.security.oauth2.resourceserver.jwt.authorities-claim-delimiter` without any other JWT converter properties has no effect. For example, given a JWT with a `scope` claim of `read,write` and the following configuration:

```properties
spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://example.com/.well-known/jwks.json
spring.security.oauth2.resourceserver.jwt.authorities-claim-delimiter=,
```

The resulting authentication has a single authority, `SCOPE_read,write`, instead of `SCOPE_read` and `SCOPE_write`. An authorization rule using `hasAuthority('SCOPE_read')` therefore denies access.

In both `OAuth2ResourceServerJwtConfiguration` and its reactive counterpart, `JwtConverterConfiguration` is guarded by `JwtConverterPropertiesCondition`. This `AnyNestedCondition` checks three properties:

- `authority-prefix`
- `principal-claim-name`
- `authorities-claim-name`

The converter bean method also applies `authorities-claim-delimiter`, but that property is missing from the condition. When it is the only converter property set, the condition does not match and Spring Boot does not configure a converter bean. Spring Security then uses its default converter, which splits the claim on a single space.

Support for all four properties was added in #38105. The condition added as part of that change checks only three of them.

The existing "Custom delimiter for JWT scopes" test case did not catch this because it also set `authority-prefix`, which satisfied the condition.

## What does this PR change?

Adds a nested condition for `authorities-claim-delimiter` to `JwtConverterPropertiesCondition` in both the servlet and reactive configurations. Setting the delimiter alone now enables the converter configuration.

Unset properties retain their defaults because `PropertyMapper` skips null values. User-defined converter beans still take precedence through `@ConditionalOnMissingBean`.

The delimiter is also missing from the corresponding conditions on `4.1.x` and `main`, where they live in `JwtConverterConfiguration.PropertiesCondition` and `ReactiveJwtConverterConfiguration.PropertiesCondition`.

## Tests

- Added `shouldConfigureJwtConverterIfAuthoritiesClaimDelimiterIsSet` to both `OAuth2ResourceServerAutoConfigurationTests` and `ReactiveOAuth2ResourceServerAutoConfigurationTests`, following the existing tests for the other three properties.
- Updated the "Custom delimiter for JWT scopes" case in `JwtConverterCustomizationsArgumentsProvider` to set the delimiter without a custom authority prefix. It now expects the split scopes to use the default `SCOPE_` prefix.

The new tests and the updated parameterized case fail without the fix. The parameterized case fails with `NoSuchBeanDefinitionException` because no converter bean is configured.

`:module:spring-boot-security-oauth2-resource-server:check` passes with JDK 25.