### PR TITLE
Resolve property placeholders in constructor binding default values

### DIFF
--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/DefaultValue.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/DefaultValue.java
@@ -33,11 +33,12 @@ import java.lang.annotation.Target;
  * the default value for the property will not be used even if the property value is
  * empty.
  * <p>
- * NOTE: This annotation does not support property placeholder resolution and the value
- * must be constant.
+ * Property placeholders in the default value are resolved using the {@link Binder}'s
+ * {@link PlaceholdersResolver} before the value is converted to the property's type.
  *
  * @author Madhura Bhave
  * @author Pavel Anisimov
+ * @author Wan bin yu
  * @since 2.2.0
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/ValueObjectBinder.java
+++ b/core/spring-boot/src/main/java/org/springframework/boot/context/properties/bind/ValueObjectBinder.java
@@ -62,6 +62,7 @@ import org.springframework.util.Assert;
  * @author Phillip Webb
  * @author Scott Frederick
  * @author Ondřej Světlík
+ * @author Wan bin yu
  */
 class ValueObjectBinder implements DataObjectBinder {
 
@@ -135,10 +136,20 @@ class ValueObjectBinder implements DataObjectBinder {
 				if (defaultValue.length == 0) {
 					return getNewDefaultValueInstanceIfPossible(context, type);
 				}
-				return convertDefaultValue(context.getConverter(), defaultValue, type, annotations);
+				return convertDefaultValue(context.getConverter(),
+						resolveDefaultValue(context.getPlaceholdersResolver(), defaultValue), type, annotations);
 			}
 		}
 		return context.getConverter().convert(null, type);
