### PR TITLE
Retain Spring Session's default SameSite in war deployments

### DIFF
--- a/module/spring-boot-session/src/main/java/org/springframework/boot/session/autoconfigure/SessionAutoConfiguration.java
+++ b/module/spring-boot-session/src/main/java/org/springframework/boot/session/autoconfigure/SessionAutoConfiguration.java
@@ -156,7 +156,7 @@ public final class SessionAutoConfiguration {
 				map.from(cookie::isHttpOnly).to(cookieSerializer::setUseHttpOnlyCookie);
 				map.from(cookie::isSecure).to(cookieSerializer::setUseSecureCookie);
 				map.from(cookie::getMaxAge).to(cookieSerializer::setCookieMaxAge);
-				map.from(cookie.getAttribute("SameSite")).always().to(cookieSerializer::setSameSite);
+				map.from(cookie.getAttribute("SameSite")).to(cookieSerializer::setSameSite);
 				map.from(cookie.getAttribute("Partitioned")).as(Boolean::valueOf).to(cookieSerializer::setPartitioned);
 				cookieSerializerCustomizers.orderedStream()
 					.forEach((customizer) -> customizer.customize(cookieSerializer));

--- a/module/spring-boot-session/src/test/java/org/springframework/boot/session/autoconfigure/SessionAutoConfigurationTests.java
+++ b/module/spring-boot-session/src/test/java/org/springframework/boot/session/autoconfigure/SessionAutoConfigurationTests.java
@@ -242,6 +242,17 @@ class SessionAutoConfigurationTests {
 		});
 	}
 
+	@Test
+	void cookieSerializerUsesLaxSameSitePolicyByDefaultInAWarDeployment() {
+		MockServletContext servletContext = new MockServletContext();
+		this.contextRunner.withUserConfiguration(SessionRepositoryConfiguration.class)
+			.withInitializer((context) -> context.setServletContext(servletContext)) // war
+			.run((context) -> {
+				DefaultCookieSerializer cookieSerializer = context.getBean(DefaultCookieSerializer.class);
+				assertThat(cookieSerializer).hasFieldOrPropertyWithValue("sameSite", "Lax");
+			});
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	@EnableSpringHttpSession
 	static class SessionRepositoryConfiguration {


### PR DESCRIPTION
While reading the fix for #48830, I noticed that `SessionAutoConfiguration` has a second `DefaultCookieSerializer` bean for war deployments, added in #48493 a month before that fix, and it still maps SameSite with `always()`:

```java
map.from(cookie.getAttribute("SameSite")).always().to(cookieSerializer::setSameSite);
```

When the servlet container's `SessionCookieConfig` has no `SameSite` attribute, `getAttribute` returns `null` and the serializer's default of `Lax` is overwritten with `null`, so the session cookie ends up without a SameSite attribute. That's the behaviour #48830 fixed for the embedded server case. In 3.5.x a war deployment went through the `ServerProperties` mapping with a non-null mapper, so it kept `Lax` as well.

The change drops `always()` from that mapping. A SameSite value set on the container is still applied (the existing `sessionCookieConfigIsAppliedToAutoConfiguredCookieSerializerInAWarDeployment` test covers `Strict`), and there's no "omitted" equivalent on `SessionCookieConfig` that would need a null to get through.

I added `cookieSerializerUsesLaxSameSitePolicyByDefaultInAWarDeployment`, the war counterpart of the test added for #48830. On 4.0.x without the change it fails with `expected "Lax" but value was: null`; with the change all 16 tests in `SessionAutoConfigurationTests` pass, as does `./gradlew :module:spring-boot-session:check`. I targeted 4.0.x since the war configuration has been there since 4.0.1.

AI tools used
