### PR TITLE
Simplify configuration metadata changelog generation

### DIFF
--- a/configuration-metadata/spring-boot-configuration-metadata-changelog-generator/src/main/java/org/springframework/boot/configurationmetadata/changelog/Changelog.java
+++ b/configuration-metadata/spring-boot-configuration-metadata-changelog-generator/src/main/java/org/springframework/boot/configurationmetadata/changelog/Changelog.java
@@ -18,6 +18,7 @@ package org.springframework.boot.configurationmetadata.changelog;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataRepository;
@@ -34,6 +35,7 @@ import org.springframework.boot.configurationmetadata.Deprecation.Level;
  * @author Andy Wilkinson
  * @author Phillip Webb
  * @author Yoobin Yoon
+ * @author Junggi Kim
  */
 record Changelog(String oldVersionNumber, String newVersionNumber, List<Difference> differences) {
 
@@ -44,19 +46,18 @@ record Changelog(String oldVersionNumber, String newVersionNumber, List<Differen
 
 	static List<Difference> computeDifferences(ConfigurationMetadataRepository oldMetadata,
 			ConfigurationMetadataRepository newMetadata) {
-		List<String> seenIds = new ArrayList<>();
+		Map<String, ConfigurationMetadataProperty> oldProperties = oldMetadata.getAllProperties();
+		Map<String, ConfigurationMetadataProperty> newProperties = newMetadata.getAllProperties();
 		List<Difference> differences = new ArrayList<>();
-		for (ConfigurationMetadataProperty oldProperty : oldMetadata.getAllProperties().values()) {
-			String id = oldProperty.getId();
-			seenIds.add(id);
-			ConfigurationMetadataProperty newProperty = newMetadata.getAllProperties().get(id);
+		for (ConfigurationMetadataProperty oldProperty : oldProperties.values()) {
+			ConfigurationMetadataProperty newProperty = newProperties.get(oldProperty.getId());
 			Difference difference = Difference.compute(oldProperty, newProperty);
 			if (difference != null) {
 				differences.add(difference);
 			}
 		}
-		for (ConfigurationMetadataProperty newProperty : newMetadata.getAllProperties().values()) {
-			if (!seenIds.contains(newProperty.getId())) {
+		for (ConfigurationMetadataProperty newProperty : newProperties.values()) {
+			if (!oldProperties.containsKey(newProperty.getId())) {
 				if (!newProperty.isDeprecated()) {
 					differences.add(new Difference(DifferenceType.ADDED, null, newProperty));
 				}


### PR DESCRIPTION
`Changelog.computeDifferences(...)` is quadratic in the number of configuration properties, in two independent ways.

Its first loop asks the new repository for its properties on every iteration, and `SimpleConfigurationMetadataRepository.getAllProperties()` is not a plain getter: it allocates a `HashMap` and copies every group's properties into it on each call. A counting decorator around both repositories shows it being called 2,499 times on the new metadata while generating the 3.4.0 to 3.5.0 changelog, once per property of the old version. Separately, `seenIds` is an `ArrayList` that is only ever added to and searched with `contains`, so the second loop scans it from the start for every property of the new version.

This reads the properties of each repository once. The membership check then no longer needs a collection of its own: `ConfigurationMetadataRepository.getAllProperties()` is documented to return the properties indexed by id, so the map of the old properties already answers what `seenIds` was tracking.

Measured on my machine (JDK 25, aarch64) against the published metadata jars of the versions below, so the numbers describe that environment rather than a guarantee: generating the 3.4.0 to 3.5.0 changelog (2,498 and 2,555 properties) takes 0.16s instead of 0.38s and peaks at 91MB rather than 302MB, with `computeDifferences` itself going from 203ms to 0.5ms. Both halves have to be fixed before that shows up — with the map still being rebuilt, giving `seenIds` a `HashSet` on its own only reaches 159ms. This only runs when a changelog is generated for a release, so the time saved is a fraction of a second and no build will notice it; the allocation is the more interesting half.

The generated asciidoc is unchanged. Both 3.4.0 to 3.5.0 and 3.5.0 to 4.1.1 produce a file with an identical SHA-256 before and after.

I have not added a test. Inverting the new membership check, pointing it at the new properties instead of the old ones, and looking a property up in the old map instead of the new one all fail `ChangelogTests` and `ChangelogGeneratorTests` as they stand, and what is left is not observable through behaviour. Happy to add one if you would prefer it pinned.

Verified with `./gradlew :configuration-metadata:spring-boot-configuration-metadata-changelog-generator:build checkFormatMain checkFormatTest`: 10 tests, no Checkstyle or format violations.