+	}
+
+	private String[] resolveDefaultValue(PlaceholdersResolver resolver, String[] defaultValue) {
+		String[] resolved = new String[defaultValue.length];
+		for (int i = 0; i < defaultValue.length; i++) {
+			Object value = resolver.resolvePlaceholders(defaultValue[i]);
+			resolved[i] = String.valueOf(value);
+		}
+		return resolved;
 	}
 
 	private <T> @Nullable T convertDefaultValue(BindConverter converter, String[] defaultValue, ResolvableType type,

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/ConfigurationPropertiesTests.java
@@ -132,6 +132,7 @@ import static org.mockito.Mockito.mock;
  * @author Stephane Nicoll
  * @author Madhura Bhave
  * @author Vladislav Kisel
+ * @author Wan bin yu
  */
 @ExtendWith(OutputCaptureExtension.class)
 class ConfigurationPropertiesTests {
@@ -1014,6 +1015,38 @@ class ConfigurationPropertiesTests {
 		assertThat(bean.getMap()).isEmpty();
 		assertThat(bean.getArray()).isEmpty();
 		assertThat(bean.getOptional()).isEmpty();
+	}
+
+	@Test
+	void loadWhenDefaultValuesContainPlaceholdersShouldResolveAndConvert() {
+		load(PlaceholderDefaultsConfiguration.class, "defaults.name=resolved", "defaults.duration=3d",
+				"defaults.count=7");
+		PlaceholderDefaultsProperties bean = this.context.getBean(PlaceholderDefaultsProperties.class);
+		assertThat(bean.name).isEqualTo("resolved/suffix");
+		assertThat(bean.duration).isEqualTo(Duration.ofDays(3));
+		assertThat(bean.counts).containsExactly(7, 2);
+		assertThat(bean.names).containsExactly("resolved", "fallback");
+	}
+
+	@Test
+	void loadWhenDefaultValuesContainPlaceholdersShouldUsePlaceholderDefaults() {
+		load(PlaceholderDefaultsConfiguration.class);
+		PlaceholderDefaultsProperties bean = this.context.getBean(PlaceholderDefaultsProperties.class);
+		assertThat(bean.name).isEqualTo("default/suffix");
+		assertThat(bean.duration).isEqualTo(Duration.ofDays(1));
+		assertThat(bean.counts).containsExactly(1, 2);
+		assertThat(bean.names).containsExactly("default", "fallback");
+	}
+
+	@Test
+	void loadWhenExplicitValuesOverridePlaceholderDefaultsShouldUseExplicitValues() {
+		load(PlaceholderDefaultsConfiguration.class, "test.name=explicit", "test.duration=5d", "test.counts=8,9",
+				"test.names=one,two");
+		PlaceholderDefaultsProperties bean = this.context.getBean(PlaceholderDefaultsProperties.class);
+		assertThat(bean.name).isEqualTo("explicit");
+		assertThat(bean.duration).isEqualTo(Duration.ofDays(5));
+		assertThat(bean.counts).containsExactly(8, 9);
+		assertThat(bean.names).containsExactly("one", "two");
 	}
 
 	@Test
@@ -2463,6 +2496,35 @@ class ConfigurationPropertiesTests {
 
 		int getBar() {
 			return this.bar;
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableConfigurationProperties(PlaceholderDefaultsProperties.class)
+	static class PlaceholderDefaultsConfiguration {
+
+	}
+
+	@ConfigurationProperties("test")
+	static class PlaceholderDefaultsProperties {
+
+		private final String name;
+
+		private final Duration duration;
+
+		private final int[] counts;
+
+		private final List<String> names;
+
+		PlaceholderDefaultsProperties(@DefaultValue("${defaults.name:default}/suffix") String name,
+				@DefaultValue("${defaults.duration:1d}") Duration duration,
+				@DefaultValue({ "${defaults.count:1}", "2" }) int[] counts,
+				@DefaultValue({ "${defaults.name:default}", "${defaults.other:fallback}" }) List<String> names) {
+			this.name = name;
+			this.duration = duration;
+			this.counts = counts;
+			this.names = names;
 		}
 
 	}

--- a/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/ValueObjectBinderTests.java
+++ b/core/spring-boot/src/test/java/org/springframework/boot/context/properties/bind/ValueObjectBinderTests.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +53,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Pavel Anisimov
  * @author Yanming Zhou
  * @author Ondřej Světlík
+ * @author Wan bin yu
  */
 class ValueObjectBinderTests {
 
@@ -305,6 +307,26 @@ class ValueObjectBinderTests {
 		ConverterAnnotatedExampleBean bean = this.binder.bindOrCreate("foo",
 				Bindable.of(ConverterAnnotatedExampleBean.class));
 		assertThat(bean.getDate()).hasToString("2019-05-10");
+	}
+
+	@Test
+	void createWithDefaultValuePlaceholderAndNoResolverShouldRetainPlaceholder() {
+		PlaceholderDefaultValue bean = this.binder.bindOrCreate("foo", PlaceholderDefaultValue.class);
+		assertThat(bean.value()).isEqualTo("${value}");
+	}
+
+	@Test
+	void createWithUnresolvedDefaultValuePlaceholderShouldRetainPlaceholder() {
+		Binder binder = new Binder(this.sources, new PropertySourcesPlaceholdersResolver(Collections.emptyList()));
+		PlaceholderDefaultValue bean = binder.bindOrCreate("foo", PlaceholderDefaultValue.class);
+		assertThat(bean.value()).isEqualTo("${value}");
+	}
+
+	@Test
+	void createWithDefaultValuePlaceholderResolvingToNonStringShouldConvert() {
+		Binder binder = new Binder(this.sources, (value) -> 42);
+		PlaceholderDefaultValue bean = binder.bindOrCreate("foo", PlaceholderDefaultValue.class);
+		assertThat(bean.value()).isEqualTo("42");
 	}
 
 	@Test
@@ -636,6 +658,10 @@ class ValueObjectBinderTests {
 		ExampleValueBean getValueBean() {
 			return this.valueBean;
 		}
+
+	}
+
+	record PlaceholderDefaultValue(@DefaultValue("${value}") String value) {
 
 	}
 

--- a/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/external-config.adoc
+++ b/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/features/external-config.adoc
@@ -884,7 +884,7 @@ TIP: To use a reserved keyword in the name of a property, such as `my.service.im
 ==== @DefaultValue and Binding
 
 Default values can be specified using javadoc:org.springframework.boot.context.properties.bind.DefaultValue[format=annotation] on constructor parameters and record components.
-The conversion service will be applied to coerce the annotation's javadoc:java.lang.String[] value to the target type of a missing property.
+Property placeholders in the annotation's javadoc:java.lang.String[] value are replaced and the conversion service is applied to coerce it to the target type of a missing property.
 
 In the `MyProperties` example above, you can see the nested `Security` class uses `@DefaultValue("USER")` for the `roles` parameter.
 This means that if `security` properties are defined, but `roles` is not, the default of `"USER"` will be bound.


### PR DESCRIPTION
Resolve property placeholders in `@DefaultValue` before converting constructor arguments, following the team decision in https://github.com/spring-projects/spring-boot/issues/29495#issuecomment-1028709043.

For example, with `defaults.duration=3d`, a constructor parameter annotated with `@DefaultValue("${defaults.duration:1d}")` now receives `Duration.ofDays(3)` when no explicit value is configured for that parameter. Without `defaults.duration`, it receives `Duration.ofDays(1)`.

The change uses the Binder's existing `PlaceholdersResolver` for each default value and `String.valueOf` to return the resolved values as a `String[]`, consistently with `PropertySourcesPlaceholdersResolver`. Explicit property values still take precedence; empty `@DefaultValue` handling and ordinary field initializers are unchanged. Update the annotation's Javadoc accordingly.

Verification (Java 25):

- Added real application-context tests using `@EnableConfigurationProperties`, checking the constructed bean's string, Duration, primitive-array and collection values. The initial reproduction failed before the production change (2 failing default-value cases, with the explicit-override control passing).
- The application-context tests pass with the fix, including placeholder fallback values and explicit overrides.
- Added Binder tests for no resolver, unresolved placeholders, and a custom resolver returning a non-string value.
- Ran all core tests matching `*context.properties.*` and `*boot.convert.*`: 1,220 tests, 0 failures/errors, 1 skipped.
- `:core:spring-boot:checkstyleMain`, `checkstyleTest`, `checkFormatMain`, and `checkFormatTest` passed.

This targets `main`, not a maintenance branch: resolving placeholders in defaults is an intentional behavior change for applications that previously received the literal placeholder. This does not change default-value collection conversion rules or resolve placeholders in ordinary field initializers. The entire repository test suite was not run.

Closes #29495.
