### PR TITLE
Avoid Gradle deprecation warnings for Project.getProperties

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/antora/AntoraAsciidocAttributes.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/antora/AntoraAsciidocAttributes.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 import java.util.TreeMap;
 
 import org.gradle.api.Project;
+import org.gradle.api.provider.ProviderFactory;
 
 import org.springframework.boot.build.artifacts.ArtifactRelease;
 import org.springframework.boot.build.bom.BomExtension;
@@ -59,7 +60,7 @@ public class AntoraAsciidocAttributes {
 
 	private final ResolvedBom resolvedBom;
 
-	private final Map<String, ?> projectProperties;
+	private final ProviderFactory providers;
 
 	public AntoraAsciidocAttributes(Project project, BomExtension dependencyBom, ResolvedBom resolvedBom) {
 		this.version = String.valueOf(project.getVersion());
@@ -68,7 +69,7 @@ public class AntoraAsciidocAttributes {
 		this.artifactRelease = ArtifactRelease.forProject(project);
 		this.libraries = dependencyBom.getLibraries();
 		this.resolvedBom = resolvedBom;
-		this.projectProperties = project.getProperties();
+		this.providers = project.getProviders();
 	}
 
 	public Map<String, String> get() {
@@ -108,8 +109,9 @@ public class AntoraAsciidocAttributes {
 
 	private void addVersionAttributes(Map<String, String> attributes, Map<String, String> internal) {
 		this.libraries.forEach((library) -> addVersionAttributes(attributes, library));
-		attributes.put("version-native-build-tools", (String) this.projectProperties.get("nativeBuildToolsVersion"));
-		attributes.put("version-graal", (String) this.projectProperties.get("graalVersion"));
+		attributes.put("version-native-build-tools",
+				this.providers.gradleProperty("nativeBuildToolsVersion").getOrNull());
+		attributes.put("version-graal", this.providers.gradleProperty("graalVersion").getOrNull());
 	}
 
 	private void addVersionAttributes(Map<String, String> attributes, Library library) {

--- a/buildSrc/src/test/java/org/springframework/boot/build/antora/AntoraAsciidocAttributesTests.java
+++ b/buildSrc/src/test/java/org/springframework/boot/build/antora/AntoraAsciidocAttributesTests.java
@@ -26,6 +26,8 @@ import java.util.function.Function;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.build.bom.BomExtension;
@@ -113,6 +115,13 @@ class AntoraAsciidocAttributesTests {
 		AntoraAsciidocAttributes attributes = attributes("1.2.3", true, BuildType.OPEN_SOURCE, null,
 				mockDependencyVersions(), Map.of("nativeBuildToolsVersion", "3.4.5"));
 		assertThat(attributes.get()).containsEntry("version-native-build-tools", "3.4.5");
+	}
+
+	@Test
+	void versionGraal() {
+		AntoraAsciidocAttributes attributes = attributes("1.2.3", true, BuildType.OPEN_SOURCE, null,
+				mockDependencyVersions(), Map.of("graalVersion", "25"));
+		assertThat(attributes.get()).containsEntry("version-graal", "25");
 	}
 
 	@Test
@@ -234,7 +243,6 @@ class AntoraAsciidocAttributesTests {
 		assertThat(keys.indexOf("include-java")).isLessThan(keys.indexOf("code-spring-boot-latest"));
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
 	private AntoraAsciidocAttributes attributes(String version, boolean latestVersion, BuildType buildType,
 			List<Library> libraries, Map<String, String> dependencyVersions, Map<String, ?> projectProperties) {
 		libraries = (libraries != null) ? libraries : Collections.emptyList();
@@ -246,7 +254,8 @@ class AntoraAsciidocAttributesTests {
 		given(project.findProperty("latestVersion")).willReturn(String.valueOf(latestVersion));
 		given(project.findProperty("spring.build-type"))
 			.willReturn((buildType == BuildType.OPEN_SOURCE) ? "oss" : "commercial");
-		given(project.getProperties()).willReturn((Map) projectProperties);
+		ProviderFactory providers = mockProviders(projectProperties);
+		given(project.getProviders()).willReturn(providers);
 		given(project.getExtensions()).willReturn(extensions);
 		given(extensions.getExtraProperties()).willReturn(extraPropertiesExtension);
 		BomExtension dependencyBom = mock();
@@ -260,6 +269,17 @@ class AntoraAsciidocAttributesTests {
 			return dependencyVersions.get(module.moduleNames().get(0));
 		});
 		return new AntoraAsciidocAttributes(project, dependencyBom, resolvedBom);
+	}
+
+	private ProviderFactory mockProviders(Map<String, ?> projectProperties) {
+		ProviderFactory providers = mock();
+		given(providers.gradleProperty(any(String.class))).willAnswer((invocation) -> {
+			String propertyName = invocation.getArgument(0);
+			Provider<Object> provider = mock();
+			given(provider.getOrNull()).willReturn(projectProperties.get(propertyName));
+			return provider;
+		});
+		return providers;
 	}
 
 	private Library mockLibrary(Map<LinkType, List<Link>> links) {

--- a/system-test/spring-boot-image-system-tests/build.gradle
+++ b/system-test/spring-boot-image-system-tests/build.gradle
@@ -35,11 +35,8 @@ tasks.register("syncMavenRepository", Sync) {
 
 systemTest {
 	dependsOn syncMavenRepository
-	if (project.hasProperty("springBootVersion")) {
-		systemProperty "springBootVersion", project.properties["springBootVersion"]
-	} else {
-		systemProperty "springBootVersion", project.getVersion()
-	}
+	systemProperty "springBootVersion",
+			providers.gradleProperty("springBootVersion").getOrElse(project.getVersion().toString())
 }
 
 dependencies {


### PR DESCRIPTION
This addresses another Gradle 9.6 deprecation, following #51598 and #51625:

```text
> Task :documentation:spring-boot-docs:generateAntoraYml
The Project.getProperties method has been deprecated. This will fail with an error in Gradle 10. Consult the upgrading guide for further information: https://docs.gradle.org/9.7.0/userguide/upgrading_version_9.html#deprecated_get_properties
```

The deprecated `Project.getProperties()` API is used in two places:

- `AntoraAsciidocAttributes` captures the project's entire property map to read `nativeBuildToolsVersion`, `graalVersion`, and `protobufGradlePluginVersion` when generating documentation attributes.
- The image system tests build script accesses `project.properties["springBootVersion"]` when `springBootVersion` is set.

This PR replaces these usages with `providers.gradleProperty(...)`, as recommended by the Gradle upgrading guide. The three documentation versions are defined in the root `gradle.properties`, and the system tests support a build-wide `springBootVersion` override, such as `-PspringBootVersion=4.0.0`

Missing documentation properties continue to produce `null`, and the system tests continue to fall back to the project version when springBootVersion is not configured.

Reference: https://docs.gradle.org/9.7.0/userguide/upgrading_version_9.html#deprecated_get_properties