### PR TITLE
Avoid implicit property lookup in parent projects

### DIFF
--- a/gradle/plugins/settings.gradle
+++ b/gradle/plugins/settings.gradle
@@ -20,10 +20,12 @@ pluginManagement {
 		def properties = new Properties()
 		properties.load(it)
 		properties.forEach(settings.ext::set)
-		gradle.rootProject {
+		gradle.lifecycle.beforeProject {
 			properties.forEach(project.ext::set)
 		}
 	}
 }
+
+enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS")
 
 include 'cycle-detection-plugin'

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,6 +45,7 @@ plugins {
 rootProject.name="spring-boot-build"
 
 enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
+enableFeaturePreview("NO_IMPLICIT_LOOKUP_IN_PARENT_PROJECTS")
 
 settings.gradle.projectsLoaded {
 	develocity {


### PR DESCRIPTION
This is a follow-up to #51598, which left the deprecation warning for implicit property lookup in parent projects to be addressed separately.

Currently, running the build with `--warning-mode=all` reports three deprecation warnings, such as the following:
```text
> Configure project :plugins:cycle-detection-plugin
Implicit lookup of properties in parent projects has been deprecated. This will fail with an error in Gradle 10. Property 'javaFormatVersion' was not declared in project ':plugins:cycle-detection-plugin' and was resolved from project ':plugins'. Consult the upgrading guide for further information: https://docs.gradle.org/9.7.0/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects
```

The settings script for the `gradle/plugins` build currently sets properties from the root `gradle.properties` file only on its root project. As a result, the `cycle-detection-plugin` subproject resolves `javaFormatVersion` and `checkstyleToolVersion` by walking up to its parent project, triggering the deprecation.

This PR uses `Gradle#beforeProject` instead of `Gradle#rootProject` so that the properties are set directly on every project in the build, avoiding implicit parent-project lookup.

`buildSrc/settings.gradle` uses the same pattern, but that build has no subprojects, so no parent-project lookup occurs and it does not trigger the deprecation. It is left unchanged.

I also considered `GradleLifecycle#beforeProject` (`gradle.lifecycle.beforeProject`), which the Javadoc describes as a lifecycle callback "compatible with Configuration Cache and Isolated Projects". As it is still `@Incubating`, this PR uses the stable `Gradle#beforeProject` instead. Happy to switch if you would prefer the incubating API.

Reference: https://docs.gradle.org/9.7.0/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects