### PR TITLE
Preserve read-timeout for WebClient HTTP service groups

### DIFF
--- a/module/spring-boot-webclient/src/main/java/org/springframework/boot/webclient/autoconfigure/service/PropertiesWebClientHttpServiceGroupConfigurer.java
+++ b/module/spring-boot-webclient/src/main/java/org/springframework/boot/webclient/autoconfigure/service/PropertiesWebClientHttpServiceGroupConfigurer.java
@@ -49,8 +49,22 @@ class PropertiesWebClientHttpServiceGroupConfigurer implements WebClientHttpServ
 
 	/**
 	 * The default order for the PropertiesWebClientHttpServiceGroupConfigurer.
+	 * <p>
+	 * This must run after {@link WebClientCustomizerHttpServiceGroupConfigurer} (order
+	 * {@code 0}): that configurer re-applies every auto-configured
+	 * {@code WebClientCustomizer} bean to each group's builder, including
+	 * {@code WebClientAutoConfiguration.webClientHttpConnectorCustomizer}, which
+	 * unconditionally sets the connector built from the single, non-group-aware
+	 * {@code ClientHttpConnector} bean whenever one is present (which it is for any
+	 * typical reactive application). Running before it, as this configurer originally
+	 * did, meant that customizer would silently overwrite the connector this class builds
+	 * from group-specific {@code spring.http.serviceclient.*} settings - including
+	 * {@code read-timeout}, which would then be dropped entirely with no error. Running
+	 * after it lets an unordered user-defined {@link WebClientHttpServiceGroupConfigurer}
+	 * (default order {@link Ordered#LOWEST_PRECEDENCE}) still have the final say if it
+	 * wants it.
 	 */
-	private static final int DEFAULT_ORDER = Ordered.HIGHEST_PRECEDENCE + 10;
+	private static final int DEFAULT_ORDER = Ordered.LOWEST_PRECEDENCE - 10;
 
 	private final HttpServiceClientProperties properties;
 

--- a/module/spring-boot-webclient/src/test/java/org/springframework/boot/webclient/autoconfigure/service/ReactiveHttpServiceClientAutoConfigurationTests.java
+++ b/module/spring-boot-webclient/src/test/java/org/springframework/boot/webclient/autoconfigure/service/ReactiveHttpServiceClientAutoConfigurationTests.java
@@ -43,6 +43,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.support.WebClientHttpServiceGroupConfigurer;
@@ -130,6 +131,35 @@ class ReactiveHttpServiceClientAutoConfigurationTests {
 		HttpClient httpClient = (HttpClient) ReflectionTestUtils.getField(client, "httpClient");
 		assertThat(httpClient).isNotNull();
 		assertThat(httpClient.connectTimeout()).contains(expectedReadTimeout);
+	}
+
+	@Test // gh-49279
+	void readTimeoutSurvivesWhenAutoConfiguredClientHttpConnectorBeanIsPresent() {
+		// Auto-configuring a ClientHttpConnector bean (as
+		// ReactiveHttpClientAutoConfiguration
+		// does by default) makes WebClientAutoConfiguration's
+		// webClientHttpConnectorCustomizer
+		// active. Before this was fixed, WebClientCustomizerHttpServiceGroupConfigurer
+		// re-applied that customizer to every group's builder *after*
+		// PropertiesWebClientHttpServiceGroupConfigurer had already set the group's own
+		// connector, silently overwriting it - and every property configured through that
+		// connector, including read-timeout, with the single, non-group-aware default.
+		this.contextRunner.withConfiguration(AutoConfigurations.of(HttpClientAutoConfiguration.class))
+			.withPropertyValues("spring.http.serviceclient.one.base-url=https://example.com/one",
+					"spring.http.serviceclient.one.read-timeout=5s")
+			.withUserConfiguration(HttpClientConfiguration.class)
+			.run((context) -> {
+				assertThat(context).hasSingleBean(ClientHttpConnector.class);
+				TestClientOne clientOne = context.getBean(TestClientOne.class);
+				WebClient webClientOne = getWebClient(clientOne);
+				ClientHttpConnector connector = (ClientHttpConnector) Extractors.byName("exchangeFunction.connector")
+					.apply(webClientOne);
+				assertThat(connector).isInstanceOf(ReactorClientHttpConnector.class);
+				reactor.netty.http.client.HttpClient httpClient = (reactor.netty.http.client.HttpClient) ReflectionTestUtils
+					.getField(connector, "httpClient");
+				assertThat(httpClient).isNotNull();
+				assertThat(httpClient.configuration().responseTimeout()).isEqualTo(Duration.ofSeconds(5));
+			});
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #49279.

## The problem

For `WEB_CLIENT` HTTP service groups configured via `spring.http.serviceclient.<group>.read-timeout`, the timeout is silently dropped whenever a `ClientHttpConnector` bean is present in the context (the default for any typical reactive application, via `ReactiveHttpClientAutoConfiguration`). `REST_CLIENT` groups are unaffected, matching what's reported in the issue.

## Root cause

`PropertiesWebClientHttpServiceGroupConfigurer` (which applies the group-specific properties, including `read-timeout`, to that group's `WebClient.Builder`) originally ran with order `Ordered.HIGHEST_PRECEDENCE + 10`, i.e. before `WebClientCustomizerHttpServiceGroupConfigurer` (order `0`).

`WebClientCustomizerHttpServiceGroupConfigurer` re-applies every registered `WebClientCustomizer` bean to each group's builder. `WebClientAutoConfiguration#webClientHttpConnectorCustomizer` is one such customizer, and it unconditionally does `builder.clientConnector(clientHttpConnector)` using the single, non-group-aware `ClientHttpConnector` bean.

Because the properties configurer ran first, this later reapplication silently overwrote the group-specific connector (built with the correct `read-timeout`) with the generic default, which has no timeout configured. Nothing surfaces an error - the property is just quietly ignored.

## The fix

Move `PropertiesWebClientHttpServiceGroupConfigurer`'s default order to `Ordered.LOWEST_PRECEDENCE - 10`, so it runs after the customizer reapplication instead of before it. An unordered user-defined `WebClientHttpServiceGroupConfigurer` (default order `Ordered.LOWEST_PRECEDENCE`) still runs after this and keeps the final say if it wants it.

## Verification

- Added a regression test, `readTimeoutSurvivesWhenAutoConfiguredClientHttpConnectorBeanIsPresent`, to `ReactiveHttpServiceClientAutoConfigurationTests`. It configures a group's `read-timeout` alongside an auto-configured `ClientHttpConnector` bean and asserts the resulting Reactor Netty `HttpClient`'s `responseTimeout()` matches. This test fails against the pre-fix ordering and passes with the fix.
- Isolated (mocked) invocation of `PropertiesWebClientHttpServiceGroupConfigurer` alone confirmed it correctly produces a builder with `responseTimeout` set - the bug is in the interaction between the two configurers, not in either one's own logic.
- Full `spring-boot-webclient` module test suite passes (`./gradlew :module:spring-boot-webclient:test`), along with `checkFormatMain`, `checkFormatTest`, `checkstyleMain`, `checkstyleTest`.