### PR TITLE
Add HttpComponents connection pool metrics

### DIFF
--- a/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/HttpComponentsClientHttpRequestFactoryBuilder.java
+++ b/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/HttpComponentsClientHttpRequestFactoryBuilder.java
@@ -26,6 +26,7 @@ import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
 import org.apache.hc.core5.http.io.SocketConfig;
@@ -169,6 +170,22 @@ public final class HttpComponentsClientHttpRequestFactoryBuilder
 		Assert.notNull(dnsResolver, "'dnsResolver' must not be null");
 		return new HttpComponentsClientHttpRequestFactoryBuilder(getCustomizers(),
 				this.httpClientBuilder.withDnsResolver(dnsResolver));
+	}
+
+	/**
+	 * Return a new {@link HttpComponentsClientHttpRequestFactoryBuilder} that applies
+	 * additional customization to the {@link PoolingHttpClientConnectionManager} after it
+	 * has been built. This can be used, for example, to bind the connection pool to a
+	 * metrics registry.
+	 * @param connectionManagerPostConfigurer the post-configurer to apply
+	 * @return a new {@link HttpComponentsClientHttpRequestFactoryBuilder} instance
+	 * @since 4.0.0
+	 */
+	public HttpComponentsClientHttpRequestFactoryBuilder withConnectionManagerPostConfigurer(
+			Consumer<PoolingHttpClientConnectionManager> connectionManagerPostConfigurer) {
+		Assert.notNull(connectionManagerPostConfigurer, "'connectionManagerPostConfigurer' must not be null");
+		return new HttpComponentsClientHttpRequestFactoryBuilder(getCustomizers(),
+				this.httpClientBuilder.withConnectionManagerPostConfigurer(connectionManagerPostConfigurer));
 	}
 
 	/**

--- a/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/HttpComponentsHttpClientBuilder.java
+++ b/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/HttpComponentsHttpClientBuilder.java
@@ -16,6 +16,7 @@
 
 package org.springframework.boot.http.client;
 
+import java.lang.reflect.Field;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -30,6 +31,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
 import org.apache.hc.core5.http.io.SocketConfig;
 import org.jspecify.annotations.Nullable;
@@ -37,6 +39,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.boot.ssl.SslBundle;
 import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * Builder that can be used to create a
@@ -64,9 +67,11 @@ public final class HttpComponentsHttpClientBuilder {
 
 	private final DnsResolver dnsResolver;
 
+	private final Consumer<PoolingHttpClientConnectionManager> connectionManagerPostConfigurer;
+
 	public HttpComponentsHttpClientBuilder() {
 		this(Empty.consumer(), Empty.consumer(), Empty.consumer(), Empty.consumer(), Empty.consumer(),
-				HttpComponentsSslBundleTlsStrategy::get, SystemDefaultDnsResolver.INSTANCE);
+				HttpComponentsSslBundleTlsStrategy::get, SystemDefaultDnsResolver.INSTANCE, Empty.consumer());
 	}
 
 	private HttpComponentsHttpClientBuilder(Consumer<HttpClientBuilder> customizer,
@@ -74,7 +79,8 @@ public final class HttpComponentsHttpClientBuilder {
 			Consumer<SocketConfig.Builder> socketConfigCustomizer,
 			Consumer<ConnectionConfig.Builder> connectionConfigCustomizer,
 			Consumer<RequestConfig.Builder> defaultRequestConfigCustomizer,
-			TlsSocketStrategyFactory tlsSocketStrategyFactory, DnsResolver dnsResolver) {
+			TlsSocketStrategyFactory tlsSocketStrategyFactory, DnsResolver dnsResolver,
+			Consumer<PoolingHttpClientConnectionManager> connectionManagerPostConfigurer) {
 		this.customizer = customizer;
 		this.connectionManagerCustomizer = connectionManagerCustomizer;
 		this.socketConfigCustomizer = socketConfigCustomizer;
@@ -82,6 +88,7 @@ public final class HttpComponentsHttpClientBuilder {
 		this.defaultRequestConfigCustomizer = defaultRequestConfigCustomizer;
 		this.tlsSocketStrategyFactory = tlsSocketStrategyFactory;
 		this.dnsResolver = dnsResolver;
+		this.connectionManagerPostConfigurer = connectionManagerPostConfigurer;
 	}
 
 	/**
@@ -94,7 +101,8 @@ public final class HttpComponentsHttpClientBuilder {
 		Assert.notNull(customizer, "'customizer' must not be null");
 		return new HttpComponentsHttpClientBuilder(this.customizer.andThen(customizer),
 				this.connectionManagerCustomizer, this.socketConfigCustomizer, this.connectionConfigCustomizer,
-				this.defaultRequestConfigCustomizer, this.tlsSocketStrategyFactory, this.dnsResolver);
+				this.defaultRequestConfigCustomizer, this.tlsSocketStrategyFactory, this.dnsResolver,
+				this.connectionManagerPostConfigurer);
 	}
 
 	/**
@@ -109,7 +117,7 @@ public final class HttpComponentsHttpClientBuilder {
 		return new HttpComponentsHttpClientBuilder(this.customizer,
 				this.connectionManagerCustomizer.andThen(connectionManagerCustomizer), this.socketConfigCustomizer,
 				this.connectionConfigCustomizer, this.defaultRequestConfigCustomizer, this.tlsSocketStrategyFactory,
-				this.dnsResolver);
+				this.dnsResolver, this.connectionManagerPostConfigurer);
 	}
 
 	/**
@@ -124,7 +132,8 @@ public final class HttpComponentsHttpClientBuilder {
 		Assert.notNull(socketConfigCustomizer, "'socketConfigCustomizer' must not be null");
 		return new HttpComponentsHttpClientBuilder(this.customizer, this.connectionManagerCustomizer,
 				this.socketConfigCustomizer.andThen(socketConfigCustomizer), this.connectionConfigCustomizer,
-				this.defaultRequestConfigCustomizer, this.tlsSocketStrategyFactory, this.dnsResolver);
+				this.defaultRequestConfigCustomizer, this.tlsSocketStrategyFactory, this.dnsResolver,
+				this.connectionManagerPostConfigurer);
 	}
 
 	/**
@@ -139,7 +148,8 @@ public final class HttpComponentsHttpClientBuilder {
 		Assert.notNull(connectionConfigCustomizer, "'connectionConfigCustomizer' must not be null");
 		return new HttpComponentsHttpClientBuilder(this.customizer, this.connectionManagerCustomizer,
 				this.socketConfigCustomizer, this.connectionConfigCustomizer.andThen(connectionConfigCustomizer),
-				this.defaultRequestConfigCustomizer, this.tlsSocketStrategyFactory, this.dnsResolver);
+				this.defaultRequestConfigCustomizer, this.tlsSocketStrategyFactory, this.dnsResolver,
+				this.connectionManagerPostConfigurer);
 	}
 
 	/**
@@ -156,7 +166,7 @@ public final class HttpComponentsHttpClientBuilder {
 		Assert.notNull(tlsSocketStrategyFactory, "'tlsSocketStrategyFactory' must not be null");
 		return new HttpComponentsHttpClientBuilder(this.customizer, this.connectionManagerCustomizer,
 				this.socketConfigCustomizer, this.connectionConfigCustomizer, this.defaultRequestConfigCustomizer,
-				tlsSocketStrategyFactory, this.dnsResolver);
+				tlsSocketStrategyFactory, this.dnsResolver, this.connectionManagerPostConfigurer);
 	}
 
 	/**
@@ -173,7 +183,7 @@ public final class HttpComponentsHttpClientBuilder {
 		return new HttpComponentsHttpClientBuilder(this.customizer, this.connectionManagerCustomizer,
 				this.socketConfigCustomizer, this.connectionConfigCustomizer,
 				this.defaultRequestConfigCustomizer.andThen(defaultRequestConfigCustomizer),
-				this.tlsSocketStrategyFactory, this.dnsResolver);
+				this.tlsSocketStrategyFactory, this.dnsResolver, this.connectionManagerPostConfigurer);
 	}
 
 	/**
@@ -187,7 +197,25 @@ public final class HttpComponentsHttpClientBuilder {
 		Assert.notNull(dnsResolver, "'dnsResolver' must not be null");
 		return new HttpComponentsHttpClientBuilder(this.customizer, this.connectionManagerCustomizer,
 				this.socketConfigCustomizer, this.connectionConfigCustomizer, this.defaultRequestConfigCustomizer,
-				this.tlsSocketStrategyFactory, dnsResolver);
+				this.tlsSocketStrategyFactory, dnsResolver, this.connectionManagerPostConfigurer);
+	}
+
+	/**
+	 * Return a new {@link HttpComponentsHttpClientBuilder} that applies additional
+	 * customization to the {@link PoolingHttpClientConnectionManager} after it has been
+	 * built. This can be used, for example, to bind the connection pool to a metrics
+	 * registry.
+	 * @param connectionManagerPostConfigurer the post-configurer to apply
+	 * @return a new {@link HttpComponentsHttpClientBuilder} instance
+	 * @since 4.0.0
+	 */
+	public HttpComponentsHttpClientBuilder withConnectionManagerPostConfigurer(
+			Consumer<PoolingHttpClientConnectionManager> connectionManagerPostConfigurer) {
+		Assert.notNull(connectionManagerPostConfigurer, "'connectionManagerPostConfigurer' must not be null");
+		return new HttpComponentsHttpClientBuilder(this.customizer, this.connectionManagerCustomizer,
+				this.socketConfigCustomizer, this.connectionConfigCustomizer, this.defaultRequestConfigCustomizer,
+				this.tlsSocketStrategyFactory, this.dnsResolver,
+				this.connectionManagerPostConfigurer.andThen(connectionManagerPostConfigurer));
 	}
 
 	/**
@@ -203,7 +231,28 @@ public final class HttpComponentsHttpClientBuilder {
 			.setConnectionManager(createConnectionManager(settings))
 			.setDefaultRequestConfig(createDefaultRequestConfig(settings));
 		this.customizer.accept(builder);
-		return builder.build();
+		CloseableHttpClient httpClient = builder.build();
+		HttpClientConnectionManager connectionManager = getConnectionManager(builder);
+		if (connectionManager instanceof PoolingHttpClientConnectionManager poolingConnectionManager) {
+			this.connectionManagerPostConfigurer.accept(poolingConnectionManager);
+		}
+		return httpClient;
+	}
+
+	/**
+	 * {@link HttpClientBuilder#setConnectionManager} is {@code final} and does not
+	 * expose the configured manager, so we read it reflectively to capture the manager
+	 * that ends up being used by the built client (which may have been replaced by a
+	 * customizer).
+	 */
+	@Nullable
+	private static HttpClientConnectionManager getConnectionManager(HttpClientBuilder builder) {
+		Field field = ReflectionUtils.findField(HttpClientBuilder.class, "connManager");
+		if (field == null) {
+			return null;
+		}
+		ReflectionUtils.makeAccessible(field);
+		return (HttpClientConnectionManager) ReflectionUtils.getField(field, builder);
 	}
 
 	private PoolingHttpClientConnectionManager createConnectionManager(HttpClientSettings settings) {

--- a/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/autoconfigure/metrics/HttpClientMetricsAutoConfiguration.java
+++ b/module/spring-boot-http-client/src/main/java/org/springframework/boot/http/client/autoconfigure/metrics/HttpClientMetricsAutoConfiguration.java
@@ -16,19 +16,31 @@
 
 package org.springframework.boot.http.client.autoconfigure.metrics;
 
-import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.httpcomponents.hc5.PoolingHttpClientConnectionManagerMetricsBinder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.http.client.HttpComponentsClientHttpRequestFactoryBuilder;
 import org.springframework.boot.micrometer.metrics.MaximumAllowableTagsMeterFilter;
 import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsProperties;
 import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsProperties.Web.Client;
 import org.springframework.boot.micrometer.observation.autoconfigure.ObservationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.util.function.SingletonSupplier;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for HTTP client-related metrics.
@@ -56,6 +68,54 @@ public final class HttpClientMetricsAutoConfiguration {
 		String meterNamePrefix = observationProperties.getHttp().getClient().getRequests().getName();
 		int maxUriTags = clientProperties.getMaxUriTags();
 		return new MaximumAllowableTagsMeterFilter(meterNamePrefix, "uri", maxUriTags, "Are you using 'uriVariables'?");
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnClass(name = { "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager",
+			"io.micrometer.core.instrument.binder.httpcomponents.hc5.PoolingHttpClientConnectionManagerMetricsBinder" })
+	static HttpComponentsConnectionPoolMetricsBeanPostProcessor httpComponentsConnectionPoolMetricsBeanPostProcessor(
+			ObjectProvider<MeterRegistry> meterRegistry) {
+		return new HttpComponentsConnectionPoolMetricsBeanPostProcessor(meterRegistry);
+	}
+
+	/**
+	 * {@link BeanPostProcessor} that customizes every
+	 * {@link HttpComponentsClientHttpRequestFactoryBuilder} bean so that its
+	 * {@link PoolingHttpClientConnectionManager} is bound to the application's
+	 * {@link MeterRegistry}.
+	 */
+	@SuppressWarnings("deprecation")
+	static final class HttpComponentsConnectionPoolMetricsBeanPostProcessor implements BeanPostProcessor, Ordered {
+
+		private final Supplier<MeterRegistry> meterRegistry;
+
+		private final AtomicInteger poolCounter = new AtomicInteger();
+
+		HttpComponentsConnectionPoolMetricsBeanPostProcessor(ObjectProvider<MeterRegistry> meterRegistry) {
+			this.meterRegistry = SingletonSupplier.of(meterRegistry::getObject);
+		}
+
+		@Override
+		public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+			if (bean instanceof HttpComponentsClientHttpRequestFactoryBuilder builder) {
+				return builder.withConnectionManagerPostConfigurer(
+						(connectionManager) -> bindToMeterRegistry(beanName, connectionManager));
+			}
+			return bean;
+		}
+
+		private void bindToMeterRegistry(String beanName, PoolingHttpClientConnectionManager connectionManager) {
+			String poolName = beanName + ".pool-" + this.poolCounter.getAndIncrement();
+			new PoolingHttpClientConnectionManagerMetricsBinder(connectionManager, poolName)
+				.bindTo(this.meterRegistry.get());
+		}
+
+		@Override
+		public int getOrder() {
+			return Ordered.HIGHEST_PRECEDENCE;
+		}
+
 	}
 
 }

