### PR TITLE
Fix typo in deprecated Pushgateway base-url property metadata

### DIFF
--- a/module/spring-boot-micrometer-metrics/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/module/spring-boot-micrometer-metrics/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1822,7 +1822,7 @@
       }
     },
     {
-      "name": "management.promethus.metrics.export.pushgateway.base-url",
+      "name": "management.prometheus.metrics.export.pushgateway.base-url",
       "type": "java.lang.String",
       "deprecation": {
         "level": "error",


### PR DESCRIPTION
The deprecation entry for `management.prometheus.metrics.export.pushgateway.base-url` (added in 3.5.0 when the property was replaced by `management.prometheus.metrics.export.pushgateway.address`) was declared with the misspelled prefix `management.promethus`.

As a result, IDEs and other consumers of the configuration metadata never reported the error-level deprecation, nor the replacement, to users who still had the old property configured. This PR fixes the property name in `additional-spring-configuration-metadata.json`.

The entry was introduced in 63ecfac40d8 ("Support Pushgateway with new Prometheus client") and is present on all branches since 3.5.x, so this targets `4.0.x`.
