### PR TITLE
Connection fails when rabbitmq Docker Compose service is configured to use SSL

### DIFF
--- a/module/spring-boot-amqp/src/dockerTest/java/org/springframework/boot/amqp/docker/compose/RabbitDockerComposeConnectionDetailsFactoryIntegrationTests.java
+++ b/module/spring-boot-amqp/src/dockerTest/java/org/springframework/boot/amqp/docker/compose/RabbitDockerComposeConnectionDetailsFactoryIntegrationTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.boot.amqp.docker.compose;
 
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+
 import org.springframework.boot.amqp.autoconfigure.RabbitConnectionDetails;
 import org.springframework.boot.amqp.autoconfigure.RabbitConnectionDetails.Address;
 import org.springframework.boot.docker.compose.service.connection.test.DockerComposeTest;
@@ -42,10 +45,26 @@ class RabbitDockerComposeConnectionDetailsFactoryIntegrationTests {
 
 	@DockerComposeTest(composeFile = "rabbit-ssl-compose.yaml", image = TestImage.RABBITMQ,
 			additionalResources = { "ca.crt", "server.crt", "server.key", "client.crt", "client.key", "rabbitmq.conf" })
-	void runWithSslCreatesConnectionDetails(RabbitConnectionDetails connectionDetails) {
+	void runWithSslCreatesConnectionDetails(RabbitConnectionDetails connectionDetails) throws Exception {
 		assertConnectionDetails(connectionDetails);
 		SslBundle sslBundle = connectionDetails.getSslBundle();
 		assertThat(sslBundle).isNotNull();
+		assertThatSslConnectionCanBeMade(connectionDetails, sslBundle);
+	}
+
+	private void assertThatSslConnectionCanBeMade(RabbitConnectionDetails connectionDetails, SslBundle sslBundle)
+			throws Exception {
+		ConnectionFactory connectionFactory = new ConnectionFactory();
+		Address address = connectionDetails.getFirstAddress();
+		connectionFactory.setHost(address.host());
+		connectionFactory.setPort(address.port());
+		connectionFactory.setUsername(connectionDetails.getUsername());
+		connectionFactory.setPassword(connectionDetails.getPassword());
+		connectionFactory.setVirtualHost(connectionDetails.getVirtualHost());
+		connectionFactory.useSslProtocol(sslBundle.createSslContext());
+		try (Connection connection = connectionFactory.newConnection()) {
+			assertThat(connection.isOpen()).isTrue();
+		}
 	}
 
 	private void assertConnectionDetails(RabbitConnectionDetails connectionDetails) {

--- a/module/spring-boot-amqp/src/dockerTest/java/org/springframework/boot/amqp/docker/compose/RabbitDockerComposeConnectionDetailsFactoryIntegrationTests.java
+++ b/module/spring-boot-amqp/src/dockerTest/java/org/springframework/boot/amqp/docker/compose/RabbitDockerComposeConnectionDetailsFactoryIntegrationTests.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RabbitDockerComposeConnectionDetailsFactoryIntegrationTests {
 
 	@DockerComposeTest(composeFile = "rabbit-compose.yaml", image = TestImage.RABBITMQ)
-	void runCreatesConnectionDetails(RabbitConnectionDetails connectionDetails) {
+	void runCreatesConnectionDetails(RabbitConnectionDetails connectionDetails) throws Exception {
 		assertConnectionDetails(connectionDetails);
 		assertThat(connectionDetails.getSslBundle()).isNull();
 	}
@@ -47,27 +47,10 @@ class RabbitDockerComposeConnectionDetailsFactoryIntegrationTests {
 			additionalResources = { "ca.crt", "server.crt", "server.key", "client.crt", "client.key", "rabbitmq.conf" })
 	void runWithSslCreatesConnectionDetails(RabbitConnectionDetails connectionDetails) throws Exception {
 		assertConnectionDetails(connectionDetails);
-		SslBundle sslBundle = connectionDetails.getSslBundle();
-		assertThat(sslBundle).isNotNull();
-		assertThatSslConnectionCanBeMade(connectionDetails, sslBundle);
+		assertThat(connectionDetails.getSslBundle()).isNotNull();
 	}
 
-	private void assertThatSslConnectionCanBeMade(RabbitConnectionDetails connectionDetails, SslBundle sslBundle)
-			throws Exception {
-		ConnectionFactory connectionFactory = new ConnectionFactory();
-		Address address = connectionDetails.getFirstAddress();
-		connectionFactory.setHost(address.host());
-		connectionFactory.setPort(address.port());
-		connectionFactory.setUsername(connectionDetails.getUsername());
-		connectionFactory.setPassword(connectionDetails.getPassword());
-		connectionFactory.setVirtualHost(connectionDetails.getVirtualHost());
-		connectionFactory.useSslProtocol(sslBundle.createSslContext());
-		try (Connection connection = connectionFactory.newConnection()) {
-			assertThat(connection.isOpen()).isTrue();
-		}
-	}
-
-	private void assertConnectionDetails(RabbitConnectionDetails connectionDetails) {
+	private void assertConnectionDetails(RabbitConnectionDetails connectionDetails) throws Exception {
 		assertThat(connectionDetails.getUsername()).isEqualTo("myuser");
 		assertThat(connectionDetails.getPassword()).isEqualTo("secret");
 		assertThat(connectionDetails.getVirtualHost()).isEqualTo("/");
@@ -75,6 +58,24 @@ class RabbitDockerComposeConnectionDetailsFactoryIntegrationTests {
 		Address address = connectionDetails.getFirstAddress();
 		assertThat(address.host()).isNotNull();
 		assertThat(address.port()).isGreaterThan(0);
+		assertThatConnectionCanBeMade(connectionDetails);
+	}
+
+	private void assertThatConnectionCanBeMade(RabbitConnectionDetails connectionDetails) throws Exception {
+		ConnectionFactory connectionFactory = new ConnectionFactory();
+		Address address = connectionDetails.getFirstAddress();
+		connectionFactory.setHost(address.host());
+		connectionFactory.setPort(address.port());
+		connectionFactory.setUsername(connectionDetails.getUsername());
+		connectionFactory.setPassword(connectionDetails.getPassword());
+		connectionFactory.setVirtualHost(connectionDetails.getVirtualHost());
+		SslBundle sslBundle = connectionDetails.getSslBundle();
+		if (sslBundle != null) {
+			connectionFactory.useSslProtocol(sslBundle.createSslContext());
+		}
+		try (Connection connection = connectionFactory.newConnection()) {
+			assertThat(connection.isOpen()).isTrue();
+		}
 	}
 
 }

--- a/module/spring-boot-amqp/src/main/java/org/springframework/boot/amqp/docker/compose/RabbitDockerComposeConnectionDetailsFactory.java
+++ b/module/spring-boot-amqp/src/main/java/org/springframework/boot/amqp/docker/compose/RabbitDockerComposeConnectionDetailsFactory.java
@@ -40,6 +40,8 @@ class RabbitDockerComposeConnectionDetailsFactory
 
 	private static final int RABBITMQ_PORT = 5672;
 
+	private static final int RABBITMQ_TLS_PORT = 5671;
+
 	protected RabbitDockerComposeConnectionDetailsFactory() {
 		super("rabbitmq");
 	}
@@ -66,7 +68,8 @@ class RabbitDockerComposeConnectionDetailsFactory
 			super(service);
 			this.environment = new RabbitEnvironment(service.env());
 			this.sslBundle = getSslBundle(service);
-			this.addresses = List.of(new Address(service.host(), service.ports().get(RABBITMQ_PORT)));
+			int containerPort = (this.sslBundle != null) ? RABBITMQ_TLS_PORT : RABBITMQ_PORT;
+			this.addresses = List.of(new Address(service.host(), service.ports().get(containerPort)));
 		}
 
 		@Override


### PR DESCRIPTION
When a `rabbitmq` Docker Compose service is labelled with `org.springframework.boot.sslbundle.*`, `RabbitDockerComposeConnectionDetailsFactory` creates an `SslBundle` but still
  resolves the address from container port 5672, the plain AMQP listener. `RabbitConnectionFactoryBeanConfigurer` enables SSL on the connection factory when an `SslBundle` is
  present, so the client attempts a TLS handshake against the non-TLS listener and the connection fails with:

  javax.net.ssl.SSLException: Unsupported or unrecognized SSL message

  This PR resolves the address from container port 5671 (AMQPS) when an `SslBundle` is present, matching what `RabbitStreamDockerComposeConnectionDetailsFactory` does with
  `STREAMS_TLS_PORT` and what the Testcontainers-based `RabbitContainerConnectionDetailsFactory` does by switching to `getAmqpsUrl()`.

  The existing `runWithSslCreatesConnectionDetails` integration test only asserted that the port was greater than zero, so it passed with either port. It now also opens a real
  connection using the resolved address and the `SslBundle`. The test fails on the current code with the exception above and passes with this change.