### PR TITLE
Avoid Gradle deprecation warnings for publishing dependencies on unpublished projects

### DIFF
--- a/buildSrc/src/main/java/org/springframework/boot/build/JavaConventions.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/JavaConventions.java
@@ -72,7 +72,6 @@ import org.gradle.jvm.toolchain.JavaLanguageVersion;
 
 import org.springframework.boot.build.architecture.ArchitecturePlugin;
 import org.springframework.boot.build.classpath.CheckClasspathForProhibitedDependencies;
-import org.springframework.boot.build.optional.OptionalDependenciesPlugin;
 import org.springframework.boot.build.springframework.CheckAotFactories;
 import org.springframework.boot.build.springframework.CheckSpringFactories;
 import org.springframework.boot.build.testing.TestFailuresPlugin;
@@ -338,11 +337,6 @@ class JavaConventions {
 			.enforcedPlatform(project.getDependencies()
 				.project(Collections.singletonMap("path", ":platform:spring-boot-internal-dependencies")));
 		dependencyManagement.getDependencies().add(springBootParent);
-		project.getPlugins()
-			.withType(OptionalDependenciesPlugin.class,
-					(optionalDependencies) -> configurations
-						.getByName(OptionalDependenciesPlugin.OPTIONAL_CONFIGURATION_NAME)
-						.extendsFrom(dependencyManagement));
 	}
 
 	private void configureToolchain(Project project) {

--- a/buildSrc/src/main/java/org/springframework/boot/build/autoconfigure/AutoConfigurationPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/autoconfigure/AutoConfigurationPlugin.java
@@ -147,7 +147,7 @@ public class AutoConfigurationPlugin implements Plugin<Project> {
 				ConfigurationContainer configurations,
 				TaskProvider<CheckAutoConfigurationClasses> checkAutoConfigurationClasses) {
 			checkAutoConfigurationClasses.configure((check) -> {
-				Configuration optionalClasspath = configurations.create("autoConfigurationOptionalClassPath")
+				Configuration optionalClasspath = configurations.create("autoConfigurationOptionalClasspath")
 					.extendsFrom(configurations.getByName(OptionalDependenciesPlugin.OPTIONAL_CONFIGURATION_NAME));
 				check.setOptionalDependencies(optionalClasspath);
 			});

--- a/buildSrc/src/main/java/org/springframework/boot/build/mavenplugin/MavenPluginPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/boot/build/mavenplugin/MavenPluginPlugin.java
@@ -79,9 +79,6 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.external.javadoc.StandardJavadocDocletOptions;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 import org.springframework.boot.build.DeployedPlugin;
 import org.springframework.boot.build.MavenRepositoryPlugin;
@@ -134,20 +131,6 @@ public class MavenPluginPlugin implements Plugin<Project> {
 				componentWithVariants.addVariantsFromConfiguration(
 						project.getConfigurations().getByName(OptionalDependenciesPlugin.OPTIONAL_CONFIGURATION_NAME),
 						ConfigurationVariantDetails::mapToOptional);
-			}
-		});
-		MavenPublication publication = (MavenPublication) project.getExtensions()
-			.getByType(PublishingExtension.class)
-			.getPublications()
-			.getByName("maven");
-		publication.getPom().withXml((xml) -> {
-			Element root = xml.asElement();
-			NodeList children = root.getChildNodes();
-			for (int i = 0; i < children.getLength(); i++) {
-				Node child = children.item(i);
-				if ("dependencyManagement".equals(child.getNodeName())) {
-					root.removeChild(child);
-				}
 			}
 		});
 	}


### PR DESCRIPTION
This addresses another Gradle deprecation, following #51598, #51625 and #51635:

```console
$ ./gradlew build --warning-mode all

> Task :build-plugin:spring-boot-maven-plugin:generatePomFileForMavenPublication
Declaring a dependency on an unpublished project has been deprecated. This will fail with an error in Gradle 10. A dependency was declared on project ':platform:spring-boot-internal-dependencies', but that project does not declare any publications. Ensure project ':platform:spring-boot-internal-dependencies' declares at least one publication. Consult the upgrading guide for further information: https://docs.gradle.org/9.7.0/userguide/upgrading_version_9.html#publishing_dependency_on_unpublished_project
```

Deprecated in Gradle 9.3, it occurs once, when generating `spring-boot-maven-plugin`'s POM.

`JavaConventions` makes `optional` extend `dependencyManagement`, which declares an enforced platform dependency on `:platform:spring-boot-internal-dependencies`. `MavenPluginPlugin` publishes `optional` as a variant of the `java` component so that optional dependencies appear in the plugin's POM, so the enforced platform ends up in a published variant and generating the POM requires Maven coordinates for a project that declares no publications. The resulting `<dependencyManagement>` element never reached the published POM, as a `pom.withXml` block removed it again.

This PR stops `optional` from extending `dependencyManagement`, and removes the `pom.withXml` block as it no longer has anything to strip. Resolvable `*Classpath` configurations already extend `dependencyManagement` directly, so dependency resolution is unaffected. `autoConfigurationOptionalClassPath` in `AutoConfigurationPlugin` is the one resolvable configuration that took version management from `optional`; its name ends in `ClassPath` rather than `Classpath`, so the convention never matched it. It is renamed to `autoConfigurationOptionalClasspath`.

I generated all 324 published POMs with and without this change. Only `spring-boot-maven-plugin`'s POM differs, and only in the root element's attribute order and wrapping from dropping the `pom.withXml` DOM round-trip — the documents are identical after `xmllint --c14n`. `./gradlew build` passes, including `spring-boot-maven-plugin`'s integration tests, which publish the plugin to a local repository and run Maven builds against the regenerated POM.

The upgrading guide suggests declaring a publication on the unpublished project, but `:platform:spring-boot-internal-dependencies` is internal by design, and `MavenPublishingConventions` would make it a deployment candidate whenever `deploymentRepository` is set. Keeping internal dependency management out of published variants seemed preferable, but I'm happy to take a different approach if you would prefer.

Reference: https://docs.gradle.org/9.7.0/userguide/upgrading_version_9.html#publishing_dependency_on_unpublished_project
