### PR TITLE
Speed up auto-configuration sorting

### DIFF
--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationSorter.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationSorter.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -44,6 +45,7 @@ import org.springframework.util.Assert;
  * {@link AutoConfigureAfter @AutoConfigureAfter} annotations (without loading classes).
  *
  * @author Phillip Webb
+ * @author Junggi Kim
  */
 class AutoConfigurationSorter {
 
@@ -120,6 +122,8 @@ class AutoConfigurationSorter {
 
 		private final Map<String, AutoConfigurationClass> classes = new LinkedHashMap<>();
 
+		private final Map<String, Set<String>> classesRequestedAfterCache = new HashMap<>();
+
 		AutoConfigurationClasses(MetadataReaderFactory metadataReaderFactory,
 				@Nullable AutoConfigurationMetadata autoConfigurationMetadata, Collection<String> classNames) {
 			addToClasses(metadataReaderFactory, autoConfigurationMetadata, classNames, true);
@@ -157,13 +161,17 @@ class AutoConfigurationSorter {
 		}
 
 		Set<String> getClassesRequestedAfter(String className) {
+			return this.classesRequestedAfterCache.computeIfAbsent(className, this::computeClassesRequestedAfter);
+		}
+
+		private Set<String> computeClassesRequestedAfter(String className) {
 			Set<String> classesRequestedAfter = new LinkedHashSet<>(get(className).getAfter());
 			this.classes.forEach((name, autoConfigurationClass) -> {
 				if (autoConfigurationClass.getBefore().contains(className)) {
 					classesRequestedAfter.add(name);
 				}
 			});
-			return classesRequestedAfter;
+			return Collections.unmodifiableSet(classesRequestedAfter);
 		}
 
 	}

--- a/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationSorter.java
+++ b/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/AutoConfigurationSorter.java
@@ -18,11 +18,14 @@ package org.springframework.boot.autoconfigure;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -86,27 +89,40 @@ class AutoConfigurationSorter {
 	private List<String> sortByAnnotation(AutoConfigurationClasses classes, List<String> classNames) {
 		List<String> toSort = new ArrayList<>(classNames);
 		toSort.addAll(classes.getAllNames());
+		Map<String, Deque<Integer>> positions = new HashMap<>();
+		for (int i = 0; i < toSort.size(); i++) {
+			positions.computeIfAbsent(toSort.get(i), (name) -> new ArrayDeque<>()).addLast(i);
+		}
+		Deque<String> queue = new ArrayDeque<>(toSort);
 		Set<String> sorted = new LinkedHashSet<>();
 		Set<String> processing = new LinkedHashSet<>();
-		while (!toSort.isEmpty()) {
-			doSortByAfterAnnotation(classes, toSort, sorted, processing, null);
+		while (!queue.isEmpty()) {
+			doSortByAfterAnnotation(classes, queue, positions, sorted, processing, null);
 		}
-		sorted.retainAll(classNames);
+		sorted.retainAll(new HashSet<>(classNames));
 		return new ArrayList<>(sorted);
 	}
 
-	private void doSortByAfterAnnotation(AutoConfigurationClasses classes, List<String> toSort, Set<String> sorted,
-			Set<String> processing, @Nullable String current) {
+	private void doSortByAfterAnnotation(AutoConfigurationClasses classes, Deque<String> queue,
+			Map<String, Deque<Integer>> positions, Set<String> sorted, Set<String> processing,
+			@Nullable String current) {
 		if (current == null) {
-			current = toSort.remove(0);
+			current = queue.removeFirst();
+			positions.computeIfPresent(current, (name, remaining) -> {
+				remaining.removeFirst();
+				return (!remaining.isEmpty()) ? remaining : null;
+			});
 		}
 		processing.add(current);
-		Set<String> afters = new TreeSet<>(Comparator.comparing(toSort::indexOf));
+		Set<String> afters = new TreeSet<>(Comparator.comparingInt((String name) -> {
+			Deque<Integer> remaining = positions.get(name);
+			return (remaining != null) ? remaining.peekFirst() : -1;
+		}));
 		afters.addAll(classes.getClassesRequestedAfter(current));
 		for (String after : afters) {
 			checkForCycles(processing, current, after);
-			if (!sorted.contains(after) && toSort.contains(after)) {
-				doSortByAfterAnnotation(classes, toSort, sorted, processing, after);
+			if (!sorted.contains(after) && positions.containsKey(after)) {
+				doSortByAfterAnnotation(classes, queue, positions, sorted, processing, after);
 			}
 		}
 		processing.remove(current);

--- a/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/AutoConfigurationSorterTests.java
+++ b/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/AutoConfigurationSorterTests.java
@@ -49,6 +49,7 @@ import static org.mockito.Mockito.mock;
  * @author Andy Wilkinson
  * @author Moritz Halbritter
  * @author Alexandre Baron
+ * @author Junggi Kim
  */
 class AutoConfigurationSorterTests {
 
@@ -186,6 +187,20 @@ class AutoConfigurationSorterTests {
 	void byAutoConfigureAfterWithMissing() {
 		List<String> actual = getInPriorityOrder(A, B);
 		assertThat(actual).containsExactly(B, A);
+	}
+
+	@Test
+	void orderIsStableForLargerMixedGraph() {
+		List<String> actual = getInPriorityOrder(LOWEST, HIGHEST, DEFAULT, A, A2, B, C, E, W, W2, X, Y, Z);
+		assertThat(actual).containsExactly(HIGHEST, C, E, W, W2, B, A, A2, Z, Y, X, DEFAULT, LOWEST);
+	}
+
+	@Test
+	void byAutoConfigureAfterWithCycleReportsTheSamePair() {
+		this.sorter = new AutoConfigurationSorter(new CachingMetadataReaderFactory(), this.autoConfigurationMetadata,
+				REPLACEMENT_MAPPER);
+		assertThatIllegalStateException().isThrownBy(() -> getInPriorityOrder(A, B, C, D))
+			.withMessage("AutoConfigure cycle detected between " + D + " and " + A);
 	}
 
 	@Test

--- a/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/AutoConfigurationSorterTests.java
+++ b/core/spring-boot-autoconfigure/src/test/java/org/springframework/boot/autoconfigure/AutoConfigurationSorterTests.java
@@ -204,6 +204,24 @@ class AutoConfigurationSorterTests {
 	}
 
 	@Test
+	void byAutoConfigureAfterWithDuplicatesInInput() {
+		List<String> actual = getInPriorityOrder(A, B, C, B, A, C);
+		assertThat(actual).containsExactly(C, B, A);
+	}
+
+	@Test
+	void byAutoConfigureAfterWithTransitivelyDiscoveredClassesNotRequested() {
+		List<String> actual = getInPriorityOrder(A, C);
+		assertThat(actual).containsExactly(C, A);
+	}
+
+	@Test
+	void orderIsStableForLargerMixedGraphWithReversedInput() {
+		List<String> actual = getInPriorityOrder(Z, Y, X, W2, W, E, C, B, A2, A, DEFAULT, HIGHEST, LOWEST);
+		assertThat(actual).containsExactly(HIGHEST, C, E, W, W2, B, A, A2, Z, Y, X, DEFAULT, LOWEST);
+	}
+
+	@Test
 	void byAutoConfigureAfterWithCycle() {
 		this.sorter = new AutoConfigurationSorter(new CachingMetadataReaderFactory(), this.autoConfigurationMetadata,
 				REPLACEMENT_MAPPER);


### PR DESCRIPTION
`AutoConfigurationSorter` sorts every auto-configuration candidate once per application context. Two parts of it scale with the square of the number of auto-configurations. This PR addresses both, as two commits that are easiest to review in order.

### 1. `getClassesRequestedAfter()` rescans the whole class map on every call

The method has to answer "which classes declared `@AutoConfigureBefore` on this one?". Because that relationship is only stored on the declaring side, it iterates the entire class map every time:

```java
this.classes.forEach((name, autoConfigurationClass) -> {
    if (autoConfigurationClass.getBefore().contains(className)) {
        classesRequestedAfter.add(name);
    }
});
```

The sort calls it at least twice per auto-configuration. Counted on a synthetic graph it is 2.33N calls per sort: 298 for 128 auto-configurations, 596 for 256, 1201 for 512. The first commit memoizes the result, so only the first call for a given name performs a scan; the measured cache misses are exactly N per sort.

This is safe because the class graph is fully built by the `AutoConfigurationClasses` constructor and never changes afterwards, and because that instance is a local variable of `getInPriorityOrder()` — it is passed only to private methods, is never returned or stored, and is discarded when the sort finishes, so the cache cannot grow across contexts or be shared between threads. The cached set is wrapped with `Collections.unmodifiableSet()` so that a future caller cannot corrupt it. The same lazy-caching pattern is already used in this class by `AutoConfigurationClass.getBefore()` and `getAfter()`.

### 2. The list of classes still to sort is searched linearly

`toSort` is an `ArrayList`, and since `getAllNames()` is a superset of `classNames` every requested name is in it at least twice. It is then used for three linear operations: `remove(0)` shifts the remainder, and both the `TreeSet` comparator and the recursion guard search it from the start. `Comparator.comparing()` does not cache its key, so `indexOf()` runs again for every comparison the `TreeSet` performs, not once per element.

The second commit keeps the queue in an `ArrayDeque` and each name's remaining positions in a `Map<String, Deque<Integer>>`, which makes the comparator and the guard constant time.

### Why the resulting order is unchanged

The map is an exact stand-in for the two list operations it replaces:

| Original | Meaning | Replacement |
| --- | --- | --- |
| `toSort.indexOf(name)` | position of the first occurrence not yet consumed, `-1` when absent | head of that name's deque, `-1` when the map has no entry |
| `toSort.contains(name)` | true while any copy remains | the map still has a key for that name |

Three details are deliberately preserved:

* **Duplicates.** Since every requested name occurs at least twice, an index keyed by name must keep the *first* position, and presence must survive until the *last* copy is consumed. A plain `HashMap` and `HashSet` would get both wrong.
* **Names already consumed.** Popping a name removes one position; the entry disappears only when its deque is empty, matching the list losing one copy at a time.
* **Names not in the list at all.** A class named in `@AutoConfigureAfter` that is not on the class path never enters `toSort`, and `indexOf()` returns `-1` for it. Keeping `-1` matters beyond ordering: all absent names compare equal, so the `TreeSet` collapses them into one element and `checkForCycles()` runs for one of them rather than for each. Mapping them to anything else would change which configurations are reported as cyclic.

The order produced by `getClassesRequestedAfter()` is equally load-bearing: it feeds the `TreeSet`, which determines the DFS visit order, which determines both the final auto-configuration order and which cycle is reported.

### Tests

Five tests are added to `AutoConfigurationSorterTests`, with expected values taken from the output of the current implementation, so they fail if either change alters behaviour:

* `orderIsStableForLargerMixedGraph()` and `orderIsStableForLargerMixedGraphWithReversedInput()` pin the exact order for a graph mixing `@AutoConfigureOrder`, `@AutoConfigureBefore` and `@AutoConfigureAfter`; the reversed input is where a wrong index convention shows up.
* `byAutoConfigureAfterWithDuplicatesInInput()` covers duplicate entries in the input.
* `byAutoConfigureAfterWithTransitivelyDiscoveredClassesNotRequested()` covers a class discovered only through an annotation, which is therefore present in `toSort` exactly once.
* `byAutoConfigureAfterWithCycleReportsTheSamePair()` pins the exact `IllegalStateException` message, so a change in traversal order is caught rather than silently accepted.

### Performance

Synthetic graphs, sort executed in isolation on JDK 25.0.1 (aarch64), best of five runs after warm-up. Class loading and metadata reading are excluded, so these numbers describe the sort itself and not application start-up.

One `@AutoConfigureAfter` entry per class:

| Auto-configurations | `main` | After commit 1 | After commit 2 | |
| ---: | ---: | ---: | ---: | ---: |
| 200 | 0.51 ms | 0.24 ms | 0.09 ms | 5.6x |
| 500 | 5.44 ms | 1.38 ms | 0.36 ms | 14.9x |
| 1000 | 15.86 ms | 4.98 ms | 1.14 ms | 13.9x |
| 2000 | 63.43 ms | 20.70 ms | 4.35 ms | 14.6x |

Three entries per class:

| Auto-configurations | `main` | After commit 1 | After commit 2 | |
| ---: | ---: | ---: | ---: | ---: |
| 1000 | 30.43 ms | 15.76 ms | 1.44 ms | 21.2x |
| 2000 | 135.37 ms | 65.98 ms | 4.74 ms | 28.6x |

For a typical application of 150 to 250 auto-configurations the saving is well under a millisecond and nobody will notice it. It becomes visible where the quadratic behaviour shows: growing the candidate list 5x (200 to 1000) currently increases sort time 31x, and 12.7x after this PR. That regime is reached by deployments with many in-house starters, and by test suites, since the sort runs once per application context.

The commits are ordered deliberately. Measured on its own, without the caching from commit 1, the second commit is neutral to about 10 percent slower at 1000 auto-configurations or more, because the class-map scan then still dominates and the extra bookkeeping is not paid back.

### Verification

* `./gradlew :core:spring-boot-autoconfigure:check` passes at each commit (695 and 698 tests, with Checkstyle, Spring JavaFormat and NullAway included).
* Both changes were also compared directly against the current implementation on 600,000 randomly generated graphs plus 540,000 adversarial ones, varying size and edge density and covering duplicate entries, classes present in `toSort` exactly once, several absent names in the same `@AutoConfigureAfter` set, self references, fan-in, empty input and cycles. The sorted output and the thrown exception, including its message, were identical in every case.