--- a/module/spring-boot-http-client/src/test/java/org/springframework/boot/http/client/HttpComponentsClientHttpRequestFactoryBuilderTests.java
+++ b/module/spring-boot-http-client/src/test/java/org/springframework/boot/http/client/HttpComponentsClientHttpRequestFactoryBuilderTests.java
@@ -18,6 +18,7 @@ package org.springframework.boot.http.client;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.hc.client5.http.DnsResolver;
 import org.apache.hc.client5.http.HttpRoute;
@@ -26,6 +27,7 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.cookie.StandardCookieSpec;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.core5.function.Resolver;
 import org.apache.hc.core5.http.io.SocketConfig;
@@ -172,6 +174,27 @@ class HttpComponentsClientHttpRequestFactoryBuilderTests
 			.getField(manager, "connectionConfigResolver");
 		assertThat(resolver).isNotNull();
 		return resolver.resolve(null);
+	}
+
+	@Test
+	void connectionManagerPostConfigurerIsCalledWithBuiltManager() {
+		AtomicReference<PoolingHttpClientConnectionManager> postConfigured = new AtomicReference<>();
+		ClientHttpRequestFactoryBuilder.httpComponents()
+			.withConnectionManagerPostConfigurer(postConfigured::set)
+			.build();
+		assertThat(postConfigured.get()).isNotNull();
+	}
+
+	@Test
+	void connectionManagerPostConfigurerIsCalledWithCustomizedManager() {
+		PoolingHttpClientConnectionManager customManager = PoolingHttpClientConnectionManagerBuilder.create()
+			.build();
+		AtomicReference<PoolingHttpClientConnectionManager> postConfigured = new AtomicReference<>();
+		ClientHttpRequestFactoryBuilder.httpComponents()
+			.withHttpClientCustomizer((builder) -> builder.setConnectionManager(customManager))
+			.withConnectionManagerPostConfigurer(postConfigured::set)
+			.build();
+		assertThat(postConfigured).hasValue(customManager);
 	}
 
 }

