### PR TITLE
Improve the performance of layer index creation

### DIFF
--- a/loader/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/LayersIndex.java
+++ b/loader/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/LayersIndex.java
@@ -21,11 +21,12 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.util.LinkedMultiValueMap;
@@ -47,6 +48,7 @@ import org.springframework.util.MultiValueMap;
  * @author Madhura Bhave
  * @author Andy Wilkinson
  * @author Phillip Webb
+ * @author Junggi Kim
  * @since 2.3.0
  */
 public class LayersIndex {
@@ -116,28 +118,21 @@ public class LayersIndex {
 
 		private final Set<Layer> layers;
 
-		private final List<Node> children = new ArrayList<>();
+		private final Map<String, Node> children = new LinkedHashMap<>();
 
 		Node() {
-			this.name = "";
-			this.layers = new HashSet<>();
+			this("");
 		}
 
-		Node(String name, Layer layer) {
+		Node(String name) {
 			this.name = name;
-			this.layers = new HashSet<>(Collections.singleton(layer));
+			this.layers = new HashSet<>();
 		}
 
 		Node updateOrAddNode(String segment, boolean isDirectory, Layer layer) {
 			String name = segment + (isDirectory ? "/" : "");
-			for (Node child : this.children) {
-				if (name.equals(child.name)) {
-					child.layers.add(layer);
-					return child;
-				}
-			}
-			Node child = new Node(name, layer);
-			this.children.add(child);
+			Node child = this.children.computeIfAbsent(name, Node::new);
+			child.layers.add(layer);
 			return child;
 		}
 
@@ -147,7 +142,7 @@ public class LayersIndex {
 				index.add(this.layers.iterator().next(), name);
 			}
 			else {
-				for (Node child : this.children) {
+				for (Node child : this.children.values()) {
 					child.buildIndex(name, index);
 				}
 			}


### PR DESCRIPTION
`LayersIndex.add(...)` is called once for every file entry written into the jar, and walks one node per path segment. Each node holds its children in a `List`, and `updateOrAddNode(...)` finds the child for a segment by comparing names one at a time, so building the index costs `O(entries x siblings)` rather than `O(entries)`.

What decides how much that costs is the largest flat directory in the jar rather than the entry count. Application classes are spread over a package tree, so each of those directories holds relatively few children, and `BOOT-INF/lib/` holds one entry per dependency. The problem case is a genuinely flat directory: an application that bundles a front-end build has thousands of hashed files sitting directly under `BOOT-INF/classes/static/`. Filling a directory with n children by scanning costs n(n-1)/2 name comparisons, so 12,000 files in one directory is around 72 million comparisons for that directory alone, against 12,000 lookups if the children are indexed by name.

This keeps the children in a `LinkedHashMap` keyed by the segment name, so the lookup is a single hash lookup rather than a scan and the index is built in `O(entries)`. Insertion order is preserved, so `buildIndex(...)` walks the tree exactly as before. `Node(String name, Layer layer)` becomes `Node(String name)` so that the layer is recorded on one code path whether or not the node already existed.

The output is unchanged. Replaying every entry of a real `bootJar` output through `LayersIndex`, with each entry's layer taken from that jar's own `layers.idx`, produces a file that is byte for byte identical to the one the plugin originally wrote, and 300,000 randomly generated indexes produce identical output before and after, including segments that are duplicated, contain spaces or non-ASCII characters, or are used as both a file and a directory. Existing tests pass unchanged, as do `checkstyleMain`, `checkstyleTest`, `checkFormatMain` and `checkFormatTest`.

I have not added a test, since `LayersIndexTests` and the `layersIndex()` test in `AbstractPackagerTests` already fail if the child lookup or the layer accumulation is broken, but I am happy to add one if you would prefer the behaviour pinned explicitly.