--- a/module/spring-boot-http-client/src/test/java/org/springframework/boot/http/client/autoconfigure/metrics/HttpClientMetricsAutoConfigurationTests.java
+++ b/module/spring-boot-http-client/src/test/java/org/springframework/boot/http/client/autoconfigure/metrics/HttpClientMetricsAutoConfigurationTests.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
+import org.springframework.boot.http.client.HttpComponentsClientHttpRequestFactoryBuilder;
 import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.system.CapturedOutput;
@@ -54,6 +56,24 @@ class HttpClientMetricsAutoConfigurationTests {
 				assertThat(meterRegistry.find("http.client.requests").timers()).hasSize(2);
 				assertThat(output).contains("Reached the maximum number of 'uri' tags for 'http.client.requests'.")
 					.contains("Are you using 'uriVariables'?");
+			});
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	void httpComponentsConnectionPoolMetricsAreAutoConfigured() {
+		new ApplicationContextRunner()
+			.withConfiguration(
+					AutoConfigurations.of(HttpClientMetricsAutoConfiguration.class, MetricsAutoConfiguration.class))
+			.withBean(SimpleMeterRegistry.class)
+			.withBean("httpComponentsBuilder", HttpComponentsClientHttpRequestFactoryBuilder.class,
+					() -> ClientHttpRequestFactoryBuilder.httpComponents())
+			.run((context) -> {
+				context.getBean("httpComponentsBuilder", HttpComponentsClientHttpRequestFactoryBuilder.class).build();
+				MeterRegistry meterRegistry = context.getBean(MeterRegistry.class);
+				assertThat(meterRegistry.find("httpcomponents.httpclient.pool.total.connections").gauge())
+					.as("connection pool metrics should be bound")
+					.isNotNull();
 			});
 	}
 


### PR DESCRIPTION
Fixes gh-44643

## Summary

This builds on the prototype by @nosan (https://github.com/spring-projects/spring-boot/compare/main...nosan:spring-boot:44643) and rebases it onto current `main`, which has since been modularized.

* Adds `HttpComponentsClientHttpRequestFactoryBuilder.withConnectionManagerPostConfigurer(Consumer<PoolingHttpClientConnectionManager>)`.
* `HttpClientMetricsAutoConfiguration` adds a `BeanPostProcessor` that automatically binds each `HttpComponentsClientHttpRequestFactoryBuilder`'s pool to the `MeterRegistry` (pool name `beanName.pool-N`).

## Fix for the prototype's known issue

As @nosan noted, the original approach post-configured the connection manager that the builder itself creates. If a user supplies a `withHttpClientCustomizer` that calls `builder.setConnectionManager(other)`, the auto-configuration would bind metrics to the discarded manager and produce NaN.

Since `HttpClientBuilder.setConnectionManager` is `final`, this PR resolves the **final** connection manager after the customizer has run (via `ReflectionUtils` on the `connManager` field) and post-configures that one, so metrics always reflect the pool the client actually uses.

## Testing

* New tests cover: default manager is post-configured; user-supplied manager (via `setConnectionManager` in a customizer) is post-configured; auto-configuration registers `httpcomponents.httpclient.pool.*` gauges.
* `./gradlew :module:spring-boot-http-client:test` passes.

@nosan @wilkinsona - happy to adjust based on feedback.